### PR TITLE
threads_pthread: disable `USE_RWLOCK` on AIX

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -82,7 +82,7 @@
  * Likewise is there a problem with the glibc implementation on riscv.
  */
 #if defined(PTHREAD_RWLOCK_INITIALIZER) && !defined(_KLT_MODEL_) && !defined(_PUT_MODEL_) \
-    && !defined(__riscv)
+    && !defined(__riscv) && !defined(OPENSSL_SYS_AIX)
 #define USE_RWLOCK
 #endif
 


### PR DESCRIPTION
AIX's `pthread_rwlock_t` is reader-preferring per POSIX, and AIX has no `pthread_rwlockattr_setkind_np` to request writer-preference like glibc does. This starves writer threads under contention, causing test_threads' `torture_rw_low` to fail reliably on AIX (32- and 64-bit).

Exclude `OPENSSL_SYS_AIX` from the `USE_RWLOCK` guard, alongside the existing NonStop KLT/PUT and RISC-V exclusions, so AIX falls back to the mutex-emulated `CRYPTO_RWLOCK` implementation instead.

Fixes #31365

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
