### PR TITLE
x509: avoid NULL memcmp argument in nc_dn()

### DIFF
--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -615,6 +615,12 @@ static int nc_dn(const X509_NAME *nm, const X509_NAME *base)
         return X509_V_ERR_OUT_OF_MEM;
     if (base->canon_enclen > nm->canon_enclen)
         return X509_V_ERR_PERMITTED_VIOLATION;
+    /*
+     * An empty base Name has no canonical encoding (canon_enc == NULL) and is
+     * a prefix of every Name, so it matches unconditionally.
+     */
+    if (base->canon_enclen == 0)
+        return X509_V_OK;
     if (memcmp(base->canon_enc, nm->canon_enc, base->canon_enclen))
         return X509_V_ERR_PERMITTED_VIOLATION;
     return X509_V_OK;

--- a/test/x509_test.c
+++ b/test/x509_test.c
@@ -550,6 +550,101 @@ err:
     return ret;
 }
 
+/*
+ * nameConstraints extnValue contents with one empty directoryName subtree.
+ * Empty X509_NAME has canon_enc == NULL / canon_enclen == 0.
+ *
+ *   SEQUENCE { [0|1] { SEQUENCE { [4] { SEQUENCE {} } } } }
+ */
+static const unsigned char nc_excluded_empty_dirname[] = {
+    0x30, 0x08, 0xa1, 0x06, 0x30, 0x04, 0xa4, 0x02, 0x30, 0x00
+};
+static const unsigned char nc_permitted_empty_dirname[] = {
+    0x30, 0x08, 0xa0, 0x06, 0x30, 0x04, 0xa4, 0x02, 0x30, 0x00
+};
+
+/* Decode a raw nameConstraints extnValue into a NAME_CONSTRAINTS object. */
+static NAME_CONSTRAINTS *nc_empty_dirname_from_der(const unsigned char *der,
+    unsigned int der_len)
+{
+    NAME_CONSTRAINTS *nc = NULL;
+    ASN1_OCTET_STRING *os = NULL;
+    X509_EXTENSION *ext = NULL;
+
+    os = ASN1_OCTET_STRING_new();
+    if (!TEST_ptr(os)
+        || !TEST_true(ASN1_OCTET_STRING_set(os, der, der_len)))
+        goto end;
+    ext = X509_EXTENSION_create_by_NID(NULL, NID_name_constraints,
+        1 /* critical */, os);
+    if (!TEST_ptr(ext))
+        goto end;
+    nc = X509V3_EXT_d2i(ext);
+
+end:
+    X509_EXTENSION_free(ext);
+    ASN1_OCTET_STRING_free(os);
+    return nc;
+}
+
+/* Build a minimal certificate with a non-empty subject DN. */
+static X509 *nc_empty_dirname_subject(const char *cn)
+{
+    X509 *x = NULL;
+    X509_NAME *nm = NULL;
+
+    if (!TEST_ptr(x = X509_new()))
+        goto err;
+    nm = X509_NAME_new();
+    if (!TEST_ptr(nm)
+        || !TEST_true(X509_NAME_add_entry_by_txt(nm, "CN", MBSTRING_ASC,
+            (const unsigned char *)cn, -1, -1, 0))
+        || !TEST_true(X509_set_subject_name(x, nm)))
+        goto err;
+    X509_NAME_free(nm);
+    return x;
+
+err:
+    X509_NAME_free(nm);
+    X509_free(x);
+    return NULL;
+}
+
+/* Check an empty directoryName constraint against a non-empty subject DN. */
+static int nc_check_empty_dirname(const unsigned char *der, unsigned int der_len,
+    int expected)
+{
+    int ok = 0;
+    NAME_CONSTRAINTS *nc = NULL;
+    X509 *x = NULL;
+
+    if (!TEST_ptr(nc = nc_empty_dirname_from_der(der, der_len))
+        || !TEST_ptr(x = nc_empty_dirname_subject("leaf.example"))
+        || !TEST_int_eq(NAME_CONSTRAINTS_check(x, nc), expected))
+        goto end;
+
+    ok = 1;
+
+end:
+    X509_free(x);
+    NAME_CONSTRAINTS_free(nc);
+    return ok;
+}
+
+/* Empty excluded directoryName matches the subject DN: excluded violation. */
+static int test_nc_empty_dirname_excluded(void)
+{
+    return nc_check_empty_dirname(nc_excluded_empty_dirname,
+        sizeof(nc_excluded_empty_dirname), X509_V_ERR_EXCLUDED_VIOLATION);
+}
+
+/* Empty permitted directoryName matches the subject DN: permitted. */
+static int test_nc_empty_dirname_permitted(void)
+{
+    return nc_check_empty_dirname(nc_permitted_empty_dirname,
+        sizeof(nc_permitted_empty_dirname), X509_V_OK);
+}
+
 OPT_TEST_DECLARE_USAGE("<pss-self-signed-cert.pem>\n")
 
 int setup_tests(void)
@@ -591,6 +686,8 @@ int setup_tests(void)
     ADD_TEST(test_drop_empty_csr_keyids);
     ADD_TEST(test_rsaesoaep_spki);
     ADD_TEST(test_x509_verify_with_new);
+    ADD_TEST(test_nc_empty_dirname_excluded);
+    ADD_TEST(test_nc_empty_dirname_permitted);
     return 1;
 }
 


### PR DESCRIPTION
An empty `directoryName` name constraint is encoded as an empty `X509_NAME`. Its canonical form has `canon_enc == NULL` and `canon_enclen == 0`, as produced by `x509_name_canon`.

`nc_dn` currently lets this case fall through to:

    memcmp(base->canon_enc, nm->canon_enc, base->canon_enclen)

Passing a NULL pointer to `memcmp` is undefined behaviour even when the length is zero, and UBSan reports it in `X509_verify_cert` when a chain contains an empty `directoryName` subtree.

Return `X509_V_OK` before the comparison when the base `directoryName` is empty. An empty `directoryName` base matches every `X509_NAME`, so this preserves the existing behavior in ordinary builds while avoiding the UB.

Add regression coverage for both relevant paths using `NAME_CONSTRAINTS_check` directly. These tests assert the existing result in ordinary builds and catch the NULL `memcmp` argument under UBSan:

- empty `excludedSubtrees` `directoryName`, expected result: `X509_V_ERR_EXCLUDED_VIOLATION`
- empty `permittedSubtrees` `directoryName`, expected result: `X509_V_OK`

This PR is split into two commits to simplify backports. The first commit contains only the `crypto/x509/v3_ncons.c` fix and applies cleanly to all release branches from `openssl-3.0` onward. The second commit adds regression coverage and may need branch specific adjustment on older branches.

Fixes #31687
Fixes #31688
