### PR TITLE
Make a doc comments checker to enforce DOCUMENTATION.md

### DIFF
--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -23,17 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
-      - name: "Get changed files"
-        env:
-          NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          {
-            echo 'CHANGED_FILES<<EOF'
-            gh pr view $NUMBER --json files --jq '.files.[].path'
-            echo EOF
-          } >> "$GITHUB_ENV"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
         with:
-          extra_args: "--files $CHANGED_FILES"
+          extra_args: >-
+            --from-ref $(git merge-base HEAD^1 HEAD^2)
+            --to-ref HEAD

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
       - name: "Get changed files"
         env:
@@ -35,5 +37,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_ENV"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
+        env:
+          DOC_COMMENTS_RANGE: "${{ github.event.pull_request.base.sha }}...HEAD"
         with:
           extra_args: "--files $CHANGED_FILES"

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -29,5 +29,5 @@ jobs:
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
         with:
           extra_args: >-
-            --from-ref ${{ github.event.pull_request.base.sha }}
+            --from-ref $(git merge-base HEAD^1 HEAD^2)
             --to-ref HEAD

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -29,5 +29,5 @@ jobs:
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
         with:
           extra_args: >-
-            --from-ref $(git merge-base HEAD^1 HEAD^2)
+            --from-ref ${{ github.event.pull_request.base.sha }}
             --to-ref HEAD

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -26,18 +26,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v6
-      - name: "Get changed files"
-        env:
-          NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          {
-            echo 'CHANGED_FILES<<EOF'
-            gh pr view $NUMBER --json files --jq '.files.[].path'
-            echo EOF
-          } >> "$GITHUB_ENV"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
-        env:
-          DOC_COMMENTS_RANGE: "${{ github.event.pull_request.base.sha }}...HEAD"
         with:
-          extra_args: "--files $CHANGED_FILES"
+          extra_args: >-
+            --from-ref ${{ github.event.pull_request.base.sha }}
+            --to-ref HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,11 @@ repos:
                   crypto/objects/obj_xref.h|
                   include/openssl/obj_mac.h
                  )$
+  - repo: local
+    hooks:
+      - id: "doc-comments"
+        name: "documentation comments on new function declarations"
+        entry: "perl util/check-doc-comments.pl"
+        language: "system"
+        files: '\.h(\.in)?$'
+        require_serial: true

