### PR TITLE
[4.0] crypto/x509/x509_lu.c: fix memory leak in obj_ht_foreach_object()

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -769,6 +769,7 @@ static int obj_ht_foreach_object(HT_VALUE *v, void *arg)
     return 1;
 
 err:
+    X509_OBJECT_free(dup);
     sk_X509_OBJECT_pop_free(*sk, X509_OBJECT_free);
     *sk = NULL;
 


### PR DESCRIPTION
when sk_X509_OBJECT_push() fails after x509_object_dup() has already allocated the duplicate, the dup is neither stored on the destination stack nor freed: the error path only pop_free()s the stack the dup was never pushed onto, so it is leaked.

Fixes: 08cecb4448e9 "Add X509_STORE_get1_objects"
Fixes: https://github.com/openssl/openssl/issues/31771
