### PR TITLE
Add -n option to openssl-rand to not output the trailing newline

### DIFF
--- a/apps/rand.c
+++ b/apps/rand.c
@@ -53,8 +53,7 @@ int rand_main(int argc, char **argv)
     BIO *out = NULL;
     char *outfile = NULL, *prog;
     OPTION_CHOICE o;
-    int format = FORMAT_BINARY, r, i, ret = 1;
-    bool newline = true;
+    int format = FORMAT_BINARY, r, i, ret = 1, newline = 1;
     size_t buflen = (1 << 16); /* max rand chunk size is 2^16 bytes */
     long num = -1;
     uint64_t scaled_num = 0;
@@ -86,7 +85,7 @@ int rand_main(int argc, char **argv)
             format = FORMAT_TEXT;
             break;
         case OPT_NO_NEWLINE:
-            newline = false;
+            newline = 0;
             break;
         case OPT_PROV_CASES:
             if (!opt_provider(o))

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -23,6 +23,7 @@ typedef enum OPTION_choice {
     OPT_OUT,
     OPT_BASE64,
     OPT_HEX,
+    OPT_NO_NEWLINE,
     OPT_R_ENUM,
     OPT_PROV_ENUM
 } OPTION_CHOICE;
@@ -37,6 +38,7 @@ const OPTIONS rand_options[] = {
     { "out", OPT_OUT, '>', "Output file" },
     { "base64", OPT_BASE64, '-', "Base64 encode output" },
     { "hex", OPT_HEX, '-', "Hex encode output" },
+    { "n", OPT_NO_NEWLINE, '-', "Do not output the trailing newline" },
 
     OPT_R_OPTIONS,
     OPT_PROV_OPTIONS,
@@ -52,6 +54,7 @@ int rand_main(int argc, char **argv)
     char *outfile = NULL, *prog;
     OPTION_CHOICE o;
     int format = FORMAT_BINARY, r, i, ret = 1;
+    bool newline = true;
     size_t buflen = (1 << 16); /* max rand chunk size is 2^16 bytes */
     long num = -1;
     uint64_t scaled_num = 0;
@@ -81,6 +84,9 @@ int rand_main(int argc, char **argv)
             break;
         case OPT_HEX:
             format = FORMAT_TEXT;
+            break;
+        case OPT_NO_NEWLINE:
+            newline = false;
             break;
         case OPT_PROV_CASES:
             if (!opt_provider(o))
@@ -208,7 +214,7 @@ int rand_main(int argc, char **argv)
         }
         scaled_num -= chunk;
     }
-    if (format == FORMAT_TEXT)
+    if (newline && format == FORMAT_TEXT)
         BIO_puts(out, "\n");
     if (BIO_flush(out) <= 0)
         goto end;

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -12,6 +12,7 @@ B<openssl rand>
 [B<-out> I<file>]
 [B<-base64>]
 [B<-hex>]
+[B<-n>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 I<num>[K|M|G|T]
@@ -54,6 +55,10 @@ Perform base64 encoding on the output.
 =item B<-hex>
 
 Show the output as a hex string.
+
+=item B<-n>
+
+Do not output the trailing newline.
 
 {- $OpenSSL::safe::opt_r_item -}
 


### PR DESCRIPTION
The openssl-rand tool always outputs a trailing newline and I've been piping it into `tr -d '\n'` to get rid of it.

The `-n` option just disables that newline.

The default behavior is still the same and scripts with older versions should work without issues.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