--- a/util/check-doc-comments.pl
+++ b/util/check-doc-comments.pl
@@ -78,6 +78,8 @@ sub nit {
 sub is_public { return $_[0] =~ m{(?:^|/)include/openssl/}; }
 
 sub diff_range {
+    return "$ENV{PRE_COMMIT_FROM_REF}...$ENV{PRE_COMMIT_TO_REF}"
+        if $ENV{PRE_COMMIT_FROM_REF} && $ENV{PRE_COMMIT_TO_REF};
     return $ENV{DOC_COMMENTS_RANGE} if $ENV{DOC_COMMENTS_RANGE};
     my $staged = `git diff --cached --name-only 2>/dev/null`;
     return '--cached' if length $staged;

--- a/util/check-doc-comments.pl
+++ b/util/check-doc-comments.pl
@@ -1,0 +1,328 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# check-doc-comments.pl - check that new or changed function declarations in
+# header files carry the documentation comments required by DOCUMENTATION.md
+# and STYLE.md.  It only verifies that the required documentation is present;
+# it does not judge whether the content is correct.
+#
+# Those two documents are authoritative.  The rules below come from STYLE.md
+# "Applicability" and "Doxygen comments" (including "Public functions: link the
+# manual page") and DOCUMENTATION.md "Public symbols in the libraries" and
+# "Internal functions, structures, globals and macros".
+#
+# Runs as a pre-commit hook (.pre-commit-config.yaml) and in CI via
+# .github/workflows/style-checks.yml on a pull request's changed files.  Only
+# function prototypes on added or modified lines are checked; unchanged code is
+# left alone.
+#
+# Rules:
+#   * public headers (include/openssl/...): the prototype must be immediately
+#     preceded by a /** ... */ doxygen block containing "@see NAME(3)" for the
+#     function's own name, and that manual page must exist in the doc/ tree.
+#   * other (internal) headers: the prototype must be immediately preceded by a
+#     /** ... */ block with a @param for each named parameter and a @returns
+#     when the return type is not void.  When the parameter list cannot be
+#     parsed with confidence the @param check is skipped; the block is still
+#     required.
+#
+# Not checked: static functions, non-function declarations (macros, typedefs,
+# function-pointer typedefs), and declarations carrying a "doc-exempt" marker.
+# The marker invokes the trivial-item exception from DOCUMENTATION.md; place
+# /* doc-exempt: <reason> */ immediately before the declaration.
+#
+# The diff range is $DOC_COMMENTS_RANGE if set (CI sets it to the PR base sha),
+# else the staged changes if any exist, else the merge-base with the upstream
+# default branch.
+
+use strict;
+use warnings;
+
+my @files = grep { /\.h(?:\.in)?$/ && -f $_ } @ARGV;
+exit 0 unless @files;
+
+my $range     = diff_range();
+print STDERR "check-doc-comments: diffing changed lines against '$range'\n";
+my %doc_name  = harvest_pod_names();          # NAME => { section => 1 }
+my $nerrors   = 0;
+
+for my $file (@files) {
+    # Skip a generated header when its .h.in source exists; the source is
+    # what contributors edit and what carries the declarations.
+    next if $file =~ /\.h$/ && -f "$file.in";
+    my %changed = changed_lines($range, $file);
+    next unless %changed;
+    check_file($file, \%changed);
+}
+
+print STDERR "note: a trivial function may be exempted with a "
+    . "\"/* doc-exempt: <reason> */\" comment immediately before its "
+    . "declaration\n"
+    if $nerrors;
+
+exit($nerrors ? 1 : 0);
+
+# ---------------------------------------------------------------------------
+
+sub nit {
+    my ($file, $line, $msg) = @_;
+    print STDERR "$file:$line: $msg\n";
+    $nerrors++;
+}
+
+sub is_public { return $_[0] =~ m{(?:^|/)include/openssl/}; }
+
+sub diff_range {
+    return $ENV{DOC_COMMENTS_RANGE} if $ENV{DOC_COMMENTS_RANGE};
+    my $staged = `git diff --cached --name-only 2>/dev/null`;
+    return '--cached' if length $staged;
+    for my $base (qw(upstream/master origin/master master)) {
+        chomp(my $mb = `git merge-base $base HEAD 2>/dev/null`);
+        return $mb if $mb ne '';
+    }
+    return 'HEAD~1';
+}
+
+# Set of new-side line numbers added/changed for $file in $range.
+sub changed_lines {
+    my ($range, $file) = @_;
+    my @cmd = $range eq '--cached'
+        ? ('git', 'diff', '--cached', '-U0', '--', $file)
+        : ('git', 'diff', '-U0', $range, '--', $file);
+    my %ch;
+    open my $fh, '-|', @cmd or return %ch;
+    while (<$fh>) {
+        next unless /^\@\@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? \@\@/;
+        my ($start, $count) = ($1, defined $2 ? $2 : 1);
+        next unless $count > 0;
+        $ch{$_} = 1 for $start .. $start + $count - 1;
+    }
+    close $fh;
+    return %ch;
+}
+
+# Build NAME => { section => 1 } from doc/man*/*.pod on disk (the working
+# tree), so a page added in the same change resolves.
+sub harvest_pod_names {
+    my %names;
+    for my $pod (glob 'doc/man*/*.pod') {
+        my ($sec) = $pod =~ m{doc/man(\d)/} or next;
+        open my $fh, '<', $pod or next;
+        my ($in_name, $buf) = (0, '');
+        while (<$fh>) {
+            if (/^=head1\s+NAME/)      { $in_name = 1; next; }
+            if ($in_name && /^=head1/) { last; }
+            $buf .= $_ if $in_name;
+        }
+        close $fh;
+        $buf =~ s/\s+-\s+.*\z//s;          # drop the " - description" tail
+        $names{$_}{$sec} = 1 for ($buf =~ /([A-Za-z_]\w*)/g);
+    }
+    return %names;
+}
+
+sub check_file {
+    my ($file, $changed) = @_;
+    open my $fh, '<', $file or return;
+    my @lines = <$fh>;
+    close $fh;
+    chomp @lines;
+    my $is_hin = $file =~ /\.h\.in$/ ? 1 : 0;
+
+    for my $p (@{ parse_prototypes(\@lines, $is_hin) }) {
+        # Only new/changed declarations.
+        next unless grep { $changed->{$_} } $p->{start} .. $p->{end};
+
+        my ($block, $doxy) = preceding_block(\@lines, $p->{start});
+        next if defined $block && $block =~ /doc-exempt/;   # opt-out
+
+        if (!$doxy) {
+            nit($file, $p->{start},
+                "$p->{name}(): missing doxygen /** */ documentation block");
+            next;
+        }
+
+        if (is_public($file)) {
+            if ($block !~ /\@see\b[^*]*?\b\Q$p->{name}\E\s*\(3\)/s) {
+                nit($file, $p->{start},
+                    "$p->{name}(): doxygen block must link its manual page "
+                    . "with \@see $p->{name}(3)");
+            } elsif (!$doc_name{$p->{name}}{3}) {
+                nit($file, $p->{start},
+                    "$p->{name}(): \@see $p->{name}(3) has no matching "
+                    . "doc/man3 page");
+            }
+        } else {
+            # Report a function's missing tags on one line; they are all fixed
+            # in the single doxygen block attached to the declaration.
+            my @clauses;
+            push @clauses, "\@returns for the return value"
+                if !$p->{ret_void} && $block !~ /\@returns?\b/;
+            my @params;
+            unless ($p->{params_uncertain}) {        # fail open on parse doubt
+                # Harvest the names doxygen actually documents.  Accept an
+                # optional [in]/[out]/[in,out] direction attribute and a
+                # comma-separated list of names on a single @param line.
+                my %documented;
+                while ($block =~ /\@param\b\s*(?:\[[^\]]*\])?\s*
+                                  ([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)/gx) {
+                    $documented{$_} = 1 for split /\s*,\s*/, $1;
+                }
+                for my $param (@{ $p->{params} }) {
+                    push @params, "'$param'" unless $documented{$param};
+                }
+            }
+            if (@params) {
+                my $word = @params == 1 ? 'parameter' : 'parameters';
+                push @clauses, "\@param for $word " . join(', ', @params);
+            }
+            nit($file, $p->{start},
+                "$p->{name}(): doxygen block missing " . join(' and ', @clauses))
+                if @clauses;
+        }
+    }
+}
+
+# Find the doxygen/comment block immediately preceding (adjacent to) $start
+# (1-indexed).  Returns ($text, $is_doxygen).
+sub preceding_block {
+    my ($lines, $start) = @_;
+    my $i = $start - 2;                    # 0-indexed line just above
+    return (undef, 0) if $i < 0 || $lines->[$i] !~ m{\*/\s*$};
+    my @blk;
+    while ($i >= 0) {
+        unshift @blk, $lines->[$i];
+        last if $lines->[$i] =~ m{/\*};
+        $i--;
+    }
+    my $doxy = ($blk[0] // '') =~ m{/\*\*} ? 1 : 0;
+    return (join("\n", @blk), $doxy);
+}
+
+# Return arrayref of prototypes: { name, start, end, ret_void, params,
+# params_uncertain }.  Comments are blanked first so they do not interfere.
+sub parse_prototypes {
+    my ($lines, $is_hin) = @_;
+    my @code = blank_noncode($lines, $is_hin);
+
+    # Prototypes appear at file scope or directly inside an extern "C" {}
+    # linkage block; never inside a struct/union/enum body or a function
+    # body.  So track a "skip depth": every '{' opens a skip scope EXCEPT an
+    # extern "..." linkage block, which is transparent.  Prototypes are only
+    # recorded when the skip depth is zero.
+    my @protos;
+    my @stack;                          # 1 = skip brace, 0 = transparent
+    my ($stmt, $sline, $sskip, $skip) = ('', 0, 0, 0);
+    for my $idx (0 .. $#code) {
+        next if $lines->[$idx] =~ /^\s*#/;         # preprocessor directive
+        for my $ch (split //, $code[$idx]) {
+            if ($ch eq '{') {
+                (my $pre = $stmt) =~ s/\s+$//;
+                my $transparent = $pre =~ /\bextern\s*"[^"]*"$/ ? 1 : 0;
+                push @stack, $transparent ? 0 : 1;
+                $skip++ unless $transparent;
+                $stmt = '';
+            } elsif ($ch eq '}') {
+                my $was = pop @stack;
+                $skip-- if $was;
+                $skip = 0 if $skip < 0;
+                $stmt = '';
+            } elsif ($ch eq ';') {
+                if ($sskip == 0 && $stmt !~ /[{}]/) {
+                    my $p = classify_stmt($stmt . ';', $sline, $idx + 1);
+                    push @protos, $p if $p;
+                }
+                $stmt = '';
+            } else {
+                if ($stmt eq '' && $ch =~ /\S/) { $sline = $idx + 1; $sskip = $skip; }
+                $stmt .= $ch if $stmt ne '' || $ch =~ /\S/;
+            }
+        }
+        $stmt .= ' ' if $stmt ne '';
+    }
+    return \@protos;
+}
+
+sub classify_stmt {
+    my ($raw, $start, $end) = @_;
+    (my $s = $raw) =~ s/\s+/ /g;
+    $s =~ s/^\s+//;
+    return undef if $s =~ /^typedef\b/;                      # typedef
+    return undef if $s =~ /^\s*static\b/;                    # static fn
+    # Collapse the STACK_OF()/LHASH_OF() type macros to a plain type token so
+    # a return type like "const STACK_OF(X509) *" does not get mistaken for a
+    # function named STACK_OF.
+    $s =~ s/\b(?:STACK_OF|LHASH_OF|SPARSE_ARRAY_OF)\s*\(\s*\w+\s*\)/OSSL_TYPE/g;
+    # strip leading attribute / deprecation qualifier macros
+    1 while $s =~ s/^(?:OSSL_DEPRECATEDIN_\S+|__owur|ossl_unused)\s+//;
+    # ret-type (must contain a space or '*' before the name) then NAME(args);
+    return undef unless
+        $s =~ /^((?:\w[\w ]*?)[ \*]+)([A-Za-z_]\w*)\s*\((.*)\)\s*;$/;
+    my ($ret, $name, $args) = ($1, $2, $3);
+    (my $rt = $ret) =~ s/\s+$//;
+    my $ret_void = ($rt eq 'void') ? 1 : 0;
+
+    my ($params, $uncertain) = parse_params($args);
+    return {
+        name             => $name,
+        start            => $start,
+        end              => $end,
+        ret_void         => $ret_void,
+        params           => $params,
+        params_uncertain => $uncertain,
+    };
+}
+
+# Extract parameter names.  Returns (\@names, $uncertain).  We fail open
+# (uncertain=1) on anything we cannot confidently name.
+sub parse_params {
+    my ($args) = @_;
+    $args =~ s/^\s+//; $args =~ s/\s+$//;
+    return ([], 0) if $args eq '' || $args eq 'void';
+    return ([], 1) if $args =~ /\Q...\E/ || $args =~ /\(\s*\*/;  # varargs / fn-ptr
+    my @names;
+    for my $a (split /,/, $args) {
+        $a =~ s/\[.*?\]//g;                       # drop array dims
+        if ($a =~ /([A-Za-z_]\w*)\s*$/) {
+            my $n = $1;
+            # a trailing bare type keyword => unnamed parameter => uncertain
+            return ([], 1) if $n =~ /^(void|int|char|long|short|unsigned|
+                                       signed|size_t|double|float)$/x;
+            push @names, $n;
+        } else {
+            return ([], 1);
+        }
+    }
+    return (\@names, 0);
+}
+
+# Blank out /* */ and // comments, and (for .h.in files) {- ... -} template
+# fragments, preserving line count and columns so line numbers stay accurate.
+sub blank_noncode {
+    my ($lines, $is_hin) = @_;
+    my @out;
+    my $mode = 0;                       # 0 code, 1 /* */ comment, 2 {- -} template
+    for my $l (@$lines) {
+        my ($o, $j) = ('', 0);
+        while ($j < length $l) {
+            my $two = substr($l, $j, 2);
+            if ($mode == 1) {
+                if ($two eq '*/') { $mode = 0; $o .= '  '; $j += 2; }
+                else              { $o .= ' ';             $j++;    }
+            } elsif ($mode == 2) {
+                if ($two eq '-}') { $mode = 0; $o .= '  '; $j += 2; }
+                else              { $o .= ' ';             $j++;    }
+            } elsif ($two eq '/*')            { $mode = 1; $o .= '  '; $j += 2; }
+            elsif ($is_hin && $two eq '{-')   { $mode = 2; $o .= '  '; $j += 2; }
+            elsif ($two eq '//') { $o .= ' ' x (length($l) - $j);   last; }
+            else                 { $o .= substr($l, $j, 1);         $j++;   }
+        }
+        push @out, $o;
+    }
+    return @out;
+}

--- a/util/check-doc-comments.pl
+++ b/util/check-doc-comments.pl
@@ -203,7 +203,11 @@ sub preceding_block {
         $i--;
     }
     my $doxy = ($blk[0] // '') =~ m{/\*\*} ? 1 : 0;
-    return (join("\n", @blk), $doxy);
+    # Strip the leading " * " from each comment line so a tag that spans lines
+    # (e.g. a multi-line @see list) can be matched without the '*' at the start
+    # of a continuation line interfering.
+    (my $text = join("\n", @blk)) =~ s/^\s*\*\s?//gm;
+    return ($text, $doxy);
 }
 
 # Return arrayref of prototypes: { name, start, end, ret_void, params,

--- a/util/check-doc-comments.pl
+++ b/util/check-doc-comments.pl
@@ -1,0 +1,334 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# check-doc-comments.pl - check that new or changed function declarations in
+# header files carry the documentation comments required by DOCUMENTATION.md
+# and STYLE.md.  It only verifies that the required documentation is present;
+# it does not judge whether the content is correct.
+#
+# Those two documents are authoritative.  The rules below come from STYLE.md
+# "Applicability" and "Doxygen comments" (including "Public functions: link the
+# manual page") and DOCUMENTATION.md "Public symbols in the libraries" and
+# "Internal functions, structures, globals and macros".
+#
+# Runs as a pre-commit hook (.pre-commit-config.yaml) and in CI via
+# .github/workflows/style-checks.yml on a pull request's changed files.  Only
+# function prototypes on added or modified lines are checked; unchanged code is
+# left alone.
+#
+# Rules:
+#   * public headers (include/openssl/...): the prototype must be immediately
+#     preceded by a /** ... */ doxygen block containing "@see NAME(3)" for the
+#     function's own name, and that manual page must exist in the doc/ tree.
+#   * other (internal) headers: the prototype must be immediately preceded by a
+#     /** ... */ block with a @param for each named parameter and a @returns
+#     when the return type is not void.  When the parameter list cannot be
+#     parsed with confidence the @param check is skipped; the block is still
+#     required.
+#
+# Not checked: static functions, non-function declarations (macros, typedefs,
+# function-pointer typedefs), and declarations carrying a "doc-exempt" marker.
+# The marker invokes the trivial-item exception from DOCUMENTATION.md; place
+# /* doc-exempt: <reason> */ immediately before the declaration.
+#
+# The diff range is $DOC_COMMENTS_RANGE if set (CI sets it to the PR base sha),
+# else the staged changes if any exist, else the merge-base with the upstream
+# default branch.
+
+use strict;
+use warnings;
+
+my @files = grep { /\.h(?:\.in)?$/ && -f $_ } @ARGV;
+exit 0 unless @files;
+
+my $range     = diff_range();
+print STDERR "check-doc-comments: diffing changed lines against '$range'\n";
+my %doc_name  = harvest_pod_names();          # NAME => { section => 1 }
+my $nerrors   = 0;
+
+for my $file (@files) {
+    # Skip a generated header when its .h.in source exists; the source is
+    # what contributors edit and what carries the declarations.
+    next if $file =~ /\.h$/ && -f "$file.in";
+    my %changed = changed_lines($range, $file);
+    next unless %changed;
+    check_file($file, \%changed);
+}
+
+print STDERR "note: a trivial function may be exempted with a "
+    . "\"/* doc-exempt: <reason> */\" comment immediately before its "
+    . "declaration\n"
+    if $nerrors;
+
+exit($nerrors ? 1 : 0);
+
+# ---------------------------------------------------------------------------
+
+sub nit {
+    my ($file, $line, $msg) = @_;
+    print STDERR "$file:$line: $msg\n";
+    $nerrors++;
+}
+
+sub is_public { return $_[0] =~ m{(?:^|/)include/openssl/}; }
+
+sub diff_range {
+    return "$ENV{PRE_COMMIT_FROM_REF}...$ENV{PRE_COMMIT_TO_REF}"
+        if $ENV{PRE_COMMIT_FROM_REF} && $ENV{PRE_COMMIT_TO_REF};
+    return $ENV{DOC_COMMENTS_RANGE} if $ENV{DOC_COMMENTS_RANGE};
+    my $staged = `git diff --cached --name-only 2>/dev/null`;
+    return '--cached' if length $staged;
+    for my $base (qw(upstream/master origin/master master)) {
+        chomp(my $mb = `git merge-base $base HEAD 2>/dev/null`);
+        return $mb if $mb ne '';
+    }
+    return 'HEAD~1';
+}
+
+# Set of new-side line numbers added/changed for $file in $range.
+sub changed_lines {
+    my ($range, $file) = @_;
+    my @cmd = $range eq '--cached'
+        ? ('git', 'diff', '--cached', '-U0', '--', $file)
+        : ('git', 'diff', '-U0', $range, '--', $file);
+    my %ch;
+    open my $fh, '-|', @cmd or return %ch;
+    while (<$fh>) {
+        next unless /^\@\@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? \@\@/;
+        my ($start, $count) = ($1, defined $2 ? $2 : 1);
+        next unless $count > 0;
+        $ch{$_} = 1 for $start .. $start + $count - 1;
+    }
+    close $fh;
+    return %ch;
+}
+
+# Build NAME => { section => 1 } from doc/man*/*.pod on disk (the working
+# tree), so a page added in the same change resolves.
+sub harvest_pod_names {
+    my %names;
+    for my $pod (glob 'doc/man*/*.pod') {
+        my ($sec) = $pod =~ m{doc/man(\d)/} or next;
+        open my $fh, '<', $pod or next;
+        my ($in_name, $buf) = (0, '');
+        while (<$fh>) {
+            if (/^=head1\s+NAME/)      { $in_name = 1; next; }
+            if ($in_name && /^=head1/) { last; }
+            $buf .= $_ if $in_name;
+        }
+        close $fh;
+        $buf =~ s/\s+-\s+.*\z//s;          # drop the " - description" tail
+        $names{$_}{$sec} = 1 for ($buf =~ /([A-Za-z_]\w*)/g);
+    }
+    return %names;
+}
+
+sub check_file {
+    my ($file, $changed) = @_;
+    open my $fh, '<', $file or return;
+    my @lines = <$fh>;
+    close $fh;
+    chomp @lines;
+    my $is_hin = $file =~ /\.h\.in$/ ? 1 : 0;
+
+    for my $p (@{ parse_prototypes(\@lines, $is_hin) }) {
+        # Only new/changed declarations.
+        next unless grep { $changed->{$_} } $p->{start} .. $p->{end};
+
+        my ($block, $doxy) = preceding_block(\@lines, $p->{start});
+        next if defined $block && $block =~ /doc-exempt/;   # opt-out
+
+        if (!$doxy) {
+            nit($file, $p->{start},
+                "$p->{name}(): missing doxygen /** */ documentation block");
+            next;
+        }
+
+        if (is_public($file)) {
+            if ($block !~ /\@see\b[^*]*?\b\Q$p->{name}\E\s*\(3\)/s) {
+                nit($file, $p->{start},
+                    "$p->{name}(): doxygen block must link its manual page "
+                    . "with \@see $p->{name}(3)");
+            } elsif (!$doc_name{$p->{name}}{3}) {
+                nit($file, $p->{start},
+                    "$p->{name}(): \@see $p->{name}(3) has no matching "
+                    . "doc/man3 page");
+            }
+        } else {
+            # Report a function's missing tags on one line; they are all fixed
+            # in the single doxygen block attached to the declaration.
+            my @clauses;
+            push @clauses, "\@returns for the return value"
+                if !$p->{ret_void} && $block !~ /\@returns?\b/;
+            my @params;
+            unless ($p->{params_uncertain}) {        # fail open on parse doubt
+                # Harvest the names doxygen actually documents.  Accept an
+                # optional [in]/[out]/[in,out] direction attribute and a
+                # comma-separated list of names on a single @param line.
+                my %documented;
+                while ($block =~ /\@param\b\s*(?:\[[^\]]*\])?\s*
+                                  ([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)/gx) {
+                    $documented{$_} = 1 for split /\s*,\s*/, $1;
+                }
+                for my $param (@{ $p->{params} }) {
+                    push @params, "'$param'" unless $documented{$param};
+                }
+            }
+            if (@params) {
+                my $word = @params == 1 ? 'parameter' : 'parameters';
+                push @clauses, "\@param for $word " . join(', ', @params);
+            }
+            nit($file, $p->{start},
+                "$p->{name}(): doxygen block missing " . join(' and ', @clauses))
+                if @clauses;
+        }
+    }
+}
+
+# Find the doxygen/comment block immediately preceding (adjacent to) $start
+# (1-indexed).  Returns ($text, $is_doxygen).
+sub preceding_block {
+    my ($lines, $start) = @_;
+    my $i = $start - 2;                    # 0-indexed line just above
+    return (undef, 0) if $i < 0 || $lines->[$i] !~ m{\*/\s*$};
+    my @blk;
+    while ($i >= 0) {
+        unshift @blk, $lines->[$i];
+        last if $lines->[$i] =~ m{/\*};
+        $i--;
+    }
+    my $doxy = ($blk[0] // '') =~ m{/\*\*} ? 1 : 0;
+    # Strip the leading " * " from each comment line so a tag that spans lines
+    # (e.g. a multi-line @see list) can be matched without the '*' at the start
+    # of a continuation line interfering.
+    (my $text = join("\n", @blk)) =~ s/^\s*\*\s?//gm;
+    return ($text, $doxy);
+}
+
+# Return arrayref of prototypes: { name, start, end, ret_void, params,
+# params_uncertain }.  Comments are blanked first so they do not interfere.
+sub parse_prototypes {
+    my ($lines, $is_hin) = @_;
+    my @code = blank_noncode($lines, $is_hin);
+
+    # Prototypes appear at file scope or directly inside an extern "C" {}
+    # linkage block; never inside a struct/union/enum body or a function
+    # body.  So track a "skip depth": every '{' opens a skip scope EXCEPT an
+    # extern "..." linkage block, which is transparent.  Prototypes are only
+    # recorded when the skip depth is zero.
+    my @protos;
+    my @stack;                          # 1 = skip brace, 0 = transparent
+    my ($stmt, $sline, $sskip, $skip) = ('', 0, 0, 0);
+    for my $idx (0 .. $#code) {
+        next if $lines->[$idx] =~ /^\s*#/;         # preprocessor directive
+        for my $ch (split //, $code[$idx]) {
+            if ($ch eq '{') {
+                (my $pre = $stmt) =~ s/\s+$//;
+                my $transparent = $pre =~ /\bextern\s*"[^"]*"$/ ? 1 : 0;
+                push @stack, $transparent ? 0 : 1;
+                $skip++ unless $transparent;
+                $stmt = '';
+            } elsif ($ch eq '}') {
+                my $was = pop @stack;
+                $skip-- if $was;
+                $skip = 0 if $skip < 0;
+                $stmt = '';
+            } elsif ($ch eq ';') {
+                if ($sskip == 0 && $stmt !~ /[{}]/) {
+                    my $p = classify_stmt($stmt . ';', $sline, $idx + 1);
+                    push @protos, $p if $p;
+                }
+                $stmt = '';
+            } else {
+                if ($stmt eq '' && $ch =~ /\S/) { $sline = $idx + 1; $sskip = $skip; }
+                $stmt .= $ch if $stmt ne '' || $ch =~ /\S/;
+            }
+        }
+        $stmt .= ' ' if $stmt ne '';
+    }
+    return \@protos;
+}
+
+sub classify_stmt {
+    my ($raw, $start, $end) = @_;
+    (my $s = $raw) =~ s/\s+/ /g;
+    $s =~ s/^\s+//;
+    return undef if $s =~ /^typedef\b/;                      # typedef
+    return undef if $s =~ /^\s*static\b/;                    # static fn
+    # Collapse the STACK_OF()/LHASH_OF() type macros to a plain type token so
+    # a return type like "const STACK_OF(X509) *" does not get mistaken for a
+    # function named STACK_OF.
+    $s =~ s/\b(?:STACK_OF|LHASH_OF|SPARSE_ARRAY_OF)\s*\(\s*\w+\s*\)/OSSL_TYPE/g;
+    # strip leading attribute / deprecation qualifier macros
+    1 while $s =~ s/^(?:OSSL_DEPRECATEDIN_\S+|__owur|ossl_unused)\s+//;
+    # ret-type (must contain a space or '*' before the name) then NAME(args);
+    return undef unless
+        $s =~ /^((?:\w[\w ]*?)[ \*]+)([A-Za-z_]\w*)\s*\((.*)\)\s*;$/;
+    my ($ret, $name, $args) = ($1, $2, $3);
+    (my $rt = $ret) =~ s/\s+$//;
+    my $ret_void = ($rt eq 'void') ? 1 : 0;
+
+    my ($params, $uncertain) = parse_params($args);
+    return {
+        name             => $name,
+        start            => $start,
+        end              => $end,
+        ret_void         => $ret_void,
+        params           => $params,
+        params_uncertain => $uncertain,
+    };
+}
+
+# Extract parameter names.  Returns (\@names, $uncertain).  We fail open
+# (uncertain=1) on anything we cannot confidently name.
+sub parse_params {
+    my ($args) = @_;
+    $args =~ s/^\s+//; $args =~ s/\s+$//;
+    return ([], 0) if $args eq '' || $args eq 'void';
+    return ([], 1) if $args =~ /\Q...\E/ || $args =~ /\(\s*\*/;  # varargs / fn-ptr
+    my @names;
+    for my $a (split /,/, $args) {
+        $a =~ s/\[.*?\]//g;                       # drop array dims
+        if ($a =~ /([A-Za-z_]\w*)\s*$/) {
+            my $n = $1;
+            # a trailing bare type keyword => unnamed parameter => uncertain
+            return ([], 1) if $n =~ /^(void|int|char|long|short|unsigned|
+                                       signed|size_t|double|float)$/x;
+            push @names, $n;
+        } else {
+            return ([], 1);
+        }
+    }
+    return (\@names, 0);
+}
+
+# Blank out /* */ and // comments, and (for .h.in files) {- ... -} template
+# fragments, preserving line count and columns so line numbers stay accurate.
+sub blank_noncode {
+    my ($lines, $is_hin) = @_;
+    my @out;
+    my $mode = 0;                       # 0 code, 1 /* */ comment, 2 {- -} template
+    for my $l (@$lines) {
+        my ($o, $j) = ('', 0);
+        while ($j < length $l) {
+            my $two = substr($l, $j, 2);
+            if ($mode == 1) {
+                if ($two eq '*/') { $mode = 0; $o .= '  '; $j += 2; }
+                else              { $o .= ' ';             $j++;    }
+            } elsif ($mode == 2) {
+                if ($two eq '-}') { $mode = 0; $o .= '  '; $j += 2; }
+                else              { $o .= ' ';             $j++;    }
+            } elsif ($two eq '/*')            { $mode = 1; $o .= '  '; $j += 2; }
+            elsif ($is_hin && $two eq '{-')   { $mode = 2; $o .= '  '; $j += 2; }
+            elsif ($two eq '//') { $o .= ' ' x (length($l) - $j);   last; }
+            else                 { $o .= substr($l, $j, 1);         $j++;   }
+        }
+        push @out, $o;
+    }
+    return @out;
+}


### PR DESCRIPTION
For the documentation requirements laid out in  https://github.com/openssl/openssl/pull/29295
to address concerns like https://github.com/openssl/openssl/pull/29295#discussion_r3429995823

Run in pre-commit and CI, complains if you don't have the required doxygen looking something like
correct on public functions and shared internal functions. Ignores static functions as we do say
they are optional. 

spits out one line per nonconforming function telling you what it does not like. 

This is done incrementally like clang-format, so you only have to do it for things you touch.

output looks like: 

```
check-doc-comments: diffing changed lines against 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0'
include/crypto/widget.h:41: ossl_widget_new(): doxygen block missing @param for parameter 'ctx'
include/crypto/widget.h:58: ossl_widget_resize(): doxygen block missing @returns for the return value and @param for parameter 'height'
include/crypto/widget.h:73: ossl_widget_bounds(): doxygen block missing @param for parameters 'width', 'height'
include/crypto/widget.h:96: ossl_widget_blit(): doxygen block missing @param for parameters 'src', 'dst', 'len'
include/internal/gadget.h:22: ossl_gadget_hash(): doxygen block missing @returns for the return value and @param for parameter 'gadget'
include/openssl/frobnicator.h:64: OSSL_frobnicator_start(): doxygen block must link its manual page with @see OSSL_frobnicator_start(3)
include/openssl/frobnicator.h:74: OSSL_frobnicator_frob(): @see OSSL_frobnicator_frob(3) has no matching doc/man3 page
ssl/statem/statem_local.h:512: tls_construct_ctos_gizmo(): missing doxygen /** */ documentation block
note: a trivial function may be exempted with a "/* doc-exempt: <reason> */" comment immediately before its declaration
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
