### PR TITLE
openssl.cnf: Suggest provider configuration directory

### DIFF
--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -81,6 +81,13 @@ default = default_sect
 [default_sect]
 # activate = 1
 
+# Provider Configuration Directory
+# To aid in deployment of providers, place configuration snippets
+# in this directory. Each snippet must include the [ provider_sect ]
+# and its own provider section. Note that if providers are configured,
+# the default provider may need to be enabled (see above).
+# .include /etc/pki/tls/providers.d
+
 
 ####################################################################
 [ ca ]

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -84,8 +84,8 @@ default = default_sect
 # Provider Configuration Directory
 # To aid in deployment of providers, place configuration snippets
 # in this directory. Each snipped must include the [ provider_sect ]
-# and its own provider section. Note  Note that if providers are configured,
-# the default prfault provider may need to be enabled (see above).
+# and its own provider section. Note that if providers are configured,
+# the default provider may need to be enabled (see above).
 # .include ./providers.d
 
 ####################################################################

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -81,6 +81,12 @@ default = default_sect
 [default_sect]
 # activate = 1
 
+# Provider Configuration Directory
+# To aid in deployment of providers, place configuration snippets
+# in this directory. Each snipped must include the [ provider_sect ]
+# and its own provider section. Note  Note that if providers are configured,
+# the default prfault provider may need to be enabled (see above).
+# .include ./providers.d
 
 ####################################################################
 [ ca ]

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -83,7 +83,7 @@ default = default_sect
 
 # Provider Configuration Directory
 # To aid in deployment of providers, place configuration snippets
-# in this directory. Each snipped must include the [ provider_sect ]
+# in this directory. Each snippet must include the [ provider_sect ]
 # and its own provider section. Note that if providers are configured,
 # the default provider may need to be enabled (see above).
 # .include ./providers.d

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -86,7 +86,7 @@ default = default_sect
 # in this directory. Each snippet must include the [ provider_sect ]
 # and its own provider section. Note that if providers are configured,
 # the default provider may need to be enabled (see above).
-# .include ./providers.d
+# .include ./etc/pki/tls/providers.d
 
 ####################################################################
 [ ca ]


### PR DESCRIPTION
This adds a suggested include directory for provider configurations. It is disabled by default; Downstream distributions may enable it with a simple one-line patch.

Fixes #31835

CLA: trivial
