### PR TITLE
OSSL_FN: Size contexts in bytes

### DIFF
--- a/crypto/fn/fn_ctx.c
+++ b/crypto/fn/fn_ctx.c
@@ -9,8 +9,12 @@
 
 #include <assert.h>
 #include <openssl/crypto.h>
+#include "internal/safe_math.h"
 #include "crypto/fn.h"
 #include "fn_local.h"
+
+OSSL_SAFE_MATH_ADDU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
+OSSL_SAFE_MATH_MULU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
 
 /*
  * An OSSL_FN_CTX is a large pre-allocated chunk of memory that can be used
@@ -24,14 +28,68 @@
  * it when it's done.
  */
 
+size_t OSSL_FN_CTX_size(size_t max_n_frames, size_t max_n_numbers,
+    size_t max_n_limbs)
+{
+    int err = 0;
+    size_t frames, numbers, limbs, total;
+
+    /*
+     * A context always needs at least one frame, since every use of an
+     * OSSL_FN_CTX calls OSSL_FN_CTX_start(), which carves out a frame.
+     */
+    if (max_n_frames == 0)
+        return 0;
+    /*
+     * Number-header and limb budgets must both be present or both absent.
+     * OSSL_FN_CTX_get_limbs() allocates an OSSL_FN header and its limbs
+     * together, so a context with one budget but not the other can never
+     * produce a usable number.
+     */
+    if ((max_n_numbers == 0) != (max_n_limbs == 0))
+        return 0;
+
+    frames = safe_mul_size_t(max_n_frames,
+        sizeof(struct ossl_fn_ctx_frame_st), &err);
+    numbers = safe_mul_size_t(max_n_numbers, sizeof(OSSL_FN), &err);
+    limbs = safe_mul_size_t(max_n_limbs, OSSL_FN_BYTES, &err);
+    total = safe_add_size_t(frames, numbers, &err);
+    total = safe_add_size_t(total, limbs, &err);
+
+    return err == 0 ? total : 0;
+}
+
 OSSL_FN_CTX *OSSL_FN_CTX_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs)
 {
-    size_t arena_size = ossl_fn_ctx_calculate_arena_size(max_n_frames, max_n_numbers, max_n_limbs);
-    OSSL_FN_CTX *ctx = OPENSSL_zalloc(sizeof(OSSL_FN_CTX) + arena_size);
+    return OSSL_FN_CTX_new_size(libctx,
+        OSSL_FN_CTX_size(max_n_frames, max_n_numbers, max_n_limbs));
+}
+
+OSSL_FN_CTX *OSSL_FN_CTX_new_size(OSSL_LIB_CTX *libctx, size_t size)
+{
+    size_t total_size;
+    OSSL_FN_CTX *ctx;
+
+    int err = 0;
+
+    /*
+     * A size of 0 is the error return of OSSL_FN_CTX_size() (and the
+     * per-operation ctx-size helpers).  Treat it as an error here too, so a
+     * caller does not get back a context with a zero-size arena that it
+     * would then hand to an operation expecting usable scratch space.
+     */
+    if (size == 0)
+        return NULL;
+
+    total_size = safe_add_size_t(sizeof(*ctx), size, &err);
+    if (err != 0)
+        return NULL;
+
+    ctx = OPENSSL_zalloc(total_size);
 
     if (ctx != NULL)
-        ctx->msize = arena_size;
+        ctx->msize = size;
 
     return ctx;
 }
