### PR TITLE
Fix in-place BN_sqr operand size

### DIFF
--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -10,7 +10,6 @@
 #include "internal/cryptlib.h"
 #include "bn_local.h"
 
-/* r must not be a */
 /*
  * I've just gone over this and it is now %20 faster on x86 - eay - 27 Jun 96
  */
@@ -29,17 +28,13 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
     bn_check_top(a);
     bn_check_top(r);
 
-    /*
-     * Acquiring rf may make r larger.
-     * If r == a, then a will also become larger.  Therefore, max must
-     * be calculated after rf has been acquired.
-     */
-    size_t top = a->top * 2;
+    size_t al = (size_t)a->top;
+    size_t top = al * 2;
     OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
     if (rf == NULL)
         return 0;
 
-    size_t max = a->dmax * 2;
+    size_t max = top;
 
     OSSL_FN_CTX *fnctx = bn_ctx_acquire_ossl_fn_ctx(ctx, 1, 2, max * 4);
     if (fnctx == NULL) {
@@ -47,7 +42,7 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
         return 0;
     }
 
-    int ret = OSSL_FN_sqr(rf, a->data, fnctx);
+    int ret = OSSL_FN_sqr_limbs(rf, a->data, al, fnctx);
     bn_release(r, (int)top);
     r->neg = 0;
 

--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -42,7 +42,7 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
         return 0;
     }
 
-    int ret = OSSL_FN_sqr_limbs(rf, a->data, al, fnctx);
+    int ret = ossl_fn_sqr_limbs(rf, a->data, al, fnctx);
     bn_release(r, (int)top);
     r->neg = 0;
 

