### PR TITLE
quic: make tserver fake-time idle test deterministic

### DIFF
--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -60,7 +60,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
     BIO *c_pair_own = NULL, *s_pair_own = NULL;
     QUIC_TSERVER_ARGS tserver_args = { 0 };
     QUIC_TSERVER *tserver = NULL;
-    BIO_ADDR *s_addr_ = NULL;
+    BIO_ADDR *s_addr_ = NULL, *c_addr_ = NULL;
     struct in_addr ina = { 0 };
     union BIO_sock_info_u s_info = { 0 };
     SSL_CTX *c_ctx = NULL;
@@ -85,31 +85,57 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
     ina.s_addr = htonl(0x7f000001UL);
 
     /* Setup test server. */
-    s_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
-    if (!TEST_int_ge(s_fd, 0))
-        goto err;
-
-    if (!TEST_true(BIO_socket_nbio(s_fd, 1)))
-        goto err;
-
     if (!TEST_ptr(s_addr_ = BIO_ADDR_new()))
         goto err;
 
     if (!TEST_true(BIO_ADDR_rawmake(s_addr_, AF_INET, &ina, sizeof(ina), 0)))
         goto err;
 
-    if (!TEST_true(BIO_bind(s_fd, s_addr_, 0)))
-        goto err;
+    if (use_fake_time) {
+        /*
+         * Keep accelerated fake time independent of OS network scheduling.
+         * Other iterations retain real UDP socket coverage.
+         */
+        if (!TEST_true(BIO_new_bio_dgram_pair(&c_net_bio_own, 0,
+                &s_net_bio_own, 0)))
+            goto err;
 
-    s_info.addr = s_addr_;
-    if (!TEST_true(BIO_sock_info(s_fd, BIO_SOCK_INFO_ADDRESS, &s_info)))
-        goto err;
+        c_net_bio = c_net_bio_own;
+        s_net_bio = s_net_bio_own;
 
-    if (!TEST_int_gt(BIO_ADDR_rawport(s_addr_), 0))
-        goto err;
+        if (!TEST_true(BIO_dgram_set_caps(c_net_bio,
+                BIO_DGRAM_CAP_HANDLES_DST_ADDR))
+            || !TEST_true(BIO_dgram_set_caps(s_net_bio,
+                BIO_DGRAM_CAP_HANDLES_DST_ADDR)))
+            goto err;
 
-    if (!TEST_ptr(s_net_bio = s_net_bio_own = BIO_new_dgram(s_fd, 0)))
-        goto err;
+        if (!TEST_ptr(c_addr_ = BIO_ADDR_new())
+            || !TEST_true(BIO_ADDR_rawmake(c_addr_, AF_INET, &ina,
+                sizeof(ina), 0))
+            || !TEST_true(BIO_dgram_set0_local_addr(c_net_bio, c_addr_)))
+            goto err;
+        c_addr_ = NULL;
+    } else {
+        s_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+        if (!TEST_int_ge(s_fd, 0))
+            goto err;
+
+        if (!TEST_true(BIO_socket_nbio(s_fd, 1)))
+            goto err;
+
+        if (!TEST_true(BIO_bind(s_fd, s_addr_, 0)))
+            goto err;
+
+        s_info.addr = s_addr_;
+        if (!TEST_true(BIO_sock_info(s_fd, BIO_SOCK_INFO_ADDRESS, &s_info)))
+            goto err;
+
+        if (!TEST_int_gt(BIO_ADDR_rawport(s_addr_), 0))
+            goto err;
+
+        if (!TEST_ptr(s_net_bio = s_net_bio_own = BIO_new_dgram(s_fd, 0)))
+            goto err;
+    }
 
     if (!BIO_up_ref(s_net_bio))
         goto err;
@@ -144,18 +170,20 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
     }
 
     /* Setup test client. */
