### PR TITLE
Expose SSL_default_security_callback()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,12 @@ OpenSSL Releases
 
    *Dimitri John Ledkov*
 
+ * Added SSL_default_security_callback(), to expose the default security
+   callback. Applications that install their own security callback can use
+   this to fall back to the default behaviour.
+
+   *Tim Perry*
+
 OpenSSL 4.0
 -----------
 

--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-SSL_CTX_set_security_level, SSL_set_security_level, SSL_CTX_get_security_level, SSL_get_security_level, SSL_CTX_set_security_callback, SSL_set_security_callback, SSL_CTX_get_security_callback, SSL_get_security_callback, SSL_CTX_set0_security_ex_data, SSL_set0_security_ex_data, SSL_CTX_get0_security_ex_data, SSL_get0_security_ex_data - SSL/TLS security framework
+SSL_CTX_set_security_level, SSL_set_security_level, SSL_CTX_get_security_level, SSL_get_security_level, SSL_CTX_set_security_callback, SSL_set_security_callback, SSL_CTX_get_security_callback, SSL_get_security_callback, SSL_CTX_set0_security_ex_data, SSL_set0_security_ex_data, SSL_CTX_get0_security_ex_data, SSL_get0_security_ex_data, SSL_default_security_callback - SSL/TLS security framework
 
 =head1 SYNOPSIS
 
@@ -36,6 +36,9 @@ SSL_CTX_set_security_level, SSL_set_security_level, SSL_CTX_get_security_level, 
  void *SSL_CTX_get0_security_ex_data(const SSL_CTX *ctx);
  void *SSL_get0_security_ex_data(const SSL *s);
 
+ int SSL_default_security_callback(const SSL *s, const SSL_CTX *ctx, int op,
+                                   int bits, int nid, void *other, void *ex);
+
 =head1 DESCRIPTION
 
 The functions SSL_CTX_set_security_level() and SSL_set_security_level() set
@@ -50,6 +53,12 @@ SSL_CTX_get_security_callback() and SSL_get_security_callback() get or set
 the security callback associated with B<ctx> or B<s>. If not set a default
 security callback is used. The meaning of the parameters and the behaviour
 of the default callbacks is described below.
+
+SSL_default_security_callback() is the security callback that is used if the
+application does not install one of its own. It is exposed so that an
+application-defined callback can defer to the default behaviour for any
+operation it does not wish to handle itself, by calling it with the same
+arguments the callback received.
 
 SSL_CTX_set0_security_ex_data(), SSL_set0_security_ex_data(),
 SSL_CTX_get0_security_ex_data() and SSL_get0_security_ex_data() set the
@@ -169,6 +178,9 @@ to the security callback or NULL if the callback is not set.
 SSL_CTX_get0_security_ex_data() and SSL_get0_security_ex_data() return the extra
 data pointer or NULL if the ex data is not set.
 
+SSL_default_security_callback() returns 1 if the operation is permitted and 0
+otherwise.
+
 =head1 SEE ALSO
 
 L<ssl(7)>
@@ -176,6 +188,8 @@ L<ssl(7)>
 =head1 HISTORY
 
 These functions were added in OpenSSL 1.1.0.
+
+SSL_default_security_callback() was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2771,6 +2771,8 @@ int (*SSL_CTX_get_security_callback(const SSL_CTX *ctx))(const SSL *s,
     int nid,
     void *other,
     void *ex);
+int SSL_default_security_callback(const SSL *s, const SSL_CTX *ctx,
+    int op, int bits, int nid, void *other, void *ex);
 void SSL_CTX_set0_security_ex_data(SSL_CTX *ctx, void *ex);
 __owur void *SSL_CTX_get0_security_ex_data(const SSL_CTX *ctx);
 

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -37,10 +37,6 @@
 #endif
 #endif
 
-static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
-    int op, int bits, int nid, void *other,
-    void *ex);
-
 static CRYPTO_ONCE ssl_x509_store_ctx_once = CRYPTO_ONCE_STATIC_INIT;
 static volatile int ssl_x509_store_ctx_idx = -1;
 
@@ -80,7 +76,7 @@ CERT *ssl_cert_new(size_t ssl_pkey_num)
     }
 
     ret->key = &(ret->pkeys[SSL_PKEY_RSA]);
-    ret->sec_cb = ssl_security_default_callback;
+    ret->sec_cb = SSL_default_security_callback;
     ret->sec_level = OPENSSL_TLS_SECURITY_LEVEL;
     ret->sec_ex = NULL;
     if (!CRYPTO_NEW_REF(&ret->references, 1)) {
@@ -1244,7 +1240,7 @@ int ssl_get_security_level_bits(const SSL *s, const SSL_CTX *ctx, int *levelp)
     return minbits_table[level];
 }
 
-static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
+int SSL_default_security_callback(const SSL *s, const SSL_CTX *ctx,
     int op, int bits, int nid, void *other,
     void *ex)
 {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -727,6 +727,49 @@ end:
     return ret;
 }
 
+static int test_default_security_callback(void)
+{
+    SSL_CTX *ctx = NULL;
+    SSL *ssl = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new_ex(libctx, NULL, TLS_client_method())))
+        return 0;
+
+    SSL_CTX_set_security_level(ctx, 2);
+
+    /* Check callback is callable & behaves as expected for level 2 with ctx: */
+    if (!TEST_int_eq(SSL_default_security_callback(NULL, ctx, SSL_SECOP_EE_KEY,
+                         80, 0, NULL, NULL),
+            0)
+        || !TEST_int_eq(SSL_default_security_callback(NULL, ctx, SSL_SECOP_EE_KEY,
+                            128, 0, NULL, NULL),
+            1))
+        goto end;
+
+    if (!TEST_ptr(ssl = SSL_new(ctx)))
+        goto end;
+
+    /* Check callback is callable & behaves as expected for level 2 with ssl: */
+    if (!TEST_int_eq(SSL_default_security_callback(ssl, NULL, SSL_SECOP_EE_KEY,
+                         80, 0, NULL, NULL),
+            0))
+        goto end;
+
+    /* Check the same 80-bit object is now permitted once level 0 is set: */
+    SSL_set_security_level(ssl, 0);
+    if (!TEST_int_eq(SSL_default_security_callback(ssl, NULL, SSL_SECOP_EE_KEY,
+                         80, 0, NULL, NULL),
+            1))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    return testresult;
+}
+
 #ifndef OPENSSL_NO_TLS1_2
 static int full_client_hello_callback(SSL *s, int *al, void *arg)
 {
@@ -15250,6 +15293,7 @@ int setup_tests(void)
     ADD_TEST(test_client_cert_verify_cb);
     ADD_TEST(test_ssl_build_cert_chain);
     ADD_TEST(test_ssl_ctx_build_cert_chain);
+    ADD_TEST(test_default_security_callback);
 #ifndef OPENSSL_NO_TLS1_2
     ADD_TEST(test_client_hello_cb);
     ADD_TEST(test_no_ems);

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -626,3 +626,4 @@ SSL_CTX_ech_set1_outer_alpn_protos      625	4_0_0	EXIST::FUNCTION:ECH
 SSL_set1_ech_config_list                626	4_0_0	EXIST::FUNCTION:ECH
 SSL_get0_sigalg                         627	4_0_0	EXIST::FUNCTION:
 SSL_get0_shared_sigalg                  628	4_0_0	EXIST::FUNCTION:
+SSL_default_security_callback           ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This PR exposes the existing default security callback. This is useful when defining your own callback with SSL_set_security_callback, because it means you can override the behaviour you're interested in, but pass through to the default callback to preserve normal behaviour for the current level.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
