### PR TITLE
EVP_CTRL_AEAD_SET_IV_FIXED: reject negative arg values below -1

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -986,6 +986,10 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
         ctx->iv_len = -1;
         break;
     case EVP_CTRL_AEAD_SET_IV_FIXED:
+        /* arg=-1 is a valid sentinel meaning "use full ivlen"; anything
+         * below that would wrap to a huge size_t and overflow on memcpy. */
+        if (arg < -1)
+            return 0;
         params[0] = OSSL_PARAM_construct_octet_string(
             OSSL_CIPHER_PARAM_AEAD_TLS1_IV_FIXED, ptr, sz);
         break;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -986,8 +986,10 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
         ctx->iv_len = -1;
         break;
     case EVP_CTRL_AEAD_SET_IV_FIXED:
-        /* arg=-1 is a valid sentinel meaning "use full ivlen"; anything
-         * below that would wrap to a huge size_t and overflow on memcpy. */
+        /*
+         * arg == -1 is a valid sentinel meaning "use full ivlen"; anything
+         * below that would wrap to a huge size_t and overflow on memcpy.
+         */
         if (arg < -1)
             return 0;
         params[0] = OSSL_PARAM_construct_octet_string(

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -525,8 +525,9 @@ static int gcm_tls_iv_set_fixed(PROV_GCM_CTX *ctx, unsigned char *iv,
         return 1;
     }
     /* Fixed field must be at least 4 bytes and invocation field at least 8 */
-    if ((len < EVP_GCM_TLS_FIXED_IV_LEN)
-        || (ctx->ivlen - (int)len) < EVP_GCM_TLS_EXPLICIT_IV_LEN)
+    if (len < EVP_GCM_TLS_FIXED_IV_LEN
+        || len > ctx->ivlen
+        || (ctx->ivlen - len) < EVP_GCM_TLS_EXPLICIT_IV_LEN)
         return 0;
     if (len > 0)
         memcpy(ctx->iv, iv, len);


### PR DESCRIPTION
EVP_CIPHER_CTX_ctrl() converts int arg to size_t at the top of the
function before dispatching. For EVP_CTRL_AEAD_SET_IV_FIXED the value
-1 is a valid sentinel (copy full IV), but any value below -1 wraps
silently to a near-SIZE_MAX size_t. The existing guards in
gcm_tls_iv_set_fixed() do not catch this: the sentinel check tests
only for SIZE_MAX, and the bounds check uses an (int) back-cast that
undoes the wrap, allowing memcpy to be called with a near-SIZE_MAX
length.

Add the missing guard in the EVP_CTRL_AEAD_SET_IV_FIXED case,
consistent with the pattern already used for EVP_CTRL_SET_KEY_LENGTH,
EVP_CTRL_AEAD_SET_IVLEN, EVP_CTRL_GCM_SET_IV_INV and others.

As defense-in-depth, also replace the (int) back-cast in
gcm_tls_iv_set_fixed() with a safe size_t upper-bound check so the
provider rejects any out-of-range length independently of the caller.