### PR TITLE
Split up and correct the X509_VERIFY_PARAM man pages

### DIFF
--- a/doc/build.info
+++ b/doc/build.info
@@ -3027,6 +3027,10 @@ DEPEND[html/man3/X509_STORE_set_verify_cb_func.html]=man3/X509_STORE_set_verify_
 GENERATE[html/man3/X509_STORE_set_verify_cb_func.html]=man3/X509_STORE_set_verify_cb_func.pod
 DEPEND[man/man3/X509_STORE_set_verify_cb_func.3]=man3/X509_STORE_set_verify_cb_func.pod
 GENERATE[man/man3/X509_STORE_set_verify_cb_func.3]=man3/X509_STORE_set_verify_cb_func.pod
+DEPEND[html/man3/X509_VERIFY_PARAM_set1_host.html]=man3/X509_VERIFY_PARAM_set1_host.pod
+GENERATE[html/man3/X509_VERIFY_PARAM_set1_host.html]=man3/X509_VERIFY_PARAM_set1_host.pod
+DEPEND[man/man3/X509_VERIFY_PARAM_set1_host.3]=man3/X509_VERIFY_PARAM_set1_host.pod
+GENERATE[man/man3/X509_VERIFY_PARAM_set1_host.3]=man3/X509_VERIFY_PARAM_set1_host.pod
 DEPEND[html/man3/X509_VERIFY_PARAM_set_flags.html]=man3/X509_VERIFY_PARAM_set_flags.pod
 GENERATE[html/man3/X509_VERIFY_PARAM_set_flags.html]=man3/X509_VERIFY_PARAM_set_flags.pod
 DEPEND[man/man3/X509_VERIFY_PARAM_set_flags.3]=man3/X509_VERIFY_PARAM_set_flags.pod
@@ -3820,6 +3824,7 @@ html/man3/X509_STORE_add_cert.html \
 html/man3/X509_STORE_get0_param.html \
 html/man3/X509_STORE_new.html \
 html/man3/X509_STORE_set_verify_cb_func.html \
+html/man3/X509_VERIFY_PARAM_set1_host.html \
 html/man3/X509_VERIFY_PARAM_set_flags.html \
 html/man3/X509_add_cert.html \
 html/man3/X509_check_ca.html \
@@ -4498,6 +4503,7 @@ man/man3/X509_STORE_add_cert.3 \
 man/man3/X509_STORE_get0_param.3 \
 man/man3/X509_STORE_new.3 \
 man/man3/X509_STORE_set_verify_cb_func.3 \
+man/man3/X509_VERIFY_PARAM_set1_host.3 \
 man/man3/X509_VERIFY_PARAM_set_flags.3 \
 man/man3/X509_add_cert.3 \
 man/man3/X509_check_ca.3 \

--- a/doc/build.info
+++ b/doc/build.info
@@ -3035,6 +3035,10 @@ DEPEND[html/man3/X509_VERIFY_PARAM_set_flags.html]=man3/X509_VERIFY_PARAM_set_fl
 GENERATE[html/man3/X509_VERIFY_PARAM_set_flags.html]=man3/X509_VERIFY_PARAM_set_flags.pod
 DEPEND[man/man3/X509_VERIFY_PARAM_set_flags.3]=man3/X509_VERIFY_PARAM_set_flags.pod
 GENERATE[man/man3/X509_VERIFY_PARAM_set_flags.3]=man3/X509_VERIFY_PARAM_set_flags.pod
+DEPEND[html/man3/X509_VERIFY_PARAM_set_hostflags.html]=man3/X509_VERIFY_PARAM_set_hostflags.pod
+GENERATE[html/man3/X509_VERIFY_PARAM_set_hostflags.html]=man3/X509_VERIFY_PARAM_set_hostflags.pod
+DEPEND[man/man3/X509_VERIFY_PARAM_set_hostflags.3]=man3/X509_VERIFY_PARAM_set_hostflags.pod
+GENERATE[man/man3/X509_VERIFY_PARAM_set_hostflags.3]=man3/X509_VERIFY_PARAM_set_hostflags.pod
 DEPEND[html/man3/X509_add_cert.html]=man3/X509_add_cert.pod
 GENERATE[html/man3/X509_add_cert.html]=man3/X509_add_cert.pod
 DEPEND[man/man3/X509_add_cert.3]=man3/X509_add_cert.pod
@@ -3826,6 +3830,7 @@ html/man3/X509_STORE_new.html \
 html/man3/X509_STORE_set_verify_cb_func.html \
 html/man3/X509_VERIFY_PARAM_set1_host.html \
 html/man3/X509_VERIFY_PARAM_set_flags.html \
+html/man3/X509_VERIFY_PARAM_set_hostflags.html \
 html/man3/X509_add_cert.html \
 html/man3/X509_check_ca.html \
 html/man3/X509_check_certificate_times.html \
@@ -4505,6 +4510,7 @@ man/man3/X509_STORE_new.3 \
 man/man3/X509_STORE_set_verify_cb_func.3 \
 man/man3/X509_VERIFY_PARAM_set1_host.3 \
 man/man3/X509_VERIFY_PARAM_set_flags.3 \
+man/man3/X509_VERIFY_PARAM_set_hostflags.3 \
 man/man3/X509_add_cert.3 \
 man/man3/X509_check_ca.3 \
 man/man3/X509_check_certificate_times.3 \

