### PR TITLE
apps: test dsa app PVK output

### DIFF
--- a/test/recipes/15-test_dsa.t
+++ b/test/recipes/15-test_dsa.t
@@ -17,7 +17,7 @@ use OpenSSL::Test::Utils;
 setup("test_dsa");
 
 plan skip_all => 'DSA is not supported in this build' if disabled('dsa');
-plan tests => 7;
+plan tests => 9;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -44,4 +44,29 @@ subtest "dsa conversions using 'openssl pkey' -- public key" => sub {
     tconversion( -type => 'dsa', -prefix => 'dsa-pkey-pub',
                  -in => srctop_file("test","testdsapub.pem"),
                  -args => ["pkey", "-pubin", "-pubout"] );
+};
+
+SKIP: {
+    skip "Skipping PVK conversion test", 1
+        if disabled("rc4") || disabled("legacy") || disabled("pvkkdf");
+
+    subtest "dsa conversions using 'openssl dsa' -- PVK" => sub {
+        tconversion( -type => 'pvk', -prefix => 'dsa-pvk',
+                     -in => srctop_file("test", "testdsa.pem"),
+                     -args => ["dsa", "-passin", "pass:testpass",
+                               "-passout", "pass:testpass",
+                               "-provider", "default",
+                               "-provider", "legacy"] );
+    };
+}
+
+subtest "dsa PVK output is rejected for public key input" => sub {
+    plan tests => 1;
+
+    # Note: -noout would short-circuit before the format check, so request
+    # an actual encoding to reach the PVK-with-public-key rejection.
+    ok(!run(app(['openssl', 'dsa', '-pubin', '-outform', 'PVK',
+                 '-in', srctop_file("test", "testdsapub.pem"),
+                 '-out', 'dsa-pubin.pvk'])),
+       "-outform PVK with -pubin is rejected");
 };


### PR DESCRIPTION
Cover the previously untested PVK code paths of the dsa app: round-trip the test key through the PVK encoding (mirroring the existing rsa PVK test, and skipped unless rc4, legacy and pvkkdf are enabled), and check that requesting PVK output for a public key input is rejected.

Assisted-by: Claude:claude-opus-4-8