### PR TITLE
keccak1600x4-avx512vl: fix undefined symbols on macOS (#31941)

### DIFF
--- a/.github/workflows/macos-intel-pr.yml
+++ b/.github/workflows/macos-intel-pr.yml
@@ -1,0 +1,42 @@
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# TEMPORARY: run only the darwin64-x86_64 (macos-15-intel) build that the
+# os-zoo workflow otherwise runs on schedule, so the keccak1600x4-avx512vl
+# link fix for #31941 can be verified directly on the pull request.
+# This file MUST be removed before merge.
+name: macOS x86_64 (PR verify)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  macos-15-intel:
+    if: github.repository == 'openssl/openssl'
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: checkout fuzz/corpora submodule
+        run: git submodule update --init --depth 1 fuzz/corpora
+      - name: config
+        run: ./config --strict-warnings --banner=Configured enable-fips enable-demos enable-h3demo
+      - name: config dump
+        run: ./configdata.pm --dump
+      - name: make
+        run: make -s -j4
+      - name: get cpu info
+        run: |
+          sysctl machdep.cpu
+          ./util/opensslwrap.sh version -c
+      - name: make test
+        run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} LHASH_WORKERS=${LHASH_WORKERS:-16}

--- a/crypto/sha/asm/keccak1600x4-avx512vl.pl
+++ b/crypto/sha/asm/keccak1600x4-avx512vl.pl
@@ -85,7 +85,12 @@ $sf_size="856";       # 48 + 808 = 856 bytes
 # Emit an internal helper call used by one-shot wrappers.
 # - Win64: call the provided *_internal shim and bracket it with 32-byte
 #   shadow space so shim entry can use xlate-compatible [rsp+8]/[rsp+16].
-# - non-Win64: call the public API symbol (same base name without _internal).
+# - non-Win64: call the local function entry label (.L_<base name>), which
+#   sits at the same address as the public symbol.  Calling the public
+#   global symbol by name here would break Mach-O builds: the call textually
+#   precedes the symbol's .globl declaration, so x86_64-xlate.pl never gets
+#   a chance to prepend the platform's leading-underscore, leaving an
+#   undefined reference to the un-decorated name.
 # The argument must be the shim/internal symbol name, e.g.
 #   SHA3_shake128_x4_inc_squeeze_avx512vl_internal
 sub call_internal {
@@ -101,7 +106,7 @@ sub call_internal {
 ___
 
     return <<___;
-    call    $external_name
+    call    .L_$external_name
 ___
 }
 


### PR DESCRIPTION
Fixes the `darwin64-x86_64` (macOS, x86_64) link failure reported in #31941 — a regression introduced by #31090 ("ML-DSA: Add AVX512VL SHAKE x4 multi-buffer integration").

## Root cause

The one-shot SHAKE x4 wrappers in `crypto/sha/asm/keccak1600x4-avx512vl.pl` call the incremental absorb/squeeze routines through a `call_internal()` helper, whose non-Win64 branch emits a `call` to the **public global symbol by its bare name**:

```
call    SHA3_shake128_x4_inc_absorb_avx512vl
```

Those `call`s live *inside* the one-shot wrappers, which textually **precede** the callees' `.globl` declarations.

`crypto/perlasm/x86_64-xlate.pl` only prepends the platform's leading underscore to a referenced symbol once it has seen that symbol's `.globl` (it keys off a `%globals` map populated by `.globl`). Because the `call` precedes the `.globl`, the prefix substitution never fires on Mach-O:

- defined symbol: `_SHA3_shake128_x4_inc_absorb_avx512vl` (with `_`)
- the `call` references: `SHA3_shake128_x4_inc_absorb_avx512vl` (no `_`) → undefined external

On ELF (Linux) symbols carry no leading underscore, so the bare name matches the definition and links fine — which is why only the macOS job failed and the AVX512 SDE CI passed. Only `macos-15-intel` (x86_64) caught it: the `x4-avx512vl` assembly is x86_64-only, and the other macOS jobs (`ci.yml`) run on arm64 runners that never compile this file.

The four affected symbols are exactly the inc-absorb / inc-squeeze routines — the only ones called by-name via `call_internal()`'s non-Win64 path. The finalize and one-shot symbols were never affected: finalize is called via a `.L_` local label, and the one-shots are called from C, which the compiler decorates correctly.

## The fix

Make `call_internal()`'s non-Win64 path call the **local entry label** `.L_<name>` — the same address as the public symbol, and the pattern the finalize calls already use:

```diff
-    call    $external_name
+    call    .L_$external_name
```

This resolves the reference locally and also prevents interposition of these internal routines. The Win64 path is unchanged.

Keeping this as a **draft** until the OS-Zoo `macos-15-intel` (and the rest of CI) confirm green here.

Fixes: https://github.com/openssl/openssl/issues/31941
