### PR TITLE
rand: fix jitter seed macro logic

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -25,12 +25,6 @@
 #include "internal/provider.h"
 #include "internal/common.h"
 
-/* clang-format off */
-#ifndef OPENSSL_DEFAULT_SEED_SRC
-#define OPENSSL_DEFAULT_SEED_SRC SEED-SRC
-#endif
-/* clang-format on */
-
 typedef struct rand_global_st {
     /*
      * The three shared DRBG instances
@@ -545,10 +539,10 @@ static EVP_RAND_CTX *rand_new_seed(OSSL_LIB_CTX *libctx)
         name = dgbl->seed_name;
     } else {
         fallback = 1;
-        name = OPENSSL_MSTR(OPENSSL_DEFAULT_SEED_SRC);
+        name = OPENSSL_SEED_SRC_NAME;
     }
 #else /* !OPENSSL_NO_FIPS_JITTER */
-    name = "JITTER";
+    name = OPENSSL_SEED_SRC_NAME;
     propq = "";
 #endif /* OPENSSL_NO_FIPS_JITTER */
 

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -39,6 +39,16 @@
 /*
  * Defines related to seed sources
  */
+
+/* Name of the seed source used to seed the primary DRBG. */
+#ifndef OPENSSL_NO_FIPS_JITTER
+#define OPENSSL_SEED_SRC_NAME "JITTER"
+#elif defined(OPENSSL_DEFAULT_SEED_SRC)
+#define OPENSSL_SEED_SRC_NAME OPENSSL_MSTR(OPENSSL_DEFAULT_SEED_SRC)
+#else
+#define OPENSSL_SEED_SRC_NAME "SEED-SRC"
+#endif
+
 #ifndef DEVRANDOM
 /*
  * set this to a comma-separated list of 'random' device files to try out. By

--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -15,13 +15,6 @@
 #include "crypto/rand.h"
 #include "testutil.h"
 
-/* For builds where OPENSSL_DEFAULT_SEED_SRC is explicitly set. */
-/* clang-format off */
-#ifndef OPENSSL_DEFAULT_SEED_SRC
-#define OPENSSL_DEFAULT_SEED_SRC SEED-SRC
-#endif
-/* clang-format on */
-
 static char *configfile;
 
 static int test_rand(void)
@@ -319,11 +312,7 @@ static int test_rand_bytes_mfail(int idx)
         goto end;
     /* The default seed source may be unavailable in some configurations */
     ERR_set_mark();
-#if !defined(OPENSSL_NO_FIPS_JITTER)
-    seed = EVP_RAND_fetch(ctx, "JITTER", NULL);
-#else
-    seed = EVP_RAND_fetch(ctx, OPENSSL_MSTR(OPENSSL_DEFAULT_SEED_SRC), NULL);
-#endif
+    seed = EVP_RAND_fetch(ctx, OPENSSL_SEED_SRC_NAME, NULL);
     ERR_pop_to_mark();
 
     MFAIL_start();
@@ -349,7 +338,7 @@ static int test_rand_seed_src_mfail(void)
     int rc = -1;
 
     if (!TEST_ptr(ctx = OSSL_LIB_CTX_new())
-        || !TEST_ptr(rand = EVP_RAND_fetch(ctx, "SEED-SRC", NULL)))
+        || !TEST_ptr(rand = EVP_RAND_fetch(ctx, OPENSSL_SEED_SRC_NAME, NULL)))
         goto end;
 
     MFAIL_start();


### PR DESCRIPTION
The seeding macro logic was mixed up and incompletely applied. The macro logic was also cleaned up.