--- a/doc/man3/X509_VERIFY_PARAM_set1_host.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set1_host.pod
@@ -1,0 +1,329 @@
+=pod
+
+=head1 NAME
+
+X509_VERIFY_PARAM_set1_host, X509_VERIFY_PARAM_add1_host,
+X509_VERIFY_PARAM_get0_host,
+X509_VERIFY_PARAM_set1_email,
+X509_VERIFY_PARAM_get0_email,
+X509_VERIFY_PARAM_set1_rfc822, X509_VERIFY_PARAM_add1_rfc822,
+X509_VERIFY_PARAM_set1_smtputf8, X509_VERIFY_PARAM_add1_smtputf8,
+X509_VERIFY_PARAM_set1_ip, X509_VERIFY_PARAM_add1_ip,
+X509_VERIFY_PARAM_set1_ip_asc, X509_VERIFY_PARAM_add1_ip_asc,
+X509_VERIFY_PARAM_get1_ip_asc,
+X509_VERIFY_PARAM_set1_host_input_validation,
+X509_VERIFY_PARAM_set1_rfc822_input_validation,
+X509_VERIFY_PARAM_set1_smtputf8_input_validation,
+X509_VERIFY_PARAM_set1_ip_input_validation
+- X509 verification reference identifier configuration
+
+=head1 SYNOPSIS
+
+ #include <openssl/x509_vfy.h>
+
+ int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param,
+                                 const char *name, size_t namelen);
+ int X509_VERIFY_PARAM_add1_host(X509_VERIFY_PARAM *param,
+                                 const char *name, size_t namelen);
+ char *X509_VERIFY_PARAM_get0_host(X509_VERIFY_PARAM *param, int idx);
+
+ int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
+                                  const char *email, size_t emaillen);
+ char *X509_VERIFY_PARAM_get0_email(X509_VERIFY_PARAM *param);
+ int X509_VERIFY_PARAM_set1_rfc822(X509_VERIFY_PARAM *param,
+                                   const char *email, size_t emaillen);
+ int X509_VERIFY_PARAM_add1_rfc822(X509_VERIFY_PARAM *param,
+                                   const char *email, size_t emaillen);
+ int X509_VERIFY_PARAM_set1_smtputf8(X509_VERIFY_PARAM *param,
+                                     const char *email, size_t emaillen);
+ int X509_VERIFY_PARAM_add1_smtputf8(X509_VERIFY_PARAM *param,
+                                     const char *email, size_t emaillen);
+
+ int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
+                               const unsigned char *ip, size_t iplen);
+ int X509_VERIFY_PARAM_add1_ip(X509_VERIFY_PARAM *param,
+                               const unsigned char *ip, size_t iplen);
+ int X509_VERIFY_PARAM_set1_ip_asc(X509_VERIFY_PARAM *param,
+                                   const char *ip_asc);
+ int X509_VERIFY_PARAM_add1_ip_asc(X509_VERIFY_PARAM *param,
+                                   const char *ip_asc);
+ char *X509_VERIFY_PARAM_get1_ip_asc(X509_VERIFY_PARAM *param);
+
+ void X509_VERIFY_PARAM_set1_host_input_validation(X509_VERIFY_PARAM *param,
+     int (*validate_host)(const char *name, size_t len));
+ void X509_VERIFY_PARAM_set1_rfc822_input_validation(X509_VERIFY_PARAM *param,
+     int (*validate_rfc822)(const char *name, size_t len));
+ void X509_VERIFY_PARAM_set1_smtputf8_input_validation(X509_VERIFY_PARAM *param,
+     int (*validate_smtputf8)(const char *name, size_t len));
+ void X509_VERIFY_PARAM_set1_ip_input_validation(X509_VERIFY_PARAM *param,
+     int (*validate_ip)(const uint8_t *name, size_t len));
+
+=head1 DESCRIPTION
+
+These functions configure the set of B<reference identifiers> that an
+B<X509_VERIFY_PARAM> will match against the names asserted by a peer's
+certificate during certificate verification. Four families of reference
+identifier are supported, each matched against a distinct location in the
+certificate:
+
+=over 4
+
+=item *
+
+B<DNS hostnames>, matched against B<dNSName> entries in the certificate's
+subject alternative name (SAN) extension.
+
+=item *
+
+B<RFC 822 email addresses>, matched against B<rfc822Name> entries in the
+certificate's SAN.
+
+=item *
+
+B<SMTPUTF8 email addresses>, matched against B<otherName> entries of type
+B<id-on-SmtpUTF8Mailbox> (RFC 8398) in the certificate's SAN.
+
+=item *
+
+B<IP addresses>, matched against B<iPAddress> entries in the certificate's
+SAN.
+
+=back
+
+For each family the C<set1_> form clears any previously configured values
+and installs the supplied value as the sole reference identifier, and the
+C<add1_> form appends the supplied value to the existing list. When a list contains more than
+one entry, the certificate is considered to match if any of the configured
+values matches a corresponding name in the certificate.
+
+For the functions whose value is a string with an explicit length (the
+hostname and email families), if the length argument is zero
+the value must be NUL-terminated; otherwise the length argument must be the
+length of the value in bytes.
+
+=head2 Hostname matching
+
+X509_VERIFY_PARAM_set1_host() sets in I<param> the expected DNS hostname to
+I<name>, for matching against B<dNSName> SAN entries in the peer's
+certificate, clearing any previously specified hostname. If I<name> is NULL
+or the empty string, the host list is cleared, hostname matching is
+disabled, and the call succeeds.
+
+X509_VERIFY_PARAM_add1_host() adds I<name> as an additional reference
+identifier that can match a B<dNSName> SAN entry in the peer's certificate.
+Any previous names set via X509_VERIFY_PARAM_set1_host() or
+X509_VERIFY_PARAM_add1_host() are retained. If I<name> is NULL or the empty
+string, the list is left unchanged and the call succeeds.
+
+X509_VERIFY_PARAM_get0_host() returns the I<idx>th DNS hostname previously
+configured on I<param> via X509_VERIFY_PARAM_set1_host() or
+X509_VERIFY_PARAM_add1_host(), or NULL if I<idx> is out of range. To iterate
+over the configured hostnames, start with I<idx> = 0 and increment I<idx>
+until the function returns NULL. The returned string is owned by the library
+and remains valid until I<param> is modified or freed; the caller must
+not free it.
+
+Hostname matching is governed by the B<X509_CHECK_FLAG_*> host flags;
+see L<X509_VERIFY_PARAM_set_hostflags(3)> for the available flags and
+their effect on wildcards and subject-DN consultation. The names by which
+the peer matched can be retrieved via L<X509_VERIFY_PARAM_get0_peername(3)>.
+
+=head2 Email matching
+
+The C<_rfc822()> family of functions is used for email names that have
+ASCII localpart addresses, in which case the domain part of the address
+must be represented in A-label form. They are used to specify the list of
+values to match against the SAN B<rfc822Name> entries in certificates.
+
+X509_VERIFY_PARAM_set1_rfc822() clears all expected RFC 822 email
+addresses, and sets the expected RFC 822 email address to I<email> for
+matching against B<rfc822Name> SAN entries in the peer's certificate. A NULL
+I<email> clears the RFC 822 list and returns success; the empty string
+clears the list but returns failure.
+
+X509_VERIFY_PARAM_add1_rfc822() adds I<email> as an additional reference
+identifier that can match a B<rfc822Name> SAN entry in the peer's
+certificate. Any previous names set via X509_VERIFY_PARAM_set1_rfc822(),
+X509_VERIFY_PARAM_add1_rfc822(), or X509_VERIFY_PARAM_set1_email() are
+retained on success; no change is made on failure. I<email> must not be
+NULL, and the empty string is rejected as a failure.
+
+The C<_smtputf8()> family of functions is used for email names that have a
+non-ASCII localpart, in which case the domain part of the address must be
+represented in U-label form. They are used to specify the list of values
+to match against the B<otherName> entries of type
+B<id-on-SmtpUTF8Mailbox> (RFC 8398) in certificates.
+
+X509_VERIFY_PARAM_set1_smtputf8() sets the expected SMTPUTF8 email address
+to I<email> for matching against B<otherName> SAN entries of type
+B<id-on-SmtpUTF8Mailbox>, clearing any previously specified SMTPUTF8 email
+address. A NULL I<email> clears the SMTPUTF8 list and returns success; the
+empty string clears the list but returns failure.
+
+X509_VERIFY_PARAM_add1_smtputf8() adds I<email> as an additional reference
+identifier that can match an B<otherName> SAN entry of type
+B<id-on-SmtpUTF8Mailbox> in the peer's certificate. Any previous names set
+via X509_VERIFY_PARAM_set1_smtputf8(), X509_VERIFY_PARAM_add1_smtputf8(),
+or X509_VERIFY_PARAM_set1_email() are retained on success; no change is
+made on failure. I<email> must not be NULL, and the empty string is
+rejected as a failure.
+
+X509_VERIFY_PARAM_set1_email() is a convenience function that calls
+X509_VERIFY_PARAM_set1_rfc822() and X509_VERIFY_PARAM_set1_smtputf8() with
+the same I<email> argument and succeeds if either call succeeds. This
+allows a caller that does not know whether a given email value is
+ASCII-localpart or SMTPUTF8 to install it for matching against both
+B<rfc822Name> and B<otherName> id-on-SmtpUTF8Mailbox SAN entries. A NULL
+I<email> clears both lists and returns success.
+
+When any email address is configured, certificate verification
+automatically invokes L<X509_check_email(3)>. The peer is considered
+verified when any one of the specified RFC 822 names matches an
+B<rfc822Name> SAN entry, or any one of the specified SMTPUTF8 names
+matches an B<otherName> id-on-SmtpUTF8Mailbox SAN entry, in the
+certificate.
+
+X509_VERIFY_PARAM_get0_email() returns a previously configured expected
+email address from I<param>, or NULL if neither an RFC 822 nor an
+SMTPUTF8 address has been set. When both have been configured, the first
+RFC 822 address is returned in preference to any SMTPUTF8 address. The
+returned string is owned by the library and remains valid until I<param>
+is modified or freed; the caller must not free it.
+
+=head2 IP address matching
+
+X509_VERIFY_PARAM_set1_ip() sets the expected IP address to I<ip> for
+matching against B<iPAddress> SAN entries in the peer's certificate,
+clearing any previously specified IP address. The I<ip> argument must be
+in binary format, in network byte order, and I<iplen> must be 4 for IPv4
+or 16 for IPv6. A NULL I<ip> clears the IP list, disables IP matching, and
+returns success.
+
+X509_VERIFY_PARAM_add1_ip() adds I<ip> as an additional reference
+identifier that can match an B<iPAddress> SAN entry in the peer's
+certificate. Any previous addresses set via X509_VERIFY_PARAM_set1_ip(),
+X509_VERIFY_PARAM_add1_ip(), X509_VERIFY_PARAM_set1_ip_asc(), or
+X509_VERIFY_PARAM_add1_ip_asc() are retained on success; no change is
+made on failure. It is a failure if I<ip> is NULL or I<iplen> is neither
+4 nor 16.
+
+X509_VERIFY_PARAM_set1_ip_asc() sets the expected IP address to I<ip_asc>
+for matching against B<iPAddress> SAN entries in the peer's certificate,
+clearing any previously specified IP address. The I<ip_asc> argument
+must be a NUL-terminated ASCII string: dotted decimal quad for IPv4 and
+colon-separated hexadecimal for IPv6. The condensed "::" notation is
+supported for IPv6 addresses. A NULL I<ip_asc> clears the IP list and
+returns success; a string that cannot be parsed as an IP address, including
+the empty string, returns failure and leaves the list unchanged.
+
+X509_VERIFY_PARAM_add1_ip_asc() adds I<ip_asc> as an additional reference
+identifier that can match an B<iPAddress> SAN entry in the peer's
+certificate. The format requirements on I<ip_asc> are the same as for
+X509_VERIFY_PARAM_set1_ip_asc(). Any previous addresses set via
+X509_VERIFY_PARAM_set1_ip(), X509_VERIFY_PARAM_add1_ip(),
+X509_VERIFY_PARAM_set1_ip_asc(), or X509_VERIFY_PARAM_add1_ip_asc() are
+retained on success; no change is made on failure. I<ip_asc> must not be
+NULL; a string that cannot be parsed as an IP address, including the empty
+string, is a failure.
+
+When any IP address is configured, certificate verification automatically
+invokes L<X509_check_ip(3)> to match against B<iPAddress> SAN entries.
+
+X509_VERIFY_PARAM_get1_ip_asc() returns a previously configured expected
+IP address from I<param> as a freshly allocated ASCII string (dotted
+decimal quad for IPv4, colon-separated hexadecimal for IPv6), or NULL if
+no IP address has been set. The caller is responsible for freeing the
+returned string with L<OPENSSL_free(3)>.
+
+=head2 Input validation
+
+X509_VERIFY_PARAM_set1_host_input_validation(),
+X509_VERIFY_PARAM_set1_rfc822_input_validation(),
+X509_VERIFY_PARAM_set1_smtputf8_input_validation() and
+X509_VERIFY_PARAM_set1_ip_input_validation() install a caller-supplied
+callback that validates a reference-identifier value at the point it is
+configured via the corresponding C<set1_> or C<add1_> function. The
+callback receives the value and its length, and returns a nonzero value to
+accept the input or zero to reject it; on rejection the C<set1_>/C<add1_>
+call fails and no value is stored.
+
+These callbacks override OpenSSL's built-in input validation for the
+corresponding name type. They affect only the validation performed when
+reference identifiers are installed on the verification parameters; they
+do not affect the actual matching performed during certificate
+verification.
+
+=head1 RETURN VALUES
+
+The C<set1_> and C<add1_> functions return 1 for success and 0 for
+failure.
+
+X509_VERIFY_PARAM_get0_host() and X509_VERIFY_PARAM_get0_email() return
+a pointer to a library-owned string, or NULL if no such configured value
+exists (X509_VERIFY_PARAM_get0_host() also returns NULL when its index
+argument is out of range). Callers must not free the returned pointer.
+
+X509_VERIFY_PARAM_get1_ip_asc() returns a freshly allocated string that
+the caller must free with L<OPENSSL_free(3)>, or NULL if no IP address
+has been configured.
+
+The C<set1_*_input_validation()> functions do not return a value.
+
+=head1 NOTES
+
+The reference identifier lists configured by these functions are
+consulted by L<X509_verify_cert(3)> when the corresponding B<X509_check_*>
+checks are performed. Configuring a list for a given name type implicitly
+enables the corresponding check; clearing it (by passing NULL or the
+empty string to the C<set1_> form) disables it.
+
+Unless suppressed by the host flags, the configured hostnames are also
+matched against the B<commonName> attribute of the certificate's subject
+distinguished name, and the configured RFC 822 email addresses against the
+subject B<emailAddress> attribute. SMTPUTF8 email and IP addresses have no
+subject distinguished name counterpart and are matched only against the
+subject alternative name extension. See L<X509_VERIFY_PARAM_set_hostflags(3)>
+and L<X509_check_host(3)> for the flags that govern whether and when the
+subject distinguished name is consulted.
+
+=head1 SEE ALSO
+
+L<X509_verify_cert(3)>,
+L<X509_VERIFY_PARAM_set_flags(3)>,
+L<X509_VERIFY_PARAM_set_hostflags(3)>,
+L<X509_check_host(3)>,
+L<X509_check_email(3)>,
+L<X509_check_ip(3)>,
+L<NAME_CONSTRAINTS_check(3)>,
+L<SSL_set1_host(3)>,
+L<SSL_add1_host(3)>
+
+=head1 HISTORY
+
+X509_VERIFY_PARAM_set1_host(), X509_VERIFY_PARAM_add1_host(),
+X509_VERIFY_PARAM_set1_email(), X509_VERIFY_PARAM_set1_ip(), and
+X509_VERIFY_PARAM_set1_ip_asc() were added in OpenSSL 1.0.2.
+
+X509_VERIFY_PARAM_get0_host(), X509_VERIFY_PARAM_get0_email(), and
+X509_VERIFY_PARAM_get1_ip_asc() were added in OpenSSL 3.0.
+
+X509_VERIFY_PARAM_add1_ip_asc() was added in OpenSSL 1.1.0.
+
+X509_VERIFY_PARAM_set1_rfc822(), X509_VERIFY_PARAM_add1_rfc822(),
+X509_VERIFY_PARAM_set1_smtputf8(), X509_VERIFY_PARAM_add1_smtputf8(),
+X509_VERIFY_PARAM_add1_ip(),
+X509_VERIFY_PARAM_set1_host_input_validation(),
+X509_VERIFY_PARAM_set1_rfc822_input_validation(),
+X509_VERIFY_PARAM_set1_smtputf8_input_validation(), and
+X509_VERIFY_PARAM_set1_ip_input_validation() were added in OpenSSL 4.0.
+
+=head1 COPYRIGHT
+
+Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -88,12 +88,9 @@ X509_VERIFY_PARAM_get_purpose() returns the purpose in I<param>.
 
 X509_VERIFY_PARAM_set_trust() sets the trust selector in I<param> to
 I<trust>, which must be one of the B<X509_TRUST_*> identifiers defined
