### PR TITLE
NULL-pointer subtraction UB in tls_collect_extensions()

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -857,6 +857,11 @@ int tls_collect_extensions(SSL_CONNECTION *s, PACKET *packet,
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_BAD_EXTENSION);
             goto err;
         }
+
+        /* The server must tolerate the unknown extension and complete. */
+        if (thisex == NULL)
+            continue;
+
         idx = (unsigned int)(thisex - raw_extensions);
         /*-
          * Check that we requested this extension (if appropriate). Requests can
@@ -887,17 +892,15 @@ int tls_collect_extensions(SSL_CONNECTION *s, PACKET *packet,
                 SSL_R_UNSOLICITED_EXTENSION);
             goto err;
         }
-        if (thisex != NULL) {
-            thisex->data = extension;
-            thisex->present = 1;
-            thisex->type = type;
-            thisex->received_order = i++;
-            if (s->ext.debug_cb)
-                s->ext.debug_cb(SSL_CONNECTION_GET_USER_SSL(s), !s->server,
-                    thisex->type, PACKET_data(&thisex->data),
-                    (int)PACKET_remaining(&thisex->data),
-                    s->ext.debug_arg);
-        }
+        thisex->data = extension;
+        thisex->present = 1;
+        thisex->type = type;
+        thisex->received_order = i++;
+        if (s->ext.debug_cb)
+            s->ext.debug_cb(SSL_CONNECTION_GET_USER_SSL(s), !s->server,
+                thisex->type, PACKET_data(&thisex->data),
+                (int)PACKET_remaining(&thisex->data),
+                s->ext.debug_arg);
     }
 
     if (init) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12868,6 +12868,51 @@ end:
     SSL_CTX_free(cctx);
     return testresult;
 }
+
+static int un_ext_add_cb(SSL *s, unsigned int ext_type,
+    unsigned int context, const unsigned char **out, size_t *outlen, X509 *x,
+    size_t chainidx, int *al, void *add_arg)
+{
+    static const unsigned char data[] = { 0xaa };
+    *out = data;
+    *outlen = sizeof(data);
+    return 1;
+}
+
+static int un_ext_parse_cb(SSL *s, unsigned int ext_type,
+    unsigned int context, const unsigned char *in, size_t inlen, X509 *x,
+    size_t chainidx, int *al, void *parse_arg)
+{
+    return 1;
+}
+
+/*
+ * Test that a handshake succeeds when the peer sends an extension type we do
+ * not recognise. The client registers a custom extension in its ClientHello
+ * that the server knows nothing about, so on the server tls_collect_extensions()
+ * takes the "unknown extension" branch.
+ */
+static int test_tls13_unknown_extension(void)
+{
+    SSL_CTX *s = NULL, *c = NULL;
+    SSL *s_ssl = NULL, *c_ssl = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+               TLS_client_method(), TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, privkey))
+        && TEST_true(SSL_CTX_add_custom_ext(c, 0xfefe, SSL_EXT_CLIENT_HELLO,
+            un_ext_add_cb, NULL, NULL, un_ext_parse_cb, NULL))
+        && TEST_true(create_ssl_objects(s, c, &s_ssl, &c_ssl, NULL, NULL))
+        /* The server must tolerate the unknown extension and complete. */
+        && TEST_true(create_ssl_connection(s_ssl, c_ssl, SSL_ERROR_NONE));
+
+    SSL_free(s_ssl);
+    SSL_free(c_ssl);
+    SSL_CTX_free(s);
+    SSL_CTX_free(c);
+    return test;
+}
+
 #endif /* OSSL_NO_USABLE_TLS1_3 */
 
 static int check_version_string(SSL *s, int version)
@@ -15327,6 +15372,7 @@ int setup_tests(void)
 #ifndef OSSL_NO_USABLE_TLS1_3
     ADD_TEST(test_read_ahead_key_change);
     ADD_ALL_TESTS(test_tls13_record_padding, 6);
+    ADD_TEST(test_tls13_unknown_extension);
 #endif
 #if !defined(OPENSSL_NO_TLS1_2) && !defined(OSSL_NO_USABLE_TLS1_3)
     ADD_ALL_TESTS(test_serverinfo_custom, 4);


### PR DESCRIPTION
Fixed invalid-pointer-pair in the existing branch by ensuring thisex != NULL before subtraction.

- When two pointers are subtracted, both shall point to elements of the same array object, or one past the last element of the array object; the result is the difference of the subscripts of the two array elements. The size of the result is implementation-defined, and its type (a signed integer type) is ptrdiff_t defined in the [<stddef.h>](https://oifans.cn/docs/c11/n1570.html?utm_source=chatgpt.com#7.19) header. If the result is not representable in an object of that type, the behavior is undefined.

https://oifans.cn/docs/c11/n1570.html?utm_source=chatgpt.com#6.5.6p9

```
./Configure -fsanitize=address -fsanitize=pointer-subtract -fsanitize=pointer-compare
ASAN_OPTIONS=detect_invalid_pointer_pairs=2:halt_on_error=1 make TESTS=test_sslapi test

#16 0xc10c251aceac in _start (/hdd/osf/git/openssl/test/sslapitest+0x26ceac) (BuildId: 0d3aa290c3595f2e939f451fcc1d3c7cea0b1a1a)
SUMMARY: AddressSanitizer: invalid-pointer-pair ssl/statem/extensions.c:860 in tls_collect_extensions
```

Fixes #31689


