### PR TITLE
OSSL_FN: Add greatest-common-divisor function

### DIFF
--- a/crypto/fn/build.info
+++ b/crypto/fn/build.info
@@ -3,7 +3,7 @@ $LIBFIPS=../../providers/libfips.a
 LIBS=$LIBCRYPTO
 
 $COMMON=fn_err.c fn_lib.c fn_ctx.c fn_intern.c fn_addsub.c fn_shift.c fn_mul.c \
-        fn_sqr.c fn_div.c fn_rand.c fn_mod.c
+        fn_sqr.c fn_div.c fn_rand.c fn_mod.c fn_gcd.c
 
 SOURCE[$LIBCRYPTO]=$COMMON
 SOURCE[$LIBFIPS]=$COMMON

--- a/crypto/fn/fn_gcd.c
+++ b/crypto/fn/fn_gcd.c
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You may obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <limits.h>
+#include <openssl/err.h>
+#include "internal/safe_math.h"
+#include "crypto/cryptlib.h"
+#include "crypto/fnerr.h"
+#include "internal/constant_time.h"
+#include "fn_local.h"
+
+OSSL_SAFE_MATH_MULU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
+
+/*
+ * Constant-time helpers.
+ *
+ * OSSL_FN values are fixed-width: there is no |top|, so any zero/nonzero
+ * classification must scan the full |dsize|.  These helpers perform such scans
+ * without branching on the scanned value.  They branch only on the (public)
+ * limb count.
+ */
+
+/* Returns all-ones if |a| is zero, zero otherwise. */
+static OSSL_FN_ULONG ossl_fn_ct_is_zero_mask(const OSSL_FN *a)
+{
+    OSSL_FN_ULONG acc = 0;
+
+    for (int i = 0; i < a->dsize; i++)
+        acc |= a->d[i];
+
+    return constant_time_is_zero_bn(acc);
+}
+
+/*
+ * Returns all-ones if |a| is odd, zero otherwise.  Odd implies non-zero
+ * (d[0] & 1 == 1 implies d[0] >= 1), so a separate full-width non-zero
+ * scan would not affect the result and is omitted: testing d[0] alone is
+ * sufficient and avoids an extra scan of the whole |dsize|.
+ *
+ * Precondition: |a| has at least one limb (dsize >= 1), so a->d[0] is a
+ * valid access.  In OSSL_FN_gcd() the operands are always allocated with
+ * scratch = max(dsize) + 1 >= 1 limbs.
+ */
+static OSSL_FN_ULONG ossl_fn_ct_odd_mask(const OSSL_FN *a)
+{
+    return 0 - (a->d[0] & 1);
+}
+
+/*
+ * Conditionally swap the limb contents of |a| and |b|, and the accompanying
+ * sign flags, without branching on |mask|.  |mask| is all-ones to swap or
+ * zero to leave both untouched.  |a| and |b| must have the same |dsize|,
+ * which is asserted below.  The limbs are swapped with a per-limb XOR under
+ * |mask|, and the sign flags with a masked XOR of their low bit.
+ */
+static int ossl_fn_ct_swap(OSSL_FN_ULONG mask, OSSL_FN *a, OSSL_FN *b,
+    int *aneg, int *bneg)
+{
+    if (!ossl_assert(a->dsize == b->dsize))
+        return 0;
+
+    for (int i = 0; i < a->dsize; i++) {
+        OSSL_FN_ULONG t = (a->d[i] ^ b->d[i]) & mask;
+
+        a->d[i] ^= t;
+        b->d[i] ^= t;
+    }
+
+    int bit = (int)(mask & (OSSL_FN_ULONG)1);
+    int t = (*aneg ^ *bneg) & bit;
+
+    *aneg ^= t;
+    *bneg ^= t;
+    return 1;
+}
+
+/*
+ * Compute r = a + b as a signed sum, where |aneg|/|bneg| carry the signs of
+ * |a|/|b| (0 = non-negative, 1 = negative).  |rneg| receives the sign of the
+ * result.  OSSL_FN storage is unsigned, so the magnitude operation is chosen
+ * with ordinary branches on the sign flags: same signs add (OSSL_FN_add),
+ * opposite signs subtract the smaller magnitude from the larger
+ * (OSSL_FN_sub, selected via OSSL_FN_cmp()).  That add/subtract selection is
+ * the only value-dependent branch; the trailing zero-sign normalisation is
+ * performed in constant time.
+ */
+static int ossl_fn_signed_add(OSSL_FN *r, int *rneg,
+    const OSSL_FN *a, int aneg, const OSSL_FN *b, int bneg)
+{
+    OSSL_FN_ULONG z;
+
+    if (aneg == bneg) {
+        if (!OSSL_FN_add(r, a, b))
+            return 0;
+        *rneg = aneg;
+    } else if (OSSL_FN_cmp(a, b) >= 0) {
+        if (!OSSL_FN_sub(r, a, b))
+            return 0;
+        *rneg = aneg;
+    } else {
+        if (!OSSL_FN_sub(r, b, a))
+            return 0;
+        *rneg = bneg;
+    }
+
+    /*
+     * A zero result is non-negative; clear the sign without branching.
+     * OSSL_FN_add() / OSSL_FN_sub() are unsigned and carry no sign, so the
+     * non-negative-zero guard is applied here on the external |rneg| flag in
+     * constant time.
+     */
+    z = ossl_fn_ct_is_zero_mask(r);
+    *rneg = constant_time_select_int((unsigned int)z, 0, *rneg);
+
+    return 1;
+}
+
+size_t OSSL_FN_gcd_ctx_size(const OSSL_FN *a, const OSSL_FN *b)
+{
+    size_t max, scratch, limbs;
+    int err = 0;
+
+    if (a == NULL || b == NULL)
+        return 0;
+
+    /*
+     * dsize is an int, so max <= INT_MAX and max + 1 cannot overflow a
+     * size_t.  The 4 * scratch product is checked via safe_mul_size_t.
+     */
+    max = (size_t)((a->dsize > b->dsize) ? a->dsize : b->dsize);
+    scratch = max + 1;
+    limbs = safe_mul_size_t(4, scratch, &err);
+
+    return err == 0 ? OSSL_FN_CTX_size(1, 4, limbs) : 0;
+}
+
+int OSSL_FN_gcd(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b,
+    OSSL_FN_CTX *ctx)
+{
+    const void *token = OSSL_FN_CTX_start(ctx);
+    if (token == NULL)
+        return 0;
+
+    int ret = 0;
+    size_t al = (size_t)a->dsize;
+    size_t bl = (size_t)b->dsize;
+    size_t max = al > bl ? al : bl;
+    size_t scratch = max + 1;
+    OSSL_FN *u = NULL, *v = NULL, *t = NULL, *rr = NULL;
+    int uneg = 0, vneg = 0, tneg = 0, delta = 1;
+    int shift;
+    size_t ubits, vbits, m;
+
+    if ((u = OSSL_FN_CTX_get_limbs(ctx, scratch)) == NULL
+        || (v = OSSL_FN_CTX_get_limbs(ctx, scratch)) == NULL
+        || (t = OSSL_FN_CTX_get_limbs(ctx, scratch)) == NULL
+        || (rr = OSSL_FN_CTX_get_limbs(ctx, scratch)) == NULL)
+        goto err;
+
+    /*
+     * Constant-time binary GCD (Bernstein-Yang style).  Control flow is
+     * mask-driven throughout so that limb values never select a branch:
+     *
+     *   - The shared power of two is removed via a constant-time scan over
+     *     u | v (the |pow2_*| block below) rather than a value-branching
+     *     trailing-zero count.
+     *   - The loop condition, conditional swaps, conditional delta negation,
+     *     and sign flips are all computed as masks and applied with
+     *     ossl_fn_ct_swap(), never with "if (cond) swap".
+     *   - Zero inputs are not short-circuited.  This is a deliberate
+     *     constant-time strengthening: gcd(0, x) = x and gcd(0, 0) = 0 are
+     *     reduced through the loop instead of via early returns.  The
+     *     oversized |shift| that an all-zero u | v produces is safe:
+     *     OSSL_FN_rshift() / OSSL_FN_lshift() zero the result when the shift
+     *     reaches or exceeds the width.
+     *
+     *   - The per-iteration zero-sign normalisation (in ossl_fn_signed_add()
+     *     and after OSSL_FN_rshift1()) keeps intermediates from going
+     *     negative zero.  OSSL_FN_add() / OSSL_FN_sub() / OSSL_FN_rshift1()
+     *     are unsigned and carry no sign, so that guard is applied here on the
+     *     external rneg/vneg flags, in constant time.
+     *
+     * What still leaks: the iteration count |m| (derived from
+     * OSSL_FN_num_bits(), which reveals input magnitudes), and the
+     * add/subtract selection inside ossl_fn_signed_add().  Limb values
+     * themselves do not drive any branch.
+     *
+     * The loop treats |u|, |v|, and |t| as signed intermediate values via the
+     * separate |uneg|, |vneg|, and |tneg| flags.  OSSL_FN remains unsigned
+     * throughout; the flags only choose the correct unsigned add/sub for these
+     * intermediates, and travel with the values through ossl_fn_ct_swap().
+     */
+    if (!OSSL_FN_lshift1(u, a)
+        || !OSSL_FN_lshift1(v, b))
+        goto err;
+
+    /*
+     * Find the shared power of two as v2(u | v).  Since u = 2*a and v = 2*b,
+     * this equals 1 + min(v2(a), v2(b)), which is exactly the |shift| to
+     * remove (the artificial lshift1 bit plus the shared trailing zeros).
+     * The scan counts trailing zero limbs and captures the first non-zero OR
+     * limb without branching on limb values.
+     */
+    OSSL_FN_ULONG pow2_flag = (OSSL_FN_ULONG)1;
+    OSSL_FN_ULONG pow2_numbits = 0;
+    int pow2_shifts = 0;
+
+    for (int i = 0; i < u->dsize; i++) {
+        OSSL_FN_ULONG temp = u->d[i] | v->d[i];
+        OSSL_FN_ULONG cond = constant_time_is_zero_bn(pow2_flag);
+
+        pow2_flag &= constant_time_is_zero_bn(temp);
+        pow2_shifts += (int)pow2_flag;
+        pow2_numbits = constant_time_select_bn(cond, pow2_numbits, temp);
+    }
+
+    pow2_numbits = ~pow2_numbits;
+    pow2_shifts *= OSSL_FN_BITS;
+    pow2_flag = (OSSL_FN_ULONG)1;
+    for (int j = 0; j < OSSL_FN_BITS; j++) {
+        pow2_flag &= pow2_numbits;
+        pow2_shifts += (int)pow2_flag;
+        pow2_numbits >>= 1;
+    }
+
+    shift = pow2_shifts;
+
+    if (!OSSL_FN_rshift(u, u, shift)
+        || !OSSL_FN_rshift(v, v, shift))
+        goto err;
+
+    /* Rearrange so that u is odd, without branching on u's value. */
+    if (!ossl_fn_ct_swap(0 - (OSSL_FN_ULONG)(~u->d[0] & 1), u, v,
+            &uneg, &vneg))
+        goto err;
+
+    ubits = OSSL_FN_num_bits(u);
+    vbits = OSSL_FN_num_bits(v);
+    m = ubits > vbits ? ubits : vbits;
+    if (m > ((size_t)INT_MAX - 4) / 3)
+        goto err;
+    m = 4 + 3 * m;
+
+    for (size_t i = 0; i < m; i++) {
+        /*
+         * Conditionally flip signs if delta is positive and v is odd and
+         * non-zero.  |cond| is a full-width all-ones/zero mask used for the
+         * constant-time swap; |condb| is the 0/1 bit used for the delta and
+         * sign arithmetic.
+         */
+        OSSL_FN_ULONG v_odd = ossl_fn_ct_odd_mask(v);
+        OSSL_FN_ULONG delta_pos = 0
+            - (OSSL_FN_ULONG)(((unsigned int)-delta
+                                  >> (8 * sizeof(delta) - 1))
+                & 1u);
+        OSSL_FN_ULONG cond = delta_pos & v_odd;
+        unsigned int condb = (unsigned int)(cond & (OSSL_FN_ULONG)1);
+
+        delta = ((0 - condb) & (unsigned int)-delta)
+            | ((condb - 1) & (unsigned int)delta);
+        uneg ^= (int)condb;
+        if (!ossl_fn_ct_swap(cond, u, v, &uneg, &vneg))
+            goto err;
+
+        /* Elimination step: t = v + u (signed). */
+        delta++;
+        if (!ossl_fn_signed_add(t, &tneg, v, vneg, u, uneg))
+            goto err;
+
+        /* If v is odd and non-zero, v = t.  Recompute after the swap above. */
+        v_odd = ossl_fn_ct_odd_mask(v);
+        if (!ossl_fn_ct_swap(v_odd, v, t, &vneg, &tneg))
+            goto err;
+
+        if (!OSSL_FN_rshift1(v, v))
+            goto err;
+
+        /*
+         * A zero v is non-negative; clear the sign without branching.
+         * OSSL_FN_rshift1() is unsigned and carries no sign, so the
+         * non-negative-zero guard is applied here on |vneg| in constant time.
+         */
+        OSSL_FN_ULONG z = ossl_fn_ct_is_zero_mask(v);
+        vneg = constant_time_select_int((unsigned int)z, 0, vneg);
+    }
+
+    if (!OSSL_FN_lshift(rr, u, shift)
+        || !OSSL_FN_rshift1(rr, rr))
+        goto err;
+
+    OSSL_FN_copy_truncate(r, rr);
+    ret = 1;
+err:
+    OSSL_FN_CTX_end(ctx, token);
+    return ret;
+}

