### PR TITLE
apps/x509: Do not set an invalid trust identifier

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2524,7 +2524,6 @@ int check_cert_might_be_valid(BIO *bio, BIO *b_err, X509 *x, const char *checkho
     X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_PARTIAL_CHAIN);
     X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_IGNORE_CRITICAL);
     X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_ALLOW_PROXY_CERTS);
-    X509_VERIFY_PARAM_set_trust(vpm, X509_TRUST_OK_ANY_EKU);
 
     if (!X509_VERIFY_PARAM_set1_ip_asc(vpm, checkip)) {
         maybe_printf(b_err, "Invalid IP address: %s\n", checkip);

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2015-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2015-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -17,7 +17,7 @@ use File::Compare qw/compare_text/;
 
 setup("test_x509");
 
-plan tests => 153;
+plan tests => 155;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -120,6 +120,14 @@ ok(run(app(["openssl", "x509", "-in", $ca, "-addreject", "emailProtection",
             "-out", "ca-rejected.pem"])));
 cert_contains("ca-rejected.pem", "Rejected Uses: E-mail Protection",
               1, 'rejected use - E-mail Protection');
+
+my $check_trust_err = "x509-check-trust.err";
+ok(run(app(["openssl", "x509", "-noout", "-text", "-in", $ca],
+           stderr => $check_trust_err, stdout => undef)),
+   "x509 -text does not fail on a trusted certificate");
+test_file_contains("x509 -text diagnostics", $check_trust_err,
+                   "invalid trust", 0);
+unlink $check_trust_err;
 
 subtest 'x509 -- x.509 v1 certificate' => sub {
     tconversion( -type => 'x509', -prefix => 'x509v1',


### PR DESCRIPTION
`openssl x509 -text` can emit an unexpected `invalid trust` diagnostic when printing a trusted certificate because `check_cert_might_be_valid` calls `X509_VERIFY_PARAM_set_trust` with `X509_TRUST_OK_ANY_EKU`.

`X509_TRUST_OK_ANY_EKU` is a trust flag, not a valid trust identifier for `X509_VERIFY_PARAM_set_trust`, so the call queues an error even though the command itself succeeds.

Remove the invalid trust assignment and rely on `X509_PURPOSE_ANY` and the default trust handling.
Add a regression test to verify that `openssl x509 -noout -text` succeeds for the test CA certificate without emitting `invalid trust` on stderr.

Fixes #31836

##### Checklist
- [x] tests are added or updated

Assisted-by: Codex:GPT-5.5