### PR TITLE
apps: test pkcs8 -nocrypt reading a PKCS#8 PEM

### DIFF
--- a/test/recipes/25-test_pkcs8.t
+++ b/test/recipes/25-test_pkcs8.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips is_nofips/;
 
 setup("test_pkcs8");
 
-plan tests => 19;
+plan tests => 20;
 
 my $pc5_key = srctop_file('test', 'certs', 'pc5-key.pem');
 
@@ -158,6 +158,23 @@ subtest 'PKCS#8 DER inform/outform round trip' => sub {
                 '-inform', 'DER', '-in', 'p8-enc.der',
                 '-out', 'p8-dec.pem', '-passin', 'pass:password'])),
        "read encrypted PKCS#8 from DER form");
+};
+
+subtest 'PKCS#8 -nocrypt reads an unencrypted PKCS#8 PEM' => sub {
+    plan tests => 3;
+
+    # Write an unencrypted PKCS#8 (PrivateKeyInfo) in PEM form.
+    my $p8_pem = 'p8-nocrypt-pem.pem';
+    ok(run(app(['openssl', 'pkcs8', '-topk8', '-nocrypt',
+                '-in', $pc5_key, '-out', $p8_pem])),
+       "write unencrypted PKCS#8 in PEM form");
+    # Read it back with -nocrypt from PEM (the default input format).
+    my $recovered = 'p8-nocrypt-pem-read.pem';
+    ok(run(app(['openssl', 'pkcs8', '-nocrypt',
+                '-in', $p8_pem, '-out', $recovered])),
+       "read unencrypted PKCS#8 from PEM form");
+    is(compare_text($pc5_key, $recovered), 0,
+       "recovered key matches the original");
 };
 
 SKIP: {


### PR DESCRIPTION
Reading an unencrypted PKCS#8 (PrivateKeyInfo) in PEM form with -nocrypt was not exercised by any test; the existing round-trip test only read the DER form via -inform DER. Add a subtest that writes an unencrypted PKCS#8 PEM and reads it back with -nocrypt from PEM, exercising the PEM_read_bio_PKCS8_PRIV_KEY_INFO path, and checks the recovered key matches the original.
