### PR TITLE
apps/s_server.c: fix BIO leak in ech_load_dir on read failure

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1591,7 +1591,6 @@ static int ech_load_dir(SSL_CTX *lctx, const char *thedir,
     OPENSSL_DIR_CTX *d = NULL;
     const char *thisfile = NULL;
     OSSL_ECHSTORE *es = NULL;
-    BIO *in = NULL;
     int loaded = 0;
     int ret = 0;
 
@@ -1619,6 +1618,7 @@ static int ech_load_dir(SSL_CTX *lctx, const char *thedir,
     }
     while ((thisfile = OPENSSL_DIR_read(&d, thedir))) {
         char filepath[PATH_MAX];
+        BIO *in = NULL;
         int r;
 
 #ifdef OPENSSL_SYS_VMS
@@ -1634,6 +1634,7 @@ static int ech_load_dir(SSL_CTX *lctx, const char *thedir,
         if (r < 0
             || (in = BIO_new_file(filepath, "r")) == NULL
             || OSSL_ECHSTORE_read_pem(es, in, for_retry) != 1) {
+            BIO_free_all(in);
             BIO_printf(bio_err, "Failed reading from: %s\n", filepath);
             continue;
         }


### PR DESCRIPTION
Fixes #31770

`ech_load_dir` in apps/s_server.c loads ECH key pairs from directories via `s_server -ech_dir` and `-ech_noretry_dir`.

It allocated a file `BIO` with `BIO_new_file` but only freed it on the success path. If the file was readable but `OSSL_ECHSTORE_read_pem` failed, for example because the ECH PEM was invalid, the error path executed `continue` before `BIO_free_all(in)`, leaking the file BIO.

`OSSL_ECHSTORE_read_pem` doesn't take ownership of the BIO supplied by the caller. It pushes and pops its own internal buffer BIO, so the caller remains responsible for freeing the file BIO in all cases.

Fix this by making `in` local to each loop iteration and freeing it in the failure branch as well as the success branch. This also avoids carrying a dangling BIO pointer from one loop iteration to the next.

This was reproduced under Valgrind from #31770. After the fix, Valgrind against `test/certs/echdir` reports `definitely lost: 0 bytes`. Before the fix it leaked 128 bytes per failing file.
