### PR TITLE
TLS 1.3: Fix SSL_export_keying_material_early() when 0-RTT is suppressed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,12 @@ OpenSSL Releases
 
    *Jakub Zelenka*
 
+ * Fixed TLS 1.3 servers to reject early data when the selected ciphersuite
+   differs from the ciphersuite associated with the selected PSK. Same-hash
+   PSK resumption can still continue without accepting 0-RTT data.
+
+   *Mounir IDRASSI*
+
  * Added support for Ed25519 and Ed448 certificates in DTLS 1.2. Previously,
    these certificate types were only supported in TLS 1.2 and TLS 1.3.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,30 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Fixed a bug where a TLS 1.3 session ticket could retain a stale ALPN
+   protocol from an earlier connection after a resumption negotiated a
+   different protocol (or none), on both the server and the client,
+   which could otherwise affect a later 0-RTT decision.
+
+   *Daniel Kubec and Viktor Dukhovni*
+
+ * Fixed TLS 1.3 servers to reject early data when a resumed PSK's
+   ticket age is outside tolerance, per RFC 8446, instead of accepting
+   0-RTT data from a ticket that has aged out.
+
+   *Daniel Kubec*
+
+ * Fixed external TLS 1.3 PSK connections being wrongly rejected when
+   the client sets a non-empty session ID context.
+
+   *Viktor Dukhovni*
+
+ * Fixed TLS 1.3 PSK connections, both session tickets and external
+   PSKs, being wrongly rejected by a server that requests client
+   certificate verification but has no session ID context configured.
+
+   *Viktor Dukhovni*
+
  * EC key point format simplification.
 
    The point conversion form (compressed, uncompressed, or hybrid)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2899,7 +2899,7 @@ int SSL_write_early_data(SSL *s, const void *buf, size_t num, size_t *written)
              * In that case leave the state alone so the handshake can complete
              * normally without 0-RTT.
              */
-            if (sc->early_data_state == SSL_EARLY_DATA_CONNECTING)
+            if (!sc->ext.early_data_suppressed)
                 sc->early_data_state = SSL_EARLY_DATA_CONNECT_RETRY;
             return 0;
         }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -586,6 +586,9 @@ int ossl_ssl_connection_reset(SSL *s)
     sc->error = 0;
     sc->hit = 0;
     sc->shutdown = 0;