-in F<openssl/x509_vfy.h> (such as B<X509_TRUST_SSL_SERVER>,
-B<X509_TRUST_SSL_CLIENT>, B<X509_TRUST_EMAIL>, or B<X509_TRUST_OBJECT_SIGN>).
-The trust selector determines how explicit trust settings recorded on
-trust-anchor certificates are matched against the verification operation;
-see the TRUST SETTINGS section of L<openssl-x509(1)>. There is no
-public getter for the trust selector.
+in F<openssl/x509_vfy.h>. This is a legacy mechanism that most
+applications should not use; see L</BUGS>. There is no public getter
+for the trust selector.
 
 X509_VERIFY_PARAM_set_time() sets the verification time in I<param> to
 I<t>, which is then used as the reference time for certificate and CRL
@@ -373,6 +370,15 @@ maintained.
 If CRL checking is enabled, CRLs are expected to be available in the
 corresponding B<X509_STORE> structure. No attempt is made to download
 CRLs from the CRL distribution points extension.
+
+The B<X509_TRUST_*> selectors used by X509_VERIFY_PARAM_set_trust() are
+deceptively named: although each mirrors a PKIX extended key usage, the
+selector does not check that B<extKeyUsage>. It matches only auxiliary
+trust information that is never carried in the certificate itself but
+must be attached to the in-memory B<X509> object by the application;
+absent that, the selector has no effect. Use
+X509_VERIFY_PARAM_set_purpose() to constrain a certificate by its
+extended key usage instead.
 
 =head1 EXAMPLES
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -11,8 +11,6 @@ X509_VERIFY_PARAM_get_depth, X509_VERIFY_PARAM_set_auth_level,
 X509_VERIFY_PARAM_get_auth_level, X509_VERIFY_PARAM_set_time,
 X509_VERIFY_PARAM_get_time,
 X509_VERIFY_PARAM_add0_policy, X509_VERIFY_PARAM_set1_policies,
-X509_VERIFY_PARAM_set_hostflags,
-X509_VERIFY_PARAM_get_hostflags,
 X509_VERIFY_PARAM_get0_peername
 - X509 verification parameters
 
@@ -49,19 +47,30 @@ X509_VERIFY_PARAM_get0_peername
                                        int auth_level);
  int X509_VERIFY_PARAM_get_auth_level(const X509_VERIFY_PARAM *param);
 
- void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
-                                      unsigned int flags);
- unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param);
  char *X509_VERIFY_PARAM_get0_peername(const X509_VERIFY_PARAM *param);
 
 =head1 DESCRIPTION
 
-These functions manipulate the B<X509_VERIFY_PARAM> structure associated with
-a certificate verification operation.
+An B<X509_VERIFY_PARAM> object collects the configuration consumed by a
+certificate verification operation: the verification flags, the purpose
+and trust selectors, the verification time, the maximum chain depth, the
+required security level, the acceptable certificate policies, and the
+reference identifiers against which the peer certificate's names are
+matched. B<X509_VERIFY_PARAM> objects are typically attached to an
+B<X509_STORE> or an B<SSL_CTX>/B<SSL> and reach L<X509_verify_cert(3)>
+through the B<X509_STORE_CTX> being verified; values propagate from one
+parameter set to another according to the rules in L</INHERITANCE FLAGS>.
 