--- a/include/crypto/fn.h
+++ b/include/crypto/fn.h
@@ -565,6 +565,36 @@ int OSSL_FN_rshift(OSSL_FN *r, const OSSL_FN *a, int n);
 int OSSL_FN_rshift1(OSSL_FN *r, const OSSL_FN *a);
 
 /**
+ * Calculate the greatest common divisor of two OSSL_FN numbers.  Truncates
+ * the result to fit in r.
+ *
+ * @param[out]          r       The OSSL_FN for the result
+ * @param[in]           a       The first operand
+ * @param[in]           b       The second operand
+ * @param[in]           ctx     A context to get temporary OSSL_FN
+ *                              instances from.
+ * @returns             1 on success, 0 on error
+ *
+ * @note This function currently requires that the OSSL_FN_CTX has free
+ * space for four temporary OSSL_FNs, max(a->dsize, b->dsize) + 1 limbs
+ * each, plus one frame.
+ */
+int OSSL_FN_gcd(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b,
+    OSSL_FN_CTX *ctx);
+
+/**
+ * Calculate the arena payload size that OSSL_FN_gcd() needs.
+ *
+ * @param[in]           a       The first operand
+ * @param[in]           b       The second operand
+ * @returns             The arena payload size, in bytes.
+ * @retval              0       on arithmetic overflow or invalid input.
+ *
+ * The returned size includes any frame budget needed by OSSL_FN_gcd().
+ */
+size_t OSSL_FN_gcd_ctx_size(const OSSL_FN *a, const OSSL_FN *b);
+
+/**
  * Add two OSSL_FN numbers.
  *
  * @param[out]          r       The OSSL_FN for the result

--- a/test/fn_api_test.c
+++ b/test/fn_api_test.c
@@ -506,6 +506,78 @@ static const OSSL_FN_ULONG ex_rshift_zero[] = {
     OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
 };
 
+static const OSSL_FN_ULONG gcd_num48[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000030),
+};
+static const OSSL_FN_ULONG gcd_num72[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000048),
+};
+static const OSSL_FN_ULONG gcd_ex24[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000018),
+};
+static const OSSL_FN_ULONG gcd_ex15[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x0000000f),
+};
+static const OSSL_FN_ULONG gcd_num_pow2_a[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
+    OSSL_FN_ULONG64_C(0x10000000, 0x00000000),
+};
+static const OSSL_FN_ULONG gcd_num_pow2_b[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
+    OSSL_FN_ULONG64_C(0x18000000, 0x00000000),
+};
+static const OSSL_FN_ULONG gcd_ex_pow2[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
+    OSSL_FN_ULONG64_C(0x08000000, 0x00000000),
+};
+static const OSSL_FN_ULONG gcd_num_mixed_a[] = {
+    OSSL_FN_ULONG64_C(0xffffffff, 0xffffffff),
+};
+static const OSSL_FN_ULONG gcd_num_mixed_b[] = {
+    OSSL_FN_ULONG64_C(0xffffffff, 0x00000000),
+};
+static const OSSL_FN_ULONG gcd_ex_mixed[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0xffffffff),
+};
+/*
+ * gcd(1, a) = 1, for any a.  Exercises a unit operand, which the
+ * Bernstein-Yang loop reduces to a no-op (it never eliminates past 1).
+ */
+static const OSSL_FN_ULONG gcd_num_one[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000001),
+};
+static const OSSL_FN_ULONG gcd_ex_one[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000001),
+};
+/*
+ * 2^96 + 1 and 3 * (2^96 + 1).  Their gcd is 2^96 + 1, a value spanning
+ * two limbs on 64-bit and four on 32-bit, with a non-zero low limb.  Used for
+ * a real truncation test: the destination is one limb narrower than the
+ * result, so a non-zero top limb is dropped on both platforms.
+ */
+static const OSSL_FN_ULONG gcd_num_2p96p1_a[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000001),
+    OSSL_FN_ULONG64_C(0x00000001, 0x00000000),
+};
+static const OSSL_FN_ULONG gcd_num_2p96p1_b[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000003),
+    OSSL_FN_ULONG64_C(0x00000003, 0x00000000),
+};
+static const OSSL_FN_ULONG gcd_ex_2p96p1[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000001),
+    OSSL_FN_ULONG64_C(0x00000001, 0x00000000),
+};
+
+/*
+ * Multi-limb all-zero operand, to exercise the zero path (no short-circuit)
+ * on a wider field than the single-limb zero num4 used by cases 0-2, including
+ * the oversized shift that an all-zero u | v produces.
+ */
+static const OSSL_FN_ULONG gcd_zero_wide[] = {
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
+};
+
 static int test_sub_common(struct test_case_st test_case)
 {
     const OSSL_FN_ULONG *n1 = test_case.op1;
@@ -1326,6 +1398,150 @@ err:
     OSSL_FN_free(a);
     OSSL_FN_free(r);
     return ret;
+}
+
+static int test_gcd_common(struct test_case_st test_case, int alias)
+{
+    const OSSL_FN_ULONG *n1 = test_case.op1;
+    size_t n1_limbs = test_case.op1_size;
+    const OSSL_FN_ULONG *n2 = test_case.op2;
+    size_t n2_limbs = test_case.op2_size;
+    const OSSL_FN_ULONG *ex = test_case.ex1;
+    size_t n1_new_limbs = test_case.op1_live_size;
+    size_t n2_new_limbs = test_case.op2_live_size;
+    size_t res_limbs = test_case.res1_live_size;
+    size_t check_limbs = test_case.check1_size;
+    OSSL_FN_ULONG extended_value = test_case.extended_limb_value1;
+    OSSL_FN *fn1 = NULL, *fn2 = NULL, *res = NULL;
+    OSSL_FN_CTX *ctx = NULL;
+    const OSSL_FN_ULONG *u = NULL;
+    size_t max = n1_new_limbs > n2_new_limbs ? n1_new_limbs : n2_new_limbs;
+    int ret = 0;
+
+    if (!TEST_ptr(ctx = OSSL_FN_CTX_new(NULL, 1, 4, (max + 1) * 4))
+        || !TEST_ptr(fn1 = OSSL_FN_new_limbs(n1_new_limbs))
+        || !TEST_ptr(fn2 = OSSL_FN_new_limbs(n2_new_limbs))
+        || !TEST_true(ossl_fn_set_words(fn1, n1, n1_limbs))
+        || !TEST_true(ossl_fn_set_words(fn2, n2, n2_limbs)))
+        goto err;
+
+    if (alias == 1) {
+        res = fn1;
+        res_limbs = n1_new_limbs;
+    } else if (alias == 2) {
+        res = fn2;
+        res_limbs = n2_new_limbs;
+    } else if (!TEST_ptr(res = OSSL_FN_new_limbs(res_limbs))
+        || !TEST_true(pollute(res, 0, res_limbs))) {
+        goto err;
+    }
+
+    if (!TEST_true(OSSL_FN_gcd(res, fn1, fn2, ctx))
+        || !TEST_ptr(u = ossl_fn_get_words(res))
+        || !TEST_mem_eq(u, check_limbs * OSSL_FN_BYTES,
+            ex, check_limbs * OSSL_FN_BYTES)
+        || !TEST_true(check_limbs_value(res, check_limbs, res_limbs,
+            extended_value)))
+        goto err;
+
+    ret = 1;
+err:
+    OSSL_FN_CTX_free(ctx);
+    if (res != fn1 && res != fn2)
+        OSSL_FN_free(res);
+    OSSL_FN_free(fn1);
+    OSSL_FN_free(fn2);
+    return ret;
+}
+
+#define GCD_CASE(op1, op2, ex, rsize, check, ext)      \
+    {                                                  \
+        /* op1 */ op1,                                 \
+        /* op1_size */ LIMBSOF(op1),                   \
+        /* op2 */ op2,                                 \
+        /* op2_size */ LIMBSOF(op2),                   \
+        /* ex1 */ ex,                                  \
+        /* ex1_size */ LIMBSOF(ex),                    \
+        /* ex2 */ NULL,                                \
+        /* ex2_size */ 0,                              \
+        /* op1_live_size */ LIMBSOF(op1) + 1,          \
+        /* op2_live_size */ LIMBSOF(op2) + 2,          \
+        /* res1_live_size */ (rsize),                  \
+        /* res2_live_size */ 0,                        \
+        /* check1_size */ (check),                     \
+        /* check2_size */ 0,                           \
+        /* extended_limb_value1 */ (ext),              \
+        /* extended_limb_value2 */ EXTENDED_LIMB_ZERO, \
+    }
+
+static struct test_case_st test_gcd_cases[] = {
+    GCD_CASE(num4, num4, num4, LIMBSOF(num4) + 2, LIMBSOF(num4),
+        EXTENDED_LIMB_ZERO),
+    GCD_CASE(num2, num4, num2, LIMBSOF(num2) + 2, LIMBSOF(num2),
+        EXTENDED_LIMB_ZERO),
+    GCD_CASE(num4, num2, num2, LIMBSOF(num2) + 2, LIMBSOF(num2),
+        EXTENDED_LIMB_ZERO),
+    GCD_CASE(gcd_num48, gcd_num72, gcd_ex24, LIMBSOF(gcd_ex24) + 2,
+        LIMBSOF(gcd_ex24), EXTENDED_LIMB_ZERO),
+    GCD_CASE(num2, num3, gcd_ex15, LIMBSOF(gcd_ex15) + 2,
+        LIMBSOF(gcd_ex15), EXTENDED_LIMB_ZERO),
+    GCD_CASE(gcd_num_pow2_a, gcd_num_pow2_b, gcd_ex_pow2,
+        LIMBSOF(gcd_ex_pow2) + 2, LIMBSOF(gcd_ex_pow2),
+        EXTENDED_LIMB_ZERO),
+    GCD_CASE(gcd_num_mixed_a, gcd_num_mixed_b, gcd_ex_mixed,
+        LIMBSOF(gcd_ex_mixed) + 2, LIMBSOF(gcd_ex_mixed),
+        EXTENDED_LIMB_ZERO),
+    GCD_CASE(num2, num2, num2, LIMBSOF(num2) + 2, LIMBSOF(num2),
+        EXTENDED_LIMB_ZERO),
+    /* Destination one limb narrower than the result; drops a non-zero top limb. */
+    GCD_CASE(gcd_num_2p96p1_a, gcd_num_2p96p1_b, gcd_ex_2p96p1,
+        LIMBSOF(gcd_ex_2p96p1) - 1, LIMBSOF(gcd_ex_2p96p1) - 1,
+        EXTENDED_LIMB_ZERO),
+    /* gcd(1, a) = 1 */
+    GCD_CASE(gcd_num_one, num2, gcd_ex_one, LIMBSOF(gcd_ex_one) + 2,
+        LIMBSOF(gcd_ex_one), EXTENDED_LIMB_ZERO),
+    /*
+     * Zero-input coverage through the loop.  OSSL_FN_gcd() deliberately does
+     * not short-circuit these cases, so they exercise the no-short-circuit
+     * path.  Cases 0-2 cover single-limb zeros (num4); these widen the zero
+     * field.
+     */
+    /* gcd(0, 0) = 0, multi-limb: oversized shift on a wide field. */
+    GCD_CASE(gcd_zero_wide, gcd_zero_wide, gcd_zero_wide,
+        LIMBSOF(gcd_zero_wide) + 2, LIMBSOF(gcd_zero_wide),
+        EXTENDED_LIMB_ZERO),
+    /* gcd(0, x) = x, with a wider zero operand than the nonzero one. */
+    GCD_CASE(gcd_zero_wide, gcd_num_2p96p1_b, gcd_num_2p96p1_b,
+        LIMBSOF(gcd_num_2p96p1_b) + 2, LIMBSOF(gcd_num_2p96p1_b),
+        EXTENDED_LIMB_ZERO),
+    /* gcd(x, 0) = x, with a wider zero operand than the nonzero one. */
+    GCD_CASE(gcd_num_2p96p1_b, gcd_zero_wide, gcd_num_2p96p1_b,
+        LIMBSOF(gcd_num_2p96p1_b) + 2, LIMBSOF(gcd_num_2p96p1_b),
+        EXTENDED_LIMB_ZERO),
+};
+
+static int test_gcd(int i)
+{
+    return test_gcd_common(test_gcd_cases[i], 0);
+}
+
+/*
+ * Alias r == a and r == b, on both a single-limb result (case 3) and a
+ * multi-limb result (case 5, the shared-powers-of-two case).
+ */
+static int test_gcd_alias(int i)
+{
+    static const struct {
+        size_t cas;
+        int alias;
+    } aliases[] = {
+        { 3, 1 },
+        { 3, 2 },
+        { 5, 1 },
+        { 5, 2 },
+    };
+
+    return test_gcd_common(test_gcd_cases[aliases[i].cas], aliases[i].alias);
 }
 
 /* A set of expected results, also in OSSL_FN_ULONG array form */
