### PR TITLE
Explain inconsistency in X25519 ladder copies

### DIFF
--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -236,6 +236,13 @@ static void x25519_scalar_mulx(uint8_t out[32], const uint8_t scalar[32],
         fe64_sub(tmp1, x2, z2);
         fe64_add(x2, x2, z2);
         fe64_add(z2, x3, z3);
+        /* The original copy in x25519_scalar_mult_generic uses argument order
+         * fe_mul(z3, tmp0, x2), with the input arguments swapped.
+         *
+         * The assembly implementation of fe64_mul used here runs faster in
+         * parallel with its nearby instructions when an earlier-computable
+         * input (like tmp0) is passed as the 2nd input because it consumes
+         * the 2nd input at a faster rate than the 1st input. */
         fe64_mul(z3, x2, tmp0);
         fe64_mul(z2, z2, tmp1);
         fe64_sqr(tmp0, tmp1);


### PR DESCRIPTION
Fixes #31560

### Summary

As described in more detail in issue https://github.com/openssl/openssl/issues/31560 , the 3 copies of the Montgomery Ladder implementation in `crypto/ec/curve25519.c` are not identical. Discussion on that issue led to an explanation of why the divergence occurred and why it is safe (producing identical outputs as a non-diverged version). This PR encodes that learning into the code itself, by adding an explanatory comment directly before the code line that differs from the other 2 copies of that line.

### Checklist
- ~~documentation is added or updated~~
    - No user-observable behavior change.
- ~~tests are added or updated~~
    - No no functionality to test.