-The X509_VERIFY_PARAM_set_flags() function sets the flags in I<param> by oring
-it with I<flags>. See L</VERIFICATION FLAGS> for a complete
+These functions manipulate an B<X509_VERIFY_PARAM>. The functions for
+configuring its reference identifiers (hostnames, email addresses, and
+IP addresses) are documented in
+L<X509_VERIFY_PARAM_set1_host(3)>.
+
+The X509_VERIFY_PARAM_set_flags() function sets the flags in I<param> by
+ORing it with I<flags>. See L</VERIFICATION FLAGS> for a complete
 description of values the I<flags> parameter can take.
+
+X509_VERIFY_PARAM_clear_flags() clears the flags I<flags> in I<param>.
 
 X509_VERIFY_PARAM_get_flags() returns the flags in I<param>.
 
@@ -70,8 +79,6 @@ which specifies how verification flags are copied from one structure to
 another. X509_VERIFY_PARAM_set_inh_flags() sets the inheritance flags.
 See the L</INHERITANCE FLAGS> section for a description of these bits.
 
-X509_VERIFY_PARAM_clear_flags() clears the flags I<flags> in I<param>.
-
 X509_VERIFY_PARAM_set_purpose() sets the verification purpose in I<param>
 to I<purpose>. This determines the acceptable purpose of the certificate
 chain, for example B<X509_PURPOSE_SSL_CLIENT>.
@@ -79,24 +86,39 @@ The purpose requirement is cleared if I<purpose> is B<X509_PURPOSE_DEFAULT_ANY>.
 
 X509_VERIFY_PARAM_get_purpose() returns the purpose in I<param>.
 
-X509_VERIFY_PARAM_set_trust() sets the trust setting in I<param> to
-I<trust>.
+X509_VERIFY_PARAM_set_trust() sets the trust selector in I<param> to
+I<trust>, which must be one of the B<X509_TRUST_*> identifiers defined
+in F<openssl/x509_vfy.h> (such as B<X509_TRUST_SSL_SERVER>,
+B<X509_TRUST_SSL_CLIENT>, B<X509_TRUST_EMAIL>, or B<X509_TRUST_OBJECT_SIGN>).
+The trust selector determines how explicit trust settings recorded on
+trust-anchor certificates are matched against the verification operation;
+see the TRUST SETTINGS section of L<openssl-x509(1)>. There is no
+public getter for the trust selector.
 
 X509_VERIFY_PARAM_set_time() sets the verification time in I<param> to
-I<t>. Normally the current time is used.
+I<t>, which is then used as the reference time for certificate and CRL
+validity-period checks in place of the current time. Calling this
+function automatically sets the B<X509_V_FLAG_USE_CHECK_TIME> flag (see
+L</Validity period (time)>). If X509_VERIFY_PARAM_set_time() has not
+been called, validity checks are performed against the current time.
 
-X509_VERIFY_PARAM_add0_policy() adds I<policy> to the acceptable policy set.
-Contrary to preexisting documentation of this function it does not enable
-policy checking.
+X509_VERIFY_PARAM_get_time() returns the verification time configured on
+I<param>.
+
+X509_VERIFY_PARAM_add0_policy() adds I<policy> to the acceptable policy
+set. Policy checking itself must be enabled separately, either by setting
+B<X509_V_FLAG_POLICY_CHECK> via X509_VERIFY_PARAM_set_flags() or by
+calling X509_VERIFY_PARAM_set1_policies().
 
 X509_VERIFY_PARAM_set1_policies() enables policy checking (it is disabled
 by default) and sets the acceptable policy set to I<policies>. Any existing
 policy set is cleared. The I<policies> parameter can be NULL to clear
 an existing policy set.
 
-X509_VERIFY_PARAM_set_depth() sets the maximum verification depth to I<depth>.
-That is the maximum number of intermediate CA certificates that can appear in a
-chain.
+X509_VERIFY_PARAM_set_depth() sets the maximum verification depth to
+I<depth>. That is the maximum number of intermediate CA certificates that
+can appear in a chain. If X509_VERIFY_PARAM_set_depth() is not called,
+the verification depth defaults to 100.
 A maximal depth chain contains 2 more certificates than the limit, since
 neither the end-entity certificate nor the trust-anchor count against this
 limit.
@@ -122,49 +144,38 @@ Security level 1 requires at least 80-bit-equivalent security and is broadly
 interoperable, though it will, for example, reject MD5 signatures or RSA keys
 shorter than 1024 bits.
 
-When the subject CommonName will not be ignored, whether as a result of the
-B<X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT> host flag, or because no DNS subject
-alternative names are present in the certificate, any DNS name constraints in
-issuer certificates apply to the subject CommonName as well as the subject
-alternative name extension.
-
-When the subject CommonName will be ignored, whether as a result of the
-B<X509_CHECK_FLAG_NEVER_CHECK_SUBJECT> host flag, or because some DNS subject
-alternative names are present in the certificate, DNS name constraints in
-issuer certificates will not be applied to the subject DN.
-As described in X509_check_host(3) the B<X509_CHECK_FLAG_NEVER_CHECK_SUBJECT>
-flag takes precedence over the B<X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT> flag.
-
-X509_VERIFY_PARAM_get_hostflags() returns any host flags previously set via a
-call to X509_VERIFY_PARAM_set_hostflags().
-
+The remaining accessor on this page reports a result populated during
+certificate verification rather than a configured parameter:
 X509_VERIFY_PARAM_get0_peername() returns the DNS hostname or subject
 CommonName from the peer certificate that matched one of the reference
-identifiers.  When wildcard matching is not disabled, or when a
-reference identifier specifies a parent domain (starts with ".")
-rather than a hostname, the peer name may be a wildcard name or a
-sub-domain of the reference identifier respectively.  The return
-string is allocated by the library and is no longer valid once the
-associated I<param> argument is freed.  Applications must not free
-the return value.
+identifiers. When wildcard matching is not disabled, or when a reference
+identifier specifies a parent domain (starts with "."), rather than a
+hostname, the peer name may be a wildcard name or a sub-domain of the
+reference identifier respectively. The returned string is allocated by
+the library and is no longer valid once the associated I<param> argument
+is freed. Applications must not free the return value.
 
 =head1 RETURN VALUES
 
 X509_VERIFY_PARAM_set_flags(), X509_VERIFY_PARAM_clear_flags(),
 X509_VERIFY_PARAM_set_inh_flags(),
 X509_VERIFY_PARAM_set_purpose(), X509_VERIFY_PARAM_set_trust(),
-X509_VERIFY_PARAM_add0_policy() X509_VERIFY_PARAM_set1_policies()
-return 1 for success and 0 for
-failure.
+X509_VERIFY_PARAM_add0_policy(), and X509_VERIFY_PARAM_set1_policies()
+return 1 for success and 0 for failure.
+
+X509_VERIFY_PARAM_get0_peername() returns a pointer to the name from the
+peer certificate that matched a configured reference identifier, or NULL
+if no match has been recorded.
 
 X509_VERIFY_PARAM_get_flags() returns the current verification flags.
 
-X509_VERIFY_PARAM_get_hostflags() returns any current host flags.
-
 X509_VERIFY_PARAM_get_inh_flags() returns the current inheritance flags.
 
-X509_VERIFY_PARAM_set_time() and X509_VERIFY_PARAM_set_depth() do not return
-values.
+X509_VERIFY_PARAM_set_time(), X509_VERIFY_PARAM_set_depth(), and
+X509_VERIFY_PARAM_set_auth_level() do not return values.
+
+X509_VERIFY_PARAM_get_time() returns the verification time previously
+configured on I<param> via X509_VERIFY_PARAM_set_time().
 
 X509_VERIFY_PARAM_get_depth() returns the current verification depth.
 
@@ -176,99 +187,151 @@ which may be B<X509_PURPOSE_DEFAULT_ANY> if unset.
 
 =head1 VERIFICATION FLAGS
 
-The verification flags consists of zero or more of the following flags
-ored together.
+The verification flags consist of zero or more of the following values
+ORed together. Unless noted otherwise, each flag is off by default.
 
-B<X509_V_FLAG_CRL_CHECK> enables CRL checking for the certificate chain leaf
-certificate. An error occurs if a suitable CRL cannot be found.
+=head2 Revocation checking
 
