### PR TITLE
Allow `getentropy` for Emscripten

### DIFF
--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -396,7 +396,7 @@ static ssize_t syscall_random(void *buf, size_t buflen)
     return getrandom(buf, buflen, 0);
 #elif (defined(__FreeBSD__) || defined(__NetBSD__)) && defined(KERN_ARND)
     return sysctl_random(buf, buflen);
-#elif defined(__wasi__)
+#elif defined(__wasi__) || defined(__EMSCRIPTEN__)
     if (getentropy(buf, buflen) == 0)
         return (ssize_t)buflen;
     return -1;


### PR DESCRIPTION
Usually Emscripten emulates `/dev/urandom`, but in some cases, like with `-sNODERAWFS`, it doesn't. This means that on non-Unix platforms, where `/dev/urandom` does not exist on the host, OpenSSL will fail to seed its PRNG. This fixes that by instead using the POSIX function `getentropy` that it implements, like which was already done for WASI.
See https://github.com/emscripten-core/emscripten/issues/9628#issuecomment-4892658766 for more context.

I tested that this indeed fixes the problem. Since I don't normally use Windows for development myself, I tested on Linux with `--with-rand-seed=getrandom`, thus disabling `/dev/urandom` usage, which means it fails before this patch.

I based this on the 3.6 branch such that this can be merged into both v3 and v4, but tell me if you have a different procedure for this. Should the target branch stay `openssl-3.6`?