### PR TITLE
 Fix:Add missingcrypto check and auto-fix to doc-nits: 31566

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1173,7 +1173,7 @@ uninstall_image_docs:
 
 # It's important that generate_buildinfo comes after ordinals, as ordinals
 # is sensitive to build.info changes.
-update: generate errors ordinals generate_buildinfo ## Update errors, ordinals and build info
+update: generate errors ordinals generate_buildinfo update_doc_nits ## Update errors, ordinals and build info
 
 .PHONY: generate generate_apps generate_crypto_bn generate_crypto_objects \
           generate_crypto_conf generate_crypto_asn1 generate_fuzz_oids
@@ -1182,6 +1182,10 @@ generate: generate_apps generate_crypto_bn generate_crypto_objects \
 
 .PHONY: generate_buildinfo generate_doc_buildinfo
 generate_buildinfo: generate_doc_buildinfo
+
+.PHONY: update_doc_nits
+update_doc_nits:
+	$(PERL) $(SRCDIR)/util/find-doc-nits -U
 
 .PHONY: doc-nits md-nits
 doc-nits: build_generated_pods ## Evaluate OpenSSL documentation

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -796,6 +796,13 @@ int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
 
     if (!match_ri)
         ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
+    else
+        /*
+         * Recipients of the right key type exist but none matched the
+         * provided certificate. Raise a meaningful error so callers can
+         * determine the reason for failure via ERR_get_error().
+         */
+        ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
     return 0;
 }
 

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -275,6 +275,59 @@ static int test_encrypt_decrypt_aes_256_gcm(void)
     return test_encrypt_decrypt(EVP_aes_256_gcm());
 }
 
