### PR TITLE
apps: test dsaparam app DER output paths

### DIFF
--- a/test/recipes/15-test_dsaparam.t
+++ b/test/recipes/15-test_dsaparam.t
@@ -68,7 +68,7 @@ plan skip_all => "DSA isn't supported in this build"
 my @valid = glob(data_file("valid", "*.pem"));
 my @invalid = glob(data_file("invalid", "*.pem"));
 
-my $num_tests = scalar @valid + scalar @invalid + 2;
+my $num_tests = scalar @valid + scalar @invalid + 4;
 plan tests => $num_tests;
 
 foreach (@valid) {
@@ -85,3 +85,32 @@ copy($input, $inout);
 ok(run(app(['openssl', 'dsaparam', '-in', $inout, '-out', $inout])),
     "identical infile and outfile");
 ok(!compare_text($input, $inout), "converted file $inout did not change");
+
+# Cover the DER (ASN.1) output paths of the dsaparam app.
+my $srcparams = data_file("valid", "p1024_q160_t1862.pem");
+my $params_der = "dsaparam.der";
+my $key_der = "dsakey.der";
+
+subtest "dsaparam DER parameter output" => sub {
+    plan tests => 2;
+
+    # Exercises i2d_KeyParams_bio().
+    ok(run(app(['openssl', 'dsaparam', '-in', $srcparams,
+                '-outform', 'DER', '-out', $params_der])),
+       "write DSA parameters in DER form");
+    ok(run(app(['openssl', 'dsaparam', '-inform', 'DER', '-in', $params_der,
+                '-noout'])),
+       "read the DER DSA parameters back");
+};
+
+subtest "dsaparam DER private key output with -genkey" => sub {
+    plan tests => 2;
+
+    # Exercises i2d_PrivateKey_bio().
+    ok(run(app(['openssl', 'dsaparam', '-in', $srcparams, '-genkey',
+                '-outform', 'DER', '-out', $key_der])),
+       "generate a DSA key and write it in DER form");
+    ok(run(app(['openssl', 'pkey', '-inform', 'DER', '-in', $key_der,
+                '-noout', '-check'])),
+       "read the DER DSA private key back");
+};


### PR DESCRIPTION
Add coverage for the DER (ASN.1) output of the dsaparam app, exercising both the parameter output (i2d_KeyParams_bio) and the -genkey private key output (i2d_PrivateKey_bio).

Assisted-by: Claude:claude-opus-4-8