--- a/crypto/fn/fn_sqr.c
+++ b/crypto/fn/fn_sqr.c
@@ -16,37 +16,51 @@
 
 int OSSL_FN_sqr(OSSL_FN *r, const OSSL_FN *a, OSSL_FN_CTX *ctx)
 {
+    return OSSL_FN_sqr_limbs(r, a, (size_t)a->dsize, ctx);
+}
+
+int OSSL_FN_sqr_limbs(OSSL_FN *r, const OSSL_FN *a, size_t al,
+    OSSL_FN_CTX *ctx)
+{
     const void *token = OSSL_FN_CTX_start(ctx);
     if (token == NULL)
         return 0;
 
-    size_t al = (size_t)a->dsize;
+    int ret = 0;
+
+    if (al > (size_t)a->dsize)
+        goto err;
+
     size_t rl = (size_t)r->dsize;
     size_t max = (size_t)(2 * al);
+    OSSL_FN *rr = r;
 
-    int ret = 0;
+    if (max > 0 && (r == a || rl < max))
+        if ((rr = OSSL_FN_CTX_get_limbs(ctx, max)) == NULL)
+            goto err;
+
 #ifdef BN_SQR_COMBA
-    if (al == 4 && rl >= 8) {
-        bn_sqr_comba4(r->d, a->d);
+    if (al == 4) {
+        bn_sqr_comba4(rr->d, a->d);
         goto end;
-    } else if (al == 8 && rl >= 16) {
-        bn_sqr_comba8(r->d, a->d);
+    } else if (al == 8) {
+        bn_sqr_comba8(rr->d, a->d);
         goto end;
     }
 #endif
 
-    /* rl < max is always true when r == a, so covers that case too */
-    OSSL_FN *rr = r;
-    if (rl < max)
-        if ((rr = OSSL_FN_CTX_get_limbs(ctx, max)) == NULL)
+    if (al != 0) {
+        OSSL_FN *tmp = NULL;
+
+        if ((tmp = OSSL_FN_CTX_get_limbs(ctx, max)) == NULL)
             goto err;
 
-    OSSL_FN *tmp = NULL;
-    if ((tmp = OSSL_FN_CTX_get_limbs(ctx, max)) == NULL)
-        goto err;
-
-    if (al != 0)
         bn_sqr_normal(rr->d, a->d, (int)al, tmp->d);
+    }
+
+#ifdef BN_SQR_COMBA
+end:
+#endif
 
     if (rr != r) {
         /*
@@ -55,10 +69,6 @@ int OSSL_FN_sqr(OSSL_FN *r, const OSSL_FN *a, OSSL_FN_CTX *ctx)
          */
         OSSL_FN_copy_truncate(r, rr);
     }
-
-#ifdef BN_SQR_COMBA
-end:
-#endif
 
     ret = 1;
 

--- a/crypto/fn/fn_sqr.c
+++ b/crypto/fn/fn_sqr.c
@@ -16,10 +16,10 @@
 
 int OSSL_FN_sqr(OSSL_FN *r, const OSSL_FN *a, OSSL_FN_CTX *ctx)
 {
-    return OSSL_FN_sqr_limbs(r, a, (size_t)a->dsize, ctx);
+    return ossl_fn_sqr_limbs(r, a, (size_t)a->dsize, ctx);
 }
 
-int OSSL_FN_sqr_limbs(OSSL_FN *r, const OSSL_FN *a, size_t al,
+int ossl_fn_sqr_limbs(OSSL_FN *r, const OSSL_FN *a, size_t al,
     OSSL_FN_CTX *ctx)
 {
     const void *token = OSSL_FN_CTX_start(ctx);

--- a/include/crypto/fn.h
+++ b/include/crypto/fn.h
@@ -368,24 +368,6 @@ int OSSL_FN_mul(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b,
  */
 int OSSL_FN_sqr(OSSL_FN *r, const OSSL_FN *a, OSSL_FN_CTX *ctx);
 
-/**
- * Calculate the square of the low |al| limbs of an OSSL_FN number.
- * Truncates the result to fit in r.
- *
- * @param[out]          r       The OSSL_FN for the result
- * @param[in]           a       The operand
- * @param[in]           al      The number of low limbs of a to square
- * @param[in]           ctx     A context to get temporary OSSL_FN
- *                              instances from.
- * @returns             1 on success, 0 on error
- *
- * @note This function currently requires that the OSSL_FN_CTX has free
- * space for two temporary OSSL_FNs, al * 2 limbs each, plus one frame
- * (currently 32 bytes).
- */
-int OSSL_FN_sqr_limbs(OSSL_FN *r, const OSSL_FN *a, size_t al,
-    OSSL_FN_CTX *ctx);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/crypto/fn.h
+++ b/include/crypto/fn.h
@@ -368,6 +368,24 @@ int OSSL_FN_mul(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b,
  */
 int OSSL_FN_sqr(OSSL_FN *r, const OSSL_FN *a, OSSL_FN_CTX *ctx);
 
+/**
+ * Calculate the square of the low |al| limbs of an OSSL_FN number.
+ * Truncates the result to fit in r.
+ *
+ * @param[out]          r       The OSSL_FN for the result
+ * @param[in]           a       The operand
+ * @param[in]           al      The number of low limbs of a to square
+ * @param[in]           ctx     A context to get temporary OSSL_FN
+ *                              instances from.
+ * @returns             1 on success, 0 on error
+ *
+ * @note This function currently requires that the OSSL_FN_CTX has free
+ * space for two temporary OSSL_FNs, al * 2 limbs each, plus one frame
+ * (currently 32 bytes).
+ */
+int OSSL_FN_sqr_limbs(OSSL_FN *r, const OSSL_FN *a, size_t al,
+    OSSL_FN_CTX *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crypto/fn_intern.h
+++ b/include/crypto/fn_intern.h
@@ -46,6 +46,14 @@ bool ossl_fn_is_negative(const OSSL_FN *f);
 bool ossl_fn_is_dynamically_allocated(const OSSL_FN *f);
 bool ossl_fn_is_securely_allocated(const OSSL_FN *f);
 
+/*
+ * Internal helper for callers that already know a non-secret active limb count,
+ * such as BN_sqr().  The public OSSL_FN_sqr() operation squares the full fixed
+ * width.
+ */
+int ossl_fn_sqr_limbs(OSSL_FN *r, const OSSL_FN *a, size_t al,
+    OSSL_FN_CTX *ctx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
`BN_sqr` expands the result before calling into the `OSSL_FN` square
implementation.  When the result aliases the input, that expansion also
changes the input `OSSL_FN` *dsize*, so the square used the expanded
allocation width instead of the original `BIGNUM` *top*.

Add an internal `ossl_fn_sqr_limbs()` helper for callers that already know
a non-secret active limb count, and keep `OSSL_FN_sqr()` as the full-width
wrapper.  `BN_sqr` now saves the original top and passes it through,
preserving `OSSL_FN` semantics while avoiding extra work over zero limbs.

Assisted-by: Pi:openai/gpt-5.5
