### PR TITLE
Fix new statem_clnt_test when dtls is disabled

### DIFF
--- a/test/statem_clnt_construct_test.c
+++ b/test/statem_clnt_construct_test.c
@@ -408,7 +408,7 @@ static int test_construct_ch_hrr(void)
 
 /* DTLS happy-path / cookie / random-reuse tests */
 
-#ifndef OPENSSL_NO_DTLS
+#if !defined(OPENSSL_NO_DTLS) && !defined(OPENSSL_NO_DTLS1_2)
 static int test_construct_ch_dtls(void)
 {
     CH_CONFIG cfg = { 1, 0, 0, 0 };
@@ -715,7 +715,7 @@ int setup_tests(void)
 #endif /* OPENSSL_NO_CACHED_FETCH */
 #endif /* OSSL_NO_USABLE_TLS1_3 */
 
-#ifndef OPENSSL_NO_DTLS
+#if !defined(OPENSSL_NO_DTLS) && !defined(OPENSSL_NO_DTLS1_2)
     ADD_TEST(test_construct_ch_dtls);
     ADD_TEST(test_construct_ch_dtls_cookie);
     ADD_TEST(test_construct_ch_dtls_client_random);


### PR DESCRIPTION
The new statem client tests added in comimt c36a9b4 assume that if OPENSSL_NO_DTLS is not defined, that we have DTLS support, but we have this odd setup in which we can have DTLS enabled, but DTLS1_2 disabled, in which case the needed support isn't present, and the test fails.

why we have it setup that way, I'm not sure, but we should only run the dtls tests if both DTLS and DTLS1_2 support is available.

Fixes #31851


##### Checklist
- [x] tests are added or updated


Setting urgent, as this is currently breaking Nightly ci.