### PR TITLE
apps: test dsa -text option

### DIFF
--- a/test/recipes/15-test_dsa.t
+++ b/test/recipes/15-test_dsa.t
@@ -17,7 +17,7 @@ use OpenSSL::Test::Utils;
 setup("test_dsa");
 
 plan skip_all => 'DSA is not supported in this build' if disabled('dsa');
-plan tests => 10;
+plan tests => 11;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -86,6 +86,49 @@ subtest "dsa -modulus prints the DSA public value" => sub {
     chomp @pub;
     ok(grep(/^\Q$expected\E$/, @pub),
        "-modulus prints the expected public value for a public key");
+};
+
+subtest "dsa -text prints the key in text form" => sub {
+    plan tests => 6;
+
+    # The private (x) and public (y) values of the committed testdsa.pem /
+    # testdsapub.pem keypair.  -text prints them as colon-separated hex; we
+    # strip the formatting and compare against the known values so the actual
+    # key material, not just the labels, is verified.
+    my $priv_hex = "BF71D497B89755D0C5E41285D81F9577CC3DF8C2";
+    my $pub_hex = "CC99A07D9817BFF03BB09B183E9B19EB77ABECF192C3A9FBA833DBE"
+        . "69EDB719A8E9777BB82736CEC6A8E4E2FAD0693ACC3D14565D62710B95B02CC"
+        . "6A5CF091EEF9C22F20193EBE114C45A0B5E54A645037E8787FE01B3871508A2"
+        . "5BDBF7C6B81428F89858F133FDB858C390C2EF7BCF7E41D7C66578F792A2488"
+        . "C787EF7C7D41";
+
+    my @priv = run(app(['openssl', 'dsa', '-text', '-noout',
+                        '-in', srctop_file("test", "testdsa.pem")],
+                       stderr => undef),
+                   capture => 1);
+    chomp @priv;
+    my $priv_blob = uc join('', @priv);
+    $priv_blob =~ s/[^0-9A-F]//g;
+    ok(grep(/^Private-Key: \(1024 bit\)$/, @priv),
+       "-text prints the private key header");
+    ok(index($priv_blob, $priv_hex) >= 0,
+       "-text prints the expected private value");
+    ok(index($priv_blob, $pub_hex) >= 0,
+       "-text prints the expected public value for a private key");
+
+    my @pub = run(app(['openssl', 'dsa', '-pubin', '-text', '-noout',
+                       '-in', srctop_file("test", "testdsapub.pem")],
+                      stderr => undef),
+                  capture => 1);
+    chomp @pub;
+    my $pub_blob = uc join('', @pub);
+    $pub_blob =~ s/[^0-9A-F]//g;
+    ok(grep(/^Public-Key: \(1024 bit\)$/, @pub),
+       "-text prints the public key header");
+    ok(index($pub_blob, $pub_hex) >= 0,
+       "-text prints the expected public value for a public key");
+    ok(!grep(/^priv:/, @pub),
+       "-text does not print a private component for a public key");
 };
 
 subtest "dsa PVK output is rejected for public key input" => sub {


### PR DESCRIPTION
The -text option of the dsa app was not exercised by any test. Add a subtest that prints both a private and a public key in text form and, after stripping the colon-separated hex formatting, verifies the printed private and public values match the committed testdsa.pem keypair rather than merely checking that the labels are present.