### PR TITLE
mfail: add sampled and count-only modes to test driver

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -196,6 +196,13 @@ return 0 when a failure was triggered. The `ADD_MFAIL_ALL_TESTS` and
 `ADD_MFAIL_ALL_NO_CHECK_TESTS` variants apply the same cycle to each index
 of a parameterised test, the same way `ADD_ALL_TESTS` does.
 
+The `ADD_MFAIL_SAMPLED_TEST(fn, cnt)` variant (and its `NO_CHECK` and `ALL`
+forms) caps injection at `cnt` points: it injects at every allocation when
+there are at most `cnt` of them, and otherwise samples `cnt` points spread
+across the run. This keeps tests with very many allocations bounded. On
+`no-cached-fetch` builds, where allocation counts explode, non-sampled tests
+run the counting phase only and skip injection; sampled tests still run.
+
 An mfail test returns 1 on success or 0 on failure; under `NO_CHECK` a 0 is
 tolerated since a function may legitimately fail when an allocation fails.
 Returning -1 forces a failure that is reported even under `NO_CHECK`, for
@@ -211,6 +218,11 @@ Behavior is controlled with the following environment variables:
                                     exceeds the slow threshold.
 
     OPENSSL_TEST_MFAIL_SLOW=N       Slow threshold (default 1000).
+
+    OPENSSL_TEST_MFAIL_COUNT=N      Override the sampled point count, taking
+                                    precedence over the per-test value.
+
+    OPENSSL_TEST_MFAIL_COUNT_ONLY=1 Run the counting phase only, never inject.
 
     OPENSSL_TEST_MFAIL_POINT=N      Run only failure point N (0-indexed),
                                     useful for debugging a specific failure.

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -8978,12 +8978,7 @@ int setup_tests(void)
     ADD_TEST(test_EVP_SM2_verify);
 #endif
     ADD_ALL_TESTS(test_set_get_raw_keys, OSSL_NELEM(keys));
-#if defined(_MSC_VER) || defined(OPENSSL_NO_CACHED_FETCH)
-    ADD_MFAIL_ALL_NO_CHECK_TESTS(test_set_get_raw_keys_mfail,
-        OSSL_NELEM(keys));
-#else
     ADD_MFAIL_ALL_TESTS(test_set_get_raw_keys_mfail, OSSL_NELEM(keys));
-#endif
     ADD_ALL_TESTS(test_EVP_PKEY_check, OSSL_NELEM(keycheckdata));
 #ifndef OPENSSL_NO_CMAC
     ADD_TEST(test_CMAC_keygen);

