### PR TITLE
fix dangling pointers in radix test framework

### DIFF
--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -52,6 +52,7 @@ typedef struct radix_obj_st {
     SSL *ssl; /* owns one reference */
     unsigned int registered : 1; /* in LHASH? */
     unsigned int active : 1; /* tick? */
+    CRYPTO_MUTEX *mx;
 } RADIX_OBJ;
 
 DEFINE_LHASH_OF_EX(RADIX_OBJ);
@@ -104,11 +105,11 @@ typedef struct radix_thread_st {
 DEFINE_STACK_OF(RADIX_THREAD)
 
 /* ssl reference is transferred. name is copied and is required. */
-static RADIX_OBJ *RADIX_OBJ_new(const char *name, SSL *ssl)
+static RADIX_OBJ *RADIX_OBJ_new_empty(const char *name)
 {
     RADIX_OBJ *obj;
 
-    if (!TEST_ptr(name) || !TEST_ptr(ssl))
+    if (!TEST_ptr(name))
         return NULL;
 
     if (!TEST_ptr(obj = OPENSSL_zalloc(sizeof(*obj))))
@@ -119,7 +120,28 @@ static RADIX_OBJ *RADIX_OBJ_new(const char *name, SSL *ssl)
         return NULL;
     }
 
+    obj->mx = ossl_crypto_mutex_new();
+    if (obj->mx == NULL) {
+        OPENSSL_free(obj->name);
+        OPENSSL_free(obj);
+    }
+
+    return obj;
+}
+
+static RADIX_OBJ *RADIX_OBJ_new(const char *name, SSL *ssl)
+{
+    RADIX_OBJ *obj;
+
+    if (!TEST_ptr(ssl))
+        return NULL;
+
+    obj = RADIX_OBJ_new_empty(name);
+    if (!TEST_ptr(obj))
+        return NULL;
+
     obj->ssl = ssl;
+
     return obj;
 }
 
@@ -132,6 +154,7 @@ static void RADIX_OBJ_free(RADIX_OBJ *obj)
 
     SSL_free(obj->ssl);
     OPENSSL_free(obj->name);
+    ossl_crypto_mutex_free(&obj->mx);
     OPENSSL_free(obj);
 }
 
@@ -444,6 +467,9 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
     const char *name, RADIX_OBJ *obj)
 {
     RADIX_OBJ *existing;
+    SSL *existing_ssl;
+    RADIX_THREAD *rt;
+    int i, j;
 
     if (obj != NULL && !TEST_false(obj->registered))
         return 0;
@@ -455,12 +481,31 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
 
         lh_RADIX_OBJ_delete(rp->objs, existing);
         existing->registered = 0;
+        existing_ssl = existing->ssl;
         RADIX_OBJ_free(existing);
+    } else {
+        existing = NULL;
     }
 
     if (obj != NULL) {
         lh_RADIX_OBJ_insert(rp->objs, obj);
         obj->registered = 1;
+    }
+
+    /*
+     * update also slot so it does not keep a stale pointer.
+     * do it for all threads.
+     */
+    if (existing != NULL) {
+        for (i = 0; i < sk_RADIX_THREAD_num(rp->threads); i++) {
+            rt = (RADIX_THREAD *)sk_RADIX_THREAD_value(rp->threads, i);
+            for (j = 0; j < NUM_SLOTS; j++) {
+                if (rt->slot[j] == existing)
+                    rt->slot[j] = obj;
+                if (rt->ssl[j] == existing_ssl)
+                    rt->ssl[j] = (obj == NULL) ? NULL : obj->ssl;
+            }
+        }
     }
 
     return 1;
@@ -650,8 +695,10 @@ ossl_unused static void radix_skip_time(OSSL_TIME t)
 
 static void per_op_tick_obj(RADIX_OBJ *obj)
 {
-    if (obj->active)
+    ossl_crypto_mutex_lock(obj->mx);
+    if (obj->active && obj->ssl)
         SSL_handle_events(obj->ssl);
+    ossl_crypto_mutex_unlock(obj->mx);
 }
 
 static int do_per_op(TERP *terp, void *arg)

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -27,6 +27,24 @@ err:
     return ok;
 }
 
