### PR TITLE
apps: test dsa app -modulus option

### DIFF
--- a/test/recipes/15-test_dsa.t
+++ b/test/recipes/15-test_dsa.t
@@ -17,7 +17,7 @@ use OpenSSL::Test::Utils;
 setup("test_dsa");
 
 plan skip_all => 'DSA is not supported in this build' if disabled('dsa');
-plan tests => 9;
+plan tests => 10;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -59,6 +59,34 @@ SKIP: {
                                "-provider", "legacy"] );
     };
 }
+
+subtest "dsa -modulus prints the DSA public value" => sub {
+    plan tests => 2;
+
+    # The public value (y) of the committed testdsa.pem / testdsapub.pem
+    # keypair, i.e. the "pub:" field of 'openssl pkey -text'.
+    my $expected = "Public Key=CC99A07D9817BFF03BB09B183E9B19EB77ABECF192"
+        . "C3A9FBA833DBE69EDB719A8E9777BB82736CEC6A8E4E2FAD0693ACC3D1456"
+        . "5D62710B95B02CC6A5CF091EEF9C22F20193EBE114C45A0B5E54A645037E8"
+        . "787FE01B3871508A25BDBF7C6B81428F89858F133FDB858C390C2EF7BCF7E"
+        . "41D7C66578F792A2488C787EF7C7D41";
+
+    my @priv = run(app(['openssl', 'dsa', '-modulus', '-noout',
+                        '-in', srctop_file("test", "testdsa.pem")],
+                       stderr => undef),
+                   capture => 1);
+    chomp @priv;
+    ok(grep(/^\Q$expected\E$/, @priv),
+       "-modulus prints the expected public value for a private key");
+
+    my @pub = run(app(['openssl', 'dsa', '-pubin', '-modulus', '-noout',
+                       '-in', srctop_file("test", "testdsapub.pem")],
+                      stderr => undef),
+                  capture => 1);
+    chomp @pub;
+    ok(grep(/^\Q$expected\E$/, @pub),
+       "-modulus prints the expected public value for a public key");
+};
 
 subtest "dsa PVK output is rejected for public key input" => sub {
     plan tests => 1;


### PR DESCRIPTION
Add coverage for the -modulus option of the dsa app, checking the public value is printed for both private and public key input.

Assisted-by: Claude:claude-opus-4-8