-    c_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
-    if (!TEST_int_ge(c_fd, 0))
-        goto err;
+    if (!use_fake_time) {
+        c_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+        if (!TEST_int_ge(c_fd, 0))
+            goto err;
 
-    if (!TEST_true(BIO_socket_nbio(c_fd, 1)))
-        goto err;
+        if (!TEST_true(BIO_socket_nbio(c_fd, 1)))
+            goto err;
 
-    if (!TEST_ptr(c_net_bio = c_net_bio_own = BIO_new_dgram(c_fd, 0)))
-        goto err;
+        if (!TEST_ptr(c_net_bio = c_net_bio_own = BIO_new_dgram(c_fd, 0)))
+            goto err;
 
-    if (!BIO_dgram_set_peer(c_net_bio, s_addr_))
-        goto err;
+        if (!BIO_dgram_set_peer(c_net_bio, s_addr_))
+            goto err;
+    }
 
     if (!TEST_ptr(c_ctx = SSL_CTX_new(use_thread_assist
                           ? OSSL_QUIC_client_thread_method()
@@ -165,9 +193,12 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
     if (!TEST_ptr(c_ssl = SSL_new(c_ctx)))
         goto err;
 
-    if (use_fake_time)
+    if (use_fake_time) {
+        if (!TEST_true(SSL_set1_initial_peer_addr(c_ssl, s_addr_)))
+            goto err;
         if (!TEST_true(ossl_quic_set_override_now_cb(c_ssl, fake_now, NULL)))
             goto err;
+    }
 
     /* 0 is a success for SSL_set_alpn_protos() */
     if (!TEST_false(SSL_set_alpn_protos(c_ssl, alpn, sizeof(alpn))))
@@ -397,7 +428,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
 
             for (;;) {
                 /*
-                 * Manually spoonfeed received datagrams from the real BIO_dgram
+                 * Manually spoonfeed received datagrams from the network BIO
                  * into QUIC via the injection interface, thereby testing the
                  * injection interface.
                  */
@@ -421,6 +452,7 @@ err:
     SSL_CTX_free(c_ctx);
     ossl_quic_tserver_free(tserver);
     BIO_ADDR_free(s_addr_);
+    BIO_ADDR_free(c_addr_);
     BIO_free(s_net_bio_own);
     BIO_free(c_net_bio_own);
     BIO_free(c_pair_own);


### PR DESCRIPTION
The thread-assisted tserver idle test advances a shared fake clock while the client and server exchange datagrams through real UDP sockets.

#31746 synchronizes fake-time advancement with client assist-thread processing. However, once the client has serviced a due keepalive, the resulting PING can still be pending in the operating system's UDP path while the test continues advancing the server's fake clock. Observing a positive next-event timeout via `SSL_get_event_timeout()` only establishes that the client-side scheduler has advanced beyond the due event; it does not establish that the server has received the datagram. The server can consequently reach its idle deadline before the datagram becomes visible on its socket.

Use an in-memory datagram BIO pair for the fake-time variants so client writes are immediately available to the next server tick. All non-fake-time variants continue using real UDP sockets, including the real-time thread-assisted variant. The datagram injection variant also continues exercising `SSL_inject_net_dgram()`.

The negotiated 30-second idle timeout and simulated 60-second idle period remain unchanged, so the client assist thread must still generate keepalives for the test to pass.

This change is complementary to #31746, not a replacement for it: #31746 synchronizes fake-time advancement with client-side processing, while this change removes the remaining unsynchronized datagram-delivery boundary.

#31921 targets `openssl-3.5`, and its tested head already contained the #31746 backport (`840158a273`). The remaining failure was observed independently in both failing macOS jobs — `no-shared-macos` and `out-of-readonly-source-and-install-macos` — with different random seeds.
In both jobs, iteration 6 failed at the final `ossl_quic_tserver_is_connected()` check. Rerunning the same CI became green.

- [`no-shared-macos`](https://github.com/openssl/openssl/actions/runs/29140982452/job/86513966792) failed iteration 6 with `OPENSSL_TEST_RAND_SEED=1783747351`.
- [`out-of-readonly-source-and-install-macos`](https://github.com/openssl/openssl/actions/runs/29140982452/job/86513966756) failed iteration 6 with `OPENSSL_TEST_RAND_SEED=1783747445`.

This addresses the remaining race without increasing the idle timeout or adding server keepalives as proposed in #29988.

Testing:

- `VC-WIN64A no-shared`
  - `nmake test TESTS=test_quic_tserver`
  - Full eight-iteration `quic_tserver_test`
  - 500 fresh-process runs of iteration 6
  - 500 fresh-process runs of iteration 8
- `linux-x86_64 no-shared --strict-warnings`
  - Strict-warning build and full eight-iteration `quic_tserver_test`

##### Checklist
- [x] tests are added or updated

Assisted-by: Codex:gpt-5.6-sol
