### PR TITLE
comp/brotli: return byte counts from BIO_pending and BIO_wpending

### DIFF
--- a/crypto/comp/c_brotli.c
+++ b/crypto/comp/c_brotli.c
@@ -696,7 +696,8 @@ static long bio_brotli_ctrl(BIO *b, int cmd, long num, void *ptr)
 {
     BIO_BROTLI_CTX *ctx;
     unsigned char *tmp;
-    int ret = 0, *ip;
+    long ret = 0;
+    int *ip;
     size_t ibs, obs;
     BIO *next = BIO_next(b);
 
@@ -764,16 +765,20 @@ static long bio_brotli_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
 
     case BIO_CTRL_WPENDING:
-        if (BrotliEncoderHasMoreOutput(ctx->encode.state))
+        ret = (long)ctx->encode.count;
+        if (ret == 0 && BrotliEncoderHasMoreOutput(ctx->encode.state))
+            /* Unknown amount pending but the encoder has more output */
             ret = 1;
-        else
+        if (ret == 0)
             ret = BIO_ctrl(next, cmd, num, ptr);
         break;
 
     case BIO_CTRL_PENDING:
-        if (!BrotliDecoderIsFinished(ctx->decode.state))
+        ret = (long)ctx->decode.avail_in;
+        if (ret == 0 && BrotliDecoderHasMoreOutput(ctx->decode.state))
+            /* Unknown amount pending but the decoder has more output */
             ret = 1;
-        else
+        if (ret == 0)
             ret = BIO_ctrl(next, cmd, num, ptr);
         break;
 

--- a/test/bio_comp_test.c
+++ b/test/bio_comp_test.c
@@ -132,6 +132,99 @@ static int test_brotli(int n)
 {
     return do_bio_comp(BIO_f_brotli(), n);
 }
+
+static int test_brotli_wpending(void)
+{
+    BIO *bcomp = NULL;
+    BIO *bmem = NULL;
+    unsigned char buf[512];
+    int ret = 0;
+
+    memset(buf, 'A', sizeof(buf));
+    if (!TEST_ptr(bcomp = BIO_new(BIO_f_brotli()))
+        || !TEST_ptr(bmem = BIO_new(BIO_s_mem())))
+        goto err;
+    BIO_push(bcomp, bmem);
+    if (!TEST_int_eq(BIO_write(bcomp, buf, (int)sizeof(buf)), (int)sizeof(buf))
+        || !TEST_true(BIO_flush(bcomp)))
+        goto err;
+    if (!TEST_int_eq(BIO_wpending(bcomp), 0))
+        goto err;
+    ret = 1;
+err:
+    BIO_free(bcomp);
+    BIO_free(bmem);
+    return ret;
+}
+
+static int test_brotli_wpending_nonzero(void)
+{
+    BIO *bcomp = NULL;
+    BIO *bpair = NULL;
+    BIO *bpeer = NULL;
+    unsigned char buf[8192];
+    int ret = 0;
+
+    if (!TEST_int_gt(RAND_bytes(buf, sizeof(buf)), 0))
+        goto err;
+    if (!TEST_ptr(bcomp = BIO_new(BIO_f_brotli()))
+        || !TEST_true(BIO_new_bio_pair(&bpair, 16, &bpeer, sizeof(buf))))
+        goto err;
+    BIO_push(bcomp, bpair);
+    /* The small pair cannot drain the compressed output, so it stays pending */
+    if (!TEST_int_gt(BIO_write(bcomp, buf, (int)sizeof(buf)), 0))
+        goto err;
+    if (!TEST_int_gt(BIO_wpending(bcomp), 1))
+        goto err;
+    ret = 1;
+err:
+    BIO_free(bcomp);
+    BIO_free(bpair);
+    BIO_free(bpeer);
+    return ret;
+}
+
+static int test_brotli_pending(void)
+{
+    BIO *bcomp = NULL;
+    BIO *bdec = NULL;
+    BIO *bmem = NULL;
+    unsigned char buf[8192];
+    unsigned char slice[16];
+    int ret = 0;
+
+    /* Compressible: the decoder still holds output after avail_in hits zero */
+    memset(buf, 'A', sizeof(buf));
+    if (!TEST_ptr(bcomp = BIO_new(BIO_f_brotli()))
+        || !TEST_ptr(bmem = BIO_new(BIO_s_mem())))
+        goto err;
+    BIO_push(bcomp, bmem);
+    if (!TEST_int_eq(BIO_write(bcomp, buf, (int)sizeof(buf)), (int)sizeof(buf))
+        || !TEST_true(BIO_flush(bcomp)))
+        goto err;
+    BIO_free(bcomp);
+    bcomp = NULL;
+
+    if (!TEST_ptr(bdec = BIO_new(BIO_f_brotli())))
+        goto err;
+    BIO_push(bdec, bmem);
+    if (!TEST_int_gt(BIO_read(bdec, slice, (int)sizeof(slice)), 0))
+        goto err;
+    /* Output is still buffered in the decoder, so pending must not be zero */
+    if (!TEST_int_gt(BIO_pending(bdec), 0))
+        goto err;
+    /* Once drained, pending must report zero */
+    while (BIO_read(bdec, slice, (int)sizeof(slice)) > 0)
+        continue;
+    if (!TEST_int_eq(BIO_pending(bdec), 0))
+        goto err;
+    ret = 1;
+err:
+    BIO_free(bcomp);
+    BIO_free(bdec);
+    BIO_free(bmem);
+    return ret;
+}
 #endif
 #ifndef OPENSSL_NO_ZLIB
 static int test_zlib(int n)
@@ -147,6 +240,9 @@ int setup_tests(void)
 #endif
 #ifndef OPENSSL_NO_BROTLI
     ADD_ALL_TESTS(test_brotli, NUM_SIZES * 4);
+    ADD_TEST(test_brotli_wpending);
+    ADD_TEST(test_brotli_wpending_nonzero);
+    ADD_TEST(test_brotli_pending);
 #endif
 #ifndef OPENSSL_NO_ZSTD
     ADD_ALL_TESTS(test_zstd, NUM_SIZES * 4);


### PR DESCRIPTION
bio_brotli_ctrl returned 1 for BIO_CTRL_WPENDING whenever the encoder had more output, and 1 for BIO_CTRL_PENDING whenever the decoder was not finished. BIO_pending and BIO_wpending are documented to return the amount of pending data, not a flag.

WPENDING now returns the bytes buffered for the next write (encode.count) and PENDING the buffered compressed input not yet decoded (decode.avail_in). When only the encoder or decoder still holds output with no obtainable byte count, both fall back to 1, the same way the zlib filter does, and both fall back to the next BIO when nothing is buffered here. The local ret held BIO_ctrl's long result in an int, which truncates on LP64, so widen it to long.

@esyr noted on #31154 that the brotli filter has the same bug. As in the zlib filter, trailing bytes after a finished stream are reported as pending until consumed.

Related: #28845

##### Checklist
- [x] tests are added or updated
