### PR TITLE
keymgmt: declare der_wrap.h dependency for ml_kem_kmgmt.o

### DIFF
--- a/providers/implementations/keymgmt/build.info
+++ b/providers/implementations/keymgmt/build.info
@@ -47,7 +47,7 @@ IF[{- !$disabled{'ml-kem'} -}]
     SOURCE[$TLS_ML_KEM_HYBRID_GOAL]=mlx_kmgmt.c
   ENDIF
   SOURCE[$ML_KEM_GOAL]=ml_kem_kmgmt.c
-  DEPEND[ml_kem_kmgmt.o]=../../common/include/prov/der_hkdf.h
+  DEPEND[ml_kem_kmgmt.o]=../../common/include/prov/der_hkdf.h ../../common/include/prov/der_wrap.h
 ENDIF
 
 SOURCE[$RSA_GOAL]=rsa_kmgmt.c


### PR DESCRIPTION
ml_kem_kmgmt.c includes two generated DER headers:

    #include "prov/der_hkdf.h"
    #include "prov/der_wrap.h"

but the build.info only declares a dependency on der_hkdf.h. There is therefore no ordering edge between the generation of der_wrap.h and the compilation of ml_kem_kmgmt.o.

On a serial build der_wrap.h happens to be generated before the object is compiled, so the omission is harmless. Under a parallel build (make -j) it races, and when the compile wins the build fails with:

    providers/implementations/keymgmt/ml_kem_kmgmt.c:
        fatal error: prov/der_wrap.h: No such file or directory

Add the missing dependency so der_wrap.h is always generated first.