-B<X509_V_FLAG_CRL_CHECK_ALL> expands CRL checking to the entire certificate
-chain if B<X509_V_FLAG_CRL_CHECK> has also been enabled, and is otherwise ignored.
+B<X509_V_FLAG_CRL_CHECK> enables CRL checking for the certificate chain
+leaf certificate. An error occurs if a suitable CRL cannot be found.
 
-B<X509_V_FLAG_OCSP_RESP_CHECK> enables Online Certificate Status Protocol (OCSP)
-checking for the certificate chain leaf certificate. An error occurs if a suitable
-OCSP response cannot be found.
+B<X509_V_FLAG_CRL_CHECK_ALL> expands CRL checking to the entire
+certificate chain if B<X509_V_FLAG_CRL_CHECK> has also been enabled, and
+is otherwise ignored.
 
-B<X509_V_FLAG_OCSP_RESP_CHECK_ALL> expands OCSP checking to the entire certificate
-chain if B<X509_V_FLAG_OCSP_RESP_CHECK> has also been enabled, and is otherwise
-ignored.
+B<X509_V_FLAG_OCSP_RESP_CHECK> enables Online Certificate Status Protocol
+(OCSP) checking for the certificate chain leaf certificate. An error
+occurs if a suitable OCSP response cannot be found.
 
-B<X509_V_FLAG_IGNORE_CRITICAL> disables critical extension checking. By default
-any unhandled critical extensions in certificates or (if checked) CRLs result
-in a fatal error. If this flag is set unhandled critical extensions are
-ignored. B<WARNING> setting this option for anything other than debugging
-purposes can be a security risk. Finer control over which extensions are
-supported can be performed in the verification callback.
+B<X509_V_FLAG_OCSP_RESP_CHECK_ALL> expands OCSP checking to the entire
+certificate chain if B<X509_V_FLAG_OCSP_RESP_CHECK> has also been
+enabled, and is otherwise ignored.
 
-The B<X509_V_FLAG_X509_STRICT> flag disables workarounds for some broken
-certificates and makes the verification strictly apply B<X509> rules.
+If B<X509_V_FLAG_EXTENDED_CRL_SUPPORT> is set, some additional features
+such as indirect CRLs and CRLs signed by different keys are enabled. By
+default these features are disabled.
 
-B<X509_V_FLAG_ALLOW_PROXY_CERTS> enables proxy certificate verification.
+If B<X509_V_FLAG_USE_DELTAS> is set, delta CRLs (if present) are used to
+determine certificate status. If not set, deltas are ignored.
 
-B<X509_V_FLAG_POLICY_CHECK> enables certificate policy checking, by default
-no policy checking is performed. Additional information is sent to the
-verification callback relating to policy checking.
+=head2 Certificate policy checking
 
-B<X509_V_FLAG_EXPLICIT_POLICY>, B<X509_V_FLAG_INHIBIT_ANY> and
-B<X509_V_FLAG_INHIBIT_MAP> set the C<require explicit policy>, C<inhibit any
-policy> and C<inhibit policy mapping> flags respectively as defined in
-RFC 5280. Policy checking is automatically enabled if any of these flags
-are set.
+B<X509_V_FLAG_POLICY_CHECK> enables certificate policy checking. By
+default no policy checking is performed. Additional information is sent
+to the verification callback relating to policy checking.
 
-If B<X509_V_FLAG_NOTIFY_POLICY> is set and the policy checking is successful
-a special status code is set to the verification callback. This permits it
-to examine the valid policy tree and perform additional checks or simply
-log it for debugging purposes.
+B<X509_V_FLAG_EXPLICIT_POLICY>, B<X509_V_FLAG_INHIBIT_ANY>, and
+B<X509_V_FLAG_INHIBIT_MAP> set the C<require explicit policy>, C<inhibit
+any policy>, and C<inhibit policy mapping> flags respectively as defined
+in RFC 5280. Policy checking is automatically enabled if any of these
+flags is set.
 
-By default some additional features such as indirect CRLs and CRLs signed by
-different keys are disabled. If B<X509_V_FLAG_EXTENDED_CRL_SUPPORT> is set
-they are enabled.
+If B<X509_V_FLAG_NOTIFY_POLICY> is set and policy checking is
+successful, a special status code is delivered to the verification
+callback. This permits the callback to examine the valid policy tree
+and perform additional checks, or simply to log it for debugging
+purposes.
 
-If B<X509_V_FLAG_USE_DELTAS> is set delta CRLs (if present) are used to
-determine certificate status. If not set deltas are ignored.
-
-B<X509_V_FLAG_CHECK_SS_SIGNATURE> requests checking the signature of
-the last certificate in a chain if the certificate is supposedly self-signed.
-This is prohibited and will result in an error if it is a non-conforming CA
-certificate with key usage restrictions not including the I<keyCertSign> bit.
-By default this check is disabled because it doesn't
-add any additional security but in some cases applications might want to
-check the signature anyway. A side effect of not checking the self-signature
-of such a certificate is that disabled or unsupported message digests used for
-the signature are not treated as fatal errors.
+=head2 Chain construction
 
 When B<X509_V_FLAG_TRUSTED_FIRST> is set, which is the default since
-OpenSSL 1.1.0, construction of the certificate chain
-in L<X509_verify_cert(3)> searches the trust store for issuer certificates
-before searching the provided untrusted certificates.
-Local issuer certificates are often more likely to satisfy local security
-requirements and lead to a locally trusted root.
-This is especially important when some certificates in the trust store have
-explicit trust settings (see "TRUST SETTINGS" in L<openssl-x509(1)>).
+OpenSSL 1.1.0, construction of the certificate chain in
+L<X509_verify_cert(3)> searches the trust store for issuer certificates
+before searching the provided untrusted certificates. Local issuer
+certificates are often more likely to satisfy local security
+requirements and lead to a locally trusted root. This is especially
+important when some certificates in the trust store have explicit trust
+settings (see "TRUST SETTINGS" in L<openssl-x509(1)>).
 
-The B<X509_V_FLAG_NO_ALT_CHAINS> flag suppresses checking for alternative chains.
+The B<X509_V_FLAG_NO_ALT_CHAINS> flag suppresses checking for
+alternative chains. By default, when the initial untrusted-first chain
+fails to reach a trust anchor, the build is retried with progressively
+shorter untrusted prefixes in an attempt to find an alternative.
 
-The B<X509_V_FLAG_PARTIAL_CHAIN> flag causes non-self-signed certificates in the
-trust store to be treated as trust anchors, in the same way as self-signed
-root CA certificates.
-This makes it possible to trust self-issued certificates as well as certificates
-issued by an intermediate CA without having to trust their ancestor root CA.
-With B<X509_V_FLAG_PARTIAL_CHAIN> set, chain
-construction stops as soon as the first certificate contained in the trust store
-is added to the chain, whether that certificate is a self-signed "root"
-certificate or a not self-signed "intermediate" or self-issued certificate.
-Thus, when an intermediate certificate is found in the trust store, the
-verified chain passed to callbacks may be shorter than it otherwise would
-be without the B<X509_V_FLAG_PARTIAL_CHAIN> flag.
+The B<X509_V_FLAG_PARTIAL_CHAIN> flag causes non-self-signed
+certificates in the trust store to be treated as trust anchors, in the
+same way as self-signed root CA certificates. This makes it possible to
+trust self-issued certificates as well as certificates issued by an
+intermediate CA without having to trust their ancestor root CA. With
+B<X509_V_FLAG_PARTIAL_CHAIN> set, chain construction stops as soon as
+the first certificate contained in the trust store is added to the
+chain, whether that certificate is a self-signed "root" certificate or
+a not self-signed "intermediate" or self-issued certificate. Thus, when
+an intermediate certificate is found in the trust store, the verified
+chain passed to callbacks may be shorter than it otherwise would be
+without the B<X509_V_FLAG_PARTIAL_CHAIN> flag.
 
