### PR TITLE
Remove QUIC_TSERVER: Move script_15 to script_19

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2239,44 +2239,7 @@ static const struct script_op script_16[] = {
 
 /* 17. Key update test - unlimited */
 static const struct script_op script_17[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_CHECK(override_key_update, 1),
-
-    OP_BEGIN_REPEAT(200),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    /*
-     * TXKU frequency is bounded by RTT because a previous TXKU needs to be
-     * acknowledged by the peer first before another one can be begin. By
-     * waiting this long, we eliminate any such concern and ensure as many key
-     * updates as possible can occur for the purposes of this test.
-     */
-    OP_CHECK(skip_time_ms, 100),
-
-    OP_END_REPEAT(),
-
-    /* At least 5 RXKUs detected */
-    OP_CHECK(check_key_update_ge, 5),
-
-    /*
-     * Prove the connection is still healthy by sending something in both
-     * directions.
-     */
-    OP_C_WRITE(DEFAULT, "xyzzy", 5),
-    OP_S_READ_EXPECT(a, "xyzzy", 5),
-
-    OP_S_WRITE(a, "plugh", 5),
-    OP_C_READ_EXPECT(DEFAULT, "plugh", 5),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2227,45 +2227,7 @@ static const struct script_op script_14[] = {
 
 /* 15. Client sending large number of streams, MAX_STREAMS test */
 static const struct script_op script_15[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-
-    /*
-     * This will cause a protocol violation to be raised by the server if we are
-     * not handling the stream limit correctly on the TX side.
-     */
-    OP_BEGIN_REPEAT(200),
-
-    OP_C_NEW_STREAM_BIDI_EX(a, ANY_ID, SSL_STREAM_FLAG_ADVANCE),
-    OP_C_WRITE(a, "foo", 3),
-    OP_C_CONCLUDE(a),
-    OP_C_FREE_STREAM(a),
-
-    OP_END_REPEAT(),
-
-    /* Prove the connection is still good. */
-    OP_S_NEW_STREAM_BIDI(a, S_BIDI_ID(0)),
-    OP_S_WRITE(a, "bar", 3),
-    OP_S_CONCLUDE(a),
-
-    OP_C_ACCEPT_STREAM_WAIT(a),
-    OP_C_READ_EXPECT(a, "bar", 3),
-    OP_C_EXPECT_FIN(a),
-
-    /*
-     * Drain the queue of incoming streams. We should be able to get all 200
-     * even though only 100 can be initiated at a time.
-     */
-    OP_BEGIN_REPEAT(200),
-
-    OP_S_ACCEPT_STREAM_WAIT(b),
-    OP_S_READ_EXPECT(b, "foo", 3),
-    OP_S_EXPECT_FIN(b),
-    OP_S_UNBIND_STREAM_ID(b),
-
-    OP_END_REPEAT(),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2233,42 +2233,7 @@ static const struct script_op script_15[] = {
 
 /* 16. Server sending large number of streams, MAX_STREAMS test */
 static const struct script_op script_16[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-
-    /*
-     * This will cause a protocol violation to be raised by the client if we are
-     * not handling the stream limit correctly on the TX side.
-     */
-    OP_BEGIN_REPEAT(200),
-
-    OP_S_NEW_STREAM_BIDI(a, ANY_ID),
-    OP_S_WRITE(a, "foo", 3),
-    OP_S_CONCLUDE(a),
-    OP_S_UNBIND_STREAM_ID(a),
-
-    OP_END_REPEAT(),
-
-    /* Prove that the connection is still good. */
-    OP_C_NEW_STREAM_BIDI(a, ANY_ID),
-    OP_C_WRITE(a, "bar", 3),
-    OP_C_CONCLUDE(a),
-
-    OP_S_ACCEPT_STREAM_WAIT(b),
-    OP_S_READ_EXPECT(b, "bar", 3),
-    OP_S_EXPECT_FIN(b),
-
-    /* Drain the queue of incoming streams. */
-    OP_BEGIN_REPEAT(200),
-
-    OP_C_ACCEPT_STREAM_WAIT(b),
-    OP_C_READ_EXPECT(b, "foo", 3),
-    OP_C_EXPECT_FIN(b),
-    OP_C_FREE_STREAM(b),
-
-    OP_END_REPEAT(),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2191,30 +2191,7 @@ static const struct script_op script_18[] = {
 
 /* 19. Key update test - artificially triggered */
 static const struct script_op script_19[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_C_WRITE(DEFAULT, "orange", 6),
-    OP_S_READ_EXPECT(a, "orange", 6),
-
-    OP_S_WRITE(a, "strawberry", 10),
-    OP_C_READ_EXPECT(DEFAULT, "strawberry", 10),
-
-    OP_CHECK(check_key_update_lt, 1),
-    OP_CHECK(trigger_key_update, 0),
-
-    OP_C_WRITE(DEFAULT, "orange", 6),
-    OP_S_READ_EXPECT(a, "orange", 6),
-    OP_S_WRITE(a, "ok", 2),
-
-    OP_C_READ_EXPECT(DEFAULT, "ok", 2),
-    OP_CHECK(check_key_update_ge, 1),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -356,71 +356,11 @@ static OSSL_TIME get_time(void *arg)
     return t;
 }
 
-static int skip_time_ms(struct helper *h, struct helper_local *hl)
-{
-    if (!TEST_true(CRYPTO_THREAD_write_lock(h->time_lock)))
-        return 0;
-
-    h->time_slip = ossl_time_add(h->time_slip, ossl_ms2time(hl->check_op->arg2));
-
-    CRYPTO_THREAD_unlock(h->time_lock);
-    return 1;
-}
-
 static QUIC_TSERVER *s_lock(struct helper *h, struct helper_local *hl);
 static void s_unlock(struct helper *h, struct helper_local *hl);
 
 #define ACQUIRE_S() s_lock(h, hl)
 #define ACQUIRE_S_NOHL() s_lock(h, NULL)
-
-static int override_key_update(struct helper *h, struct helper_local *hl)
-{
-    QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
-
-    ossl_quic_channel_set_txku_threshold_override(ch, hl->check_op->arg2);
-    return 1;
-}
-
-static int trigger_key_update(struct helper *h, struct helper_local *hl)
-{
-    if (!TEST_true(SSL_key_update(h->c_conn, SSL_KEY_UPDATE_REQUESTED)))
-        return 0;
-
-    return 1;
-}
-
-static int check_key_update_ge(struct helper *h, struct helper_local *hl)
-{
-    QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
-    int64_t txke = (int64_t)ossl_quic_channel_get_tx_key_epoch(ch);
-    int64_t rxke = (int64_t)ossl_quic_channel_get_rx_key_epoch(ch);
-    int64_t diff = txke - rxke;
-
-    /*
-     * TXKE must always be equal to or ahead of RXKE.
-     * It can be ahead of RXKE by at most 1.
-     */
-    if (!TEST_int64_t_ge(diff, 0) || !TEST_int64_t_le(diff, 1))
-        return 0;
-
-    /* Caller specifies a minimum number of RXKEs which must have happened. */
-    if (!TEST_uint64_t_ge((uint64_t)rxke, hl->check_op->arg2))
-        return 0;
-
-    return 1;
-}
-
-static int check_key_update_lt(struct helper *h, struct helper_local *hl)
-{
-    QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
-    uint64_t txke = ossl_quic_channel_get_tx_key_epoch(ch);
-
-    /* Caller specifies a maximum number of TXKEs which must have happened. */
-    if (!TEST_uint64_t_lt(txke, hl->check_op->arg2))
-        return 0;
-
-    return 1;
-}
 
 static unsigned long stream_info_hash(const STREAM_INFO *info)
 {
@@ -2245,42 +2185,7 @@ static const struct script_op script_17[] = {
 
 /* 18. Key update test - RTT-bounded */
 static const struct script_op script_18[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_CHECK(override_key_update, 1),
-
-    OP_BEGIN_REPEAT(200),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_S_READ_EXPECT(a, "apple", 5),
-    OP_CHECK(skip_time_ms, 8),
-
-    OP_END_REPEAT(),
-
-    /*
-     * This time we simulate far less time passing between writes, so there are
-     * fewer opportunities to initiate TXKUs. Note that we ask for a TXKU every
-     * 1 packet above, which is absurd; thus this ensures we only actually
-     * generate TXKUs when we are allowed to.
-     */
-    OP_CHECK(check_key_update_lt, 240),
-
-    /*
-     * Prove the connection is still healthy by sending something in both
-     * directions.
-     */
-    OP_C_WRITE(DEFAULT, "xyzzy", 5),
-    OP_S_READ_EXPECT(a, "xyzzy", 5),
-
-    OP_S_WRITE(a, "plugh", 5),
-    OP_C_READ_EXPECT(DEFAULT, "plugh", 5),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -66,8 +66,11 @@ typedef struct radix_process_st {
     /* Process-global state. */
     CRYPTO_MUTEX *gm; /* global mutex */
     LHASH_OF(RADIX_OBJ) *objs; /* protected by gm */
-    OSSL_TIME time_slip; /* protected by gm */
     BIO *keylog_out; /* protected by gm */
+
+    CRYPTO_MUTEX *time_m;
+    OSSL_TIME base_time; /* set once at init, constant thereafter */
+    OSSL_TIME time_slip; /* protected by time_m */
 
     int done_join_all_threads;
 
@@ -152,6 +155,8 @@ static int RADIX_PROCESS_init(RADIX_PROCESS *rp, size_t node_idx, size_t process
 #if defined(OPENSSL_THREADS)
     if (!TEST_ptr(rp->gm = ossl_crypto_mutex_new()))
         goto err;
+    if (!TEST_ptr(rp->time_m = ossl_crypto_mutex_new()))
+        goto err;
 #endif
 
     if (!TEST_ptr(rp->objs = lh_RADIX_OBJ_new(RADIX_OBJ_hash, RADIX_OBJ_cmp)))
@@ -170,12 +175,15 @@ static int RADIX_PROCESS_init(RADIX_PROCESS *rp, size_t node_idx, size_t process
     rp->process_idx = process_idx;
     rp->done_join_all_threads = 0;
     rp->next_thread_idx = 0;
+    rp->base_time = ossl_time_now();
+    rp->time_slip = ossl_time_zero();
     return 1;
 
 err:
     lh_RADIX_OBJ_free(rp->objs);
     rp->objs = NULL;
     ossl_crypto_mutex_free(&rp->gm);
+    ossl_crypto_mutex_free(&rp->time_m);
     return 0;
 }
 
@@ -430,6 +438,7 @@ static void RADIX_PROCESS_cleanup(RADIX_PROCESS *rp)
     BIO_free_all(rp->keylog_out);
     rp->keylog_out = NULL;
     ossl_crypto_mutex_free(&rp->gm);
+    ossl_crypto_mutex_free(&rp->time_m);
 }
 
 static RADIX_OBJ *RADIX_PROCESS_get_obj(RADIX_PROCESS *rp, const char *name)
@@ -634,18 +643,23 @@ static OSSL_TIME get_time(void *arg)
 {
     OSSL_TIME time_slip;
 
-    ossl_crypto_mutex_lock(RP()->gm);
+    ossl_crypto_mutex_lock(RP()->time_m);
     time_slip = RP()->time_slip;
-    ossl_crypto_mutex_unlock(RP()->gm);
+    ossl_crypto_mutex_unlock(RP()->time_m);
 
-    return ossl_time_add(ossl_time_now(), time_slip);
+    return ossl_time_add(RP()->base_time, time_slip);
 }
 
-ossl_unused static void radix_skip_time(OSSL_TIME t)
+static OSSL_TIME terp_now(void *arg)
 {
-    ossl_crypto_mutex_lock(RP()->gm);
+    return ossl_time_now();
+}
+
+static void radix_skip_time(OSSL_TIME t)
+{
+    ossl_crypto_mutex_lock(RP()->time_m);
     RP()->time_slip = ossl_time_add(RP()->time_slip, t);
-    ossl_crypto_mutex_unlock(RP()->gm);
+    ossl_crypto_mutex_unlock(RP()->time_m);
 }
 
 static void per_op_tick_obj(RADIX_OBJ *obj)
@@ -656,14 +670,17 @@ static void per_op_tick_obj(RADIX_OBJ *obj)
 
 static int do_per_op(TERP *terp, void *arg)
 {
+    radix_skip_time(ossl_ms2time(1));
     lh_RADIX_OBJ_doall(RP()->objs, per_op_tick_obj);
     return 1;
 }
 
 static int bindings_adjust_terp_config(TERP_CONFIG *cfg)
 {
-    cfg->now_cb = get_time;
+    cfg->now_cb = terp_now;
     cfg->per_op_cb = do_per_op;
+
+    cfg->max_execution_time = ossl_ms2time(60000);
     return 1;
 }
 

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -971,6 +971,44 @@ err:
     return ok;
 }
 
+DEF_FUNC(hf_check_key_update_lt)
+{
+    int ok = 0;
+    SSL *ssl;
+    uint64_t max_txke, txke;
+    QUIC_CHANNEL *ch;
+
+    F_POP(max_txke);
+    REQUIRE_SSL(ssl);
+    ch = ossl_quic_conn_get_channel(ssl);
+    txke = ossl_quic_channel_get_tx_key_epoch(ch);
+
+    /* Caller specifies a maximum number of TXKEs which must not be exceeded. */
+    if (!TEST_uint64_t_lt(txke, max_txke))
+        goto err;
+
+    ok = 1;
+err:
+    return ok;
+}
+
+DEF_FUNC(hf_trigger_key_update)
+{
+    int ok = 0;
+    SSL *ssl;
+    uint64_t update_type;
+
+    F_POP(update_type);
+    REQUIRE_SSL(ssl);
+
+    if (!TEST_true(SSL_key_update(ssl, (int)update_type)))
+        goto err;
+
+    ok = 1;
+err:
+    return ok;
+}
+
 #define OP_UNBIND(name) \
     (OP_PUSH_PZ(#name), \
         OP_FUNC(hf_unbind))
@@ -1203,3 +1241,13 @@ err:
     (OP_SELECT_SSL(0, name),                   \
         OP_PUSH_U64(min_rxke),                 \
         OP_FUNC(hf_check_key_update_ge))
+
+#define OP_CHECK_KEY_UPDATE_LT(name, max_txke) \
+    (OP_SELECT_SSL(0, name),                   \
+        OP_PUSH_U64(max_txke),                 \
+        OP_FUNC(hf_check_key_update_lt))
+
+#define OP_TRIGGER_KEY_UPDATE(name, update_type) \
+    (OP_SELECT_SSL(0, name),                     \
+        OP_PUSH_U64(update_type),                \
+        OP_FUNC(hf_trigger_key_update))

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -924,6 +924,53 @@ err:
     return ok;
 }
 
+DEF_FUNC(hf_override_key_update)
+{
+    int ok = 0;
+    SSL *ssl;
+    uint64_t threshold;
+    QUIC_CHANNEL *ch;
+
+    F_POP(threshold);
+    REQUIRE_SSL(ssl);
+    ch = ossl_quic_conn_get_channel(ssl);
+    ossl_quic_channel_set_txku_threshold_override(ch, threshold);
+    ok = 1;
+err:
+    return ok;
+}
+
+DEF_FUNC(hf_check_key_update_ge)
+{
+    int ok = 0;
+    SSL *ssl;
+    uint64_t min_rxke, txke, rxke;
+    int64_t diff;
+    QUIC_CHANNEL *ch;
+
+    F_POP(min_rxke);
+    REQUIRE_SSL(ssl);
+    ch = ossl_quic_conn_get_channel(ssl);
+    txke = ossl_quic_channel_get_tx_key_epoch(ch);
+    rxke = ossl_quic_channel_get_rx_key_epoch(ch);
+    diff = (int64_t)txke - (int64_t)rxke;
+
+    /*
+     * TXKE must always be equal to or ahead of RXKE.
+     * It can be ahead of RXKE by at most 1.
+     */
+    if (!TEST_int64_t_ge(diff, 0) || !TEST_int64_t_le(diff, 1))
+        goto err;
+
+    /* Caller specifies a minimum number of RXKEs which must have happened. */
+    if (!TEST_uint64_t_ge(rxke, min_rxke))
+        goto err;
+
+    ok = 1;
+err:
+    return ok;
+}
+
 #define OP_UNBIND(name) \
     (OP_PUSH_PZ(#name), \
         OP_FUNC(hf_unbind))
@@ -1146,3 +1193,13 @@ err:
 #define OP_SLEEP(ms)  \
     (OP_PUSH_U64(ms), \
         OP_FUNC(hf_sleep))
+
+#define OP_OVERRIDE_KEY_UPDATE(name, threshold) \
+    (OP_SELECT_SSL(0, name),                    \
+        OP_PUSH_U64(threshold),                 \
+        OP_FUNC(hf_override_key_update))
+
+#define OP_CHECK_KEY_UPDATE_GE(name, min_rxke) \
+    (OP_SELECT_SSL(0, name),                   \
+        OP_PUSH_U64(min_rxke),                 \
+        OP_FUNC(hf_check_key_update_ge))

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -186,6 +186,11 @@ DEF_FUNC(hf_new_ssl)
     if (!is_domain && !TEST_true(ssl_attach_bio_dgram(ssl, 0, NULL)))
         goto err;
 
+    if (!TEST_true(ossl_quic_set_override_now_cb(ssl, get_time, NULL))) {
+        SSL_free(ssl);
+        goto err;
+    }
+
     if (!TEST_true(RADIX_PROCESS_set_ssl(RP(), name, ssl))) {
         SSL_free(ssl);
         goto err;
@@ -308,6 +313,7 @@ DEF_FUNC(hf_accept_conn)
         SSL_free(conn);
         goto err;
     }
+    radix_activate_obj(RADIX_PROCESS_get_obj(RP(), conn_name));
 
     ok = 1;
 err:

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -997,8 +997,43 @@ DEF_SCRIPT(script_16, "Server sending large number of streams, MAX_STREAMS test"
     }
 }
 
-DEF_SCRIPT(script_17, "place holder for multistrem script_17")
+/* 17. Key update test - unlimited */
+DEF_SCRIPT(script_17, "Key update test - unlimited")
 {
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_WRITE(C, "apple", 5);
+    OP_READ_EXPECT(S, "apple", 5);
+
+    OP_OVERRIDE_KEY_UPDATE(C, 1);
+
+    for (i = 0; i < 200; ++i) {
+        OP_WRITE(C, "apple", 5);
+        OP_READ_EXPECT(S, "apple", 5);
+        /*
+         * TXKU frequency is bounded by RTT because a previous TXKU needs to be
+         * acknowledged by the peer first before another one can begin. By
+         * waiting this long, we eliminate any such concern and ensure as many key
+         * updates as possible can occur for the purposes of this test.
+         */
+        OP_SKIP_TIME(100);
+    }
+
+    /* At least 5 RXKUs detected */
+    OP_CHECK_KEY_UPDATE_GE(C, 5);
+
+    /*
+     * Prove the connection is still healthy by sending something in both
+     * directions.
+     */
+    OP_WRITE(C, "xyzzy", 5);
+    OP_READ_EXPECT(S, "xyzzy", 5);
+
+    OP_WRITE(S, "plugh", 5);
+    OP_READ_EXPECT(C, "plugh", 5);
 }
 
 DEF_SCRIPT(script_18, "place holder for multistrem script_18")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -960,8 +960,41 @@ DEF_SCRIPT(script_15, "Client sending large number of streams, MAX_STREAMS test"
     }
 }
 
-DEF_SCRIPT(script_16, "place holder for multistrem script_16")
+/* 16. Server sending large number of streams, MAX_STREAMS test */
+DEF_SCRIPT(script_16, "Server sending large number of streams, MAX_STREAMS test")
 {
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN_ND();
+    OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
+
+    /*
+     * This will cause a protocol violation to be raised by the client if we are
+     * not handling the stream limit correctly on the TX side.
+     */
+    for (i = 0; i < 200; ++i) {
+        OP_NEW_STREAM(S, Sa, SSL_STREAM_FLAG_ADVANCE);
+        OP_WRITE(Sa, "foo", 3);
+        OP_CONCLUDE(Sa);
+        OP_UNBIND(Sa);
+    }
+
+    /* Prove that the connection is still good. */
+    OP_NEW_STREAM(C, Ca, 0);
+    OP_WRITE(Ca, "bar", 3);
+    OP_CONCLUDE(Ca);
+
+    OP_ACCEPT_STREAM_WAIT(S, Sb, 0);
+    OP_READ_EXPECT(Sb, "bar", 3);
+    OP_EXPECT_FIN(Sb);
+
+    /* Drain the queue of incoming streams. */
+    for (i = 0; i < 200; ++i) {
+        OP_ACCEPT_STREAM_WAIT(C, Cb, 0);
+        OP_READ_EXPECT(Cb, "foo", 3);
+        OP_EXPECT_FIN(Cb);
+        OP_UNBIND(Cb);
+    }
 }
 
 DEF_SCRIPT(script_17, "place holder for multistrem script_17")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -1074,8 +1074,31 @@ DEF_SCRIPT(script_18, "Key update test - RTT-bounded")
     OP_READ_EXPECT(C, "plugh", 5);
 }
 
-DEF_SCRIPT(script_19, "place holder for multistrem script_19")
+/* 19. Key update test - artificially triggered */
+DEF_SCRIPT(script_19, "Key update test - artificially triggered")
 {
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_WRITE(C, "apple", 5);
+    OP_READ_EXPECT(S, "apple", 5);
+
+    OP_WRITE(C, "orange", 6);
+    OP_READ_EXPECT(S, "orange", 6);
+
+    OP_WRITE(S, "strawberry", 10);
+    OP_READ_EXPECT(C, "strawberry", 10);
+
+    OP_CHECK_KEY_UPDATE_LT(C, 1);
+
+    OP_TRIGGER_KEY_UPDATE(C, SSL_KEY_UPDATE_REQUESTED);
+
+    OP_WRITE(C, "orange", 6);
+    OP_READ_EXPECT(S, "orange", 6);
+    OP_WRITE(S, "ok", 2);
+
+    OP_READ_EXPECT(C, "ok", 2);
+    OP_CHECK_KEY_UPDATE_GE(C, 1);
 }
 
 DEF_SCRIPT(script_20, "place holder for multistrem script_20")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -920,8 +920,44 @@ DEF_SCRIPT(script_14, "place holder for multistrem script_14")
 {
 }
 
-DEF_SCRIPT(script_15, "place holder for multistrem script_15")
+/* 15. Client sending large number of streams, MAX_STREAMS test */
+DEF_SCRIPT(script_15, "Client sending large number of streams, MAX_STREAMS test")
 {
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN_ND();
+    OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
+
+    /*
+     * This will cause a protocol violation to be raised by the server if we are
+     * not handling the stream limit correctly on the TX side.
+     */
+    for (i = 0; i < 200; ++i) {
+        OP_NEW_STREAM(C, Ca, SSL_STREAM_FLAG_ADVANCE);
+        OP_WRITE(Ca, "foo", 3);
+        OP_CONCLUDE(Ca);
+        OP_UNBIND(Ca);
+    }
+
+    /* Prove the connection is still good. */
+    OP_NEW_STREAM(S, Sa, 0);
+    OP_WRITE(Sa, "bar", 3);
+    OP_CONCLUDE(Sa);
+
+    OP_ACCEPT_STREAM_WAIT(C, Ca, 0);
+    OP_READ_EXPECT(Ca, "bar", 3);
+    OP_EXPECT_FIN(Ca);
+
+    /*
+     * Drain the queue of incoming streams. We should be able to get all 200
+     * even though only 100 can be initiated at a time.
+     */
+    for (i = 0; i < 200; ++i) {
+        OP_ACCEPT_STREAM_WAIT(S, Sb, 0);
+        OP_READ_EXPECT(Sb, "foo", 3);
+        OP_EXPECT_FIN(Sb);
+        OP_UNBIND(Sb);
+    }
 }
 
 DEF_SCRIPT(script_16, "place holder for multistrem script_16")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -1036,8 +1036,42 @@ DEF_SCRIPT(script_17, "Key update test - unlimited")
     OP_READ_EXPECT(C, "plugh", 5);
 }
 
-DEF_SCRIPT(script_18, "place holder for multistrem script_18")
+/* 18. Key update test - RTT-bounded */
+DEF_SCRIPT(script_18, "Key update test - RTT-bounded")
 {
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_WRITE(C, "apple", 5);
+    OP_READ_EXPECT(S, "apple", 5);
+
+    OP_OVERRIDE_KEY_UPDATE(C, 1);
+
+    for (i = 0; i < 200; ++i) {
+        OP_WRITE(C, "apple", 5);
+        OP_READ_EXPECT(S, "apple", 5);
+        OP_SKIP_TIME(8);
+    }
+
+    /*
+     * This time we simulate far less time passing between writes, so there are
+     * fewer opportunities to initiate TXKUs. Note that we ask for a TXKU every
+     * 1 packet above, which is absurd; thus this ensures we only actually
+     * generate TXKUs when we are allowed to.
+     */
+    OP_CHECK_KEY_UPDATE_LT(C, 240);
+
+    /*
+     * Prove the connection is still healthy by sending something in both
+     * directions.
+     */
+    OP_WRITE(C, "xyzzy", 5);
+    OP_READ_EXPECT(S, "xyzzy", 5);
+
+    OP_WRITE(S, "plugh", 5);
+    OP_READ_EXPECT(C, "plugh", 5);
 }
 
 DEF_SCRIPT(script_19, "place holder for multistrem script_19")


### PR DESCRIPTION
- script_15/script_16: client/server MAX_STREAMS stress tests (200 streams each way)
- script_17/script_18/script_19: key update tests. Added three new `quic_ops.c` functions: `OP_OVERRIDE_KEY_UPDATE`, `OP_CHECK_KEY_UPDATE_GE`/`_LT`, & `OP_TRIGGER_KEY_UPDATE`. Used `OP_SLEEP()` instead of `skip_time_ms()`.
- Emptied the functions in `quic_multistream_test.c` and removed some helper functions no longer used anywhere (`skip_time_ms`, `override_key_update`, `trigger_key_update`, `check_key_update_ge`, `check_key_update_lt`).

Fixes https://github.com/openssl/project/issues/1989

##### Checklist

- [ ] documentation is added or updated
- [x] tests are added or updated
