### PR TITLE
Suppress function pointer type validation in clang ubsan

### DIFF
--- a/Configure
+++ b/Configure
@@ -1671,8 +1671,13 @@ unless ($disabled{asan} || defined $detected_sanitizers{asan}) {
         $config{target} =~ /^VC-/ ? "/fsanitize=address" : "-fsanitize=address";
 }
 
+my %predefined_C = compiler_predefined($config{CROSS_COMPILE}.$config{CC});
+
 unless ($disabled{ubsan} || defined $detected_sanitizers{ubsan}) {
     push @{$config{cflags}}, "-fsanitize=undefined", "-fno-sanitize-recover=all", "-DPEDANTIC";
+    if ($predefined_C{__clang__}) {
+        push @{$config{cflags}}, "-fno-sanitize=function";
+    }
 }
 
 unless ($disabled{msan} || defined $detected_sanitizers{msan}) {
@@ -1752,7 +1757,6 @@ if ($target{sys_id} ne "")
         push @{$config{openssl_sys_defines}}, "OPENSSL_SYS_$target{sys_id}";
         }
 
-my %predefined_C = compiler_predefined($config{CROSS_COMPILE}.$config{CC});
 my %predefined_CXX = $config{CXX}
     ? compiler_predefined($config{CROSS_COMPILE}.$config{CXX})
     : ();


### PR DESCRIPTION
We've been concerned about ubsan errors comming with more recent versions of clang.  specifically versions of clang later than 17 generate hundreds of function pointer type validation errors, i.e. assigning a function of type `void (*)(TYPE *) `to a function pointer of type `void (*)(void *)`.

Fixing these requires the creation of lots of thunk function that get littered through the code base, and are generally unpleasant to carry. A better fix requires siginficant code refactoring, and potentially large changes to our ABI, which we can't support until the next major release.

So, for now, just suppress those ubsan errors, so we can more properly deal with the issue when we are able.