-The B<X509_V_FLAG_NO_CHECK_TIME> flag suppresses checking the validity period
-of certificates and CRLs against the current time. If X509_VERIFY_PARAM_set_time()
-is used to specify a verification time, the check is not suppressed.
+B<X509_V_FLAG_CHECK_SS_SIGNATURE> requests checking the signature of
+the last certificate in a chain if the certificate is supposedly
+self-signed. This is prohibited and will result in an error if it is a
+non-conforming CA certificate with key usage restrictions not including
+the I<keyCertSign> bit. By default this check is disabled because it
+does not add any additional security, but in some cases applications
+might want to check the signature anyway. A side effect of not checking
+the self-signature of such a certificate is that disabled or
+unsupported message digests used for the signature are not treated as
+fatal errors.
+
+=head2 Validity period (time)
+
+B<X509_V_FLAG_USE_CHECK_TIME> indicates that the time stored on the
+parameters should be used for validity period checks in place of the
+current time. This flag is set automatically by
+X509_VERIFY_PARAM_set_time(); applications do not normally manipulate
+it directly.
+
+The B<X509_V_FLAG_NO_CHECK_TIME> flag suppresses checking the validity
+period of certificates and CRLs against the current time. If
+X509_VERIFY_PARAM_set_time() has been used to specify a verification
+time, the check is performed against the specified time and this flag
+has no effect.
+
+=head2 Extension processing and strictness
+
+B<X509_V_FLAG_IGNORE_CRITICAL> disables critical extension checking. By
+default, any unhandled critical extensions in certificates or (if
+checked) CRLs result in a fatal error. If this flag is set, unhandled
+critical extensions are ignored. B<WARNING:> setting this option for
+anything other than debugging purposes can be a security risk. Finer
+control over which extensions are supported can be performed in the
+verification callback.
+
+The B<X509_V_FLAG_X509_STRICT> flag disables workarounds for some
+broken certificates and makes verification strictly apply B<X509>
+rules.
+
+B<X509_V_FLAG_ALLOW_PROXY_CERTS> enables proxy certificate verification.
+By default, proxy certificates are not accepted.
+
+=head2 Suite B compliance
+
+These flags enable enforcement of the NSA Suite B cryptographic
+profile, a now-legacy profile that restricts chain validation to a
+specific subset of elliptic-curve algorithms. Suite B has been
+superseded by NSA's Commercial National Security Algorithm (CNSA) Suite
+for new deployments.
+
+B<X509_V_FLAG_SUITEB_128_LOS_ONLY> restricts the chain to the Suite B
+128-bit level of security: certificates must use the NIST P-256 curve
+with ECDSA and SHA-256.
+
+B<X509_V_FLAG_SUITEB_192_LOS> restricts the chain to the Suite B 192-bit
+level of security: certificates must use the NIST P-384 curve with
+ECDSA and SHA-384.
+
+B<X509_V_FLAG_SUITEB_128_LOS> is the bitwise OR of the two flags above
+and permits either level of security in the chain, with the constraint
+that once a P-384 certificate has appeared in the chain, P-256
+certificates may not subsequently be used.
 
 =head1 INHERITANCE FLAGS
 
-These flags specify how parameters are "inherited" from one structure to
-another.
+These flags control how the values stored in one B<X509_VERIFY_PARAM> are
+copied into another when verification parameters are "inherited", for
+example when an B<SSL> object inherits its verification parameters from
+the B<SSL_CTX> that created it. In the descriptions below, "from" refers
+to the source B<X509_VERIFY_PARAM> from which values are copied, and "to"
+refers to the destination B<X509_VERIFY_PARAM> into which they are copied.
 
 If B<X509_VP_FLAG_ONCE> is set then the current setting is zeroed
 after the next call.
@@ -281,8 +344,8 @@ to the destination. Effectively the values in "to" become default values
 which will be used only if nothing new is set in "from".  This is the
 default.
 
-If B<X509_VP_FLAG_OVERWRITE> is set then all value are copied across whether
-they are set or not. Flags is still Ored though.
+If B<X509_VP_FLAG_OVERWRITE> is set then all values are copied across
+whether they are set or not. Flags are still ORed though.
 
 If B<X509_VP_FLAG_RESET_FLAGS> is set then the flags value is copied instead
 of ORed.
@@ -294,11 +357,12 @@ instead of functions which work in specific structures such as
 X509_STORE_CTX_set_flags() which are likely to be deprecated in a future
 release.
 
-TLS clients are recommended to set up validation of server hostname(s) and/or
-IP address (directly using the above functions
-or more conveniently using L<SSL_set1_host(3)> or L<SSL_add1_host(3)>)
-and to use L<SSL_set_tlsext_host_name(3)> for Server Name Indication (SNI),
-which may be crucial also for correct routing of the connection request.
+TLS clients are recommended to set up validation of server hostname(s)
+and/or IP address (directly using the functions described in
+L<X509_VERIFY_PARAM_set1_host(3)>, or more conveniently using
+L<SSL_set1_host(3)> or L<SSL_add1_host(3)>) and to use
+L<SSL_set_tlsext_host_name(3)> for Server Name Indication (SNI), which
+may be crucial also for correct routing of the connection request.
 
 =head1 BUGS
 
@@ -306,7 +370,7 @@ Delta CRL checking is currently primitive. Only a single delta can be used and
 (partly due to limitations of B<X509_STORE>) constructed CRLs are not
 maintained.
 
-If CRLs checking is enable CRLs are expected to be available in the
+If CRL checking is enabled, CRLs are expected to be available in the
 corresponding B<X509_STORE> structure. No attempt is made to download
 CRLs from the CRL distribution points extension.
 
@@ -327,6 +391,7 @@ connections associated with an B<SSL_CTX> structure I<ctx>:
 L<SSL_CTX_set_security_level(3)>,
 L<X509_verify_cert(3)>,
 L<X509_VERIFY_PARAM_set1_host(3)>,
+L<X509_VERIFY_PARAM_set_hostflags(3)>,
 L<X509_check_host(3)>,
 L<X509_check_email(3)>,
 L<X509_check_ip(3)>,
@@ -345,8 +410,6 @@ Since OpenSSL 1.1.0 version, the B<X509_V_FLAG_TRUSTED_FIRST> is set by default.
 The B<X509_V_FLAG_NO_ALT_CHAINS> flag was added in OpenSSL 1.1.0.
 The flag B<X509_V_FLAG_CB_ISSUER_CHECK> was deprecated in OpenSSL 1.1.0
 and has no effect.
-
-The X509_VERIFY_PARAM_get_hostflags() function was added in OpenSSL 1.1.0i.
 
 The function X509_VERIFY_PARAM_add0_policy() was historically documented as
 enabling policy checking however the implementation has never done this.

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -11,22 +11,9 @@ X509_VERIFY_PARAM_get_depth, X509_VERIFY_PARAM_set_auth_level,
 X509_VERIFY_PARAM_get_auth_level, X509_VERIFY_PARAM_set_time,
 X509_VERIFY_PARAM_get_time,
 X509_VERIFY_PARAM_add0_policy, X509_VERIFY_PARAM_set1_policies,
-X509_VERIFY_PARAM_get0_host,
-X509_VERIFY_PARAM_set1_host, X509_VERIFY_PARAM_add1_host,
 X509_VERIFY_PARAM_set_hostflags,
 X509_VERIFY_PARAM_get_hostflags,
-X509_VERIFY_PARAM_get0_peername,
-X509_VERIFY_PARAM_get0_email,
-X509_VERIFY_PARAM_set1_email,
-X509_VERIFY_PARAM_set1_rfc822, X509_VERIFY_PARAM_add1_rfc822,
-X509_VERIFY_PARAM_set1_smtputf8, X509_VERIFY_PARAM_add1_smtputf8,
-X509_VERIFY_PARAM_set1_ip, X509_VERIFY_PARAM_add1_ip,
-X509_VERIFY_PARAM_set1_ip_asc, X509_VERIFY_PARAM_add1_ip_asc,
-X509_VERIFY_PARAM_get1_ip_asc,
-X509_VERIFY_PARAM_set1_host_input_validation,
-X509_VERIFY_PARAM_set1_rfc822_input_validation,
-X509_VERIFY_PARAM_set1_smtputf8_input_validation,
-X509_VERIFY_PARAM_set1_ip_input_validation
+X509_VERIFY_PARAM_get0_peername
 - X509 verification parameters
 
 =head1 SYNOPSIS
@@ -62,41 +49,10 @@ X509_VERIFY_PARAM_set1_ip_input_validation
                                        int auth_level);
  int X509_VERIFY_PARAM_get_auth_level(const X509_VERIFY_PARAM *param);
 
- char *X509_VERIFY_PARAM_get0_host(X509_VERIFY_PARAM *param, int n);
- int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param,
-                                 const char *name, size_t namelen);
- int X509_VERIFY_PARAM_add1_host(X509_VERIFY_PARAM *param,
-                                 const char *name, size_t namelen);
  void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
                                       unsigned int flags);
  unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param);
  char *X509_VERIFY_PARAM_get0_peername(const X509_VERIFY_PARAM *param);