@@ -39,11 +97,29 @@ OSSL_FN_CTX *OSSL_FN_CTX_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
 OSSL_FN_CTX *OSSL_FN_CTX_secure_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs)
 {
-    size_t arena_size = ossl_fn_ctx_calculate_arena_size(max_n_frames, max_n_numbers, max_n_limbs);
-    OSSL_FN_CTX *ctx = OPENSSL_secure_zalloc(sizeof(OSSL_FN_CTX) + arena_size);
+    return OSSL_FN_CTX_secure_new_size(libctx,
+        OSSL_FN_CTX_size(max_n_frames, max_n_numbers, max_n_limbs));
+}
+
+OSSL_FN_CTX *OSSL_FN_CTX_secure_new_size(OSSL_LIB_CTX *libctx, size_t size)
+{
+    size_t total_size;
+    OSSL_FN_CTX *ctx;
+
+    int err = 0;
+
+    /* As in OSSL_FN_CTX_new_size(), a size of 0 is an error. */
+    if (size == 0)
+        return NULL;
+
+    total_size = safe_add_size_t(sizeof(*ctx), size, &err);
+    if (err != 0)
+        return NULL;
+
+    ctx = OPENSSL_secure_zalloc(total_size);
 
     if (ctx != NULL) {
-        ctx->msize = arena_size;
+        ctx->msize = size;
         ctx->is_securely_allocated = 1;
     }
 

--- a/crypto/fn/fn_local.h
+++ b/crypto/fn/fn_local.h
@@ -177,14 +177,6 @@ struct ossl_fn_ctx_frame_st {
     unsigned char memory[];
 };
 
-static ossl_inline size_t ossl_fn_ctx_calculate_arena_size(size_t max_n_frames,
-    size_t max_n_numbers, size_t max_n_limbs)
-{
-    return max_n_frames * sizeof(struct ossl_fn_ctx_frame_st)
-        + max_n_numbers * sizeof(OSSL_FN)
-        + max_n_limbs * OSSL_FN_BYTES;
-}
-
 /* end OSSL_FN_CTX internals */
 
 #endif

--- a/crypto/fn/fn_mul.c
+++ b/crypto/fn/fn_mul.c
@@ -14,6 +14,19 @@
 #include "../bn/bn_local.h" /* For using the low level bignum functions */
 #include "fn_local.h"
 
+size_t OSSL_FN_mul_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
+    const OSSL_FN *b)
+{
+    size_t limbs = 0;
+
+    if (r == NULL || a == NULL || b == NULL)
+        return 0;
+    if (r == a || r == b)
+        limbs = r->dsize;
+
+    return OSSL_FN_CTX_size(1, limbs == 0 ? 0 : 1, limbs);
+}
+
 int OSSL_FN_mul(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b, OSSL_FN_CTX *ctx)
 {
     size_t al = (size_t)a->dsize;

--- a/crypto/fn/fn_sqr.c
+++ b/crypto/fn/fn_sqr.c
@@ -9,10 +9,29 @@
 
 #include <assert.h>
 #include <openssl/err.h>
+#include "internal/safe_math.h"
 #include "crypto/cryptlib.h"
 #include "crypto/fnerr.h"
 #include "../bn/bn_local.h" /* For using the low level bignum functions */
 #include "fn_local.h"
+
+OSSL_SAFE_MATH_MULU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
+
+size_t OSSL_FN_sqr_ctx_size(const OSSL_FN *r, const OSSL_FN *a)
+{
+    size_t max, limbs, n_numbers = 1;
+
+    if (r == NULL || a == NULL)
+        return 0;
+    int err = 0;
+
+    max = safe_mul_size_t(2, a->dsize, &err);
+    if ((size_t)r->dsize < max)
+        n_numbers++;
+    limbs = safe_mul_size_t(n_numbers, max, &err);
+
+    return err == 0 ? OSSL_FN_CTX_size(1, n_numbers, limbs) : 0;
+}
 
 int OSSL_FN_sqr(OSSL_FN *r, const OSSL_FN *a, OSSL_FN_CTX *ctx)
 {

--- a/include/crypto/fn.h
+++ b/include/crypto/fn.h
@@ -152,6 +152,27 @@ OSSL_FN *OSSL_FN_copy(OSSL_FN *a, const OSSL_FN *b);
 OSSL_FN *OSSL_FN_copy_truncate(OSSL_FN *a, const OSSL_FN *b);
 
 /**
+ * Calculate the arena payload size for an OSSL_FN_CTX.
+ *
+ * @param[in]   max_n_frames    Maximum number of simultaneously active frames.
+ *                              This indicates the expected depth of call stack
+ *                              that the resulting OSSL_FN_CTX will be used in.
+ *                              Must be at least 1.
+ * @param[in]   max_n_numbers   Maximum number of simultaneously active OSSL_FN.
+ *                              Must be 0 if and only if @p max_n_limbs is 0.
+ * @param[in]   max_n_limbs     Maximum number of simultaneously active OSSL_FN
+ *                              limbs.  Must be 0 if and only if
+ *                              @p max_n_numbers is 0.
+ * @returns     The arena payload size, in bytes.
+ * @retval      0               on arithmetic overflow or invalid argument.
+ *
+ * The returned size is the value to pass to OSSL_FN_CTX_new_size() or
+ * OSSL_FN_CTX_secure_new_size().  It does not include sizeof(OSSL_FN_CTX).
+ */
+size_t OSSL_FN_CTX_size(size_t max_n_frames, size_t max_n_numbers,
+    size_t max_n_limbs);
+
+/**
  * Allocate a new OSSL_FN_CTX, given a set of input numbers.
  *
  * @param[in]   libctx          OpenSSL library context (currently unused)
@@ -162,17 +183,40 @@ OSSL_FN *OSSL_FN_copy_truncate(OSSL_FN *a, const OSSL_FN *b);
  * @param[in]   max_n_limbs     Maximum number of simultaneously active OSSL_FN
  *                              limbs.
  * @returns     An allocated OSSL_FN_CTX, or NULL on error.
- **/
+ */
 OSSL_FN_CTX *OSSL_FN_CTX_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs);
+
+/**
+ * Allocate a new OSSL_FN_CTX with a given arena payload size.
+ *
+ * @param[in]   libctx          OpenSSL library context (currently unused)
+ * @param[in]   size            Arena payload size in bytes, typically from
+ *                              OSSL_FN_CTX_size().  A size of 0 is the error
+ *                              return of OSSL_FN_CTX_size() and is treated as
+ *                              an error here too.
+ * @returns     An allocated OSSL_FN_CTX, or NULL on error.
+ */
+OSSL_FN_CTX *OSSL_FN_CTX_new_size(OSSL_LIB_CTX *libctx, size_t size);
 
 /**
  * Allocate a new OSSL_FN_CTX in secure memory, given a set of input numbers.
  * Other than allocating in secure memory, this function does exactly the same
  * thing as OSSL_FN_CTX_new().
- **/
+ */
 OSSL_FN_CTX *OSSL_FN_CTX_secure_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs);