+static int test_encrypt_decrypt_no_matching_recipient(void)
+{
+    int testresult = 0;
+    STACK_OF(X509) *certstack = sk_X509_new_null();
+    const char *msg = "Hello world";
+    BIO *msgbio = BIO_new_mem_buf(msg, (int)strlen(msg));
+    BIO *outmsgbio = BIO_new(BIO_s_mem());
+    CMS_ContentInfo *content = NULL;
+    const EVP_CIPHER *cipher = EVP_aes_128_cbc();
+    X509 *cert2 = NULL;
+    ASN1_INTEGER *sn = NULL;
+    unsigned long err = 0;
+
+    if (!TEST_ptr(certstack) || !TEST_ptr(msgbio) || !TEST_ptr(outmsgbio))
+        goto end;
+
+    if (!TEST_int_gt(sk_X509_push(certstack, cert), 0))
+        goto end;
+
+    content = CMS_encrypt(certstack, msgbio, cipher, CMS_TEXT);
+    if (!TEST_ptr(content))
+        goto end;
+
+    /* Create a certificate with a different serial number */
+    if (!TEST_ptr(cert2 = X509_dup(cert))
+        || !TEST_ptr(sn = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(sn, 100)) /* assuming 100 is different */
+        || !TEST_true(X509_set1_serialNumber(cert2, sn)))
+        goto end;
+
+    /* This decryption should fail because of cert mismatch */
+    if (!TEST_false(CMS_decrypt(content, privkey, cert2, NULL, outmsgbio, CMS_TEXT)))
+        goto end;
+
+    err = ERR_peek_last_error();
+    if (!TEST_int_eq(ERR_GET_LIB(err), ERR_LIB_CMS)
+        || !TEST_int_eq(ERR_GET_REASON(err), CMS_R_NO_MATCHING_RECIPIENT))
+        goto end;
+
+    testresult = 1;
+    ERR_clear_error();
+end:
+    ASN1_INTEGER_free(sn);
+    X509_free(cert2);
+    sk_X509_free(certstack);
+    BIO_free(msgbio);
+    BIO_free(outmsgbio);
+    CMS_ContentInfo_free(content);
+
+    return testresult;
+}
+
+
 static int test_CMS_add1_cert(void)
 {
     CMS_ContentInfo *cms = NULL;
@@ -785,6 +838,7 @@ int setup_tests(void)
     ADD_TEST(test_encrypt_decrypt_aes_128_gcm);
     ADD_TEST(test_encrypt_decrypt_aes_192_gcm);
     ADD_TEST(test_encrypt_decrypt_aes_256_gcm);
+    ADD_TEST(test_encrypt_decrypt_no_matching_recipient);
     ADD_TEST(test_non_aead_on_auth_envelope_enc);
     ADD_TEST(test_non_aead_on_auth_envelope_dec);
     ADD_TEST(test_short_mac_on_auth_envelope_data);

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -43,6 +43,7 @@ our($opt_v);
 our($opt_c);
 our($opt_i);
 our($opt_a);
+our($opt_U);
 
 # Print usage message and exit.
 sub help {
@@ -59,11 +60,12 @@ Find small errors (nits) in documentation.  Options:
     -i Checks for history entries available for symbols added since 4.0.0 as new
     -u Count undocumented functions
     -v Count new undocumented functions
+    -U Auto-fix missingcrypto.txt and other missing files by removing documented functions
 EOF
     exit;
 }
 
-getopts('acdehlm:niuv');
+getopts('acdehlm:niuvU');
 
 help() if $opt_h;
 $opt_u = 1 if $opt_d;
@@ -73,10 +75,10 @@ die "Cannot use both -u and -v"
 die "Cannot use both -d and -e"
     if $opt_d && $opt_e;
 
-# We only need to check c, l, n, u and v.
+# We only need to check c, l, n, u, v and U.
 # Options d, e, o imply one of the above.
-die "Need one of -[acdehlnouv] flags.\n"
-    unless $opt_a or $opt_c or $opt_l or $opt_n or $opt_u or $opt_v;
+die "Need one of -[acdehlnouvU] flags.\n"
+    unless $opt_a or $opt_c or $opt_l or $opt_n or $opt_u or $opt_v or $opt_U;
 
 
 my $temp = '/tmp/docnits.txt';
@@ -1029,6 +1031,8 @@ sub checkstate () {
             if ( $declared_public && $name_map{$_} =~ /\/internal\// );
         err("$_ is supposedly internal (maybe missing from other.syms) but is documented as public")
             if ( $declared_internal && $name_map{$_} !~ /\/internal\// );
+        err("$_ is documented in $name_map{$_} but is listed in missingcrypto.txt (or similar)")
+            if defined $missing{$_};
     }
 }
 
@@ -1486,14 +1490,14 @@ if ( $opt_u || $opt_v) {
     checkmacros();
 }
 
-if ( $opt_n || $opt_l || $opt_u || $opt_v ) {
+if ( $opt_n || $opt_l || $opt_u || $opt_v || $opt_U ) {
     my @files_to_read = ( $opt_n && @ARGV ) ? @ARGV : files(TAGS => 'manual');
 
     foreach (@files_to_read) {
         my %podinfo = extract_pod_info($_, { debug => $debug });
 
         collectnames(%podinfo)
-            if ( $opt_l || $opt_u || $opt_v );
+            if ( $opt_l || $opt_u || $opt_v || $opt_U );
 
         check(%podinfo)
             if ( $opt_n );
@@ -1526,6 +1530,46 @@ if ( $opt_u || $opt_v) {
     printem('ssl');
     checkmacros_undocumented();
     printem('macro_functions');
+}
+
+sub update_missing_file {
+    my $missingfile = shift;
+    my $filepath = catfile($config{sourcedir}, $missingfile);
+    return unless -f $filepath;
+
+    open my $in, '<', $filepath or die "Can't open $filepath for reading: $!";
+    my @lines = <$in>;
+    close $in;
+
+    open my $out, '>', $filepath or die "Can't open $filepath for writing: $!";
+    my $removed = 0;
+    foreach my $line (@lines) {
+        if ($line =~ /^#/) {
+            print $out $line;
+            next;
+        }
+        my $func = $line;
+        chomp($func);
+        if ($func eq '') {
+            print $out $line;
+            next;
+        }
+        if ( defined $name_map{$func} && $name_map{$func} ne '' ) {
+            $removed++;
+        } else {
+            print $out $line;
+        }
+    }
+    close $out;
+    print "Removed $removed documented entries from $missingfile\n" if $removed > 0;
+}
+
+if ( $opt_U ) {
+    update_missing_file('util/missingmacro.txt');
+    update_missing_file('util/missingcrypto.txt');
+    update_missing_file('util/missingssl.txt');
+    update_missing_file('util/missingcrypto-internal.txt');
+    update_missing_file('util/missingssl-internal.txt');
 }
 
 exit $status;


### PR DESCRIPTION



Add missingcrypto check and auto-fix to doc-nits

This updates util/find-doc-nits to verify that functions listed in missingcrypto.txt (and other missing files) aren't also successfully documented in the manual pages. It will now error out if redundant entries exist.

It also adds a -U flag to find-doc-nits which rewrites the missing files, automatically stripping out any documented functions, and hooks find-doc-nits -U into the update Make target so that make update automatically cleans the missing files.

Fixes #31566

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