- char *X509_VERIFY_PARAM_get0_email(X509_VERIFY_PARAM *param);
- int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
-                                  const char *email, size_t emaillen);
- int X509_VERIFY_PARAM_set1_rfc822(X509_VERIFY_PARAM *param,
-                                  const char *email, size_t emaillen);
- int X509_VERIFY_PARAM_add1_rfc822(X509_VERIFY_PARAM *param,
-                                 const char *email, size_t emaillen);
- int X509_VERIFY_PARAM_set1_smtputf8(X509_VERIFY_PARAM *param,
-                                  const char *email, size_t emaillen);
- int X509_VERIFY_PARAM_add1_smtputf8(X509_VERIFY_PARAM *param,
-                                 const char *email, size_t emaillen);
- char *X509_VERIFY_PARAM_get1_ip_asc(X509_VERIFY_PARAM *param);
- int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
-                               const unsigned char *ip, size_t iplen);
- int X509_VERIFY_PARAM_add1_ip(X509_VERIFY_PARAM *param,
-                               const unsigned char *ip, size_t iplen);
- int X509_VERIFY_PARAM_set1_ip_asc(X509_VERIFY_PARAM *param, const char *ip_asc);
- int X509_VERIFY_PARAM_add1_ip_asc(X509_VERIFY_PARAM *param, const char *ip_asc);
- void X509_VERIFY_PARAM_set1_ip_input_validation(X509_VERIFY_PARAM *param,
-    int (*validate_ip)(const uint8_t *name, size_t len));
- void X509_VERIFY_PARAM_set1_host_input_validation(X509_VERIFY_PARAM *param,
-    int (*validate_host)(const char *name, size_t len));
- void X509_VERIFY_PARAM_set1_rfc822_input_validation(X509_VERIFY_PARAM *param,
-    int (*validate_rfc822)(const char *name, size_t len));
- void X509_VERIFY_PARAM_set1_smtputf8_input_validation(X509_VERIFY_PARAM *param,
-    int (*validate_smtputf8)(const char *name, size_t len));
 
 =head1 DESCRIPTION
 
@@ -166,27 +122,6 @@ Security level 1 requires at least 80-bit-equivalent security and is broadly
 interoperable, though it will, for example, reject MD5 signatures or RSA keys
 shorter than 1024 bits.
 
-X509_VERIFY_PARAM_get0_host() returns the I<n>th expected DNS hostname that has
-been set using X509_VERIFY_PARAM_set1_host() or X509_VERIFY_PARAM_add1_host().
-To obtain all names start with I<n> = 0 and increment I<n> as long as no NULL
-pointer is returned.
-
-X509_VERIFY_PARAM_set1_host() sets in I<param> the expected
-DNS hostname to I<name>, clearing any previously specified hostname.
-If I<name> is NULL or the empty string, the list of hostnames is cleared
-and hostname checks are not performed on the peer certificate.
-If I<namelen> is zero, I<name> must be NUL-terminated,
-otherwise I<namelen> must be set to the length of I<name>.
-
-When a hostname is specified,
-certificate verification automatically invokes L<X509_check_host(3)>
-with flags equal to the I<flags> argument given to
-X509_VERIFY_PARAM_set_hostflags() (default zero).  Applications
-are strongly advised to use this interface in preference to explicitly
-calling L<X509_check_host(3)>, hostname checks may be out of scope
-with the DANE-EE(3) certificate usage, and the internal check will
-be suppressed as appropriate when DANE verification is enabled.
-
 When the subject CommonName will not be ignored, whether as a result of the
 B<X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT> host flag, or because no DNS subject
 alternative names are present in the certificate, any DNS name constraints in
@@ -203,13 +138,6 @@ flag takes precedence over the B<X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT> flag.
 X509_VERIFY_PARAM_get_hostflags() returns any host flags previously set via a
 call to X509_VERIFY_PARAM_set_hostflags().
 
-X509_VERIFY_PARAM_add1_host() adds I<name> as an additional reference
-identifier that can match the peer's certificate.  Any previous names
-set via X509_VERIFY_PARAM_set1_host() or X509_VERIFY_PARAM_add1_host()
-are retained, no change is made if I<name> is NULL or the empty string.  When
-multiple names are configured, the peer is considered verified when
-any name matches.
-
 X509_VERIFY_PARAM_get0_peername() returns the DNS hostname or subject
 CommonName from the peer certificate that matched one of the reference
 identifiers.  When wildcard matching is not disabled, or when a
@@ -220,126 +148,14 @@ string is allocated by the library and is no longer valid once the
 associated I<param> argument is freed.  Applications must not free
 the return value.
 
-X509_VERIFY_PARAM_get0_email() returns the expected RFC822 email address.
-
-The _rfc822() family of functions is used for email names that have
-ASCII localpart addresses, in which case the domain part of the
-address must be represented in A-label form. They are used to
-specify the list of values to match against the SAN Email names in
-certificates.
-
-X509_VERIFY_PARAM_set1_rfc822() clears all expected RFC822 email
-addresses, and sets the expected RFC822 email address to I<email>.  If
-I<email> is NULL no expected address is set. Otherwise, if
-I<emaillen> is zero, I<email> must be NUL-terminated; if I<emaillen>
-is nonzero, I<emaillen> must be set to the length of I<email>.  When
-any email address is specified, certificate verification automatically
-invokes L<X509_check_email(3)>.
-
-X509_VERIFY_PARAM_add1_rfc822() adds I<email> as an additional
-reference identifier that can match RFC822 email addresses in the
-peer's certificate. Any previous names set via
-X509_VERIFY_PARAM_set1_rfc822(), X509_VERIFY_PARAM_add1_rfc822(), or
-X509_VERIFY_PARAM_set1_email() are
-retained on success, no change is made on failure. It is a failure if
-email is NULL or the empty string.
-The peer is considered verified
-when any one of the specified RFC822 or SMTPUTF8 names matches a corresponding email
-address SAN in the certificate.
-
-The _smtputf8() family of functions is used for email names that have
-a non-ASCII localpart addresses, in which case the domain part of the
-address must be represented in U-label form. They are used to
-specify the list of values to match against the OTHERNAME SMTPUTF8 names in
-certificates.
-
-X509_VERIFY_PARAM_set1_smtputf8() sets the expected SMTPUTF8 email address to
-I<email>.
-If I<email> is NULL, SMTPUTF8 email checking is disabled. Otherwise,
-if I<emaillen> is zero, I<email> must be NUL-terminated; if I<emaillen> is nonzero,
-I<emaillen> must be set to the length of I<email>.  When any email address
-is specified, certificate verification automatically invokes
-L<X509_check_email(3)>.
-
-X509_VERIFY_PARAM_add1_smtputf8() adds I<email> as an additional
-reference identifier that can match SMTPUTF8 email addresses in the
-peer's certificate.  Any previous names set via
-X509_VERIFY_PARAM_set1_smtputf8(), X509_VERIFY_PARAM_add1_smtputf8(), or
-X509_VERIFY_PARAM_set1_email() are
-retained on success, no change is made on failure. It is a failure if
-email is NULL or the empty string. The peer is considered verified
-when any one of the specified RFC822 or SMTPUTF8 names matches a corresponding email
-address SAN in the certificate.
-
-X509_VERIFY_PARAM_set1_email() calls X509_VERIFY_PARAM_set_rfc822(), and
-X509_VERIFY_PARAM_set_smtputf8() and succeeds if either call succeeds.
-
-X509_VERIFY_PARAM_get1_ip_asc() returns the expected IP address as a string.
-The caller is responsible for freeing it.
-
-X509_VERIFY_PARAM_set1_ip() sets the expected IP address to I<ip>.
-If I<ip> is NULL, IP address checking is disabled. Otherwise,
-the I<ip> argument must be in binary format, in network byte-order and
-I<iplen> must be set to 4 for IPv4 and 16 for IPv6.  When an IP
-address is specified, certificate verification automatically invokes
-L<X509_check_ip(3)>.
-
-X509_VERIFY_PARAM_add1_ip() adds I<ip> as an additional reference
-identifier that can match the peer's certificate on success.  Any
-previous addresses set via X509_VERIFY_PARAM_set1_ip(),
-X509_VERIFY_PARAM_add1_ip(), X509_VERIFY_PARAM_set1_ip_asc(), or
-X509_VERIFY_PARAM_add1_ip_asc() are retained. No change is made on
-failure.
-It is a failure if I<ip> is NULL or the value I<iplen> is neither 4 nor 16 bytes.
-When
-multiple names are configured, the peer is considered verified when
-any name matches.
-
-X509_VERIFY_PARAM_set1_ip_asc() sets the expected IP address to
-I<ip_asc>.  The I<ip_asc> argument must be a NUL-terminated ASCII string:
-dotted decimal quad for IPv4 and colon-separated hexadecimal for
-IPv6.  The condensed "::" notation is supported for IPv6 addresses.
-
-X509_VERIFY_PARAM_add1_ip_asc() adds I<ip_asc> as an additional
-reference identifier that can match the peer's certificate on success.
-The I<ip_asc> argument must be a NUL-terminated ASCII string: dotted
-decimal quad for IPv4 and colon-separated hexadecimal for IPv6.  The
-condensed "::" notation is supported for IPv6 addresses.  Any previous
-names set via X509_VERIFY_PARAM_set1_ip(),
-X509_VERIFY_PARAM_add1_ip(), X509_VERIFY_PARAM_set1_ip_asc(), or
-X509_VERIFY_PARAM_add1_ip_asc() are retained. No change is made on
-failure.
-It is a failure if I<ip_asc> is NULL or the empty string.
-When multiple addresses are configured, the peer is considered verified
-when any one of the specified addresses matches a corresponding IP address SAN in the certificate.
-
-X509_VERIFY_PARAM_set1_host_input_validation(),
-X509_VERIFY_PARAM_set1_rfc822_input_validation(),
-X509_VERIFY_PARAM_set1_smtputf8_input_validation(), and
-X509_VERIFY_PARAM_set1_ip_input_validation() set a verification
-function to validate the input on setting the corresponding validation
-parameter expected values.
-These functions make it possible to override OpenSSL's built-in input validation of
-the corresponding verification parameters.
-If the provided function succeeds, the corresponding
-input will be accepted for use in certificate verification.
-
 =head1 RETURN VALUES
 
 X509_VERIFY_PARAM_set_flags(), X509_VERIFY_PARAM_clear_flags(),
 X509_VERIFY_PARAM_set_inh_flags(),
 X509_VERIFY_PARAM_set_purpose(), X509_VERIFY_PARAM_set_trust(),
