### PR TITLE
OSSL_FN: unwrap BIGNUM add/sub/mul/sqr/shift/compare functions

### DIFF
--- a/crypto/bn/bn_add.c
+++ b/crypto/bn/bn_add.c
@@ -10,16 +10,6 @@
 #include "internal/cryptlib.h"
 #include "bn_local.h"
 
-static size_t calculate_max_top(const BIGNUM *a, const BIGNUM *b)
-{
-    return (a->top > b->top) ? a->top : b->top;
-}
-
-static bool is_highest_bit_set(const BIGNUM *a)
-{
-    return a->top > 0 && (a->d[a->top - 1] & OSSL_FN_HIGH_BIT_MASK) != 0;
-}
-
 /* signed add of b to a. */
 int BN_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
 {
@@ -82,9 +72,8 @@ int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
     return ret;
 }
 
-/* TODO(FIXNUM): TO BE REMOVED */
-/* pure BIGNUM unsigned add of b to a, r can be equal to a or b. */
-static int bn_uadd_legacy(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
+/* unsigned add of b to a, r can be equal to a or b. */
+int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
 {
     int max, min, dif;
     const BN_ULONG *ap, *bp;
@@ -132,38 +121,8 @@ static int bn_uadd_legacy(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
     return 1;
 }
 
-/* unsigned add of b to a, r can be equal to a or b. */
-int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
-{
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (r->data == NULL || a->data == NULL || b->data == NULL)
-        return bn_uadd_legacy(r, a, b);
-
-    bn_check_top(a);
-    bn_check_top(b);
-
-    size_t top = calculate_max_top(a, b);
-
-    /*
-     * If either operands have the highest bit set the result may become
-     * one limb larger.
-     */
-    if (is_highest_bit_set(a) || is_highest_bit_set(b))
-        top++;
-
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
-    if (rf == NULL)
-        return 0;
-
-    int ret = OSSL_FN_add(rf, a->data, b->data);
-    bn_release(r, (int)top);
-
-    return ret;
-}
-
-/* TODO(FIXNUM): TO BE REMOVED */
-/* pure BIGNUM unsigned subtraction of b from a, a must be larger than b. */
-static int bn_usub_legacy(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
+/* unsigned subtraction of b from a, a must be larger than b. */
+int BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
 {
     int max, min, dif;
     BN_ULONG t1, t2, borrow, *rp;
@@ -207,31 +166,4 @@ static int bn_usub_legacy(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
     r->neg = 0;
 
     return 1;
-}
-
-/* unsigned subtraction of b from a, a must be larger than b. */
-int BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
-{
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (r->data == NULL || a->data == NULL || b->data == NULL)
-        return bn_usub_legacy(r, a, b);
-
-    bn_check_top(a);
-    bn_check_top(b);
-
-    if (a->top < b->top) { /* hmm... should not be happening */
-        ERR_raise(ERR_LIB_BN, BN_R_ARG2_LT_ARG3);
-        return 0;
-    }
-
-    size_t top = calculate_max_top(a, b);
-
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
-    if (rf == NULL)
-        return 0;
-
-    int ret = OSSL_FN_sub(rf, a->data, b->data);
-    bn_release(r, (int)top);
-
-    return ret;
 }

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -183,34 +183,26 @@ static ossl_inline int bn_num_bits_consttime(const BIGNUM *a)
 
 int BN_num_bits(const BIGNUM *a)
 {
+    int i = a->top - 1;
     bn_check_top(a);
 
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (a->data == NULL) {
-        int i = a->top - 1;
-
-        if (a->flags & BN_FLG_CONSTTIME) {
-            /*
-             * We assume that BIGNUMs flagged as CONSTTIME have also been expanded
-             * so that a->dmax is not leaking secret information.
-             *
-             * In other words, it's the caller's responsibility to ensure `a` has
-             * been preallocated in advance to a public length if we hit this
-             * branch.
-             *
-             */
-            return bn_num_bits_consttime(a);
-        }
-
-        if (ossl_unlikely(BN_is_zero(a)))
-            return 0;
-
-        return ((i * BN_BITS2) + BN_num_bits_word(a->d[i]));
+    if (a->flags & BN_FLG_CONSTTIME) {
+        /*
+         * We assume that BIGNUMs flagged as CONSTTIME have also been expanded
+         * so that a->dmax is not leaking secret information.
+         *
+         * In other words, it's the caller's responsibility to ensure `a` has
+         * been preallocated in advance to a public length if we hit this
+         * branch.
+         *
+         */
+        return bn_num_bits_consttime(a);
     }
 
-    size_t bits = OSSL_FN_num_bits(a->data);
+    if (ossl_unlikely(BN_is_zero(a)))
+        return 0;
 
-    return bits > INT_MAX ? INT_MAX : (int)bits;
+    return ((i * BN_BITS2) + BN_num_bits_word(a->d[i]));
 }
 
 static void bn_free_d(BIGNUM *a, bool clear)
@@ -744,49 +736,46 @@ int BN_signed_bn2native(const BIGNUM *a, unsigned char *to, int tolen)
 
 int BN_ucmp(const BIGNUM *a, const BIGNUM *b)
 {
+    int i;
+    BN_ULONG t1, t2, *ap, *bp;
+
+    ap = a->d;
+    bp = b->d;
+
+    if (BN_get_flags(a, BN_FLG_CONSTTIME)
+        && a->top == b->top) {
+        int res = 0;
+
+        for (i = 0; i < b->top; i++) {
+            res = constant_time_select_int((int)constant_time_lt_bn(ap[i], bp[i]),
+                -1, res);
+            res = constant_time_select_int((int)constant_time_lt_bn(bp[i], ap[i]),
+                1, res);
+        }
+        return res;
+    }
+
     bn_check_top(a);
     bn_check_top(b);
 
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (a->data == NULL || b->data == NULL) {
-        int i;
-        BN_ULONG t1, t2, *ap, *bp;
+    i = a->top - b->top;
+    if (i != 0)
+        return i;
 
-        ap = a->d;
-        bp = b->d;
-
-        if (BN_get_flags(a, BN_FLG_CONSTTIME)
-            && a->top == b->top) {
-            int res = 0;
-
-            for (i = 0; i < b->top; i++) {
-                res = constant_time_select_int((int)constant_time_lt_bn(ap[i], bp[i]),
-                    -1, res);
-                res = constant_time_select_int((int)constant_time_lt_bn(bp[i], ap[i]),
-                    1, res);
-            }
-            return res;
-        }
-
-        i = a->top - b->top;
-        if (i != 0)
-            return i;
-
-        for (i = a->top - 1; i >= 0; i--) {
-            t1 = ap[i];
-            t2 = bp[i];
-            if (t1 != t2)
-                return ((t1 > t2) ? 1 : -1);
-        }
-        return 0;
+    for (i = a->top - 1; i >= 0; i--) {
+        t1 = ap[i];
+        t2 = bp[i];
+        if (t1 != t2)
+            return ((t1 > t2) ? 1 : -1);
     }
-
-    return OSSL_FN_cmp(a->data, b->data);
+    return 0;
 }
 
 int BN_cmp(const BIGNUM *a, const BIGNUM *b)
 {
+    int i;
     int gt, lt;
+    BN_ULONG t1, t2;
 
     if ((a == NULL) || (b == NULL)) {
         if (a != NULL)
@@ -814,31 +803,17 @@ int BN_cmp(const BIGNUM *a, const BIGNUM *b)
         lt = 1;
     }
 
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (a->data == NULL || b->data == NULL) {
-        int i;
-        BN_ULONG t1, t2;
-
-        if (a->top > b->top)
-            return gt;
-        if (a->top < b->top)
-            return lt;
-        for (i = a->top - 1; i >= 0; i--) {
-            t1 = a->d[i];
-            t2 = b->d[i];
-            if (t1 > t2)
-                return gt;
-            if (t1 < t2)
-                return lt;
-        }
-        return 0;
-    }
-
-    switch (OSSL_FN_cmp(a->data, b->data)) {
-    case 1:
+    if (a->top > b->top)
         return gt;
-    case -1:
+    if (a->top < b->top)
         return lt;
+    for (i = a->top - 1; i >= 0; i--) {
+        t1 = a->d[i];
+        t2 = b->d[i];
+        if (t1 > t2)
+            return gt;
+        if (t1 < t2)
+            return lt;
     }
     return 0;
 }

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -13,45 +13,11 @@
 
 int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
 {
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (r->data == NULL || a->data == NULL || b->data == NULL) {
-        int ret = bn_mul_fixed_top(r, a, b, ctx);
+    int ret = bn_mul_fixed_top(r, a, b, ctx);
 
-        bn_correct_top(r);
-        bn_check_top(r);
-
-        return ret;
-    }
-
-    bn_check_top(a);
-    bn_check_top(b);
+    bn_correct_top(r);
     bn_check_top(r);
 
-    /*
-     * Acquiring rf may make r larger.
-     * If r == a, then a will also become larger.  Therefore, max must
-     * be calculated after rf has been acquired.
-     */
-    size_t top = a->top + b->top;
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
-    if (rf == NULL)
-        return 0;
-
-    size_t max = a->dmax + b->dmax;
-
-    OSSL_FN_CTX *fnctx = bn_ctx_acquire_ossl_fn_ctx(ctx, 1, 1, max);
-    if (fnctx == NULL) {
-        bn_release(r, r->top);
-        return 0;
-    }
-
-    int ret = OSSL_FN_mul(rf, a->data, b->data, fnctx);
-    bn_release(r, (int)top);
-
-    if (ret && !BN_is_zero(r))
-        r->neg = a->neg ^ b->neg;
-
-    bn_ctx_release_ossl_fn_ctx(ctx);
     return ret;
 }
 

--- a/crypto/bn/bn_shift.c
+++ b/crypto/bn/bn_shift.c
@@ -13,46 +13,33 @@
 
 int BN_lshift1(BIGNUM *r, const BIGNUM *a)
 {
+    register BN_ULONG *ap, *rp, t, c;
+    int i;
+
     bn_check_top(r);
     bn_check_top(a);
 
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (r->data == NULL || a->data == NULL) {
-        register BN_ULONG *ap, *rp, t, c;
-        int i;
-
-        if (r != a) {
-            r->neg = a->neg;
-            if (bn_wexpand(r, a->top + 1) == NULL)
-                return 0;
-            bn_set_top(r, a->top);
-        } else {
-            if (bn_wexpand(r, a->top + 1) == NULL)
-                return 0;
-        }
-        ap = a->d;
-        rp = r->d;
-        c = 0;
-        for (i = 0; i < a->top; i++) {
-            t = *(ap++);
-            *(rp++) = ((t << 1) | c) & BN_MASK2;
-            c = t >> (BN_BITS2 - 1);
-        }
-        *rp = c;
-        bn_set_top(r, r->top + (int)c);
-        bn_check_top(r);
-        return 1;
+    if (r != a) {
+        r->neg = a->neg;
+        if (bn_wexpand(r, a->top + 1) == NULL)
+            return 0;
+        bn_set_top(r, a->top);
+    } else {
+        if (bn_wexpand(r, a->top + 1) == NULL)
+            return 0;
     }
-
-    size_t top = a->top + 1;
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
-    if (rf == NULL)
-        return 0;
-    int ret = OSSL_FN_lshift1(rf, a->data);
-    bn_release(r, (int)top);
-
-    BN_set_negative(r, ret && a->neg);
-    return ret;
+    ap = a->d;
+    rp = r->d;
+    c = 0;
+    for (i = 0; i < a->top; i++) {
+        t = *(ap++);
+        *(rp++) = ((t << 1) | c) & BN_MASK2;
+        c = t >> (BN_BITS2 - 1);
+    }
+    *rp = c;
+    bn_set_top(r, r->top + (int)c);
+    bn_check_top(r);
+    return 1;
 }
 
 int BN_rshift1(BIGNUM *r, const BIGNUM *a)
@@ -99,27 +86,11 @@ int BN_lshift(BIGNUM *r, const BIGNUM *a, int n)
         return 0;
     }
 
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (r->data == NULL || a->data == NULL) {
-        ret = bn_lshift_fixed_top(r, a, n);
+    ret = bn_lshift_fixed_top(r, a, n);
 
-        bn_correct_top(r);
-        bn_check_top(r);
-
-        return ret;
-    }
-
+    bn_correct_top(r);
     bn_check_top(r);
-    bn_check_top(a);
 
-    size_t top = a->top + n / BN_BITS2 + 1;
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
-    if (rf == NULL)
-        return 0;
-    ret = OSSL_FN_lshift(rf, a->data, n);
-    bn_release(r, (int)top);
-
-    BN_set_negative(r, ret && a->neg);
     return ret;
 }
 

--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -16,42 +16,11 @@
  */
 int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
 {
-    /* TODO(FIXNUM): TO BE REMOVED */
-    if (r->data == NULL || a->data == NULL) {
-        int ret = bn_sqr_fixed_top(r, a, ctx);
+    int ret = bn_sqr_fixed_top(r, a, ctx);
 
-        bn_correct_top(r);
-        bn_check_top(r);
-
-        return ret;
-    }
-
-    bn_check_top(a);
+    bn_correct_top(r);
     bn_check_top(r);
 
-    /*
-     * Acquiring rf may make r larger.
-     * If r == a, then a will also become larger.  Therefore, max must
-     * be calculated after rf has been acquired.
-     */
-    size_t top = a->top * 2;
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
-    if (rf == NULL)
-        return 0;
-
-    size_t max = a->dmax * 2;
-
-    OSSL_FN_CTX *fnctx = bn_ctx_acquire_ossl_fn_ctx(ctx, 1, 2, max * 4);
-    if (fnctx == NULL) {
-        bn_release(r, r->top);
-        return 0;
-    }
-
-    int ret = OSSL_FN_sqr(rf, a->data, fnctx);
-    bn_release(r, (int)top);
-    r->neg = 0;
-
-    bn_ctx_release_ossl_fn_ctx(ctx);
     return ret;
 }
 


### PR DESCRIPTION
This removes the BN_xxx → OSSL_FN_xxx call-site wrapping introduced on
`feature/ossl_fn` and restores the BN operators' own top-aware
implementations. BN→OSSL_FN conversion is intended to move to the
top-level crypto call sites instead (parent issue openssl/project#2018);
this PR is sub-issue openssl/project#2020.

## What's done

Four commits, one per original wrapper. Each is a wholesale restore of
the affected file(s) to the wrapper's parent, so the wrapper and all the
in-body tuning that landed on top of it are folded away together:

- `OSSL_FN: unwrap the BIGNUM 'add' and 'sub' functions`
  undoes e3ae863a2d, plus 3eb0b45e63 and the add/sub portion of
  cbc3f0b448.
- `OSSL_FN: unwrap the BIGNUM 'mul' function`
  undoes 8f77f825fa, plus 06bc8339d9 and the mul portions of a7b662c282
  and cbc3f0b448.
- `OSSL_FN: unwrap the BIGNUM 'sqr' function`
  undoes f52bf9d167, plus 1763d6aff3 and the sqr portions of a7b662c282
  and cbc3f0b448.
- `OSSL_FN: unwrap the BIGNUM shift and compare functions`
  undoes 5072424737, plus 1a87fdb411. Restores BN_num_bits, BN_ucmp,
  BN_cmp, BN_lshift1 and BN_lshift to their pre-wrap single-path form.

## What stays

- The conversion helpers `bn_acquire_ossl_fn()` / `bn_release()` in
  `crypto/bn/bn_local.h` — still needed for top-level conversion.
- Foundational BIGNUM hardening that was bundled into wrapper commits but
  is unrelated to wrapping: the `BN_MAX_WORDS` bound in
  `bn_expand_internal()` and the `bn_check_top()` dmax assert (both from
  e3ae863a2d). These are preserved, not reverted.

## Tests

Built with `--debug --strict-warnings -DBN_DEBUG`; full `make test` passes
(373 files, 4409 tests).

The incidental OSSL_FN coverage the wrappers provided is gone with them.
It is replaced by the bntest-data-driven OSSL_FN test from sub-issue
openssl/project#2021 (separate PR); coverage parity between the lost
bntest coverage and the new fntest coverage is being checked in a
throwaway merge of the two branches (out of scope for this PR).

## Dependencies / context

- Parent issue: https://github.com/openssl/project/issues/2018
- Sub-issue:    https://github.com/openssl/project/issues/2020
- Builds on the design-doc decoupling change openssl/project#2019 (PR
  openssl/openssl#31847), currently in review. This PR is a head start
  and may need adjustment if #2019's review changes the wrapping
  direction.

Issue: https://github.com/openssl/project/issues/2020
Assisted-by: Pi:z-ai/glm-5.2
