### PR TITLE
Avoid undefined behavior adding two BN_zero() values

### DIFF
--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -8,7 +8,7 @@
 name: Run-checker merge
 # Jobs run per merge to master
 
-on: [push]
+on: [pull_request]
 permissions:
   contents: read
 

--- a/crypto/bn/bn_add.c
+++ b/crypto/bn/bn_add.c
@@ -146,6 +146,9 @@ int BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
     if (bn_wexpand(r, max) == NULL)
         return 0;
 
+    if (max == 0)
+        goto end;
+
     ap = a->d;
     bp = b->d;
     rp = r->d;
@@ -165,6 +168,7 @@ int BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
     while (max && *--rp == 0)
         max--;
 
+end:
     r->top = max;
     r->neg = 0;
     bn_pollute(r);

--- a/crypto/bn/bn_add.c
+++ b/crypto/bn/bn_add.c
@@ -97,6 +97,8 @@ int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
         return 0;
 
     r->top = max;
+    if (max == 0)
+        goto end;
 
     ap = a->d;
     bp = b->d;
@@ -116,6 +118,7 @@ int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
     *rp = carry;
     r->top += (int)carry;
 
+end:
     r->neg = 0;
     bn_check_top(r);
     return 1;


### PR DESCRIPTION
Urgent as this is a fix for a broken CI.

This issue in BN_uadd() was revealed by the recently added test in https://github.com/openssl/openssl/pull/30893

The DROP! commit must be dropped when merging!