+    sc->ext.early_data_suppressed = 0;
+    sc->ext.tick_age_checked = 0;
+    sc->ext.tick_age_ms = 0;
 
     if (sc->renegotiate) {
         ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
@@ -2856,6 +2859,22 @@ int SSL_write_early_data(SSL *s, const void *buf, size_t num, size_t *written)
 
     switch (sc->early_data_state) {
     case SSL_EARLY_DATA_NONE:
+        /*
+         * tls_construct_ctos_early_data() decided not to advertise the
+         * early_data extension.
+         *
+         * Succeed and report num bytes as written so the handshake can
+         * continue without 0-RTT; early data rejection can be detected via
+         * SSL_get_early_data_status().
+         */
+        if (!sc->server && sc->ext.early_data_suppressed && !SSL_in_before(s)) {
+            ret = SSL_connect(s);
+            if (ret <= 0)
+                return 0;
+            *written = num;
+            return 1;
+        }
+
         if (sc->server
             || !SSL_in_before(s)
             || ((sc->session == NULL || sc->session->ext.max_early_data == 0)
@@ -2870,9 +2889,24 @@ int SSL_write_early_data(SSL *s, const void *buf, size_t num, size_t *written)
         sc->early_data_state = SSL_EARLY_DATA_CONNECTING;
         ret = SSL_connect(s);
         if (ret <= 0) {
-            /* NBIO or error */
-            sc->early_data_state = SSL_EARLY_DATA_CONNECT_RETRY;
+            /*
+             * NBIO or error. Normally we stamp the state back to
+             * SSL_EARLY_DATA_CONNECT_RETRY so the next SSL_write_early_data()
+             * call resumes here. However tls_construct_ctos_early_data() may
+             * have reset early_data_state to SSL_EARLY_DATA_NONE because it
+             * decided not to send the early_data extension.
+             *
+             * In that case leave the state alone so the handshake can complete
+             * normally without 0-RTT.
+             */
+            if (sc->early_data_state == SSL_EARLY_DATA_CONNECTING)
+                sc->early_data_state = SSL_EARLY_DATA_CONNECT_RETRY;
             return 0;
+        }
+        if (sc->early_data_state == SSL_EARLY_DATA_NONE
+            && sc->ext.early_data_suppressed) {
+            *written = num;
+            return 1;
         }
         /* fall through */
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1758,6 +1758,15 @@ struct ssl_connection_st {
          */
         int tick_identity;
 
+        /*
+         * Cached result of the resumption ticket age/lifetime check for the
+         * ClientHello under construction. Time-dependent, double-checked
+         * within the same flight (see tls13_check_tick_lifetime_hint()).
+         */
+        int tick_age_checked;
+        int tick_age_ok;
+        uint32_t tick_age_ms;
+
         /* This is the list of algorithms the peer supports that we also support */
         int compress_certificate_from_peer[TLSEXT_comp_cert_limit];
 
@@ -1785,8 +1794,11 @@ struct ssl_connection_st {
         /* Set to one if we have negotiated ETM */
         bool use_etm;
 
-        /* Is the session suitable for early data? */
+        /* Is the session perhaps suitable for early data? */
         bool early_data_ok;
+
+        /* Was the session found unsuitable for early data? */
+        bool early_data_suppressed;
 
         /* Have we received a cookie from the client? */
         bool cookieok;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -518,6 +518,24 @@ struct ssl_session_st {
      * to disable session caching and tickets.
      */
     int not_resumable;
+    /*
+     * Set when this session's master key was resolved from an external PSK
+     * identity (RFC 9258 static/dynamic candidates, psk_find_session_cb(),
+     * or the legacy psk_server_callback()) rather than from a real ticket or
+     * session-cache lookup. ssl_get_prev_session() uses this to exempt such
+     * sessions from sid_ctx checks that only make sense for a real cache
+     * lookup -- there is no cache-partitioning ambiguity to guard against
+     * when the identity was just resolved, out of band, by the application's
+     * own callback.
+     *
+     * Deliberately not part of the SSL_SESSION ASN.1 encoding: it must not
+     * survive a real ticket round-trip (a session reconstructed by
+     * d2i_SSL_SESSION() from a genuine, previously-issued ticket is by
+     * definition not an external-PSK match, and should get the ordinary
+     * sid_ctx treatment). ssl_session_dup() resets it to 0 on every copy,
+     * mirroring not_resumable just above, for the same reason.
+     */
+    int psk_external;
     /* Peer raw public key, if available */
     EVP_PKEY *peer_rpk;
     /* This is the cert and type for the other end. */

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -279,8 +279,17 @@ SSL_SESSION *ssl_session_dup(const SSL_SESSION *src, int ticket)
 {
     SSL_SESSION *sess = ssl_session_dup_intern(src, ticket);
 
-    if (sess != NULL)
+    if (sess != NULL) {
         sess->not_resumable = 0;
+        /*
+         * A duplicate (e.g. one being split off for a fresh ticket) is no
+         * longer "just resolved via an external PSK callback this instant" --
+         * it's a session in its own right going forward, and should get the
+         * ordinary sid_ctx treatment on any future resumption. See the field
+         * comment in ssl_local.h.
+         */
+        sess->psk_external = 0;
+    }
 
     return sess;
 }
@@ -648,7 +657,14 @@ int ssl_get_prev_session(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello)
         goto err; /* treat like cache miss */
     }
 
-    if ((s->verify_mode & SSL_VERIFY_PEER) && s->sid_ctx_length == 0) {
+    /*
+     * sid_ctx exists to keep multiple services that happen to share one
+     * session cache from resuming each other's sessions.  This check is
+     * not relevant to sessions that were just resolved via an external
+     * PSK identity.  See the psk_external field comment in ssl_local.h.
+     */
+    if (!ret->psk_external
+        && (s->verify_mode & SSL_VERIFY_PEER) && s->sid_ctx_length == 0) {
         /*
          * We can't be sure if this session is being used out of context,
          * which is especially important for SSL_VERIFY_PEER. The application

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -2456,6 +2456,15 @@ int tls_parse_stoc_psk(SSL_CONNECTION *s, PACKET *pkt,
         || s->psksession->ext.max_early_data == 0)
         memcpy(s->early_secret, s->psksession->early_secret, EVP_MAX_MD_SIZE);
 
+    /*
+     * s->psksession was built by psk_use_session_cb()/psk_client_callback(),
+     * not via ssl_get_new_session(), so, unlike an ordinary session, it
+     * was never stamped with our own sid_ctx.  We must do so now, to avoid
+     * rejection of the PSK session in ssl_get_prev_session().
+     */
+    memcpy(s->psksession->sid_ctx, s->sid_ctx, s->sid_ctx_length);
+    s->psksession->sid_ctx_length = s->sid_ctx_length;
+
     SSL_SESSION_free(s->session);
     s->session = s->psksession;
     s->psksession = NULL;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1032,6 +1032,82 @@ end:
     return ret;
 }
 
+static int tls13_check_tick_lifetime_hint(SSL_CONNECTION *s)
+{
+    OSSL_TIME t;
+    uint32_t agesec;
+
+    if (s->ext.tick_age_checked)
+        return s->ext.tick_age_ok;
+    s->ext.tick_age_ok = 1;
+
+    /*
+     * Technically the C standard just says time() returns a time_t and says
+     * nothing about the encoding of that type. In practice most
+     * implementations follow POSIX which holds it as an integral type in
+     * seconds since epoch. We've already made the assumption that we can do
+     * this in multiple places in the code, so portability shouldn't be an
+     * issue.
+     */
+    t = ossl_time_subtract(ossl_time_now(), s->session->time);
+    agesec = (uint32_t)ossl_time2seconds(t);
+
+    /*
+     * We calculate the age in seconds but the server may work in ms. Due to
+     * rounding errors we could overestimate the age by up to 1s. It is
+     * better to underestimate it. Otherwise, if the RTT is very short, when
+     * the server calculates the age reported by the client it could be
+     * bigger than the age calculated on the server - which should never
+     * happen.
+     */
+    if (agesec > 0)
+        agesec--;
+
+    /*
+     * Calculate age in ms. We're just doing it to nearest second. Should be
+     * good enough.
+     */
+    s->ext.tick_age_ms = agesec * (uint32_t)1000;
+
+    /*
+     * Ticket is too old. Ignore it. Overflow. Shouldn't happen unless this is a
+     * *really* old session. If so we just ignore it.
+     */
+    if (s->session->ext.tick_lifetime_hint < agesec)
+        s->ext.tick_age_ok = 0;
+    else if (agesec != 0 && s->ext.tick_age_ms / (uint32_t)1000 != agesec)
+        s->ext.tick_age_ok = 0;
+
+    s->ext.tick_age_checked = 1;
+    return s->ext.tick_age_ok;
+}
+
+/*
+ * Mirrors the gating checks in tls_construct_ctos_psk() so that early_data
+ * is only advertised when the PSK will actually be sent.
+ */
+static int tls13_check_psk(SSL_CONNECTION *s, const EVP_MD *handmd)
+{
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+    const EVP_MD *mdres;
+
+    if (s->session == NULL
+        || s->session->ssl_version != TLS1_3_VERSION
+        || s->session->ext.ticklen == 0
+        || s->session->cipher == NULL)
+        return 0;
+
+    mdres = ssl_md(sctx, s->session->cipher->algorithm2);
+    if (mdres == NULL)
+        return 0;
+    if (s->hello_retry_request == SSL_HRR_PENDING && mdres != handmd)
+        return 0;
+    if (tls13_check_tick_lifetime_hint(s) == 0)
+        return 0;
+
+    return 1;
+}
+
 EXT_RETURN tls_construct_ctos_early_data(SSL_CONNECTION *s, WPACKET *pkt,
     unsigned int context, X509 *x,
     size_t chainidx)
@@ -1045,6 +1121,9 @@ EXT_RETURN tls_construct_ctos_early_data(SSL_CONNECTION *s, WPACKET *pkt,
     SSL_SESSION *edsess = NULL;
     const EVP_MD *handmd = NULL;
     SSL *ussl = SSL_CONNECTION_GET_USER_SSL(s);
+    int edok;
+
+    s->ext.tick_age_checked = 0;
 
 #ifndef OPENSSL_NO_ECH
     /*
@@ -1147,13 +1226,29 @@ EXT_RETURN tls_construct_ctos_early_data(SSL_CONNECTION *s, WPACKET *pkt,
         s->psksession_id_len = idlen;
     }
 
+    /*
+     * Suppress early_data unless a PSK is available and will be sent.
+     *
+     * RFC 8446 4.2.10: When a PSK is used and early data is allowed for that
+     * PSK, the client can send Application Data in its first flight of
+     * messages. If the client opts to do so, it MUST supply both the
+     * "pre_shared_key" and "early_data" extensions.
+     *
+     * The PSK used to encrypt the early data MUST be the first PSK listed in
+     * the client's "pre_shared_key" extension.
+     */
+    edok = (tls13_check_psk(s, handmd) && s->session->ext.max_early_data != 0);
     if (s->early_data_state != SSL_EARLY_DATA_CONNECTING
-        || (s->session->ext.max_early_data == 0
-            && (psksess == NULL || psksess->ext.max_early_data == 0))) {
+        || (edok == 0 && (psksess == NULL || psksess->ext.max_early_data == 0))) {
         s->max_early_data = 0;
+        if (s->early_data_state == SSL_EARLY_DATA_CONNECTING) {
+            s->ext.early_data_suppressed = 1;
+            s->ext.early_data = SSL_EARLY_DATA_REJECTED;
+        }
+        s->early_data_state = SSL_EARLY_DATA_NONE;
         return EXT_RETURN_NOT_SENT;
     }
-    edsess = s->session->ext.max_early_data != 0 ? s->session : psksess;
+    edsess = edok != 0 ? s->session : psksess;
     s->max_early_data = edsess->ext.max_early_data;
 
     if (edsess->ext.hostname != NULL) {
@@ -1313,14 +1408,13 @@ EXT_RETURN tls_construct_ctos_psk(SSL_CONNECTION *s, WPACKET *pkt,
     X509 *x, size_t chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
-    uint32_t agesec, agems = 0;
+    uint32_t agems = 0;
     size_t binderoffset, msglen;
     int reshashsize = 0, pskhashsize = 0;
     unsigned char *resbinder = NULL, *pskbinder = NULL, *msgstart = NULL;
     const EVP_MD *handmd = NULL, *mdres = NULL, *mdpsk = NULL;
     int dores = 0;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
-    OSSL_TIME t;
 
     s->ext.tick_identity = 0;
 
@@ -1377,46 +1471,10 @@ EXT_RETURN tls_construct_ctos_psk(SSL_CONNECTION *s, WPACKET *pkt,
         }
 #endif
 
-        /*
-         * Technically the C standard just says time() returns a time_t and says
-         * nothing about the encoding of that type. In practice most
-         * implementations follow POSIX which holds it as an integral type in
-         * seconds since epoch. We've already made the assumption that we can do
-         * this in multiple places in the code, so portability shouldn't be an
-         * issue.
-         */
-        t = ossl_time_subtract(ossl_time_now(), s->session->time);
-        agesec = (uint32_t)ossl_time2seconds(t);
-
-        /*
-         * We calculate the age in seconds but the server may work in ms. Due to
-         * rounding errors we could overestimate the age by up to 1s. It is
-         * better to underestimate it. Otherwise, if the RTT is very short, when
-         * the server calculates the age reported by the client it could be
-         * bigger than the age calculated on the server - which should never
-         * happen.
-         */
-        if (agesec > 0)
-            agesec--;
-
-        if (s->session->ext.tick_lifetime_hint < agesec) {
-            /* Ticket is too old. Ignore it. */
+        if (tls13_check_tick_lifetime_hint(s) == 0)
             goto dopsksess;
-        }
-
-        /*
-         * Calculate age in ms. We're just doing it to nearest second. Should be
-         * good enough.
-         */
-        agems = agesec * (uint32_t)1000;
-
-        if (agesec != 0 && agems / (uint32_t)1000 != agesec) {
-            /*
-             * Overflow. Shouldn't happen unless this is a *really* old session.
-             * If so we just ignore it.
-             */
-            goto dopsksess;
-        }
+        /* tls13_check_tick_lifetime_hint() updates the tick_age_ms value. */
+        agems = s->ext.tick_age_ms;
 
         /*
          * Obfuscate the age. Overflow here is fine, this addition is supposed

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1083,10 +1083,11 @@ static int tls13_check_tick_lifetime_hint(SSL_CONNECTION *s)
 }
 
 /*
- * Mirrors the gating checks in tls_construct_ctos_psk() so that early_data
- * is only advertised when the PSK will actually be sent.
+ * Mirrors the ticket-resumption gating checks in tls_construct_ctos_psk() so
+ * that early_data is only advertised when the resumption PSK will actually
+ * be sent.
  */
-static int tls13_check_psk(SSL_CONNECTION *s, const EVP_MD *handmd)
+static int tls13_check_resumption_psk(SSL_CONNECTION *s, const EVP_MD *handmd)
 {
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
     const EVP_MD *mdres;
@@ -1237,7 +1238,7 @@ EXT_RETURN tls_construct_ctos_early_data(SSL_CONNECTION *s, WPACKET *pkt,
      * The PSK used to encrypt the early data MUST be the first PSK listed in
      * the client's "pre_shared_key" extension.
      */
-    edok = (tls13_check_psk(s, handmd) && s->session->ext.max_early_data != 0);
+    edok = (tls13_check_resumption_psk(s, handmd) && s->session->ext.max_early_data != 0);
     if (s->early_data_state != SSL_EARLY_DATA_CONNECTING
         || (edok == 0 && (psksess == NULL || psksess->ext.max_early_data == 0))) {
         s->max_early_data = 0;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1516,6 +1516,13 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
             s->ext.ticket_expected = 1;
             continue;
         }
+        /*
+         * Same-hash ciphersuite changes are allowed for TLSv1.3 PSK
+         * resumption, but RFC 8446 Section 4.2.10 requires the selected
+         * ciphersuite to match the selected PSK before accepting early data.
+         */
+        if (sess->cipher->id != s->s3.tmp.new_cipher->id)
+            s->ext.early_data_ok = 0;
         break;
     }
 

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1413,6 +1413,14 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
              */
             memcpy(sess->sid_ctx, s->sid_ctx, s->sid_ctx_length);
             sess->sid_ctx_length = s->sid_ctx_length;
+            /*
+             * Resolved just now via psk_find_session_cb()/psk_server_callback(),
+             * not from a real ticket or cache lookup -- exempt from the
+             * sid_ctx checks in ssl_get_prev_session() that don't apply here.
+             * Must be set after the ssl_session_dup() above, which always
+             * resets it back to 0.
+             */
+            sess->psk_external = 1;
             ext = 1;
             if (id == 0)
                 s->ext.early_data_ok = 1;
@@ -1484,6 +1492,8 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
                  */
                 s->ext.early_data_ok = 1;
             }
+            /* This PSK is not external, use the correct binder label, ... */
+            ext = 0;
         }
 
         md = ssl_md(sctx, sess->cipher->algorithm2);
@@ -1760,7 +1770,15 @@ EXT_RETURN tls_construct_stoc_session_ticket(SSL_CONNECTION *s, WPACKET *pkt,
     unsigned int context, X509 *x,
     size_t chainidx)
 {
-    if (!s->ext.ticket_expected || !tls_use_ticket(s)) {
+    /*
+     * Don't tell the client to expect a NewSessionTicket when any
+     * ticket we'd mint would be rejected by ssl_get_prev_session()
+     * whenever SSL_VERIFY_PEER is set with no sid_ctx configured (see
+     * the checks there).  In TLS 1.2, once promised the ticket MUST
+     * be sent.
+     */
+    if (!s->ext.ticket_expected || !tls_use_ticket(s)
+        || ((s->verify_mode & SSL_VERIFY_PEER) && s->sid_ctx_length == 0)) {
         s->ext.ticket_expected = 0;
         return EXT_RETURN_NOT_SENT;
     }

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -1028,5 +1028,6 @@ int ossl_statem_export_early_allowed(SSL_CONNECTION *s)
      * as we have sent early_data.
      */
     return s->ext.early_data == SSL_EARLY_DATA_ACCEPTED
-        || (!s->server && s->ext.early_data != SSL_EARLY_DATA_NOT_SENT);
+        || (!s->server && !s->ext.early_data_suppressed
+            && s->ext.early_data != SSL_EARLY_DATA_NOT_SENT);
 }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3220,6 +3220,34 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
     s->session->session_id_length = sess_len;
     s->session->not_resumable = 0;
 
+    /*
+     * Refresh the session's recollection of the negotiated ALPN protocol to
+     * match this connection, rather than leaving it as whatever the session
+     * (or the session it was duplicated from, on a resumption) previously
+     * carried. Without this, a connection that resumes a session but
+     * negotiates no ALPN (or a different one) leaves the stale protocol
+     * name in place, and a later 0-RTT attempt against this ticket can
+     * incorrectly trip the "inconsistent early data alpn" check -- or, if
+     * the client happens to offer that same stale protocol again by
+     * coincidence, incorrectly appear consistent. This mirrors, on the
+     * client, the server-side fix for issue #11197 in
+     * tls_construct_new_session_ticket().
+     */
+    OPENSSL_free(s->session->ext.alpn_selected);
+    if (s->s3.alpn_selected != NULL) {
+        s->session->ext.alpn_selected = OPENSSL_memdup(s->s3.alpn_selected,
+            s->s3.alpn_selected_len);
+        if (s->session->ext.alpn_selected == NULL) {
+            s->session->ext.alpn_selected_len = 0;
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
+            goto err;
+        }
+        s->session->ext.alpn_selected_len = s->s3.alpn_selected_len;
+    } else {
+        s->session->ext.alpn_selected = NULL;
+        s->session->ext.alpn_selected_len = 0;
+    }
+
     /* This is a standalone message in TLSv1.3, so there is no more to read */
     if (SSL_CONNECTION_IS_TLS13(s)) {
         const EVP_MD *md = ssl_handshake_md(s);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -712,17 +712,20 @@ static WRITE_TRAN ossl_statem_server13_write_transition(SSL_CONNECTION *s)
          * session tickets or resumption (e.g. new_session_count = 0 or
          * resumption_count = 0), this implementation does not currently
          * interpret or enforce those parameters.
+         *
+         * Also skip issuance when SSL_VERIFY_PEER is set with no sid_ctx
+         * configured: any ticket minted here would be rejected by
+         * ssl_get_prev_session() in that configuration.
          */
-        if (((s->options & SSL_OP_NO_TICKET) != 0
+        if (s->num_tickets <= s->sent_tickets
+            || ((s->options & SSL_OP_NO_TICKET) != 0
                 && (SSL_CONNECTION_GET_CTX(s)->session_cache_mode & SSL_SESS_CACHE_SERVER)
                     == 0)
-            || s->ext.psk_kex_mode == TLSEXT_KEX_MODE_FLAG_NONE) {
+            || s->ext.psk_kex_mode == TLSEXT_KEX_MODE_FLAG_NONE
+            || ((s->verify_mode & SSL_VERIFY_PEER) && s->sid_ctx_length == 0))
             st->hand_state = TLS_ST_OK;
-        } else if (s->num_tickets > s->sent_tickets) {
+        else
             st->hand_state = TLS_ST_SW_SESSION_TICKET;
-        } else {
-            st->hand_state = TLS_ST_OK;
-        }
         return WRITE_TRAN_CONTINUE;
 
     case TLS_ST_SR_KEY_UPDATE:

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4590,6 +4590,18 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
                 goto err;
             }
             s->session->ext.alpn_selected_len = s->s3.alpn_selected_len;
+        } else {
+            /*
+             * No ALPN was negotiated on this handshake. If we resumed a
+             * session that had previously negotiated ALPN, the stale value
+             * must be cleared from the (copied) session before it is stored
+             * in the new ticket. Otherwise a subsequent 0-RTT attempt using
+             * that ticket would incorrectly assume an ALPN protocol had been
+             * negotiated. See tls_handle_alpn().
+             */
+            OPENSSL_free(s->session->ext.alpn_selected);
+            s->session->ext.alpn_selected = NULL;
+            s->session->ext.alpn_selected_len = 0;
         }
         s->session->ext.max_early_data = s->max_early_data;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5291,6 +5291,76 @@ end:
 }
 
 /*
+ * Locks in the requirement that a resumed PSK's exact ciphersuite, not
+ * merely a shared digest, must match the negotiated one before 0-RTT data
+ * is accepted: the client encrypts its early data with the AEAD bound to
+ * its own PSK session before it can know what cipher the server will
+ * negotiate, so a same-digest-but-different-cipher negotiation must fall
+ * back to an ordinary connection rather than attempt decryption with the
+ * wrong cipher.
+ */
+static int test_early_data_psk_cipher_mismatch(void)
+{
+#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+    SSL_SESSION *sess = NULL;
+    unsigned char buf[20];
+    size_t readbytes, written;
+
+    if (is_fips) {
+        testresult = TEST_skip("CHACHA is not supported in FIPS");
+        return 1;
+    }
+
+    if (!TEST_true(setupearly_data_test(&cctx, &sctx, &clientssl,
+            &serverssl, &sess, 2, SHA256_DIGEST_LENGTH)))
+        goto end;
+
+    /*
+     * The PSK is bound to AES-128-GCM (SHA256 digest), but both ends can
+     * only negotiate ChaCha20-Poly1305 -- same digest, different cipher.
+     */
+    if (!TEST_true(SSL_set_ciphersuites(clientssl,
+            "TLS_CHACHA20_POLY1305_SHA256"))
+        || !TEST_true(SSL_set_ciphersuites(serverssl,
+            "TLS_CHACHA20_POLY1305_SHA256")))
+        goto end;
+
+    SSL_set_connect_state(clientssl);
+    if (!TEST_true(SSL_write_early_data(clientssl, MSG1, strlen(MSG1),
+            &written)))
+        goto end;
+
+    if (!TEST_int_eq(SSL_read_early_data(serverssl, buf, sizeof(buf),
+                         &readbytes),
+            SSL_READ_EARLY_DATA_FINISH)
+        || !TEST_int_eq(SSL_get_early_data_status(serverssl),
+            SSL_EARLY_DATA_REJECTED))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(clientpsk);
+    SSL_SESSION_free(serverpsk);
+    clientpsk = serverpsk = NULL;
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+#else
+    return 1;
+#endif
+}
+
+/*
  * Test that a server that doesn't try to read early data can handle a
  * client sending some.
  */
@@ -6535,6 +6605,165 @@ static int test_tls13_psk(int idx)
     }
     testresult = 1;
 
+end:
+    SSL_SESSION_free(clientpsk);
+    SSL_SESSION_free(serverpsk);
+    clientpsk = serverpsk = NULL;
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
+ * A server with SSL_VERIFY_PEER set but no session ID context configured
+ * must still accept a TLS 1.3 external PSK connection: the session was
+ * just resolved via the application's own callback for this identity, not
+ * read back out of a shared cache, so the sid_ctx check that guards
+ * against cross-context cache reuse does not apply to it.
+ */
+static int test_tls13_psk_verify_peer_no_sid_ctx(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_VERSION, 0, &sctx, &cctx, NULL, NULL))
+        || !TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_128_GCM_SHA256")))
+        goto end;
+
+    SSL_CTX_set_verify(sctx, SSL_VERIFY_PEER, NULL);
+
+    SSL_CTX_set_psk_use_session_callback(cctx, use_session_cb);
+    SSL_CTX_set_psk_find_session_callback(sctx, find_session_cb);
+    srvid = pskid;
+    use_session_cb_cnt = 0;
+    find_session_cb_cnt = 0;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    clientpsk = create_a_psk(clientssl, SHA256_DIGEST_LENGTH);
+    if (!TEST_ptr(clientpsk) || !TEST_true(SSL_SESSION_up_ref(clientpsk)))
+        goto end;
+    serverpsk = clientpsk;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE))
+        || !TEST_true(SSL_session_reused(clientssl))
+        || !TEST_true(SSL_session_reused(serverssl)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_SESSION_free(clientpsk);
+    SSL_SESSION_free(serverpsk);
+    clientpsk = serverpsk = NULL;
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
+ * A server with SSL_VERIFY_PEER set but no session ID context configured
+ * must not issue a session ticket after a full (non-PSK) handshake: any
+ * such ticket would be a poison pill, since resuming it would hit exactly
+ * the sid_ctx check that a fresh external PSK is exempted from above.
+ */
+static int test_tls13_psk_verify_peer_no_ticket(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    SSL_SESSION *sess = NULL;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_VERSION, 0, &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    SSL_CTX_set_verify(sctx, SSL_VERIFY_PEER, NULL);
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE)))
+        goto end;
+
+    sess = SSL_get1_session(clientssl);
+    if (!TEST_ptr(sess) || !TEST_false(SSL_SESSION_has_ticket(sess)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_SESSION_free(sess);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
+ * A client with its own session ID context configured must still be able
+ * to resume a TLS 1.3 external PSK obtained via the legacy
+ * psk_use_session_cb()/psk_client_callback() callbacks. s->psksession is
+ * never routed through ssl_get_new_session(), so, unlike an ordinary
+ * session, it was never stamped with the client's own sid_ctx; without
+ * that stamp tls_process_server_hello()'s own sid_ctx self-consistency
+ * check fatally rejects marking it reused.
+ *
+ * Test 0: new style callback (psk_use_session_cb()/psk_find_session_cb()).
+ * Test 1: old style callback (psk_client_callback()/psk_server_callback()).
+ */
+static int test_tls13_psk_client_sid_ctx(int idx)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int sess_id_ctx = 1;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_VERSION, 0, &sctx, &cctx, NULL, NULL))
+        || !TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_128_GCM_SHA256"))
+        || !TEST_true(SSL_CTX_set_session_id_context(cctx,
+            (void *)&sess_id_ctx, sizeof(sess_id_ctx))))
+        goto end;
+
+    srvid = pskid;
+    if (idx == 0) {
+        SSL_CTX_set_psk_use_session_callback(cctx, use_session_cb);
+        SSL_CTX_set_psk_find_session_callback(sctx, find_session_cb);
+        use_session_cb_cnt = 0;
+        find_session_cb_cnt = 0;
+    }
+#ifndef OPENSSL_NO_PSK
+    else {
+        SSL_CTX_set_psk_client_callback(cctx, psk_client_cb);
+        SSL_CTX_set_psk_server_callback(sctx, psk_server_cb);
+        psk_client_cb_cnt = 0;
+        psk_server_cb_cnt = 0;
+    }
+#endif
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    clientpsk = create_a_psk(clientssl, SHA256_DIGEST_LENGTH);
+    if (!TEST_ptr(clientpsk) || !TEST_true(SSL_SESSION_up_ref(clientpsk)))
+        goto end;
+    serverpsk = clientpsk;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE))
+        || !TEST_true(SSL_session_reused(clientssl))
+        || !TEST_true(SSL_session_reused(serverssl)))
+        goto end;
+
+    testresult = 1;
 end:
     SSL_SESSION_free(clientpsk);
     SSL_SESSION_free(serverpsk);