@@ -3561,6 +3777,8 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_rshift, 9);
     ADD_ALL_TESTS(test_rshift_alias, 4);
     ADD_TEST(test_rshift_invalid_shift);
+    ADD_ALL_TESTS(test_gcd, OSSL_NELEM(test_gcd_cases));
+    ADD_ALL_TESTS(test_gcd_alias, 4);
     ADD_ALL_TESTS(test_mul_feature_r_is_operand, 4);
     ADD_ALL_TESTS(test_mul, OSSL_NELEM(test_mul_cases));
     ADD_ALL_TESTS(test_mul_truncated, OSSL_NELEM(test_mul_truncate_cases));

--- a/test/fntest.c
+++ b/test/fntest.c
@@ -674,6 +674,52 @@ err:
     BN_free(ret);
     return st;
 }
+static int file_gcd(STANZA *s)
+{
+    BIGNUM *a = NULL, *b = NULL, *gcd = NULL, *ret = NULL;
+    OSSL_FN *af = NULL, *bf = NULL, *rf = NULL;
+    OSSL_FN_CTX *ctx = NULL;
+    int st = 0;
+    int r_acq = 0;
+    int nlimbs = 0;
+
+    if (!TEST_ptr(a = getBN(s, "A"))
+        || !TEST_ptr(b = getBN(s, "B"))
+        || !TEST_ptr(gcd = getBN(s, "GCD"))
+        || !TEST_ptr(ret = BN_new()))
+        goto err;
+
+    nlimbs = limbs(gcd);
+
+    if (!TEST_ptr(af = bn_get_ossl_fn(a))
+        || !TEST_ptr(bf = bn_get_ossl_fn(b))
+        || !TEST_ptr(rf = bn_acquire_ossl_fn(ret, nlimbs)))
+        goto err;
+    r_acq = 1;
+    if (!TEST_ptr(ctx = OSSL_FN_CTX_new_size(NULL,
+                      OSSL_FN_gcd_ctx_size(af, bf))))
+        goto err;
+
+    if (!TEST_true(OSSL_FN_gcd(rf, af, bf, ctx)))
+        goto err;
+    bn_release(ret, nlimbs);
+    BN_set_negative(ret, 0);
+    r_acq = 0;
+    if (!equalBN("gcd(A,B)", gcd, ret))
+        goto err;
+
+    st = 1;
+err:
+    if (r_acq)
+        bn_release(ret, nlimbs);
+    OSSL_FN_CTX_free(ctx);
+    BN_free(a);
+    BN_free(b);
+    BN_free(gcd);
+    BN_free(ret);
+    return st;
+}
+
 static FILETEST filetests[] = {
     { "Sum", file_sum, 0 },
     { "LShift1", file_lshift1, 0 },
@@ -687,7 +733,7 @@ static FILETEST filetests[] = {
     { "ModExp", NULL, 0 },
     { "Exp", NULL, 0 },
     { "ModSqrt", NULL, 0 },
-    { "GCD", NULL, 0 },
+    { "GCD", file_gcd, 0 },
 };
 
 static int file_test_run(STANZA *s)

--- a/test/recipes/11-test_fn.t
+++ b/test/recipes/11-test_fn.t
@@ -12,7 +12,7 @@ use warnings;
 use OpenSSL::Test qw/:DEFAULT srctop_file/;
 setup("test_fn");
 
-my @files = qw( bnmul.txt bnshift.txt bnsum.txt bnmod.txt );
+my @files = qw( bnmul.txt bnshift.txt bnsum.txt bnmod.txt bngcd.txt );
 
 plan tests => scalar(@files);
 


### PR DESCRIPTION
Add `OSSL_FN_gcd()` and its `OSSL_FN_gcd_ctx_size()` context-sizing helper.

Focused `OSSL_FN` API tests cover zero operands, gcd(1, a), common powers
of two, result sizing, zero-padding, truncation (including a multi-limb
case that drops a non-zero top limb), mixed operand widths, and result
aliasing for single- and multi-limb results.

Full stanza-driven parity: `bngcd.txt` runs the 4327-vector gcd corpus
through `OSSL_FN_gcd()` in fntest, mirroring bntest's `file_gcd()`.

Issue: https://github.com/openssl/project/issues/2017
Assisted-by: Pi:openai/gpt-5.5
Assisted-by: Pi:z-ai/glm-5.2
