### PR TITLE
tests: reduce pkcs11-provider log to test failures

### DIFF
--- a/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
+++ b/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
@@ -85,13 +85,10 @@ echo "Running tests"
 echo "------------------------------------------------------------------"
 
 # For maintenance reasons and simplicity we only run test with kryoptic token
-meson test -C $PKCS11_PROVIDER_BUILDDIR --suite=kryoptic
+meson test -C $PKCS11_PROVIDER_BUILDDIR --print-errorlogs --suite=kryoptic
 
-if [ $? -ne 0 ]; then
-    cat $PKCS11_PROVIDER_BUILDDIR/meson-logs/testlog.txt
-    exit 1
-fi
+RESULT=$?
 
 rm -rf $PKCS11_PROVIDER_BUILDDIR
 
-exit 0
+exit $RESULT


### PR DESCRIPTION
If pkcs11-provider external test fails, only output of failed tests is printed.

##### Checklist

N/A
