### PR TITLE
crypto/x509/x509_lu.c: check X509_OBJECT_up_ref_count() in x509_objec…

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -741,7 +741,12 @@ static X509_OBJECT *x509_object_dup(const X509_OBJECT *obj)
 
     ret->type = obj->type;
     ret->data = obj->data;
-    X509_OBJECT_up_ref_count(ret);
+
+    if (!X509_OBJECT_up_ref_count(ret)) {
+        OPENSSL_free(ret);
+        return NULL;
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
…t_dup()

the return value of X509_OBJECT_up_ref_count() was ignored. If the reference count increment fails, x509_object_dup() still returned a duplicate X509_OBJECT whose ->data aliases the source X509/X509_CRL without a reference actually having been taken. Freeing that duplicate later drops a reference it never held, leading to a premature free and use-after-free of the shared object.