+DEF_FUNC(hf_bind)
+{
+    const char *name;
+    RADIX_OBJ *empty_obj;
+
+    F_POP(name);
+
+    empty_obj = RADIX_OBJ_new_empty(name);
+    if (empty_obj == NULL)
+        return 0;
+
+    RADIX_PROCESS_set_obj(RP(), name, empty_obj);
+
+    return 1;
+err:
+    return 0;
+}
+
 static int ssl_ctx_select_alpn(SSL *ssl,
     const unsigned char **out, unsigned char *out_len,
     const unsigned char *in, unsigned int in_len,
@@ -248,27 +266,53 @@ err:
     return ok;
 }
 
+/*
+ * currently when test needs to accept/create more than
+ * one stream it has two options, use unique variable
+ * for each stream it creates:
+ *    OP_ACCEPT_STREAM_WAIT(C, Ca, 0);
+ *    OP_ACCEPT_STREAM_WAIT(C, Cb, 0);
+ *    OP_ACCEPT_STREAM_WAIT(C, Cc, 0);
+ * or use unbind to free SSL object attached to variable:
+ *    OP_ACCEPT_STREAM_WAIT(C, Ca, 0);
+ *    OP_UNBIND(Ca);
+ *    OP_ACCEPT_STREAM_WAIT(C, Ca, 0);
+ *    OP_UNBIND(Ca);
+ *    OP_ACCEPT_STREAM_WAIT(C, Ca, 0);
+ *    OP_UNBIND(Ca);
+ *
+ */
+#define OP_F_REPLACE_STREAM 0x8000000000000000
+#define OP_F_MASK 0x7fffffffffffffff
+
 DEF_FUNC(hf_new_stream)
 {
     int ok = 0;
+    int replace;
+    RADIX_OBJ *stream_obj;
     const char *stream_name;
-    SSL *conn, *stream;
+    SSL *conn, *stream, *old;
     uint64_t flags, do_accept;
 
     F_POP2(flags, do_accept);
     F_POP(stream_name);
     REQUIRE_SSL(conn);
+    replace = ((OP_F_REPLACE_STREAM & flags) != 0);
 
-    if (!TEST_ptr_null(RADIX_PROCESS_get_obj(RP(), stream_name)))
+    stream_obj = RADIX_PROCESS_get_obj(RP(), stream_name);
+    if (replace == 0) {
+        if (!TEST_ptr_null(stream_obj))
+            goto err;
+    } else if (TEST_ptr_null(stream_obj))
         goto err;
 
     if (do_accept) {
-        stream = SSL_accept_stream(conn, flags);
+        stream = SSL_accept_stream(conn, flags & OP_F_MASK);
 
         if (stream == NULL)
             F_SPIN_AGAIN();
     } else {
-        stream = SSL_new_stream(conn, flags);
+        stream = SSL_new_stream(conn, flags & OP_F_MASK);
     }
 
     if (!TEST_ptr(stream))
@@ -276,8 +320,27 @@ DEF_FUNC(hf_new_stream)
 
     /* TODO(QUIC RADIX): Implement wait behaviour */
 
-    if (stream != NULL
-        && !TEST_true(RADIX_PROCESS_set_ssl(RP(), stream_name, stream))) {
+    if (stream_obj != NULL) {
+        /*
+         * OP_UNBIND() and all functions which call RP_PROCESS_{get,set}_ssl()
+         * are not thread safe. Those functions race with 'ticker' (do_per_op())
+         * functions which walks the ->objs to tick all SSL objects. Trying to
+         * add lock to do_per_op() and lock to RADIX_PROCESS_{get,set)_ssl() ends up
+         * with deadlock (may be just slow progress) making tests to timeout.
+         *
+         * Allowing test script to replace existing ?stream? ssl object with
+         * new instance created here avoids the frequent execution of remove/insert
+         * operations on hashtable. The objects to be found in hashtable
+         * are replaced under the per-object lock. Should be fine if hashtable
+         * is populated first before threads are spawned.
+         */
+        ossl_crypto_mutex_lock(stream_obj->mx);
+        old = stream_obj->ssl;
+        stream_obj->ssl = stream;
+        stream = NULL;
+        ossl_crypto_mutex_unlock(stream_obj->mx);
+        SSL_free(old);
+    } else if (!TEST_true(RADIX_PROCESS_set_ssl(RP(), stream_name, stream))) {
         SSL_free(stream);
         goto err;
     }
@@ -927,6 +990,10 @@ err:
 #define OP_UNBIND(name) \
     (OP_PUSH_PZ(#name), \
         OP_FUNC(hf_unbind))
+
+#define OP_BIND(name)   \
+    (OP_PUSH_PZ(#name), \
+        OP_FUNC(hf_bind))
 
 #define OP_SELECT_SSL(slot, name) \
     (OP_PUSH_U64(slot),           \


### PR DESCRIPTION
RADIX framework keeps objects needed by test scripts in two places:
  - hash table bound radix process (`RP()->objs`), all objects used by tests are stored there
  - slot which is a array bound to radix thread (`RT()->slot[]`)

all objects are present in radix process hashtable, objects used by thread are also placed to `->slot`. The object is typically placed to hashtable when it is created (for example during `OP_ACCEPT_STREAM()` operation.

The `slot` is an array which is used to pass arguments to RADIX ops. The typically script is doing something like this:
```
   OP_SELECT_SSL(0, C); /* places 'C' object to slot 0 in thread */
   OP_FUNC(print_ssl);  /* calls print_ssl function, which prints object */
```
All objects are managed by RADIX framework, scripts have very limited options to control object's lifetime. The only for scripts to let object go is to use `OP_UNBIND()`. The operation removes the object from hastable (`RP()->objs`) and frees the object afterwards. This is good enough as long a all tests are running in single thread. Currently `OP_UNBIND()` is required when test needs to accept/create more than one stream. The test has two options. It can use unique name for each stream it creates/accepts:
```
   OP_ACCEPT_STREAM_WAIT(C, C0, 0);
   OP_ACCEPT_STREAM_WAIT(C, C1, 0);
   OP_ACCEPT_STREAM_WAIT(C, C2, 0);
```
Or script may keep re-using same identifcator for stream, in that case `OP_UNBIND()` is needed:
```
   OP_ACCEPT_STREAM_WAIT(C, C0, 0);
   OP_UNBIND(C0);
   OP_ACCEPT_STREAM_WAIT(C, C0, 0);
   OP_UNBIND(C0);
   OP_ACCEPT_STREAM_WAIT(C, C0, 0);
   OP_UNBIND(C0);
```
Unfortunately `OP_UNBIND()` can not be used when test uses more than one thread due to missing locking of `RP()->objs`.

Introducing a locking scheme seems to be bit invasive change, The change here hopes to be sufficient and good enough to let us going.

The idea is as follows:
  - introduce `OP_BIND()` so script can insert empty object into `RP()->objs` OP_BIND() is supposed to run before script spawns thread. No manipulation of `RP()->objs` is allowed.

  - Introduce `OP_F_REPLACE_STREAM` flag which tells `OP_ACCEPT_STREAM_WAIT()`/`OP_NEW_STREAM()` to re-use existing id for stream. This `_REPLACE_` flag requires read-only acces to `RP()->objs` hash table.

  - change introduces a per radix object mutex so object can be updated safely w.r.t. RADIX thread which ticks SSL object bound in radix object.

The guideline for tests which require more then one thread is as follows:
   - the first thread creates complete set of empty objects for all threads.

   - each test thread gets its own set of objects, so it can populate them later during test with SSL objects

   - objects are not supposed to be shared between threads

This is a main thread which spawns one additional thread where streams are accepted:

```
   ...
   OP_BIND(C1);  /* stream id for child */
   OP_BIND(S1);  /* stream id for parent */

   OP_SPAWN_THREAD(child);
   for (i = 0; i < 10; i++) {
      OP_NEW_STREAM(S, S1, OP_F_REPLACE_STREAM);
      OP_WRITE_B(S1, "foo");
      OP_CONCLUDE(S1);
   }
```
This snippet comes from child:
```
   for (i = 0; i < 10; i++) {
      OP_ACCEPT_STREAM_WAIT(C, C1, OP_F_REPLACE_STREAM);
      OP_READ_EXPECT_B(C1, "foo");
      OP_EXPECT_FIN(C1);
   }
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
