### PR TITLE
Removes redundant SSLv3 version checks

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1311,7 +1311,7 @@ int tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     }
 
     if ((rl->options & SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS) == 0
-        && rl->version <= TLS1_VERSION
+        && rl->version == TLS1_VERSION
         && !EVP_CIPHER_is_a(ciph, "NULL")
         && !EVP_CIPHER_is_a(ciph, "RC4")) {
         /*

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -44,7 +44,7 @@ static int tls_any_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *recs,
 static int tls_validate_record_header(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec)
 {
     if (rl->version == TLS_ANY_VERSION) {
-        if ((rec->rec_version >> 8) != SSL3_VERSION_MAJOR) {
+        if ((rec->rec_version >> 8) != TLS1_VERSION_MAJOR) {
             if (rl->is_first_record) {
                 unsigned char *p;
 

--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -289,7 +289,7 @@ SSL_SESSION *d2i_SSL_SESSION_ex(SSL_SESSION **a, const unsigned char **pp,
         goto err;
     }
 
-    if ((as->ssl_version >> 8) != SSL3_VERSION_MAJOR
+    if ((as->ssl_version >> 8) != TLS1_VERSION_MAJOR
         && (as->ssl_version >> 8) != DTLS1_VERSION_MAJOR
         && as->ssl_version != DTLS1_BAD_VER) {
         ERR_raise(ERR_LIB_SSL, SSL_R_UNSUPPORTED_SSL_VERSION);

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -505,8 +505,7 @@ int ssl_cipher_get_evp(SSL_CTX *ctx, const SSL_SESSION *s,
         const EVP_CIPHER *evp = NULL;
 
         if (use_etm
-            || s->ssl_version >> 8 != TLS1_VERSION_MAJOR
-            || s->ssl_version < TLS1_VERSION)
+            || s->ssl_version >> 8 != TLS1_VERSION_MAJOR)
             return 1;
 
         if (c->algorithm_enc == SSL_RC4

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4038,11 +4038,7 @@ int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
 {
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
-    if (sc == NULL)
-        return -1;
-
-    if (sc->session == NULL
-        || (sc->version < TLS1_VERSION && sc->version != DTLS1_BAD_VER))
+    if (sc == NULL || sc->session == NULL)
         return -1;
 
     return sc->ssl.method->ssl3_enc->export_keying_material(sc, out, olen, label,

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -39,9 +39,9 @@ EXT_RETURN tls_construct_ctos_renegotiate(SSL_CONNECTION *s, WPACKET *pkt,
         if (!SSL_CONNECTION_IS_DTLS(s)
             && (s->min_proto_version >= TLS1_3_VERSION
                 || (ssl_security(s, SSL_SECOP_VERSION, 0, TLS1_VERSION, NULL)
-                    && s->min_proto_version <= TLS1_VERSION))) {
+                    && s->min_proto_version == TLS1_VERSION))) {
             /*
-             * For TLS <= 1.0 SCSV is used instead, and for TLS 1.3 this
+             * For TLSv1.0 SCSV is used instead, and for TLS 1.3 this
              * extension isn't used at all.
              */
             return EXT_RETURN_NOT_SENT;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -39,7 +39,7 @@ EXT_RETURN tls_construct_ctos_renegotiate(SSL_CONNECTION *s, WPACKET *pkt,
         if (!SSL_CONNECTION_IS_DTLS(s)
             && (s->min_proto_version >= TLS1_3_VERSION
                 || (ssl_security(s, SSL_SECOP_VERSION, 0, TLS1_VERSION, NULL)
-                    && s->min_proto_version == TLS1_VERSION))) {
+                    && s->min_proto_version <= TLS1_VERSION))) {
             /*
              * For TLSv1.0 SCSV is used instead, and for TLS 1.3 this
              * extension isn't used at all.

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -420,7 +420,7 @@ static int state_machine(SSL_CONNECTION *s, int server)
                 goto end;
             }
         } else {
-            if ((s->version >> 8) != SSL3_VERSION_MAJOR) {
+            if ((s->version >> 8) != TLS1_VERSION_MAJOR) {
                 SSLfatal(s, SSL_AD_NO_ALERT, ERR_R_INTERNAL_ERROR);
                 goto end;
             }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3171,7 +3171,7 @@ SSL_TICKET_STATUS tls_get_ticket_from_client(SSL_CONNECTION *s,
      * (e.g. TLSv1.3) behave as if no ticket present to permit stateful
      * resumption.
      */
-    if (s->version <= SSL3_VERSION || !tls_use_ticket(s))
+    if (!tls_use_ticket(s))
         return SSL_TICKET_NONE;
 
     ticketext = &hello->pre_proc_exts[TLSEXT_IDX_session_ticket];


### PR DESCRIPTION
Just to be pedantic.
Removes redundant SSLv3 version checks and check against TLS1_VERSION_MAJOR instead of SSL3_VERSION_MAJOR.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
