### PR TITLE
Fix a bug in BN_ucmp() when comparing constant-time BIGNUMs of different lengths - backport

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -707,19 +707,37 @@ int BN_ucmp(const BIGNUM *a, const BIGNUM *b)
     int i;
     BN_ULONG t1, t2, *ap, *bp;
 
+    /*
+     * As it is a public API function, we should handle NULL parameters in
+     * some way. The function can’t return an error, so let’s define that NULL
+     * is less than any BIGNUM.
+     */
+    if (!ossl_assert(a != NULL && b != NULL))
+        return (b == NULL) - (a == NULL);
+
     ap = a->d;
     bp = b->d;
 
     if (BN_get_flags(a, BN_FLG_CONSTTIME)
-        && a->top == b->top) {
+        || BN_get_flags(b, BN_FLG_CONSTTIME)) {
         int res = 0;
+        int min_top = a->top < b->top ? a->top : b->top;
 
-        for (i = 0; i < b->top; i++) {
+        for (i = 0; i < min_top; i++) {
             res = constant_time_select_int(constant_time_lt_bn(ap[i], bp[i]),
                 -1, res);
             res = constant_time_select_int(constant_time_lt_bn(bp[i], ap[i]),
                 1, res);
         }
+
+        for (i = min_top; i < a->top; ++i)
+            res = constant_time_select_int((int)constant_time_is_zero_bn(ap[i]),
+                res, 1);
+
+        for (i = min_top; i < b->top; ++i)
+            res = constant_time_select_int((int)constant_time_is_zero_bn(bp[i]),
+                res, -1);
+
         return res;
     }
 


### PR DESCRIPTION
Backport of #31717 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
