### PR TITLE
Fix crash in EVP_MD_CTX_copy_ex on inconsistent context

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -494,7 +494,8 @@ int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in)
         return 0;
     }
 
-    if (out->digest == in->digest && in->digest->copyctx != NULL) {
+    if (out->digest == in->digest && in->digest->copyctx != NULL
+        && out->algctx != NULL && in->algctx != NULL) {
 
         in->digest->copyctx(out->algctx, in->algctx);
 


### PR DESCRIPTION
EVP_MD_CTX_copy_ex() might crash on an NULL pointer access when an inconsistent context is copied. This happens when a context is copied where digest is set but algctx is NULL, i.e. due to an incomplete initialization.

The copyctx shortcut for cases where the in and out contexts use the exact same digest call the copyctx function attempting to copy the algctx, but it does not check if algctx is NULL on the in or out contexts.

Fix this by only taking the copyctx shortcut if algctx is non-NULL on both, in and out. Otherwise use the full copy path which will only duplicate the algctx if it is non-NULL.

Closes: https://github.com/openssl/openssl/issues/31831
