### PR TITLE
Fix capitalization in OpenSSL description CLA: Trivial

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The OpenSSL toolkit includes:
   basis of the TLS implementation, but can also be used independently.
 
 - **openssl**
-  the OpenSSL command line tool, a swiss army knife for cryptographic tasks,
+  the OpenSSL command line tool, a Swiss Army knife for cryptographic tasks,
   testing and analyzing. It can be used for
   - creation of key parameters
   - creation of X.509 certificates, CSRs and CRLs


### PR DESCRIPTION
Corrected the capitalization of 'Swiss' in the README.md
"Swiss army knife" is derived from the word Switzerland, therefore it must be capitalized

##### Checklist
- [x] documentation is added or updated


CLA: trivial