-X509_VERIFY_PARAM_add0_policy() X509_VERIFY_PARAM_set1_policies(),
-X509_VERIFY_PARAM_set1_host(), X509_VERIFY_PARAM_add1_host(),
-X509_VERIFY_PARAM_set1_email(),
-X509_VERIFY_PARAM_set1_ip(), X509_VERIFY_PARAM_add1_ip(),
-X509_VERIFY_PARAM_set1_ip_asc(),
-X509_VERIFY_PARAM_add1_ip_asc() return 1 for success and 0 for
+X509_VERIFY_PARAM_add0_policy() X509_VERIFY_PARAM_set1_policies()
+return 1 for success and 0 for
 failure.
-
-X509_VERIFY_PARAM_get0_host(), X509_VERIFY_PARAM_get0_email(), and
-X509_VERIFY_PARAM_get1_ip_asc(), return the string pointers specified above
-or NULL if the respective value has not been set or on error.
 
 X509_VERIFY_PARAM_get_flags() returns the current verification flags.
 
@@ -510,6 +326,7 @@ connections associated with an B<SSL_CTX> structure I<ctx>:
 
 L<SSL_CTX_set_security_level(3)>,
 L<X509_verify_cert(3)>,
+L<X509_VERIFY_PARAM_set1_host(3)>,
 L<X509_check_host(3)>,
 L<X509_check_email(3)>,
 L<X509_check_ip(3)>,
@@ -530,9 +347,6 @@ The flag B<X509_V_FLAG_CB_ISSUER_CHECK> was deprecated in OpenSSL 1.1.0
 and has no effect.
 
 The X509_VERIFY_PARAM_get_hostflags() function was added in OpenSSL 1.1.0i.
-
-The X509_VERIFY_PARAM_get0_host(), X509_VERIFY_PARAM_get0_email(),
-and X509_VERIFY_PARAM_get1_ip_asc() functions were added in OpenSSL 3.0.
 
 The function X509_VERIFY_PARAM_add0_policy() was historically documented as
 enabling policy checking however the implementation has never done this.

--- a/doc/man3/X509_VERIFY_PARAM_set_hostflags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_hostflags.pod
@@ -1,0 +1,109 @@
+=pod
+
+=head1 NAME
+
+X509_VERIFY_PARAM_set_hostflags, X509_VERIFY_PARAM_get_hostflags - X509 hostname verification flags
+
+=head1 SYNOPSIS
+
+ #include <openssl/x509_vfy.h>
+
+ void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
+                                      unsigned int flags);
+ unsigned int X509_VERIFY_PARAM_get_hostflags(const X509_VERIFY_PARAM *param);
+
+=head1 DESCRIPTION
+
+Host flags control how hostname matching is performed during certificate
+verification: which wildcard forms are permitted in the certificate's subject
+alternative name (SAN) entries, and whether the certificate's subject
+distinguished name is consulted in addition to the SAN.
+
+X509_VERIFY_PARAM_set_hostflags() sets the host flags on I<param> to
+I<flags>, for use during subsequent calls to L<X509_verify_cert(3)>.
+
+X509_VERIFY_PARAM_get_hostflags() returns any host flags previously set via a
+call to X509_VERIFY_PARAM_set_hostflags().
+
+The I<flags> default to 0. They may be set to a bitwise OR of the following:
+
+=over 4
+
+=item B<X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT>
+
+=item B<X509_CHECK_FLAG_NEVER_CHECK_SUBJECT>
+
+=item B<X509_CHECK_FLAG_NO_WILDCARDS>
+
+=item B<X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS>
+
+=item B<X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS>
+
+=item B<X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS>
+
+=back
+
+The B<X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT> flag causes the function
+to consider the subject DN even if the certificate contains at least
+one subject alternative name of the right type (DNS name or email
+address as appropriate); the default is to ignore the subject DN
+when at least one corresponding subject alternative names is present.
+
+The B<X509_CHECK_FLAG_NEVER_CHECK_SUBJECT> flag causes the function to never
+consider the subject DN even if the certificate contains no subject alternative
+names of the right type (DNS name or email address as appropriate); the default
+is to use the subject DN when no corresponding subject alternative names are
+present.
+
+If both B<X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT> and
+B<X509_CHECK_FLAG_NEVER_CHECK_SUBJECT> are specified, the latter takes
+precedence and the subject DN is not checked for matching names.
+
+If set, B<X509_CHECK_FLAG_NO_WILDCARDS> disables wildcard
+expansion.
+
+If set, B<X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS> suppresses support
+for "*" as wildcard pattern in labels that have a prefix or suffix,
+such as: "www*" or "*www".
+
+If set, B<X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS> allows a "*" that
+constitutes the complete label of a DNS name (e.g. "*.example.com")
+to match more than one label in the configured reference identifier.
+
+If set, B<X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS> restricts reference
+identifiers which start with ".", that would otherwise match any
+sub-domain in the peer certificate, to only match direct child
+sub-domains. Thus, for instance, with this flag set a reference
+identifier of ".example.com" would match a peer certificate with a DNS
+name of "www.example.com", but would not match a peer certificate with
+a DNS name of "www.sub.example.com".
+
+=head1 RETURN VALUES
+
+X509_VERIFY_PARAM_get_hostflags() returns the flag values.
+
+=head1 SEE ALSO
+
+L<X509_verify_cert(3)>,
+L<SSL_get_verify_result(3)>,
+L<X509_VERIFY_PARAM_set1_host(3)>,
+L<X509_VERIFY_PARAM_add1_host(3)>,
+L<X509_VERIFY_PARAM_set1_email(3)>,
+L<X509_VERIFY_PARAM_set1_ip(3)>
+
+=head1 HISTORY
+
+X509_VERIFY_PARAM_set_hostflags() was added in OpenSSL 1.0.2.
+
+X509_VERIFY_PARAM_get_hostflags() was added in OpenSSL 1.1.0i.
+
+=head1 COPYRIGHT
+
+Copyright 2012-2026 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/X509_VERIFY_PARAM_set_hostflags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_hostflags.pod
@@ -99,7 +99,7 @@ X509_VERIFY_PARAM_get_hostflags() was added in OpenSSL 1.1.0i.
 
 =head1 COPYRIGHT
 
-Copyright 2012-2026 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION

The existing X509_VERIFY_PARAM_set_hostflags(3) has become a dumping ground
for many things, and so is pretty hard to follow or change today without making it 
even worse.  So I want to clean it up before changing anything further in this area.

- Extract the reference-identifier setters into a new
  X509_VERIFY_PARAM_set1_host(3) page.
- Split the host-flag functions into X509_VERIFY_PARAM_set_hostflags(3)
  and tidy the remaining set_flags.pod (flag sections, the missing
  SUITEB flags, trust/time/policy/depth fixes).
- Clarify X509_VERIFY_PARAM_set_trust(): it does not check the
  extKeyUsage it names; prefer X509_VERIFY_PARAM_set_purpose().

Preparatory work for #31982

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
