### PR TITLE
Fix -1 return code in quicapitest mfail test

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -3643,7 +3643,7 @@ static int test_quic_handshake_multipkt_mfail(void)
         quic_advance_time(clientssl, serverssl);
     }
     if (!TEST_int_lt(i, 10)) {
-        ret = -1;
+        TEST_info("No connection advancement after 10 tries, failing test");
         goto err;
     }
 


### PR DESCRIPTION
the multipacket mfail test for quicapi erroneously returned -1 when a connection wasn't established within ten iterations of the tls state machine.  Given that mfail tests require a return code of 0 to pass (as we expect failure on malloc failures), change the return code to a zero and issue an TEST_info warning instead.

Fixes #31864


marking as urgent as this is breaking CI

##### Checklist
- [x] tests are added or updated
