### PR TITLE
apps/s_server.c: fix SSL object leak on rpk_enable() failure

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -4020,6 +4020,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
 
     if (rpk_files != NULL && !rpk_enable(con)) {
         BIO_puts(bio_err, "Error enabling client RPK verification\n");
+        SSL_free(con);
         goto err;
     }
 
@@ -4543,6 +4544,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
     if (rpk_files != NULL && !rpk_enable(con)) {
         BIO_puts(bio_err, "Error enabling client RPK verification\n");
         ERR_print_errors(bio_err);
+        SSL_free(con);
         goto err;
     }
 


### PR DESCRIPTION
In `www_body` and `rev_body`, `con = SSL_new(ctx)` is called before `rpk_enable(con)`, but ownership of `con` is transferred to `ssl_bio` only later by `BIO_set_ssl(..., BIO_CLOSE)`.

If `rpk_enable` fails, the code jumps to `err:` before that transfer, and the local cleanup doesn't free `con`. This leaks the `SSL` object.

This change adds `SSL_free(con)` before `goto err` in both `rpk_enable` failure paths, matching the nearby error handling for `SSL_set_session_id_context` and `BIO_new_socket` failures.

Note that the global `rpk_files` is not freed in these paths. Its lifetime is managed by `s_server_main`, which frees it in the `end` cleanup block.

Fixes #31769