### PR TITLE
[Coverity 1695451, 1695453, 1695454] Assorted fixes

### DIFF
--- a/crypto/pem/pem_info.c
+++ b/crypto/pem/pem_info.c
@@ -192,7 +192,7 @@ STACK_OF(X509_INFO) *PEM_X509_INFO_read_bio_ex(BIO *bp, STACK_OF(X509_INFO) *sk,
                         decoded = d2i_AutoPrivateKey_ex((EVP_PKEY **)pp, &p,
                             len, libctx, propq);
                         break;
-                    case PEM_INFO_NONE:
+                    default:
                         break;
                     }
                     if (decoded == NULL) {

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -32,8 +32,11 @@
     {                                                                    \
         STACK_OF(evp) *obj_stack = stack;                                \
                                                                          \
-        if (sk_##evp##_push(obj_stack, obj) > 0)                         \
-            evp##_up_ref(obj);                                           \
+        if (!evp##_up_ref(obj))                                          \
+            return;                                                      \
+                                                                         \
+        if (sk_##evp##_push(obj_stack, obj) <= 0)                        \
+            evp##_free(obj);                                             \
     }                                                                    \
     static void init_##name(OSSL_LIB_CTX *libctx)                        \
     {                                                                    \


### PR DESCRIPTION
This patch set addresses a couple of Coverity reports:
 * CID 1695451, 1695454: unchecked `evp##_up_ref` return code in `collect_##evp` function in `DEFINE_ALGORITHMS` macro;
 * CID 1695453: supposed dead code in `PEM_X509_INFO_read_bio_ex` after 0e8f2844ed3e "fix function pointer type mismatch in PEM_X509_INFO_read_bio_ex".