### PR TITLE
fix rio_notifier to not clean/re-init Winsock

### DIFF
--- a/ssl/rio/rio_notifier.c
+++ b/ssl/rio/rio_notifier.c
@@ -10,7 +10,6 @@
 #include "internal/sockets.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>
-#include "internal/thread_once.h"
 #include "internal/rio_notifier.h"
 
 #if !defined(OPENSSL_SYS_WINDOWS) || RIO_NOTIFIER_METHOD == RIO_NOTIFIER_METHOD_SOCKETPAIR

--- a/ssl/rio/rio_notifier.c
+++ b/ssl/rio/rio_notifier.c
@@ -30,64 +30,30 @@ static int set_cloexec(int fd)
 
 #if defined(OPENSSL_SYS_WINDOWS)
 
-static CRYPTO_ONCE ensure_wsa_startup_once = CRYPTO_ONCE_STATIC_INIT;
-static CRYPTO_RWLOCK *wsa_lock;
-static int wsa_started;
-static int wsa_ref;
-
 static void ossl_wsa_cleanup(void)
 {
-    if (wsa_started) {
-        wsa_started = 0;
-        WSACleanup();
-    }
-
-    CRYPTO_THREAD_lock_free(wsa_lock);
-    wsa_lock = NULL;
+    WSACleanup();
 }
 
-DEFINE_RUN_ONCE_STATIC(do_wsa_startup)
+static int do_wsa_startup(void)
 {
     WORD versionreq = 0x0202; /* Version 2.2 */
     WSADATA wsadata;
 
-    wsa_lock = CRYPTO_THREAD_lock_new();
-    if (wsa_lock == NULL)
+    if (WSAStartup(versionreq, &wsadata) != 0)
         return 0;
-
-    if (WSAStartup(versionreq, &wsadata) != 0) {
-        CRYPTO_THREAD_lock_free(wsa_lock);
-        wsa_lock = NULL;
-        return 0;
-    }
-    wsa_started = 1;
 
     return 1;
 }
 
 static ossl_inline int ensure_wsa_startup(void)
 {
-    int rv, unused;
-
-    rv = RUN_ONCE(&ensure_wsa_startup_once, do_wsa_startup);
-    if (rv != 0)
-        CRYPTO_atomic_add(&wsa_ref, 1, &unused, wsa_lock);
-
-    return rv;
+    return do_wsa_startup();
 }
 
 static void wsa_done(void)
 {
-    int ref;
-
-    if (wsa_lock != NULL) {
-        CRYPTO_atomic_add(&wsa_ref, -1, &ref, wsa_lock);
-        if (ref == 0) {
-            ossl_wsa_cleanup();
-            ensure_wsa_startup_once = CRYPTO_ONCE_STATIC_INIT;
-            wsa_lock = NULL;
-        }
-    }
+    ossl_wsa_cleanup();
 }
 
 #endif
@@ -188,8 +154,6 @@ int ossl_rio_notifier_init(RIO_NOTIFIER *nfy)
     if (!ensure_wsa_startup()) {
         ERR_raise_data(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR,
             "Cannot start Windows sockets");
-
-        wsa_done();
         return 0;
     }
 #endif


### PR DESCRIPTION
the rio_notifier sets up the Winsock API via WSAStartup, and tracks a refcount with the number of users, cleaning the api with WSACleanup when the refcount reaches zero.

This is bad though, because as part of that it re-initalizes the RUN_ONCE variable used to do one time initalization of the API.  We should never reset a run once variable as they are meant to run, well, once in a process lifetime, and many implementations disallow this behavior.

Instead of doing these gymnastics, lets instead rely on the documented windows behavior that winsock resources get freed on process exit automatically.  This lets us do a one time initalization and trust that we will get proper cleanup when the process exits.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
