### PR TITLE
fix use after free when printing diagnostic output

### DIFF
--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -444,6 +444,8 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
     const char *name, RADIX_OBJ *obj)
 {
     RADIX_OBJ *existing;
+    RADIX_THREAD *rt;
+    int i, j;
 
     if (obj != NULL && !TEST_false(obj->registered))
         return 0;
@@ -456,11 +458,29 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
         lh_RADIX_OBJ_delete(rp->objs, existing);
         existing->registered = 0;
         RADIX_OBJ_free(existing);
+    } else {
+        existing = NULL;
     }
 
     if (obj != NULL) {
         lh_RADIX_OBJ_insert(rp->objs, obj);
         obj->registered = 1;
+    }
+
+    /*
+     * update also slot so it does not keep a stale pointer.
+     * do it for all threads.
+     */
+    if (existing != NULL) {
+        for (i = 0; i < sk_RADIX_THREAD_num(rp->threads); i++) {
+            rt = (RADIX_THREAD *) sk_RADIX_THREAD_value(rp->threads, i);
+            for (j = 0; j < NUM_SLOTS; j++) {
+                if (rt->slot[j] == existing)
+                    rt->slot[j] = obj;
+                if (rt->ssl[j] == existing->ssl)
+                    rt->ssl[j] = (obj == NULL) ? NULL : obj->ssl;
+            }
+        }
     }
 
     return 1;

--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -444,19 +444,23 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
     const char *name, RADIX_OBJ *obj)
 {
     RADIX_OBJ *existing;
+    SSL *existing_ssl;
     RADIX_THREAD *rt;
-    int i, j;
+    int i, j, ok;
 
     if (obj != NULL && !TEST_false(obj->registered))
         return 0;
 
+    ok = 0;
+    ossl_crypto_mutex_lock(rp->gm);
     existing = RADIX_PROCESS_get_obj(rp, name);
     if (existing != NULL && obj != existing) {
         if (!TEST_true(existing->registered))
-            return 0;
+            goto done;
 
         lh_RADIX_OBJ_delete(rp->objs, existing);
         existing->registered = 0;
+        existing_ssl = existing->ssl;
         RADIX_OBJ_free(existing);
     } else {
         existing = NULL;
@@ -477,13 +481,17 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
             for (j = 0; j < NUM_SLOTS; j++) {
                 if (rt->slot[j] == existing)
                     rt->slot[j] = obj;
-                if (rt->ssl[j] == existing->ssl)
+                if (rt->ssl[j] == existing_ssl)
                     rt->ssl[j] = (obj == NULL) ? NULL : obj->ssl;
             }
         }
     }
 
-    return 1;
+    ok = 1;
+
+done:
+    ossl_crypto_mutex_unlock(rp->gm);
+    return ok;
 }
 
 static int RADIX_PROCESS_set_ssl(RADIX_PROCESS *rp, const char *name, SSL *ssl)
@@ -676,7 +684,9 @@ static void per_op_tick_obj(RADIX_OBJ *obj)
 
 static int do_per_op(TERP *terp, void *arg)
 {
+    ossl_crypto_mutex_lock(RP()->gm);
     lh_RADIX_OBJ_doall(RP()->objs, per_op_tick_obj);
+    ossl_crypto_mutex_unlock(RP()->gm);
     return 1;
 }
 

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -42,10 +42,10 @@ static int ssl_ctx_select_alpn(SSL *ssl,
 
 static void keylog_cb(const SSL *ssl, const char *line)
 {
-    ossl_crypto_mutex_lock(RP()->gm);
+/*     ossl_crypto_mutex_lock(RP()->gm); */
     BIO_printf(RP()->keylog_out, "%s", line);
     (void)BIO_flush(RP()->keylog_out);
-    ossl_crypto_mutex_unlock(RP()->gm);
+/*    ossl_crypto_mutex_unlock(RP()->gm); */
 }
 
 static int ssl_ctx_configure(SSL_CTX *ctx, int is_server)


### PR DESCRIPTION
the QUIC radix test which uses more than one thread my crash on test failure when diagnostic output is provided. The callstack reads as follows:
```
    ap=0x7137385ef620) at /usr/src/lib/libc/stdio/vfprintf.c:887
    str=0xdfdfdfdfdfdfdfd8 <error: Cannot access memory at address 0xdfdfdfdfdfdfdfd8>,
    n=<optimized out>, fmt=0x63cb342acb8 "  %3zu) '%s' (SSL: %p)\n", ap=0x7137385ef620)
    at /usr/src/lib/libc/stdio/vsnprintf.c:56
    format=0x63cb342acb8 "  %3zu) '%s' (SSL: %p)\n", args=0x7137385ef620) at crypto/bio/bio_print.c:112
    format=0x63cb342acb8 "  %3zu) '%s' (SSL: %p)\n") at crypto/bio/bio_print.c:25
    at test/radix/quic_bindings.c:306
    bio=0x63f4bd09600, verbose=1) at test/radix/quic_bindings.c:326
    test_prog_name=0x7137385f0a40 "/home/sashan/work.openssl/openssl.review/test/quic_radix_test")
    at test/testutil/driver.c:496

```

Things start to go downhill at frame number 5. The code in question reads as follows:
```
302     for (i = 0; i < NUM_SLOTS; ++i)
303         if (rt->slot[i] == NULL)
304             BIO_printf(bio, "  %3zu) <NULL>\n", i);
305         else
306             BIO_printf(bio, "  %3zu) '%s' (SSL: %p)\n", i,
307                 rt->slot[i]->name,
308                 (void *)rt->ssl[i]);
```
The variable `rt` holds pointer to thread context. When radix framework spawns a thread, it copies the context from parent thread (thread which spawns) to child. The example of radix script which may experience use after free on failure is as follows:
```
1146
1147     OP_SIMPLE_PAIR_CONN_ND();
1148     OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
1149
1150     OP_SPAWN_THREAD(child);
```
The snippet above creates a pair of connected SSL objects. The line 1147 creates trippled of objects: L (listener), S (serverside connection) and C (client side connection). At line 1148 (if I understand things right) L and S are moved out from the slot, C stays there. Line 1150 creates a thread. The new thread receives copy of thread context which still has C slot.

The child script which runs in its thread reads as follows:
```
1122         OP_ACCEPT_STREAM_WAIT(C, C3, 0 /* bidirectional */);
1123         OP_READ_EXPECT_B(C3, "foo");
```
Line 1122 moves out the C out of slot, it happens in thread context only, The parents thread still keeps that C in slot.

Once child script is done, the radix framework cleans up all objects used (instantiated) by child script. The C and C3 are destroyed, however pointer to C is still found in slot of parent thread.

The idea for the fix is to update pointer to those objects in all threads. This is a solution which works now. Alternate solution would require to figure out how to transfer ownership between threads. This requires a lot more solid understanding of radix test framework.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