@@ -15314,6 +15543,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_early_data_not_sent, 3);
     ADD_ALL_TESTS(test_early_data_psk, 8);
     ADD_ALL_TESTS(test_early_data_psk_with_all_ciphers, 7);
+    ADD_TEST(test_early_data_psk_cipher_mismatch);
     ADD_ALL_TESTS(test_early_data_not_expected, 3);
 #ifndef OPENSSL_NO_TLS1_2
     ADD_ALL_TESTS(test_early_data_tls1_2, 3);
@@ -15325,9 +15555,13 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_tls13_ciphersuite, 4);
 #ifdef OPENSSL_NO_PSK
     ADD_ALL_TESTS(test_tls13_psk, 1);
+    ADD_ALL_TESTS(test_tls13_psk_client_sid_ctx, 1);
 #else
     ADD_ALL_TESTS(test_tls13_psk, 4);
+    ADD_ALL_TESTS(test_tls13_psk_client_sid_ctx, 2);
 #endif /* OPENSSL_NO_PSK */
+    ADD_TEST(test_tls13_psk_verify_peer_no_sid_ctx);
+    ADD_TEST(test_tls13_psk_verify_peer_no_ticket);
 #ifndef OSSL_NO_USABLE_TLS1_3
     ADD_ALL_TESTS(test_tls13_no_dhe_kex, 8);
 #endif /* OSSL_NO_USABLE_TLS1_3 */

