### PR TITLE
Fix doubled semicolons as statement terminations

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -1254,25 +1254,21 @@ static int prompt_info(X509_REQ *req,
 
                 if (!join(buf, sizeof(buf), type, "_value", "Name"))
                     goto err;
-                ;
                 value = app_conf_try_string(req_conf, attr_sect, buf);
 
                 if (!join(buf, sizeof(buf), type, "_min", "Name"))
                     goto err;
-                ;
                 if (!app_conf_try_number(req_conf, attr_sect, buf, &n_min))
                     n_min = -1;
 
                 if (!join(buf, sizeof(buf), type, "_max", "Name"))
                     goto err;
-                ;
                 if (!app_conf_try_number(req_conf, attr_sect, buf, &n_max))
                     n_max = -1;
                 if (!add_attribute_object(req,
                         v->value, def, value, nid, n_min,
                         n_max, chtype))
                     goto err;
-                ;
             }
         }
     } else {

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5588,7 +5588,6 @@ long ossl_quic_callback_ctrl(SSL *s, int cmd, void (*fp)(void))
             &ctx.qc->obj.ssl);
         /* This callback also needs to be set on the internal SSL object */
         return ssl3_callback_ctrl(ctx.qc->tls, cmd, fp);
-        ;
 
     default:
         /* Probably a TLS related ctrl. Defer to our internal SSL object */


### PR DESCRIPTION
Initially noticed while running [`checkpatch.pl`](https://github.com/torvalds/linux/blob/master/scripts/checkpatch.pl) before the code was reformatted with `clang-format`. See  49e4d2b5d5fa669d42825c03ab75212dc674f29c.

In this PR, I fix all occurrences of such doubled semicolons.

**Edit:** Mmmh... I found it funny to name my branch **`;`**. Obviously not a good idea, but then take this as an opportunity to harden CI scripts :smile: