### PR TITLE
Fix SM2 RISC-V64 crash from functions emitted into .rodata

### DIFF
--- a/crypto/ec/asm/ecp_sm2p256-riscv64.pl
+++ b/crypto/ec/asm/ecp_sm2p256-riscv64.pl
@@ -366,7 +366,7 @@ $code.=<<___;
 .type .Lord_div_2,\@object
 .Lord_div_2:
 .dword	0xa9ddfa049ceaa092,0xb901efb590e30295,0xffffffffffffffff,0x7fffffff7fffffff
-
+.previous
 
 // void bn_rshift1(BN_ULONG *a);
 .globl	bn_rshift1


### PR DESCRIPTION
The `ecp_sm2p256-riscv64.pl` generator switches to `.section .rodata` to emit constant data (`.Lpoly`, `.Lord`, `.Lpoly_div_2`, `.Lord_div_2`), but never switches back before emitting function code.

As a result, the function symbols defined by this file are assembled into `.rodata` instead of executable `.text`. On systems enforcing NX for `.rodata`, calling the RISC-V64 SM2 assembly faults immediately.

Fix this by adding `.previous` after the constant block, restoring the initial `.text` section before function emission.

Verified with `readelf`:

Before the fix:
- `.text` is empty
- constants and function symbols are in `.rodata`
- relocations are against `.rodata`

After the fix:
- constants remain in `.rodata`
- function symbols are in executable `.text`
- relocations are against `.text`

Reproduced under `qemu-riscv64`: the original object crashes on the first function call and the fixed object passes the SM2 RISC-V64 functional tests.

Introduced in commit 05301b100f (PR #25918).

This also affects the 4.0 branch and should be considered for backport.

Discovered while reviewing PR #31873 (RISC-V64 NIST P-256 assembly).