### PR TITLE
ML-DSA (s390x): Fix montgomery_multiplication_vectorized on clang

### DIFF
--- a/crypto/ml_dsa/ml_dsa_ntt_vec128.c
+++ b/crypto/ml_dsa/ml_dsa_ntt_vec128.c
@@ -356,9 +356,8 @@ static ossl_inline
     vec_int32_t
     montgomery_multiplication_vectorized(vec_int32_t a, vec_int32_t a_twist, vec_int32_t b)
 {
-    vec_uint32_t k = (vec_uint32_t)a_twist * (vec_uint32_t)b;
-    vec_uint32_t c_u = vec_mulh((vec_uint32_alias_t)k, (vec_uint32_alias_t)vec_q);
-    vec_int32_t c = (vec_int32_t)c_u;
+    vec_int32_t k = a_twist * b;
+    vec_int32_t c = vec_mulh((vec_int32_alias_t)k, (vec_int32_alias_t)vec_q);
     vec_int32_t z_high = vec_mulh((vec_int32_alias_t)a, (vec_int32_alias_t)b);
     vec_int32_t r = z_high - c;
     return reduce_twice_signed(r);


### PR DESCRIPTION
Fix the problem that `montgomery_multiplication_vectorized` produced wrong results when compiled with `clang`.

The problem was that the research bot in https://github.com/openssl/openssl/pull/30812 suggested to use unsigned variables, so I changed my original implementation. I was already suspicious, but it worked with `gcc`. The solution is to restore the original implementation.