### PR TITLE
quic: do not hard fail mfail test for old fips providers

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -3643,7 +3643,9 @@ static int test_quic_handshake_multipkt_mfail(void)
         quic_advance_time(clientssl, serverssl);
     }
     if (!TEST_int_lt(i, 10)) {
-        ret = -1;
+        ret = is_fips && fips_provider_version_match(libctx, ">=3.5.0 <4.1.0")
+            ? 0
+            : -1;
         goto err;
     }
 


### PR DESCRIPTION
This is because ML-KEM change from #31432 is not backported there.

This is alternative fix for https://github.com/openssl/openssl/issues/31864 and keeps the condition still tested for majority of other tests.