### PR TITLE
pkcs12: free PKCS7 elements on error in PKCS12_unpack_authsafes

### DIFF
--- a/crypto/pkcs12/p12_add.c
+++ b/crypto/pkcs12/p12_add.c
@@ -219,6 +219,6 @@ STACK_OF(PKCS7) *PKCS12_unpack_authsafes(const PKCS12 *p12)
     }
     return p7s;
 err:
-    sk_PKCS7_free(p7s);
+    sk_PKCS7_pop_free(p7s, PKCS7_free);
     return NULL;
 }


### PR DESCRIPTION
`PKCS12_unpack_authsafes` bails out through `sk_PKCS7_free` when `ossl_pkcs7_ctx_propagate` fails, which frees only the stack and leaks every `PKCS7` element `ASN1_item_unpack_ex` decoded from the authsafes blob, so free them with `sk_PKCS7_pop_free` like `p12_kiss.c` and `p12_npas.c` already do.