--- a/test/tls13tickettest.c
+++ b/test/tls13tickettest.c
@@ -61,6 +61,7 @@ struct stats {
     unsigned int sh_has_psk;
     unsigned int sh_has_supported_versions;
     unsigned int ee_has_early_data;
+    unsigned int ee_has_alpn;
 };
 
 struct tls13_endpoint {
@@ -195,9 +196,13 @@ static void parse_ee_exts(const unsigned char *buf, size_t len, struct stats *x)
         case TLSEXT_TYPE_early_data:
             x->ee_has_early_data = 1;
             break;
+        case TLSEXT_TYPE_application_layer_protocol_negotiation:
+            x->ee_has_alpn = 1;
+            break;
         }
     }
-    TEST_info("ee extensions: early_data=%d", x->ee_has_early_data);
+    TEST_info("ee extensions: early_data=%d alpn=%d",
+        x->ee_has_early_data, x->ee_has_alpn);
 }
 
 static void msg_cb(int write_p, int version, int content_type,
@@ -282,6 +287,120 @@ static int ticket_disable(SSL_CTX *ctx)
 }
 
 /*
+ * The server offers a single protocol via server_alpn and selects it when the
+ * client advertises it. The client advertises a protocol using the
+ * length-prefixed wire form expected by SSL_set_alpn_protos().
+ */
+static const char *server_alpn = NULL;
+
+static int alpn_select_cb(SSL *ssl, const unsigned char **out,
+    unsigned char *outlen, const unsigned char *in,
+    unsigned int inlen, void *arg)
+{
+    unsigned int protlen = 0;
+    const unsigned char *prot;
+
+    if (server_alpn == NULL)
+        return SSL_TLSEXT_ERR_NOACK;
+
+    for (prot = in; prot < in + inlen; prot += protlen) {
+        protlen = *prot++;
+        if (in + inlen < prot + protlen)
+            return SSL_TLSEXT_ERR_NOACK;
+        if (protlen == strlen(server_alpn)
+            && memcmp(prot, server_alpn, protlen) == 0) {
+            *out = prot;
+            *outlen = protlen;
+            return SSL_TLSEXT_ERR_OK;
+        }
+    }
+    return SSL_TLSEXT_ERR_NOACK;
+}
+
+static int alpn_server_enable(SSL_CTX *ctx, const char *proto)
+{
+    server_alpn = proto;
+    SSL_CTX_set_alpn_select_cb(ctx, alpn_select_cb, NULL);
+    return 1;
+}
+
+/* Change which protocol the server selects for the next handshake. */
+static int alpn_server_select(const char *proto)
+{
+    server_alpn = proto;
+    return 1;
+}
+
+/* Append protocol proto (length-prefixed) to the wire buffer at *n. */
+static int alpn_wire_add(unsigned char *wire, size_t cap, unsigned int *n,
+    const char *proto)
+{
+    unsigned int plen = (unsigned int)strlen(proto);
+
+    if (plen == 0 || plen > 255 || *n + 1 + plen > cap)
+        return 0;
+    wire[(*n)++] = (unsigned char)plen;
+    memcpy(wire + *n, proto, plen);
+    *n += plen;
+    return 1;
+}
+
+static int alpn_client_offer(SSL *ssl, const char *proto)
+{
+    unsigned char wire[256];
+    unsigned int n = 0;
+
+    if (!alpn_wire_add(wire, sizeof(wire), &n, proto))
+        return 0;
+    /* SSL_set_alpn_protos() returns 0 on success. */
+    return SSL_set_alpn_protos(ssl, wire, n) == 0;
+}
+
+static int alpn_client_offer2(SSL *ssl, const char *p1, const char *p2)
+{
+    unsigned char wire[256];
+    unsigned int n = 0;
+
+    if (!alpn_wire_add(wire, sizeof(wire), &n, p1)
+        || !alpn_wire_add(wire, sizeof(wire), &n, p2))
+        return 0;
+    /* SSL_set_alpn_protos() returns 0 on success. */
+    return SSL_set_alpn_protos(ssl, wire, n) == 0;
+}
+
+/* Returns 1 if the connection negotiated exactly the given ALPN protocol. */
+static int alpn_conn_selected_is(SSL *ssl, const char *proto)
+{
+    const unsigned char *alpn = NULL;
+    unsigned int alpnlen = 0;
+
+    SSL_get0_alpn_selected(ssl, &alpn, &alpnlen);
+    return alpn != NULL
+        && alpnlen == strlen(proto)
+        && memcmp(alpn, proto, alpnlen) == 0;
+}
+
+/* Returns 1 if the connection negotiated no ALPN protocol. */
+static int alpn_conn_selected_none(SSL *ssl)
+{
+    const unsigned char *alpn = NULL;
+    unsigned int alpnlen = 0;
+
+    SSL_get0_alpn_selected(ssl, &alpn, &alpnlen);
+    return alpn == NULL && alpnlen == 0;
+}
+
+/* Returns 1 if the session stores no ALPN protocol. */
+static int alpn_sess_selected_none(SSL *ssl)
+{
+    const unsigned char *alpn = NULL;
+    size_t alpnlen = 0;
+
+    SSL_SESSION_get0_alpn_selected(SSL_get_session(ssl), &alpn, &alpnlen);
+    return alpn == NULL && alpnlen == 0;
+}
+
+/*
  * RFC 5077 3.1: The server sends an empty SessionTicket extension to indicate
  * that it will send a new session ticket using the NewSessionTicket handshake
  * message.
@@ -301,7 +420,7 @@ static int test_tls12_ticket_enable(void)
         && TEST_true(ticket_enable(s))
         && TEST_true(ticket_enable(c))
         && TEST_true(tls_channel_init(c, s, &initial))
-        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, 0))
         && TEST_true(tls_shutdown(&initial))
         && TEST_uint_eq(initial.s.stats.nst_msgs, 1)
         && TEST_uint_eq(initial.c.stats.nst_msgs, 1)
@@ -316,7 +435,7 @@ static int test_tls12_ticket_enable(void)
         && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
         && TEST_true(tls_channel_init(c, s, &resumed))
         && TEST_true(SSL_set_session(resumed.c.ssl, sess))
-        && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, 0))
         && TEST_true(SSL_session_reused(resumed.c.ssl))
         && TEST_uint_eq(resumed.s.stats.nst_msgs, 0)
         && TEST_uint_eq(resumed.c.stats.nst_msgs, 0)
@@ -758,6 +877,176 @@ static int test_tls13_ticket_early_data_accepted(void)
     return test;
 }
 
+/*
+ * TLS 1.3 stale ALPN cleared from a resumption ticket
+ *
+ * A session that negotiated ALPN is resumed on a connection that negotiates no
+ * ALPN at all (the client advertises none). The NewSessionTicket issued for the
+ * resumed session must not retain the ALPN protocol from the original session;
+ * otherwise a later 0-RTT attempt using that ticket would incorrectly assume
+ * that protocol had been negotiated.
+ *
+ * Regression test for GitHub issue #11197: tls_construct_new_session_ticket()
+ * copied s->s3.alpn_selected into the session only when an ALPN protocol was
+ * negotiated, but failed to clear s->session->ext.alpn_selected when it wasn't.
+ */
+static int test_tls13_ticket_alpn_cleared(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(alpn_server_enable(s, "goodalpn"))
+        /*
+         * Connection 1: the client advertises "goodalpn", the server selects
+         * it, and the negotiated protocol is stored in the session.
+         */
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(alpn_client_offer(initial.c.ssl, "goodalpn"))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(alpn_conn_selected_is(initial.s.ssl, "goodalpn"))
+        && TEST_true(alpn_conn_selected_is(initial.c.ssl, "goodalpn"))
+        && TEST_uint_eq(initial.c.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.s.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.c.stats.tickets, 2)
+        && TEST_uint_eq(initial.s.stats.tickets, 2)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(initial.s.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(initial.c.stats.ee_has_alpn, 1)
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        /*
+         * Connection 2: resume the session, but the client advertises no ALPN
+         * this time so nothing is negotiated. The server issues a fresh
+         * NewSessionTicket for the resumed session; its stored ALPN must be
+         * cleared rather than inheriting "goodalpn" from the original session.
+         */
+        && TEST_true(tls_channel_init(c, s, &resumed))
+        && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+        && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(SSL_session_reused(resumed.c.ssl))
+        && TEST_uint_eq(resumed.c.stats.nst_msgs, 1)
+        && TEST_uint_eq(resumed.s.stats.nst_msgs, 1)
+        && TEST_uint_eq(resumed.c.stats.tickets, 1)
+        && TEST_uint_eq(resumed.s.stats.tickets, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(resumed.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.s.stats.ee_has_alpn, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_alpn, 0)
+        /* No ALPN was negotiated on the resumption handshake ... */
+        && TEST_true(alpn_conn_selected_none(resumed.s.ssl))
+        && TEST_true(alpn_conn_selected_none(resumed.c.ssl))
+        /* ... so the session written into the new ticket must carry none. */
+        && TEST_true(alpn_sess_selected_none(resumed.s.ssl));
+
+    SSL_SESSION_free(sess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    server_alpn = NULL;
+    return test;
+}
+
+/*
+ * TLS 1.3 ALPN mismatch 0-RTT rejection
+ *
+ * The session negotiated ALPN "goodalpn". On resumption the client still offers
+ * "goodalpn" (so it is willing to send early data) alongside "otheralpn", and
+ * the server selects "otheralpn" instead. Because the ALPN selected for the
+ * resumption handshake differs from the one associated with the ticket, the
+ * server must reject 0-RTT while still completing the (resumed) handshake.
+ *
+ * RFC 8446 4.2.10: In order to accept early data, the server MUST have accepted
+ * a PSK cipher suite and selected the first key offered in the client's
+ * "pre_shared_key" extension. In addition, it MUST verify that the following
+ * values are the same as those associated with the selected PSK: TLS version
+ * number, selected cipher suite, and selected ALPN (RFC 7301) protocol, if any.
+ */
+static int test_tls13_ticket_alpn_mismatch_reject_early_data(void)
+{
+    const unsigned char m[] = "message";
+    unsigned char buf[256];
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL;
+    size_t w = 0, r = 0;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(SSL_CTX_set_max_early_data(s, SSL3_RT_MAX_PLAIN_LENGTH))
+        && TEST_true(SSL_CTX_set_options(s, SSL_OP_NO_ANTI_REPLAY) != 0)
+        && TEST_true(alpn_server_enable(s, "goodalpn"))
+        /* Connection 1: negotiate ALPN "goodalpn" and store it in the ticket. */
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(alpn_client_offer(initial.c.ssl, "goodalpn"))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, 0))
+        && TEST_true(alpn_conn_selected_is(initial.s.ssl, "goodalpn"))
+        && TEST_true(alpn_conn_selected_is(initial.c.ssl, "goodalpn"))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_uint_eq(initial.c.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.s.stats.nst_msgs, 2)
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        /*
+         * Connection 2: attempt 0-RTT. The client offers "goodalpn" (matching
+         * the ticket, so it is willing to send early data) plus "otheralpn";
+         * the server selects "otheralpn", which mismatches the ticket's ALPN.
+         */
+        && TEST_true(tls_channel_init(c, s, &resumed))
+        && TEST_true(alpn_client_offer2(resumed.c.ssl, "goodalpn", "otheralpn"))
+        && TEST_true(alpn_server_select("otheralpn"))
+        && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+        && TEST_true(SSL_write_early_data(resumed.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        /* The server skips the early data: nothing is delivered to the app. */
+        && TEST_int_eq(SSL_read_early_data(resumed.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_FINISH)
+        && TEST_size_t_eq(r, 0)
+        && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, 0))
+        && TEST_int_eq(SSL_get_early_data_status(resumed.c.ssl),
+            SSL_EARLY_DATA_REJECTED)
+        /* PSK resumption still succeeds, only 0-RTT is refused. */
+        && TEST_true(SSL_session_reused(resumed.c.ssl))
+        && TEST_true(alpn_conn_selected_is(resumed.s.ssl, "otheralpn"))
+        && TEST_true(alpn_conn_selected_is(resumed.c.ssl, "otheralpn"))
+        /* ALPN was negotiated, but the server did not accept early_data. */
+        && TEST_uint_eq(resumed.s.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(resumed.c.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 0);
+
+    SSL_SESSION_free(sess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    server_alpn = NULL;
+    return test;
+}
+
 enum endpoint_state {
     ENDPOINT_WRITE_EARLY_DATA,
     ENDPOINT_READ_EARLY_DATA,
@@ -1082,6 +1371,8 @@ int setup_tests(void)
     ADD_TEST(test_tls13_ticket_resumed_set_num_tickets_zero);
     ADD_TEST(test_tls13_ticket_disable_server);
     ADD_TEST(test_tls13_ticket_no_decrypt);
+    ADD_TEST(test_tls13_ticket_alpn_cleared);
+    ADD_TEST(test_tls13_ticket_alpn_mismatch_reject_early_data);
     ADD_TEST(test_tls13_ticket_early_data_accepted);
     ADD_TEST(test_tls13_ticket_client_age_mismatch_reject_early_data_retry);
     ADD_TEST(test_tls13_ticket_client_age_mismatch_reject_early_data_outer);

--- a/test/tls13tickettest.c
+++ b/test/tls13tickettest.c
@@ -889,13 +889,42 @@ static int test_tls13_ticket_early_data_accepted(void)
  * Regression test for GitHub issue #11197: tls_construct_new_session_ticket()
  * copied s->s3.alpn_selected into the session only when an ALPN protocol was
  * negotiated, but failed to clear s->session->ext.alpn_selected when it wasn't.
+ *
+ * A third connection then resumes the now-ALPN-cleared ticket and negotiates
+ * "goodalpn" again -- the same, non-empty protocol as the original session,
+ * coincidentally. Since the ticket being resumed carries no ALPN, 0-RTT must
+ * still be rejected: the client's SSL_write_early_data() appears to succeed
+ * (the data is sent before the server's response is known), but a post hoc
+ * SSL_get_early_data_status() check confirms the server never accepted it.
+ *
+ * A fourth connection resumes that same ALPN-cleared ticket a second time --
+ * anti-replay is disabled for this test, so reusing it twice is not itself a
+ * reason for rejection -- but this time advertises no ALPN, consistent with
+ * what the ticket actually recorded. 0-RTT must now be accepted. Without this
+ * case, the rejection asserted for connection 3 would be unfalsifiable: it
+ * would look identical if early data were simply never being accepted here
+ * for any reason at all.
+ *
+ * The fourth connection resumes from an independent SSL_SESSION_dup() copy
+ * of the ticket (taken before connection 3 uses the original), rather than
+ * the original SSL_SESSION object itself: completing a handshake from a
+ * resumed session marks that SSL_SESSION object not-resumable on the client
+ * side as a single-use safeguard, independent of (and in addition to) the
+ * server's SSL_OP_NO_ANTI_REPLAY setting. Resuming the literal object a
+ * second time would therefore quietly fall back to a full, non-PSK
+ * handshake instead of testing the intended 0-RTT path.
  */
 static int test_tls13_ticket_alpn_cleared(void)
 {
+    const unsigned char m[] = "message";
+    unsigned char buf[256];
     SSL_CTX *c = NULL, *s = NULL;
     struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
     struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
-    SSL_SESSION *sess = NULL;
+    struct tls13_channel resumed2 = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed3 = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL, *sess2b = NULL;
+    size_t w = 0, r = 0;
     int test;
 
     test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
@@ -903,6 +932,8 @@ static int test_tls13_ticket_alpn_cleared(void)
         && TEST_true(set_ctx_callbacks(c, s))
         && TEST_true(ticket_enable(s))
         && TEST_true(ticket_enable(c))
+        && TEST_true(SSL_CTX_set_max_early_data(s, SSL3_RT_MAX_PLAIN_LENGTH))
+        && TEST_true(SSL_CTX_set_options(s, SSL_OP_NO_ANTI_REPLAY) != 0)
         && TEST_true(alpn_server_enable(s, "goodalpn"))
         /*
          * Connection 1: the client advertises "goodalpn", the server selects
@@ -955,11 +986,84 @@ static int test_tls13_ticket_alpn_cleared(void)
         && TEST_true(alpn_conn_selected_none(resumed.s.ssl))
         && TEST_true(alpn_conn_selected_none(resumed.c.ssl))
         /* ... so the session written into the new ticket must carry none. */
-        && TEST_true(alpn_sess_selected_none(resumed.s.ssl));
+        && TEST_true(alpn_sess_selected_none(resumed.s.ssl))
+        && TEST_true(tls_shutdown(&resumed))
+        && TEST_ptr(sess2 = SSL_get1_session(resumed.c.ssl))
+        /*
+         * Connection 3 is about to resume sess2 and, since 0-RTT is attempted
+         * on it, the client will mark sess2 not-resumable once that attempt
+         * completes (this happens on any full handshake completed from a
+         * resumed session, independent of the server's anti-replay setting --
+         * it is a client-side single-use restriction on the SSL_SESSION
+         * object itself). Take an independent copy now, while sess2 is still
+         * untouched, so connection 4 below has its own unconsumed ticket to
+         * resume from.
+         */
+        && TEST_ptr(sess2b = SSL_SESSION_dup(sess2))
+        /*
+         * Connection 3: resume the ALPN-cleared ticket from connection 2, but
+         * this time negotiate "goodalpn" again -- the same protocol as the
+         * original session, purely by coincidence. The ticket being resumed
+         * has no ALPN of its own, so 0-RTT must be rejected regardless of
+         * this match.
+         */
+        && TEST_true(tls_channel_init(c, s, &resumed2))
+        && TEST_true(alpn_client_offer(resumed2.c.ssl, "goodalpn"))
+        && TEST_true(SSL_set_session(resumed2.c.ssl, sess2))
+        && TEST_true(SSL_write_early_data(resumed2.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        /* The server skips the early data: nothing is delivered to the app. */
+        && TEST_int_eq(SSL_read_early_data(resumed2.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_FINISH)
+        && TEST_size_t_eq(r, 0)
+        && TEST_true(create_ssl_connection(resumed2.s.ssl, resumed2.c.ssl, 0))
+        && TEST_true(SSL_session_reused(resumed2.c.ssl))
+        && TEST_true(alpn_conn_selected_is(resumed2.s.ssl, "goodalpn"))
+        && TEST_true(alpn_conn_selected_is(resumed2.c.ssl, "goodalpn"))
+        && TEST_uint_eq(resumed2.s.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(resumed2.c.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(resumed2.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed2.c.stats.ee_has_early_data, 0)
+        /* Post hoc: the write appeared to succeed, but nothing was accepted. */
+        && TEST_int_eq(SSL_get_early_data_status(resumed2.c.ssl),
+            SSL_EARLY_DATA_REJECTED)
+        && TEST_true(tls_shutdown(&resumed2))
+        /*
+         * Connection 4: resume the same ticket from connection 2 again, via
+         * the untouched copy (sess2b) taken before connection 3 consumed
+         * sess2 -- anti-replay is off, so a second use of that ticket is not
+         * itself rejected -- but this time advertise no ALPN, matching what
+         * the ticket recorded. 0-RTT must be accepted, proving connection 3
+         * was rejected for the ALPN mismatch specifically, not because early
+         * data never works.
+         */
+        && TEST_true(tls_channel_init(c, s, &resumed3))
+        && TEST_true(SSL_set_session(resumed3.c.ssl, sess2b))
+        && TEST_true(SSL_write_early_data(resumed3.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        && TEST_int_eq(SSL_read_early_data(resumed3.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_SUCCESS)
+        && TEST_mem_eq(buf, r, m, sizeof(m))
+        && TEST_int_gt(SSL_connect(resumed3.c.ssl), 0)
+        && TEST_int_eq(SSL_read_early_data(resumed3.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_FINISH)
+        && TEST_size_t_eq(r, 0)
+        && TEST_int_eq(SSL_get_early_data_status(resumed3.s.ssl), SSL_EARLY_DATA_ACCEPTED)
+        && TEST_true(create_ssl_connection(resumed3.s.ssl, resumed3.c.ssl, 0))
+        && TEST_int_eq(SSL_get_early_data_status(resumed3.c.ssl), SSL_EARLY_DATA_ACCEPTED)
+        && TEST_true(SSL_session_reused(resumed3.c.ssl))
+        && TEST_true(alpn_conn_selected_none(resumed3.s.ssl))
+        && TEST_true(alpn_conn_selected_none(resumed3.c.ssl))
+        && TEST_uint_eq(resumed3.s.stats.ee_has_alpn, 0)
+        && TEST_uint_eq(resumed3.c.stats.ee_has_alpn, 0);
 
     SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    SSL_SESSION_free(sess2b);
     tls_channel_fini(&initial);
     tls_channel_fini(&resumed);
+    tls_channel_fini(&resumed2);
+    tls_channel_fini(&resumed3);
     SSL_CTX_free(c);
     SSL_CTX_free(s);
     server_alpn = NULL;

--- a/test/tls13tickettest.c
+++ b/test/tls13tickettest.c
@@ -401,6 +401,19 @@ static int alpn_sess_selected_none(SSL *ssl)
 }
 
 /*
+ * Early (0-RTT) TLS exporter wrapper with a fixed label and context, so that
+ * client and server derivations are directly comparable.
+ */
+static int early_export(SSL *ssl, unsigned char *out, size_t olen)
+{
+    const char label[] = "test early exporter";
+    const unsigned char ctx[] = "test early context";
+
+    return SSL_export_keying_material_early(ssl, out, olen, label,
+        sizeof(label) - 1, ctx, sizeof(ctx) - 1);
+}
+
+/*
  * RFC 5077 3.1: The server sends an empty SessionTicket extension to indicate
  * that it will send a new session ticket using the NewSessionTicket handshake
  * message.
@@ -813,6 +826,7 @@ static int test_tls13_ticket_early_data_accepted(void)
 {
     const unsigned char m[] = "message";
     unsigned char buf[256];
+    unsigned char cexp[32], sexp[32];
     SSL_CTX *c = NULL, *s = NULL;
     struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
     struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
@@ -848,6 +862,15 @@ static int test_tls13_ticket_early_data_accepted(void)
         && TEST_int_eq(SSL_read_early_data(resumed.s.ssl, buf, sizeof(buf), &r),
             SSL_READ_EARLY_DATA_SUCCESS)
         && TEST_mem_eq(buf, r, m, sizeof(m))
+        /*
+         * Both endpoints have derived the early exporter secret by now: the
+         * client when it started writing 0-RTT data, the server when it
+         * accepted it. RFC 8446 7.5: the early exporter must be available
+         * and both derivations must agree.
+         */
+        && TEST_int_eq(early_export(resumed.c.ssl, cexp, sizeof(cexp)), 1)
+        && TEST_int_eq(early_export(resumed.s.ssl, sexp, sizeof(sexp)), 1)
+        && TEST_mem_eq(cexp, sizeof(cexp), sexp, sizeof(sexp))
         && TEST_int_gt(SSL_connect(resumed.c.ssl), 0)
         && TEST_int_eq(SSL_read_early_data(resumed.s.ssl, buf, sizeof(buf), &r),
             SSL_READ_EARLY_DATA_FINISH)
@@ -1240,6 +1263,7 @@ static int tls_early_data_retry(struct tls13_channel *x)
  */
 static int test_tls13_ticket_client_age_mismatch_reject_early_data_retry(void)
 {
+    unsigned char buf[256];
     SSL_CTX *c = NULL, *s = NULL;
     struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
     struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
@@ -1273,6 +1297,9 @@ static int test_tls13_ticket_client_age_mismatch_reject_early_data_retry(void)
         && TEST_true(tls_early_data_retry(&resumed))
         && TEST_int_eq(SSL_get_early_data_status(resumed.c.ssl), SSL_EARLY_DATA_REJECTED)
         && TEST_false(SSL_session_reused(resumed.c.ssl))
+        /* early_data was suppressed, so no early secrets were ever derived. */
+        && TEST_int_eq(early_export(resumed.c.ssl, buf, 32), 0)
+        && TEST_int_eq(early_export(resumed.s.ssl, buf, 32), 0)
         && TEST_uint_eq(resumed.c.stats.nst_msgs, 0)
         && TEST_uint_eq(resumed.s.stats.nst_msgs, 2)
         && TEST_uint_eq(resumed.c.stats.tickets, 0)
@@ -1350,6 +1377,8 @@ static int test_tls13_ticket_server_age_mismatch_reject_early_data(void)
         && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, 0))
         && TEST_int_eq(SSL_get_early_data_status(resumed.c.ssl), SSL_EARLY_DATA_REJECTED)
         && TEST_true(SSL_session_reused(resumed.c.ssl))
+        && TEST_int_eq(early_export(resumed.c.ssl, buf, 32), 1)
+        && TEST_int_eq(early_export(resumed.s.ssl, buf, 32), 0)
         && TEST_uint_eq(resumed.c.stats.nst_msgs, 1)
         && TEST_uint_eq(resumed.s.stats.nst_msgs, 1)
         && TEST_uint_eq(resumed.c.stats.tickets, 1)
@@ -1424,6 +1453,9 @@ static int test_tls13_ticket_client_age_mismatch_reject_early_data_outer(void)
         && TEST_uint_eq(resumed.s.stats.ch_has_psk_kex_modes, 1)
         && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 0)
         && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 0)
+        /* early_data was suppressed, so no early secrets were ever derived. */
+        && TEST_int_eq(early_export(resumed.c.ssl, buf, 32), 0)
+        && TEST_int_eq(early_export(resumed.s.ssl, buf, 32), 0)
         && TEST_size_t_eq((w = SIZE_MAX), SIZE_MAX)
         && TEST_int_gt(SSL_write_ex(resumed.c.ssl, m, sizeof(m), &w), 0)
         && TEST_size_t_eq(w, sizeof(m))

--- a/test/tls13tickettest.c
+++ b/test/tls13tickettest.c
@@ -57,8 +57,10 @@ struct stats {
     unsigned int ch_has_psk;
     unsigned int ch_has_psk_kex_modes;
     unsigned int ch_has_session_ticket;
+    unsigned int ch_has_early_data;
     unsigned int sh_has_psk;
     unsigned int sh_has_supported_versions;
+    unsigned int ee_has_early_data;
 };
 
 struct tls13_endpoint {
@@ -137,10 +139,15 @@ static void parse_ch_exts(const unsigned char *buf, size_t len, struct stats *x)
         case TLSEXT_TYPE_session_ticket:
             x->ch_has_session_ticket = 1;
             break;
+        case TLSEXT_TYPE_early_data:
+            x->ch_has_early_data = 1;
+            break;
         }
     }
-    TEST_info("ch extensions: psk=%d psk_kex_modes=%d session_ticket=%d",
-        x->ch_has_psk, x->ch_has_psk_kex_modes, x->ch_has_session_ticket);
+    TEST_info("ch extensions: psk=%d psk_kex_modes=%d session_ticket=%d"
+              " early_data=%d",
+        x->ch_has_psk, x->ch_has_psk_kex_modes, x->ch_has_session_ticket,
+        x->ch_has_early_data);
 }
 
 static void parse_sh_exts(const unsigned char *buf, size_t len, struct stats *x)
@@ -171,6 +178,28 @@ static void parse_sh_exts(const unsigned char *buf, size_t len, struct stats *x)
         x->sh_has_psk, x->sh_has_supported_versions);
 }
 
+static void parse_ee_exts(const unsigned char *buf, size_t len, struct stats *x)
+{
+    PACKET pkt, e, ex;
+    unsigned int v;
+
+    if (!PACKET_buf_init(&pkt, buf, len)
+        || !PACKET_forward(&pkt, 4)
+        || !PACKET_as_length_prefixed_2(&pkt, &e))
+        return;
+
+    while (PACKET_remaining(&e) > 0) {
+        if (!PACKET_get_net_2(&e, &v) || !PACKET_get_length_prefixed_2(&e, &ex))
+            return;
+        switch (v) {
+        case TLSEXT_TYPE_early_data:
+            x->ee_has_early_data = 1;
+            break;
+        }
+    }
+    TEST_info("ee extensions: early_data=%d", x->ee_has_early_data);
+}
+
 static void msg_cb(int write_p, int version, int content_type,
     const void *buf, size_t len, SSL *ssl, void *arg)
 {
@@ -185,6 +214,8 @@ static void msg_cb(int write_p, int version, int content_type,
             parse_ch_exts(buf, len, stats);
         if (mt == SSL3_MT_SERVER_HELLO && stats != NULL)
             parse_sh_exts(buf, len, stats);
+        if (mt == SSL3_MT_ENCRYPTED_EXTENSIONS && stats != NULL)
+            parse_ee_exts(buf, len, stats);
     }
 }
 
@@ -652,6 +683,383 @@ static int test_tls13_ticket_no_decrypt(void)
     return test;
 }
 
+/*
+ * TLS 1.3 0-RTT early_data accepted
+ *
+ * Complements the suppression/rejection tests above: with a fresh resumption
+ * ticket the client advertises both pre_shared_key and early_data, the server
+ * accepts 0-RTT.
+ */
+static int test_tls13_ticket_early_data_accepted(void)
+{
+    const unsigned char m[] = "message";
+    unsigned char buf[256];
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL;
+    size_t w = 0, r = 0;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(SSL_CTX_set_max_early_data(s, SSL3_RT_MAX_PLAIN_LENGTH))
+        && TEST_true(SSL_CTX_set_options(s, SSL_OP_NO_ANTI_REPLAY) != 0)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, 0))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_uint_eq(initial.c.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.s.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.c.stats.tickets, 2)
+        && TEST_uint_eq(initial.s.stats.tickets, 2)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_true(tls_channel_init(c, s, &resumed))
+        && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+        && TEST_true(SSL_write_early_data(resumed.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        && TEST_int_eq(SSL_read_early_data(resumed.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_SUCCESS)
+        && TEST_mem_eq(buf, r, m, sizeof(m))
+        && TEST_int_gt(SSL_connect(resumed.c.ssl), 0)
+        && TEST_int_eq(SSL_read_early_data(resumed.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_FINISH)
+        && TEST_size_t_eq(r, 0)
+        && TEST_int_eq(SSL_get_early_data_status(resumed.s.ssl), SSL_EARLY_DATA_ACCEPTED)
+        && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, 0))
+        && TEST_int_eq(SSL_get_early_data_status(resumed.c.ssl), SSL_EARLY_DATA_ACCEPTED)
+        && TEST_true(SSL_session_reused(resumed.c.ssl))
+        && TEST_uint_eq(resumed.c.stats.nst_msgs, 1)
+        && TEST_uint_eq(resumed.s.stats.nst_msgs, 1)
+        && TEST_uint_eq(resumed.c.stats.tickets, 1)
+        && TEST_uint_eq(resumed.s.stats.tickets, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_early_data, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_early_data, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 1)
+        && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 1);
+
+    SSL_SESSION_free(sess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+enum endpoint_state {
+    ENDPOINT_WRITE_EARLY_DATA,
+    ENDPOINT_READ_EARLY_DATA,
+    ENDPOINT_HANDSHAKE,
+    ENDPOINT_READ_APP_DATA,
+    ENDPOINT_DONE,
+    ENDPOINT_ERROR
+};
+
+/* Retry logic switch extracted from s_client. */
+static int is_retryable(SSL *ssl, int ret)
+{
+    switch (SSL_get_error(ssl, ret)) {
+    case SSL_ERROR_WANT_WRITE:
+    case SSL_ERROR_WANT_ASYNC:
+    case SSL_ERROR_WANT_READ:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/*
+ * The client follows the s_client retry loop; the server skips early data and
+ * completes the handshake.
+ *
+ * SSL_write_early_data() states the call behaves like SSL_write_ex(): if it
+ * fails, the caller must consult SSL_get_error() and, while it reports a
+ * retryable WANT_READ/WANT_WRITE condition, keep calling SSL_write_early_data()
+ * with the same arguments until it succeeds. This helper encodes that decision.
+ */
+static int tls_early_data_retry(struct tls13_channel *x)
+{
+    const unsigned char m[] = "message";
+    unsigned char buf[256];
+    enum endpoint_state c = ENDPOINT_WRITE_EARLY_DATA;
+    enum endpoint_state s = ENDPOINT_READ_EARLY_DATA;
+    size_t w = SIZE_MAX, r = SIZE_MAX;
+
+    for (int i = 0; i < 100 && (c != ENDPOINT_DONE || s != ENDPOINT_DONE); i++) {
+        if (c == ENDPOINT_WRITE_EARLY_DATA) {
+            if (SSL_write_early_data(x->c.ssl, m, sizeof(m), &w) > 0)
+                c = ENDPOINT_DONE;
+            else if (!is_retryable(x->c.ssl, 0))
+                c = ENDPOINT_ERROR;
+        }
+        if (s == ENDPOINT_READ_EARLY_DATA) {
+            switch (SSL_read_early_data(x->s.ssl, buf, sizeof(buf), &r)) {
+            case SSL_READ_EARLY_DATA_FINISH:
+                s = ENDPOINT_HANDSHAKE;
+                break;
+            default:
+                s = ENDPOINT_ERROR;
+            }
+        }
+        if (s == ENDPOINT_HANDSHAKE) {
+            if (SSL_is_init_finished(x->s.ssl))
+                s = ENDPOINT_DONE;
+            else if (SSL_accept(x->s.ssl) <= 0 && !is_retryable(x->s.ssl, 0))
+                s = ENDPOINT_ERROR;
+        }
+        if (c == ENDPOINT_ERROR || s == ENDPOINT_ERROR)
+            break;
+    }
+
+    return TEST_int_eq(c, ENDPOINT_DONE)
+        && TEST_int_eq(s, ENDPOINT_DONE)
+        && TEST_size_t_eq(w, sizeof(m))
+        && TEST_size_t_eq(r, 0);
+}
+
+/*
+ * TLS 1.3 Client-side Ticket Age Mismatch 0-RTT Rejection (API retry test)
+ *
+ * This test exercises the case where the client does not send a PSK due to a
+ * ticket age mismatch, and verifies that the client suppresses the early_data
+ * as a result.
+ *
+ * RFC 8446 4.2.10: When a PSK is used and early data is allowed for that PSK,
+ * the client can send Application Data in its first flight of messages. If the
+ * client opts to do so, it MUST supply both the "pre_shared_key" and
+ * "early_data" extensions. The PSK used to encrypt the early data MUST be the
+ * first PSK listed in the client's "pre_shared_key" extension.
+ *
+ * RFC 8446 4.2.11.1: Clients MUST NOT attempt to use tickets which have ages
+ * greater than the "ticket_lifetime" value which was provided with the ticket.
+ */
+static int test_tls13_ticket_client_age_mismatch_reject_early_data_retry(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(SSL_CTX_set_max_early_data(s, SSL3_RT_MAX_PLAIN_LENGTH))
+        && TEST_true(SSL_CTX_set_timeout(s, 1) > 0)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, 0))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_uint_eq(initial.c.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.s.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.c.stats.tickets, 2)
+        && TEST_uint_eq(initial.s.stats.tickets, 2)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_int_gt((int)SSL_SESSION_set_time_ex(sess, time(NULL) - 10), 0)
+        && TEST_true(tls_channel_init(c, s, &resumed))
+        && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+        && TEST_true(tls_early_data_retry(&resumed))
+        && TEST_int_eq(SSL_get_early_data_status(resumed.c.ssl), SSL_EARLY_DATA_REJECTED)
+        && TEST_false(SSL_session_reused(resumed.c.ssl))
+        && TEST_uint_eq(resumed.c.stats.nst_msgs, 0)
+        && TEST_uint_eq(resumed.s.stats.nst_msgs, 2)
+        && TEST_uint_eq(resumed.c.stats.tickets, 0)
+        && TEST_uint_eq(resumed.s.stats.tickets, 2)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk, 0)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk, 0)
+        && TEST_uint_eq(resumed.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(resumed.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 0);
+
+    SSL_SESSION_free(sess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * TLS 1.3 Server-side Ticket Age Mismatch 0-RTT Rejection
+ *
+ * Exercises the server-side ticket age validation. The client considers the
+ * ticket fresh and proceeds with PSK + 0-RTT, but the transmitted
+ * obfuscated_ticket_age indicates a ticket roughly 10s old. Since the apparent
+ * ticket age exceeds TICKET_AGE_ALLOWANCE, the server rejects early data.
+ *
+ * RFC 8446 4.2.10: For PSKs provisioned via NewSessionTicket, a server MUST
+ * validate that the ticket age for the selected PSK identity is within a small
+ * tolerance of the time since the ticket was issued. If it is not, the server
+ * SHOULD proceed with the handshake but reject 0-RTT.
+ */
+static int test_tls13_ticket_server_age_mismatch_reject_early_data(void)
+{
+    const unsigned char m[] = "message";
+    unsigned char buf[256];
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL;
+    size_t w = 0, r = 0;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(SSL_CTX_set_max_early_data(s, SSL3_RT_MAX_PLAIN_LENGTH))
+        && TEST_true(SSL_CTX_set_options(s, SSL_OP_NO_ANTI_REPLAY) != 0)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, 0))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_uint_eq(initial.c.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.s.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.c.stats.tickets, 2)
+        && TEST_uint_eq(initial.s.stats.tickets, 2)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_int_gt((int)SSL_SESSION_set_time_ex(sess, time(NULL) - 10), 0)
+        && TEST_true(tls_channel_init(c, s, &resumed))
+        && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+        && TEST_true(SSL_write_early_data(resumed.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        && TEST_int_eq(SSL_read_early_data(resumed.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_FINISH)
+        && TEST_size_t_eq(r, 0)
+        && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, 0))
+        && TEST_int_eq(SSL_get_early_data_status(resumed.c.ssl), SSL_EARLY_DATA_REJECTED)
+        && TEST_true(SSL_session_reused(resumed.c.ssl))
+        && TEST_uint_eq(resumed.c.stats.nst_msgs, 1)
+        && TEST_uint_eq(resumed.s.stats.nst_msgs, 1)
+        && TEST_uint_eq(resumed.c.stats.tickets, 1)
+        && TEST_uint_eq(resumed.s.stats.tickets, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_early_data, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_early_data, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 0);
+
+    SSL_SESSION_free(sess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * TLS 1.3 Client-side Ticket Age Mismatch 0-RTT Rejection (outer test)
+ */
+static int test_tls13_ticket_client_age_mismatch_reject_early_data_outer(void)
+{
+    const unsigned char m[] = "message";
+    unsigned char buf[256];
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL;
+    size_t r = 0, w = 0;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(SSL_CTX_set_max_early_data(s, SSL3_RT_MAX_PLAIN_LENGTH))
+        && TEST_true(SSL_CTX_set_timeout(s, 1) > 0)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, 0))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_uint_eq(initial.c.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.s.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.c.stats.tickets, 2)
+        && TEST_uint_eq(initial.s.stats.tickets, 2)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_int_gt((int)SSL_SESSION_set_time_ex(sess, time(NULL) - 10), 0)
+        && TEST_true(tls_channel_init(c, s, &resumed))
+        && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+        && TEST_true(tls_early_data_retry(&resumed))
+        && TEST_int_eq(SSL_get_early_data_status(resumed.c.ssl), SSL_EARLY_DATA_REJECTED)
+        && TEST_false(SSL_session_reused(resumed.c.ssl))
+        && TEST_uint_eq(resumed.c.stats.nst_msgs, 0)
+        && TEST_uint_eq(resumed.s.stats.nst_msgs, 2)
+        && TEST_uint_eq(resumed.c.stats.tickets, 0)
+        && TEST_uint_eq(resumed.s.stats.tickets, 2)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk, 0)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk, 0)
+        && TEST_uint_eq(resumed.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(resumed.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 0)
+        && TEST_size_t_eq((w = SIZE_MAX), SIZE_MAX)
+        && TEST_int_gt(SSL_write_ex(resumed.c.ssl, m, sizeof(m), &w), 0)
+        && TEST_size_t_eq(w, sizeof(m))
+        && TEST_size_t_eq((r = SIZE_MAX), SIZE_MAX)
+        && TEST_int_gt(SSL_read_ex(resumed.s.ssl, buf, sizeof(buf), &r), 0)
+        && TEST_size_t_eq(r, sizeof(m))
+        && TEST_mem_eq(buf, r, m, sizeof(m))
+        && TEST_size_t_eq((w = SIZE_MAX), SIZE_MAX)
+        && TEST_int_gt(SSL_write_ex(resumed.s.ssl, m, sizeof(m), &w), 0)
+        && TEST_size_t_eq(w, sizeof(m))
+        && TEST_size_t_eq((r = SIZE_MAX), SIZE_MAX)
+        && TEST_int_gt(SSL_read_ex(resumed.c.ssl, buf, sizeof(buf), &r), 0)
+        && TEST_size_t_eq(r, sizeof(m))
+        && TEST_mem_eq(buf, r, m, sizeof(m))
+        && TEST_size_t_eq((w = SIZE_MAX), SIZE_MAX)
+        && TEST_true(SSL_write_early_data(resumed.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        && TEST_size_t_eq((w = SIZE_MAX), SIZE_MAX)
+        && TEST_true(SSL_write_early_data(resumed.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m));
+
+    SSL_SESSION_free(sess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
 OPT_TEST_DECLARE_USAGE("\n")
 
 int setup_tests(void)
@@ -674,6 +1082,10 @@ int setup_tests(void)
     ADD_TEST(test_tls13_ticket_resumed_set_num_tickets_zero);
     ADD_TEST(test_tls13_ticket_disable_server);
     ADD_TEST(test_tls13_ticket_no_decrypt);
+    ADD_TEST(test_tls13_ticket_early_data_accepted);
+    ADD_TEST(test_tls13_ticket_client_age_mismatch_reject_early_data_retry);
+    ADD_TEST(test_tls13_ticket_client_age_mismatch_reject_early_data_outer);
+    ADD_TEST(test_tls13_ticket_server_age_mismatch_reject_early_data);
 
     return 1;
 }


### PR DESCRIPTION
Derived from branch https://github.com/openssl/openssl/pull/31925