### PR TITLE
Fix EVP_CIPHER_CTX leak in cipher BIO duplication

### DIFF
--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -396,9 +396,6 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DUP:
         dbio = (BIO *)ptr;
         dctx = BIO_get_data(dbio);
-        dctx->cipher = EVP_CIPHER_CTX_new();
-        if (dctx->cipher == NULL)
-            return 0;
         ret = EVP_CIPHER_CTX_copy(dctx->cipher, ctx->cipher);
         if (ret)
             BIO_set_init(dbio, 1);

--- a/test/bio_enc_test.c
+++ b/test/bio_enc_test.c
@@ -327,6 +327,28 @@ end:
     return ret;
 }
 
+static int test_bio_enc_dup(void)
+{
+    BIO *b = NULL, *dup = NULL;
+    EVP_CIPHER_CTX *ctx = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(b = BIO_new(BIO_f_cipher()))
+        || !TEST_int_gt(BIO_get_cipher_ctx(b, &ctx), 0)
+        || !TEST_true(EVP_CipherInit_ex(ctx, EVP_aes_256_cbc(), NULL,
+            KEY, IV, ENCRYPT)))
+        goto err;
+
+    if (!TEST_ptr(dup = BIO_dup_chain(b)))
+        goto err;
+
+    ret = 1;
+err:
+    BIO_free_all(dup);
+    BIO_free_all(b);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_bio_enc_aes_128_cbc, 2);
@@ -340,5 +362,6 @@ int setup_tests(void)
 #endif
 #endif
     ADD_TEST(test_bio_enc_eof_read_flush);
+    ADD_TEST(test_bio_enc_dup);
     return 1;
 }


### PR DESCRIPTION
`BIO_dup_chain` creates the destination cipher BIO with `BIO_new`, so `enc_new` already allocates `dctx->cipher`. The `BIO_CTRL_DUP` handler then allocated another `EVP_CIPHER_CTX` and overwrote that pointer.

Copy into the existing destination context instead and add a regression test that exercises `BIO_dup_chain` on an initialized cipher BIO.

Fixes #31803

Verified with:

```sh
make test TESTS=test_bio_enc
make OSSL_USE_VALGRIND=yes test TESTS=test_bio_enc
```

##### Checklist

- [x] tests are added or updated
