### PR TITLE
Update FreeBSD/OpenBSD CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
       uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: |
           sudo pkg install -y gcc perl5
@@ -247,21 +247,21 @@ jobs:
       uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: ./configdata.pm --dump
     - name: make
       uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: make -j4
     - name: make test
       uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         run: |
           ./util/opensslwrap.sh version -c
           .github/workflows/make-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
       with:
         persist-credentials: false
     - name: config
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
         version: "13.4"
@@ -244,21 +244,21 @@ jobs:
           sudo pkg install -y gcc perl5
           ./config --strict-warnings enable-fips enable-lms enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-trace
     - name: config dump
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
         version: "13.4"
         shutdown_vm: false
         run: ./configdata.pm --dump
     - name: make
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
         version: "13.4"
         shutdown_vm: false
         run: make -j4
     - name: make test
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
         version: "13.4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
       with:
         persist-credentials: false
     - name: config
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
         version: "13.4"
@@ -256,21 +256,21 @@ jobs:
           sudo pkg install -y gcc perl5
           ./config --strict-warnings enable-fips enable-lms enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-trace
     - name: config dump
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
         version: "13.4"
         shutdown_vm: false
         run: ./configdata.pm --dump
     - name: make
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
         version: "13.4"
         shutdown_vm: false
         run: make -j4
     - name: make test
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
         version: "13.4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
       uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: |
           sudo pkg install -y gcc perl5
@@ -259,21 +259,21 @@ jobs:
       uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: ./configdata.pm --dump
     - name: make
       uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: make -j4
     - name: make test
       uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         run: |
           ./util/opensslwrap.sh version -c
           .github/workflows/make-test

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -327,7 +327,7 @@ jobs:
       uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: |
           sudo pkg install -y gcc perl5
@@ -336,21 +336,21 @@ jobs:
       uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: ./configdata.pm --dump
     - name: make
       uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: make -j4
     - name: make test
       uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         run: |
           ./util/opensslwrap.sh version -c
           .github/workflows/make-test
@@ -365,7 +365,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.7'
+        version: '7.9'
         shutdown_vm: false
         run: |
           ./config --strict-warnings enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-trace
@@ -374,7 +374,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.7'
+        version: '7.9'
         shutdown_vm: false
         run: |
           ./configdata.pm --dump
@@ -383,7 +383,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.7'
+        version: '7.9'
         shutdown_vm: false
         run: |
           make -j4
@@ -392,7 +392,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.7'
+        version: '7.9'
         run: |
           ./util/opensslwrap.sh version -c
           .github/workflows/make-test

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -324,7 +324,7 @@ jobs:
       with:
         persist-credentials: false
     - name: config
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
         version: "13.4"
@@ -333,21 +333,21 @@ jobs:
           sudo pkg install -y gcc perl5
           ./config --strict-warnings enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-trace
     - name: config dump
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
         version: "13.4"
         shutdown_vm: false
         run: ./configdata.pm --dump
     - name: make
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
         version: "13.4"
         shutdown_vm: false
         run: make -j4
     - name: make test
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: freebsd
         version: "13.4"
@@ -361,7 +361,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: config
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: openbsd
         architecture: x86-64
@@ -370,7 +370,7 @@ jobs:
         run: |
           ./config --strict-warnings enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-trace
     - name: config dump
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: openbsd
         architecture: x86-64
@@ -379,7 +379,7 @@ jobs:
         run: |
           ./configdata.pm --dump
     - name: make
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: openbsd
         architecture: x86-64
@@ -388,7 +388,7 @@ jobs:
         run: |
           make -j4
     - name: make test
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee #v1.30.0
       with:
         operating_system: openbsd
         architecture: x86-64

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -417,7 +417,7 @@ jobs:
         persist-credentials: false
         ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: config
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
         version: "13.4"
@@ -426,21 +426,21 @@ jobs:
           sudo pkg install -y gcc perl5
           ./config --strict-warnings enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-trace
     - name: config dump
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
         version: "13.4"
         shutdown_vm: false
         run: ./configdata.pm --dump
     - name: make
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
         version: "13.4"
         shutdown_vm: false
         run: make -j4
     - name: make test
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
         version: "13.4"
@@ -461,7 +461,7 @@ jobs:
         persist-credentials: false
         ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: config
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: openbsd
         architecture: x86-64
@@ -470,7 +470,7 @@ jobs:
         run: |
           ./config --strict-warnings enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-trace
     - name: config dump
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: openbsd
         architecture: x86-64
@@ -479,7 +479,7 @@ jobs:
         run: |
           ./configdata.pm --dump
     - name: make
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: openbsd
         architecture: x86-64
@@ -488,7 +488,7 @@ jobs:
         run: |
           make -j4
     - name: make test
-      uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda #v0.30.0
+      uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: openbsd
         architecture: x86-64

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -420,7 +420,7 @@ jobs:
       uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: |
           sudo pkg install -y gcc perl5
@@ -429,21 +429,21 @@ jobs:
       uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: ./configdata.pm --dump
     - name: make
       uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         shutdown_vm: false
         run: make -j4
     - name: make test
       uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 #v1.5.0
       with:
         operating_system: freebsd
-        version: "13.4"
+        version: "14.4"
         run: |
           ./util/opensslwrap.sh version -c
           .github/workflows/make-test
@@ -465,7 +465,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.7'
+        version: '7.9'
         shutdown_vm: false
         run: |
           ./config --strict-warnings enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-trace
@@ -474,7 +474,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.7'
+        version: '7.9'
         shutdown_vm: false
         run: |
           ./configdata.pm --dump
@@ -483,7 +483,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.7'
+        version: '7.9'
         shutdown_vm: false
         run: |
           make -j4
@@ -492,7 +492,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.7'
+        version: '7.9'
         run: |
           ./util/opensslwrap.sh version -c
           .github/workflows/make-test


### PR DESCRIPTION
This is being done to help reduce OS maintainer burden as well as OpenSSL developer burden by using versions of FreeBSD and OpenBSD which are currently supported by the respective projects.