### PR TITLE
apps: drop invalid trust setting in check_cert_might_be_valid()

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2524,7 +2524,6 @@ int check_cert_might_be_valid(BIO *bio, BIO *b_err, X509 *x, const char *checkho
     X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_PARTIAL_CHAIN);
     X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_IGNORE_CRITICAL);
     X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_ALLOW_PROXY_CERTS);
-    X509_VERIFY_PARAM_set_trust(vpm, X509_TRUST_OK_ANY_EKU);
 
     if (!X509_VERIFY_PARAM_set1_ip_asc(vpm, checkip)) {
         maybe_printf(b_err, "Invalid IP address: %s\n", checkip);

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -17,7 +17,7 @@ use File::Compare qw/compare_text/;
 
 setup("test_x509");
 
-plan tests => 153;
+plan tests => 154;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -490,6 +490,18 @@ SKIP: {
     ok(test_errors("Unable to load Public Key", "sm2.pem", '-text'),
        "error loading unsupported sm2 cert");
 }
+
+# Printing info about a plain cert must not emit anything on stderr.
+subtest "no spurious errors when printing certificate info" => sub {
+    plan tests => 2;
+
+    my $errfile = "x509-print.err";
+    ok(run(app(["openssl", "x509", "-noout", "-serial",
+                "-in", srctop_file(@certs, "ca-cert.pem")],
+               stderr => $errfile)),
+       "x509 -serial succeeds");
+    ok(-z $errfile, "x509 -serial produces no output on stderr");
+};
 
 # 3 tests for -dateopts formats
 ok(run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "rfc_822",


### PR DESCRIPTION
check_cert_might_be_valid() called X509_VERIFY_PARAM_set_trust() with X509_TRUST_OK_ANY_EKU, which is a trust_flags bit (1 << 4), not a valid trust id (1..8). The call therefore failed with X509_R_INVALID_TRUST and left that error on the error stack, which was then printed via ERR_print_errors() for every certificate loaded by the x509 app, even on success.

The intended liberal behavior is already provided by X509_PURPOSE_ANY and by suppressing X509_V_ERR_CERT_REJECTED, so just remove the bogus call.

Add a test checking that printing certificate info emits nothing on stderr.