+
+/**
+ * Allocate a new OSSL_FN_CTX in secure memory with a given arena payload size.
+ *
+ * @param[in]   libctx          OpenSSL library context (currently unused)
+ * @param[in]   size            Arena payload size in bytes, typically from
+ *                              OSSL_FN_CTX_size().  A size of 0 is treated as
+ *                              an error, as in OSSL_FN_CTX_new_size().
+ * @returns     An allocated OSSL_FN_CTX, or NULL on error.
+ */
+OSSL_FN_CTX *OSSL_FN_CTX_secure_new_size(OSSL_LIB_CTX *libctx, size_t size);
 
 /**
  * Report the peak number of frames, numbers, and limbs that were
@@ -354,6 +398,20 @@ int OSSL_FN_mul(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b,
     OSSL_FN_CTX *ctx);
 
 /**
+ * Calculate the arena payload size that OSSL_FN_mul() needs.
+ *
+ * @param[in]           r       The OSSL_FN for the result
+ * @param[in]           a       The first operand
+ * @param[in]           b       The second operand
+ * @returns             The arena payload size, in bytes.
+ * @retval              0       on arithmetic overflow or invalid input.
+ *
+ * The returned size includes any frame budget needed by OSSL_FN_mul().
+ */
+size_t OSSL_FN_mul_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
+    const OSSL_FN *b);
+
+/**
  * Calculate the square of one OSSL_FN number.  Truncates the result to fit in r.
  *
  * @param[out]          r       The OSSL_FN for the result
@@ -367,6 +425,18 @@ int OSSL_FN_mul(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b,
  * frame (currently 32 bytes).
  */
 int OSSL_FN_sqr(OSSL_FN *r, const OSSL_FN *a, OSSL_FN_CTX *ctx);
+
+/**
+ * Calculate the arena payload size that OSSL_FN_sqr() needs.
+ *
+ * @param[in]           r       The OSSL_FN for the result
+ * @param[in]           a       The operand
+ * @returns             The arena payload size, in bytes.
+ * @retval              0       on arithmetic overflow or invalid input.
+ *
+ * The returned size includes any frame budget needed by OSSL_FN_sqr().
+ */
+size_t OSSL_FN_sqr_ctx_size(const OSSL_FN *r, const OSSL_FN *a);
 
 #ifdef __cplusplus
 }

--- a/test/fn_internal_test.c
+++ b/test/fn_internal_test.c
@@ -164,6 +164,71 @@ end:
     return ret;
 }
 
