### PR TITLE
[test] exercise AEAD tag read rejection when actually present during decryption

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -6012,6 +6012,14 @@ static int test_evp_aead_tag_direction(int idx)
     tagparams[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
         tag, info->taglen);
     tagparams[1] = OSSL_PARAM_construct_end();
+
+    /* set a tag so the get below is exercised with one present */
+    if (!TEST_true(EVP_CIPHER_CTX_set_params(ctx_dec, tagparams))) {
+        errmsg = "DEC_SET_TAG_REJECTED";
+        goto err;
+    }
+
+    /* but a tag must never be readable back while decrypting */
     ERR_set_mark();
     if (!TEST_false(EVP_CIPHER_CTX_get_params(ctx_dec, tagparams))) {
         ERR_clear_last_mark();


### PR DESCRIPTION
Set a verify tag while decrypting (which must succeed) before attempting the read, so the test asserts that a tag cannot be read back while decrypting even when one is _actually_ present.

This isolates direction logic from tag present logic.

Follow-up to #31734

Assisted-by: Claude:claude-opus-4-8

##### Checklist
- [x] tests are added or updated
