### PR TITLE
Fix refcounting on decoder, encoder and store fetching 

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -406,9 +406,19 @@ inner_ossl_decoder_fetch(struct decoder_data_st *methdata,
              */
             if (id == 0 && name != NULL)
                 id = ossl_namemap_name2num(namemap, name);
-            if (id != 0)
+            if (id != 0 && methdata->tmp_store == NULL) {
                 ossl_method_store_cache_set(store, prov, id, propq, method,
                     ossl_decoder_up_ref, ossl_decoder_free);
+            } else {
+                /*
+                 * Like with EVP methods, if the provider requests no caching we need
+                 * to take an extra refcount here so that the tmp_stored decoder
+                 * lives beyond the freeing of that tmp_store
+                 */
+#ifndef OPENSSL_NO_CACHED_FETCH
+                OSSL_DECODER_up_ref((OSSL_DECODER *)method);
+#endif
+            }
         }
 
         /*

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -405,8 +405,19 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata,
              */
             if (id == 0)
                 id = ossl_namemap_name2num(namemap, name);
-            ossl_method_store_cache_set(store, prov, id, propq, method,
-                ossl_encoder_up_ref, ossl_encoder_free);
+            if (id != 0 && methdata->tmp_store == NULL) {
+                ossl_method_store_cache_set(store, prov, id, propq, method,
+                    ossl_encoder_up_ref, ossl_encoder_free);
+            } else {
+                /*
+                 * Like with EVP methods, if the provider requests no caching we need
+                 * to take an extra refcount here so that the tmp_stored encoder
+                 * lives beyond the freeing of that tmp_store
+                 */
+#ifndef OPENSSL_NO_CACHED_FETCH
+                OSSL_ENCODER_up_ref((OSSL_ENCODER *)method);
+#endif
+            }
         }
 
         /*

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -353,8 +353,19 @@ inner_loader_fetch(struct loader_data_st *methdata,
              */
             if (id == 0)
                 id = ossl_namemap_name2num(namemap, scheme);
-            ossl_method_store_cache_set(store, prov, id, propq, method,
-                up_ref_loader, free_loader);
+            if (id != 0 && methdata->tmp_store == NULL) {
+                ossl_method_store_cache_set(store, prov, id, propq, method,
+                    up_ref_loader, free_loader);
+            } else {
+                /*
+                 * Like with EVP methods, if the provider requests no caching we need
+                 * to take an extra refcount here so that the tmp_stored loader
+                 * lives beyond the freeing of that tmp_store
+                 */
+#ifndef OPENSSL_NO_CACHED_FETCH
+                OSSL_STORE_LOADER_up_ref((OSSL_STORE_LOADER *)method);
+#endif
+            }
         }
 
         /*

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -1753,6 +1753,84 @@ static const OSSL_ALGORITHM ossltest_rands[] = {
     { NULL, NULL, NULL }
 };
 
+/*
+ * The implementations for the p_ossltest provider decoder/encoder/store objects
+ * are defined below, but they are dummy implementations and do nothing.  They exist
+ * for the sole purpose of returning algorithms from this provider so that we can test if
+ * object creation and refcounting work when a provider requests no caching of the algorithm.
+ */
+
+static int ossl_test_decode(void *ctx, OSSL_CORE_BIO *in, int selection,
+    OSSL_CALLBACK *cb, void *cbarg,
+    OSSL_PASSPHRASE_CALLBACK *pb, void *pbarg)
+{
+    return 1;
+}
+
+static const OSSL_DISPATCH ossl_test_decoder_functions[] = {
+    { OSSL_FUNC_DECODER_DECODE, (void (*)(void))ossl_test_decode },
+    OSSL_DISPATCH_END
+};
+
+static const OSSL_ALGORITHM ossl_test_decoders[] = {
+    ALG("p_ossltest_decoder", ossl_test_decoder_functions),
+    { NULL, NULL, NULL }
+};
+
+static int ossl_test_encode(void *ctx, OSSL_CORE_BIO *out, const void *obj,
+    const OSSL_PARAM obj_abstract[],
+    int selection, OSSL_PASSPHRASE_CALLBACK *pb,
+    void *pbarg)
+{
+    return 1;
+}
+
+static const OSSL_DISPATCH ossl_test_encoder_functions[] = {
+    { OSSL_FUNC_ENCODER_ENCODE, (void (*)(void))ossl_test_encode },
+    OSSL_DISPATCH_END
+};
+
+static const OSSL_ALGORITHM ossl_test_encoders[] = {
+    ALG("p_ossltest_encoder", ossl_test_encoder_functions),
+    { NULL, NULL, NULL }
+};
+
+static int dummy_store_value = 0;
+
+static void *ossl_test_store_open(void *provctx, const char *uri)
+{
+    return (void *)&dummy_store_value;
+}
+
+static int ossl_test_store_load(void *ctx, OSSL_CALLBACK *object_fn, void *cbarg,
+    OSSL_PASSPHRASE_CALLBACK *pb, void *pbarg)
+{
+    return 0;
+}
+
+static int ossl_test_store_eof(void *ctx)
+{
+    return 1;
+}
+
+static int ossl_test_store_close(void *ctx)
+{
+    return 1;
+}
+
+static const OSSL_DISPATCH ossl_test_store_functions[] = {
+    { OSSL_FUNC_STORE_OPEN, (void (*)(void))ossl_test_store_open },
+    { OSSL_FUNC_STORE_LOAD, (void (*)(void))ossl_test_store_load },
+    { OSSL_FUNC_STORE_EOF, (void (*)(void))ossl_test_store_eof },
+    { OSSL_FUNC_STORE_CLOSE, (void (*)(void))ossl_test_store_close },
+    OSSL_DISPATCH_END
+};
+
+static const OSSL_ALGORITHM ossl_test_stores[] = {
+    ALG("p_ossltest_store", ossl_test_store_functions),
+    { NULL, NULL, NULL }
+};
+
 /**
  * @brief Implement ossltest query.
  *
@@ -1777,6 +1855,12 @@ static const OSSL_ALGORITHM *ossltest_query(void *provctx, int operation_id,
         return ossltest_ciphers;
     case OSSL_OP_RAND:
         return ossltest_rands;
+    case OSSL_OP_DECODER:
+        return ossl_test_decoders;
+    case OSSL_OP_ENCODER:
+        return ossl_test_encoders;
+    case OSSL_OP_STORE:
+        return ossl_test_stores;
     }
     return NULL;
 }


### PR DESCRIPTION
apologies for missing this, but in https://github.com/openssl/openssl/pull/31782 I fixed refcounting for EVP objects when the provider requests no caching.  In that fix I neglected to make the corresponding fixes for encoders, decoders and store algorithms, which have independent inner fetch paths (inner_decoder_fetch, inner_encoder_fetch and inner_loader_fetch).

I missed those because the test I added, uses the p_ossltest provider in a non-caching mode, but p_ossltest doesn't return any algorithms for DECODERS/ENCODERS/STORES.  I've addressed that here by augmenting p_ossltest such that it returns dummy algorithms for those operation types, allowing the existing test to exercise the refcounting on the missed fetch paths. 

##### Checklist
- [x] tests are added or updated