+static int test_ctx_size(void)
+{
+    int ret = 1;
+    OSSL_FN_CTX *ctx = NULL;
+    OSSL_FN *f = NULL;
+    const void *token = NULL;
+    size_t size = OSSL_FN_CTX_size(1, 2, 4096 / OSSL_FN_BITS);
+
+    if (!TEST_size_t_ne(size, 0)
+        || !TEST_ptr(ctx = OSSL_FN_CTX_new_size(NULL, size))) {
+        ret = 0;
+        goto end;
+    }
+
+    if (!TEST_ptr(token = OSSL_FN_CTX_start(ctx))) {
+        ret = 0;
+        goto end;
+    }
+
+    if (!TEST_ptr(f = OSSL_FN_CTX_get_bits(ctx, 2048))
+        || !TEST_false(ossl_fn_is_dynamically_allocated(f))
+        || !TEST_false(ossl_fn_is_securely_allocated(f))
+        || !TEST_ptr(f = OSSL_FN_CTX_get_bits(ctx, 2048))
+        || !TEST_ptr_null(f = OSSL_FN_CTX_get_bits(ctx, 2048)))
+        ret = 0;
+
+    if (!TEST_true(OSSL_FN_CTX_end(ctx, token)))
+        ret = 0;
+
+end:
+    OSSL_FN_CTX_free(ctx);
+
+    /*
+     * Force each term of OSSL_FN_CTX_size() to overflow in turn,
+     * keeping the others at a minimal valid context (1 frame, 1
+     * number, 1 limb) so only the overflowing term is unrealistic.
+     */
+    if (!TEST_size_t_eq(OSSL_FN_CTX_size(SIZE_MAX, 1, 1), 0))
+        ret = 0;
+    if (!TEST_size_t_eq(OSSL_FN_CTX_size(1, SIZE_MAX, 1), 0))
+        ret = 0;
+    if (!TEST_size_t_eq(OSSL_FN_CTX_size(1, 1, SIZE_MAX), 0))
+        ret = 0;
+    /* A context must have at least one frame. */
+    if (!TEST_size_t_eq(OSSL_FN_CTX_size(0, 1, 1), 0))
+        ret = 0;
+    /*
+     * Numbers and limbs must both be present or both absent: a context
+     * with one budget but not the other can never allocate a usable
+     * number, since OSSL_FN_CTX_get_limbs() allocates the OSSL_FN header
+     * and its limbs together.
+     */
+    if (!TEST_size_t_eq(OSSL_FN_CTX_size(1, 0, 1), 0))
+        ret = 0;
+    if (!TEST_size_t_eq(OSSL_FN_CTX_size(1, 1, 0), 0))
+        ret = 0;
+    if (!TEST_ptr_null(OSSL_FN_CTX_new_size(NULL, SIZE_MAX)))
+        ret = 0;
+    /* A size of 0 is the error return of OSSL_FN_CTX_size(). */
+    if (!TEST_ptr_null(OSSL_FN_CTX_new_size(NULL, 0)))
+        ret = 0;
+
+    return ret;
+}
+
 static int test_secure_ctx(void)
 {
     int ret = 1;
@@ -201,6 +266,46 @@ static int test_secure_ctx(void)
 
 end:
     OSSL_FN_CTX_free(ctx);
+
+    return ret;
+}
+
+static int test_secure_ctx_size(void)
+{
+    int ret = 1;
+    OSSL_FN_CTX *ctx = NULL;
+    OSSL_FN *f = NULL;
+    const void *token = NULL;
+    size_t size = OSSL_FN_CTX_size(1, 1, 2048 / OSSL_FN_BITS);
+
+    if (!TEST_size_t_ne(size, 0)
+        || !TEST_ptr(ctx = OSSL_FN_CTX_secure_new_size(NULL, size))) {
+        ret = 0;
+        goto end;
+    }
+
+    if (!TEST_ptr(token = OSSL_FN_CTX_start(ctx))) {
+        ret = 0;
+        goto end;
+    }
+
+    if (!TEST_ptr(f = OSSL_FN_CTX_get_bits(ctx, 2048))
+        || !TEST_false(ossl_fn_is_dynamically_allocated(f))
+        || !TEST_true(ossl_fn_is_securely_allocated(f))
+        || !TEST_ptr_null(f = OSSL_FN_CTX_get_bits(ctx, 2048)))
+        ret = 0;
+
+    if (!TEST_true(OSSL_FN_CTX_end(ctx, token)))
+        ret = 0;
+
+end:
+    OSSL_FN_CTX_free(ctx);
+
+    if (!TEST_ptr_null(OSSL_FN_CTX_secure_new_size(NULL, SIZE_MAX)))
+        ret = 0;
+    /* A size of 0 is the error return of OSSL_FN_CTX_size(). */
+    if (!TEST_ptr_null(OSSL_FN_CTX_secure_new_size(NULL, 0)))
+        ret = 0;
 
     return ret;
 }