--- a/test/mfail/mfail.c
+++ b/test/mfail/mfail.c
@@ -38,6 +38,9 @@ static struct {
     int single_point;
     int start_point;
     int env_count;
+    int count_only;
+    int count_only_env;
+    int sample_count;
     int slow_threshold;
     int print_bt;
     int mode;
@@ -155,11 +158,13 @@ int mfail_install(int optional)
     mf.single_point = env_int("OPENSSL_TEST_MFAIL_POINT", -1);
     mf.start_point = env_int("OPENSSL_TEST_MFAIL_START", 0);
     mf.env_count = env_int("OPENSSL_TEST_MFAIL_COUNT", 0);
+    mf.count_only_env = env_is_true("OPENSSL_TEST_MFAIL_COUNT_ONLY");
     mf.slow_threshold = env_int("OPENSSL_TEST_MFAIL_SLOW", 1000);
     mf.print_bt = env_is_true("OPENSSL_TEST_MFAIL_BACKTRACE");
 
     /* if optional and nothing configured, then no point installing hooks */
-    if (optional && mf.env_count <= 0 && mf.single_point < 0)
+    if (optional && mf.env_count <= 0 && mf.single_point < 0
+        && !mf.count_only_env)
         return 0;
 
     if (!CRYPTO_set_mem_functions(mf_malloc, mf_realloc, mf_free))
@@ -209,6 +214,11 @@ static int compute_point(int i, int total, int n, int seq, int start)
 
 void mfail_init(int seq, int flags)
 {
+    mfail_init_ex(seq, flags, 0);
+}
+
+void mfail_init_ex(int seq, int flags, int count)
+{
     mf.seq = seq;
     mf.iter_index = 0;
     mf.n = 0;
@@ -221,10 +231,13 @@ void mfail_init(int seq, int flags)
     mf.counting = 0;
     mf.slow_skipped = 0;
     mf.no_check = flags & MFAIL_FLAG_NO_CHECK;
+    mf.count_only = mf.count_only_env || (flags & MFAIL_FLAG_COUNT_ONLY) != 0;
+    /* env count overrides the requested per-test sample count */
+    mf.sample_count = mf.env_count > 0 ? mf.env_count : count;
 
     if (mf.single_point >= 0) {
         mf.mode = MFAIL_MODE_SINGLE;
-    } else if ((flags & MFAIL_FLAG_COUNT) && mf.env_count > 0) {
+    } else if ((flags & MFAIL_FLAG_COUNT) && mf.sample_count > 0) {
         mf.mode = MFAIL_MODE_SAMPLED;
     } else {
         mf.mode = MFAIL_MODE_EXHAUSTIVE;
@@ -240,7 +253,13 @@ int mfail_has_next(void)
         switch (mf.phase) {
         case MFAIL_PHASE_COUNTING:
             mf.total = mf.alloc_count;
-            if (mf.skip_slow && mf.total > mf.slow_threshold) {
+            if (mf.count_only) {
+                mf.phase = MFAIL_PHASE_DONE;
+                break;
+            }
+            /* sampled runs are bounded, so slow-skip only applies otherwise */
+            if (mf.skip_slow && mf.mode != MFAIL_MODE_SAMPLED
+                && mf.total > mf.slow_threshold) {
                 mf.slow_skipped = 1;
                 mf.phase = MFAIL_PHASE_DONE;
                 break;
@@ -256,7 +275,7 @@ int mfail_has_next(void)
                     mf.phase = MFAIL_PHASE_DONE;
                 }
             } else { /* mf.mode is MFAIL_MODE_SAMPLED */
-                mf.n = mf.env_count;
+                mf.n = mf.sample_count;
                 if (mf.n > mf.total)
                     mf.n = mf.total;
                 if (mf.n > 0 && mf.total > mf.start_point) {
@@ -334,6 +353,11 @@ int mfail_was_triggered(void)
 int mfail_was_slow_skipped(void)
 {
     return mf.slow_skipped;
+}
+
+int mfail_is_count_only(void)
+{
+    return mf.count_only;
 }
 
 int mfail_get_count(void)

--- a/test/mfail/mfail.h
+++ b/test/mfail/mfail.h
@@ -13,6 +13,8 @@
 /* Flags for mfail_init(). */
 #define MFAIL_FLAG_COUNT (1 << 0)
 #define MFAIL_FLAG_NO_CHECK (1 << 1)
+/* Force count-only run for this init */
+#define MFAIL_FLAG_COUNT_ONLY (1 << 2)
 
 /* Modes */
 #define MFAIL_MODE_EXHAUSTIVE 0
@@ -30,6 +32,8 @@ int mfail_install(int optional);
 int mfail_is_installed(void);
 /* Initialize the mfail for test case runs */
 void mfail_init(int seq, int flags);
+/* As mfail_init() but caps injection at |count| sampled points */
+void mfail_init_ex(int seq, int flags, int count);
 /* Check for the failure loop if another fail execution should be done */
 int mfail_has_next(void);
 /* Start the failure triggering block */
@@ -40,6 +44,8 @@ void mfail_end(void);
 int mfail_was_triggered(void);
 /* Check if the inject phase was skipped because it got over slow threshold */
 int mfail_was_slow_skipped(void);
+/* Check if mfail counts allocations and not inject */
+int mfail_is_count_only(void);
 /* If the counting was executed, get the total number of allocations */
 int mfail_get_count(void);
 /* Get the total number of failure points */

--- a/test/quic_srt_gen_test.c
+++ b/test/quic_srt_gen_test.c
@@ -90,10 +90,6 @@ static int test_srt_gen_new_mfail(int idx)
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_srt_gen, OSSL_NELEM(tests));
-#ifdef OPENSSL_NO_CACHED_FETCH
-    ADD_MFAIL_ALL_NO_CHECK_TESTS(test_srt_gen_new_mfail, OSSL_NELEM(tests));
-#else
     ADD_MFAIL_ALL_TESTS(test_srt_gen_new_mfail, OSSL_NELEM(tests));
-#endif
     return 1;
 }

--- a/test/quic_srtm_test.c
+++ b/test/quic_srtm_test.c
@@ -119,11 +119,7 @@ err:
 int setup_tests(void)
 {
     ADD_TEST(test_srtm);
-#ifdef OPENSSL_NO_CACHED_FETCH
-    ADD_MFAIL_NO_CHECK_TEST(test_srtm_new_mfail);
-#else
     ADD_MFAIL_TEST(test_srtm_new_mfail);
-#endif
     ADD_MFAIL_TEST(test_srtm_ops_mfail);
     return 1;
 }

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -218,7 +218,6 @@ end:
     return ret;
 }
 
-#ifndef OPENSSL_NO_CACHED_FETCH
 static int test_ssl_read_key_update_mfail(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
@@ -302,7 +301,6 @@ err:
 
     return ret;
 }
-#endif
 
 /*
  * Test that sending FIN with no data to a client blocking in SSL_read_ex() will
@@ -3520,7 +3518,6 @@ static int test_quic_peer_addr_v6(void)
 }
 #endif
 
-#ifndef OPENSSL_NO_CACHED_FETCH
 /*
  * Advance the fake clock to the next QUIC timer event when both endpoints are
  * idle, consuming no real time.
@@ -3658,7 +3655,6 @@ err:
 
     return ret;
 }
-#endif
 
 /* Test ECH with quic */
 static int test_ech(void)
@@ -3911,9 +3907,7 @@ int setup_tests(void)
         goto err;
 
     ADD_ALL_TESTS(test_quic_write_read, 3);
-#ifndef OPENSSL_NO_CACHED_FETCH
     ADD_MFAIL_NO_CHECK_TEST(test_ssl_read_key_update_mfail);
-#endif
     ADD_TEST(test_fin_only_blocking);
     ADD_TEST(test_ciphersuites);
     ADD_TEST(test_cipher_find);
@@ -3955,16 +3949,10 @@ int setup_tests(void)
     ADD_TEST(test_quic_peer_addr_v6);
 #endif
     ADD_TEST(test_quic_peer_addr_v4);
-#ifndef OPENSSL_NO_CACHED_FETCH
     ADD_MFAIL_NO_CHECK_TEST(test_quic_handshake_multipkt_mfail);
-#endif
     ADD_TEST(test_ech);
     ADD_TEST(test_quic_resize_txe);
-#ifdef OPENSSL_NO_CACHED_FETCH
-    ADD_MFAIL_NO_CHECK_TEST(test_ssl_new_mfail);
-#else
     ADD_MFAIL_TEST(test_ssl_new_mfail);
-#endif
 
     return 1;
 err:

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -757,13 +757,8 @@ int setup_tests(void)
 {
     ADD_ALL_TESTS(test_rsa_pkcs1, 3);
     ADD_ALL_TESTS(test_rsa_oaep, 3);
-#if defined(_MSC_VER) || defined(OPENSSL_NO_CACHED_FETCH)
-    ADD_MFAIL_ALL_NO_CHECK_TESTS(test_rsa_pkcs1_mfail, 3);
-    ADD_MFAIL_ALL_NO_CHECK_TESTS(test_rsa_oaep_mfail, 3);
-#else
     ADD_MFAIL_ALL_TESTS(test_rsa_pkcs1_mfail, 3);
     ADD_MFAIL_ALL_TESTS(test_rsa_oaep_mfail, 3);
-#endif
     ADD_ALL_TESTS(test_rsa_security_bit, OSSL_NELEM(rsa_security_bits_cases));
     ADD_TEST(test_rsa_saos);
     ADD_TEST(test_EVP_rsa_legacy_key);

--- a/test/statem_clnt_construct_test.c
+++ b/test/statem_clnt_construct_test.c
@@ -558,7 +558,7 @@ err:
 }
 #endif
 
-#if !defined(OSSL_NO_USABLE_TLS1_3) && !defined(OPENSSL_NO_CACHED_FETCH)
+#ifndef OSSL_NO_USABLE_TLS1_3
 static int mfail_construct_ch_tls13(void)
 {
     CH_CONFIG cfg = { 0, TLS1_3_VERSION, TLS1_3_VERSION, 0 };
@@ -670,14 +670,12 @@ static int test_construct_ch_ech_tls12(void)
 }
 #endif /* OPENSSL_NO_TLS1_2 */
 
-#ifndef OPENSSL_NO_CACHED_FETCH
 static int mfail_construct_ch_ech(void)
 {
     CH_CONFIG cfg = { 0, TLS1_3_VERSION, TLS1_3_VERSION, 0 };
 
     return mfail_construct_ch_common(&cfg, prep_ech);
 }
-#endif /* OPENSSL_NO_CACHED_FETCH */
 #endif /* OSSL_NO_USABLE_ECH */
 
 int setup_tests(void)
@@ -695,7 +693,6 @@ int setup_tests(void)
     ADD_TEST(test_construct_ch_tls13);
     ADD_TEST(test_construct_ch_tls13_no_middlebox);
     ADD_TEST(test_construct_ch_hrr);
-#ifndef OPENSSL_NO_CACHED_FETCH
     /*
      * The non-cached mfail run takes too long and does not test too much extra
      * so better to skip it.
@@ -712,7 +709,6 @@ int setup_tests(void)
 #else
     ADD_MFAIL_TEST(mfail_construct_ch_tls13);
 #endif /* OPENSSL_NO_ECX */
-#endif /* OPENSSL_NO_CACHED_FETCH */
 #endif /* OSSL_NO_USABLE_TLS1_3 */
 
 #if !defined(OPENSSL_NO_DTLS) && !defined(OPENSSL_NO_DTLS1_2)
@@ -726,9 +722,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_TLS1_2
     ADD_TEST(test_construct_ch_ech_tls12);
 #endif
-#ifndef OPENSSL_NO_CACHED_FETCH
     ADD_MFAIL_TEST(mfail_construct_ch_ech);
-#endif /* OPENSSL_NO_CACHED_FETCH */
 #endif /* OSSL_NO_USABLE_ECH */
     return 1;
 }

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -73,17 +73,32 @@
 
 /* Per-test flags for add_mfail_test() */
 #define MFAIL_TEST_NO_CHECK (1 << 0)
+#define MFAIL_TEST_SAMPLED (1 << 1)
 
 #define ADD_MFAIL_TEST(test_fn) \
-    add_mfail_test(#test_fn, test_fn, 0)
+    add_mfail_test(#test_fn, test_fn, 0, 0)
 #define ADD_MFAIL_NO_CHECK_TEST(test_fn) \
-    add_mfail_test(#test_fn, test_fn, MFAIL_TEST_NO_CHECK)
+    add_mfail_test(#test_fn, test_fn, MFAIL_TEST_NO_CHECK, 0)
+
+/* Caps injection at |cnt| points (exhaustive when allocations <= cnt) */
+#define ADD_MFAIL_SAMPLED_TEST(test_fn, cnt) \
+    add_mfail_test(#test_fn, test_fn, MFAIL_TEST_SAMPLED, cnt)
+#define ADD_MFAIL_SAMPLED_NO_CHECK_TEST(test_fn, cnt) \
+    add_mfail_test(#test_fn, test_fn,                 \
+        MFAIL_TEST_NO_CHECK | MFAIL_TEST_SAMPLED, cnt)
 
 /* Runs the exhaustive mfail cycle for each 0 <= idx < num */
 #define ADD_MFAIL_ALL_TESTS(test_fn, num) \
-    add_mfail_all_tests(#test_fn, test_fn, num, 0)
+    add_mfail_all_tests(#test_fn, test_fn, num, 0, 0)
 #define ADD_MFAIL_ALL_NO_CHECK_TESTS(test_fn, num) \
-    add_mfail_all_tests(#test_fn, test_fn, num, MFAIL_TEST_NO_CHECK)
+    add_mfail_all_tests(#test_fn, test_fn, num, MFAIL_TEST_NO_CHECK, 0)
+
+/* Sampled variants of the above */
+#define ADD_MFAIL_SAMPLED_ALL_TESTS(test_fn, num, cnt) \
+    add_mfail_all_tests(#test_fn, test_fn, num, MFAIL_TEST_SAMPLED, cnt)
+#define ADD_MFAIL_SAMPLED_ALL_NO_CHECK_TESTS(test_fn, num, cnt) \
+    add_mfail_all_tests(#test_fn, test_fn, num,                 \
+        MFAIL_TEST_NO_CHECK | MFAIL_TEST_SAMPLED, cnt)
 
 /*
  * A variant of the same without TAP output.
@@ -256,9 +271,9 @@ void add_test(const char *test_case_name, int (*test_fn)(void));
 void add_all_tests(const char *test_case_name, int (*test_fn)(int idx), int num,
     int subtest);
 void add_mfail_test(const char *test_case_name, int (*test_fn)(void),
-    int flags);
+    int flags, int sampled);
 void add_mfail_all_tests(const char *test_case_name, int (*test_fn)(int idx),
-    int num, int flags);
+    int num, int flags, int sampled);
 
 #define MFAIL_start mfail_start
 #define MFAIL_end mfail_end

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -39,6 +39,7 @@ typedef struct test_info {
     unsigned int subtest : 1;
     unsigned int mfail : 1;
     int mfail_flags;
+    int mfail_sampled;
 } TEST_INFO;
 
 static TEST_INFO all_tests[1024];
@@ -84,7 +85,8 @@ void add_all_tests(const char *test_case_name, int (*test_fn)(int idx),
         num_test_cases += num;
 }
 
-void add_mfail_test(const char *test_case_name, int (*test_fn)(void), int flags)
+void add_mfail_test(const char *test_case_name, int (*test_fn)(void), int flags,
+    int sampled)
 {
     assert(num_tests != OSSL_NELEM(all_tests));
     all_tests[num_tests].test_case_name = test_case_name;
@@ -92,12 +94,13 @@ void add_mfail_test(const char *test_case_name, int (*test_fn)(void), int flags)
     all_tests[num_tests].num = -1;
     all_tests[num_tests].mfail = 1;
     all_tests[num_tests].mfail_flags = flags;
+    all_tests[num_tests].mfail_sampled = sampled;
     ++num_tests;
     ++num_test_cases;
 }
 
 void add_mfail_all_tests(const char *test_case_name, int (*test_fn)(int idx),
-    int num, int flags)
+    int num, int flags, int sampled)
 {
     assert(num_tests != OSSL_NELEM(all_tests));
     all_tests[num_tests].test_case_name = test_case_name;
@@ -106,6 +109,7 @@ void add_mfail_all_tests(const char *test_case_name, int (*test_fn)(int idx),
     all_tests[num_tests].subtest = 1;
     all_tests[num_tests].mfail = 1;
     all_tests[num_tests].mfail_flags = flags;
+    all_tests[num_tests].mfail_sampled = sampled;
     ++num_tests;
     ++num_test_cases;
 }
@@ -321,7 +325,23 @@ static int mfail_run_test(const TEST_INFO *t, int idx)
     int injections = 0;
     int allocations = 0;
     int no_check = (t->mfail_flags & MFAIL_TEST_NO_CHECK) != 0;
+    int sampled = (t->mfail_flags & MFAIL_TEST_SAMPLED) != 0;
+    int init_flags = no_check ? MFAIL_FLAG_NO_CHECK : 0;
     clock_t start = clock();
+
+    if (sampled)
+        /* cap injection at mfail_sampled points (exhaustive below that) */
+        init_flags |= MFAIL_FLAG_COUNT;
+#ifdef OPENSSL_NO_CACHED_FETCH
+    else
+        /*
+         * The non-cached does too many allocations, which results in a
+         * significant slowdown of the tests. It does not provide much value,
+         * as it also requires NO_CHECK variant, so just run counting
+         * correctness check and skip the memory failure injection part.
+         */
+        init_flags |= MFAIL_FLAG_COUNT_ONLY;
+#endif
 
     level += 4;
     test_adjust_streams_tap_level(level);
@@ -330,7 +350,7 @@ static int mfail_run_test(const TEST_INFO *t, int idx)
     test_flush_stdout();
     test_flush_tapout();
 
-    mfail_init(0, no_check ? MFAIL_FLAG_NO_CHECK : 0);
+    mfail_init_ex(idx, init_flags, t->mfail_sampled);
 
     while (mfail_has_next()) {
         int phase = mfail_get_phase();
@@ -383,6 +403,8 @@ static int mfail_run_test(const TEST_INFO *t, int idx)
         test_verdict(TEST_SKIP_CODE, "2 - injection (mfail not installed)");
     else if (mfail_env_skip_all())
         test_verdict(TEST_SKIP_CODE, "2 - injection (mfail skip-all set)");
+    else if (mfail_is_count_only())
+        test_verdict(TEST_SKIP_CODE, "2 - injection (count only)");
     else if (mfail_was_slow_skipped())
         test_verdict(TEST_SKIP_CODE,
             "2 - injection (%d allocations exceeds slow threshold %d)",


### PR DESCRIPTION
This introduces a new mode for sampled tests that cap allocation-failure injection at a fixed number of sampled points, running exhaustively when the allocation count is below that.

It also change non-sampled (normal mfail) tests to fall back to counting only on non-cached-fetch builds, where exhaustive injection is usually taking way too long. This allows dropping extra ifdefs that were necessary to skip the non-cached CI that wasn't predictable anyway.