@@ -343,7 +448,9 @@ int setup_tests(void)
     ADD_TEST(test_alloc);
     ADD_TEST(test_secure_alloc);
     ADD_TEST(test_ctx);
+    ADD_TEST(test_ctx_size);
     ADD_TEST(test_secure_ctx);
+    ADD_TEST(test_secure_ctx_size);
     ADD_TEST(test_ctx_peak_used);
 
     return 1;

--- a/test/fntest.c
+++ b/test/fntest.c
@@ -165,11 +165,6 @@ err:
     return st;
 }
 
-static OSSL_FN_CTX *new_mul_ctx(int nlimbs)
-{
-    return OSSL_FN_CTX_new(NULL, 1, 1, nlimbs * 2);
-}
-
 static int file_product(STANZA *s)
 {
     BIGNUM *a = NULL, *b = NULL, *product = NULL, *ret = NULL;
@@ -195,7 +190,8 @@ static int file_product(STANZA *s)
         || !TEST_ptr(rf = bn_acquire_ossl_fn(ret, nlimbs)))
         goto err;
     r_acq = 1;
-    if (!TEST_ptr(ctx = new_mul_ctx(nlimbs)))
+    if (!TEST_ptr(ctx = OSSL_FN_CTX_new_size(NULL,
+                      OSSL_FN_mul_ctx_size(rf, af, bf))))
         goto err;
 
     if (!TEST_true(OSSL_FN_mul(rf, af, bf, ctx)))
@@ -218,11 +214,6 @@ err:
     return st;
 }
 
-static OSSL_FN_CTX *new_sqr_ctx(int nlimbs)
-{
-    return OSSL_FN_CTX_new(NULL, 1, 2, nlimbs * 4);
-}
-
 static int file_square(STANZA *s)
 {
     BIGNUM *a = NULL, *square = NULL, *ret = NULL;
@@ -243,7 +234,8 @@ static int file_square(STANZA *s)
         || !TEST_ptr(rf = bn_acquire_ossl_fn(ret, nlimbs)))
         goto err;
     r_acq = 1;
-    if (!TEST_ptr(ctx = new_sqr_ctx(nlimbs)))
+    if (!TEST_ptr(ctx = OSSL_FN_CTX_new_size(NULL,
+                      OSSL_FN_sqr_ctx_size(rf, af))))
         goto err;
 
     if (!TEST_true(OSSL_FN_sqr(rf, af, ctx)))


### PR DESCRIPTION
OSSL_FN_CTX callers currently describe the arena in frames, numbers
and limbs.  That works for a single operation, but it makes higher
level sizing awkward because each caller has to keep redoing the same
conversion.

Add an overflow-checked `OSSL_FN_CTX_size()` helper that returns the
arena payload size, plus byte-sized constructors
(`OSSL_FN_CTX_new_size()` / `OSSL_FN_CTX_secure_new_size()`) for
normal and secure contexts.  The existing frame/number/limb
constructors become wrappers around it so current callers keep working
while newer code can compose byte sizes directly.  The old internal
`ossl_fn_ctx_calculate_arena_size()` inline is replaced by the public,
overflow-checked helper.  `OSSL_FN_CTX_size()` also rejects argument
combinations that can never produce a usable context: a zero frame
budget, or a numbers/limbs budget where only one of the two is zero.

Add per-operation ctx-size helpers `OSSL_FN_mul_ctx_size()` and
`OSSL_FN_sqr_ctx_size()`, which fold in the aliasing and
destination-width considerations of `OSSL_FN_mul()` / `OSSL_FN_sqr()`.
The mul/sqr tests in `test/fntest.c` use these helpers to size their
contexts.  `test/fn_internal_test.c` covers the new sizing and
overflow/invalid-argument behaviour.

Stacked on #31881, #31884 and #31895.  #31796 is in turn stacked on this one.

Related-to: doc/designs/fixed-size-large-numbers.md
Assisted-by: Pi:openai/gpt-5.5
Assisted-by: Pi:z-ai/glm-5.2
