### PR TITLE
Fix windows perlasm diagnostics

### DIFF
--- a/crypto/aes/asm/aes-cfb-avx512.pl
+++ b/crypto/aes/asm/aes-cfb-avx512.pl
@@ -49,7 +49,7 @@ if (!$avx512vaes && `$ENV{CC} -v 2>&1`
     }
 }
 
-if (!$avx512vaes && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx512vaes && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avx512vaes = ($1>=11); #icx started with clang 11

--- a/crypto/aes/asm/aesni-mb-x86_64.pl
+++ b/crypto/aes/asm/aesni-mb-x86_64.pl
@@ -80,7 +80,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/aes/asm/aesni-sha1-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha1-x86_64.pl
@@ -111,7 +111,7 @@ $avx=1 if (!$avx && $win64 && ($flavour =~ /masm/ || $ENV{ASM} =~ /ml64/) &&
 	   $1>=10);
 $avx=1 if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/ && $2>=3.0);
 
-$avx=1 if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__` =~ /#define __clang_major__.([0-9]+)/ &&
+$avx=1 if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1` =~ /#define __clang_major__.([0-9]+)/ &&
 	   $1>=11); #icx started with clang 11
 
 $shaext=1;	### set to zero if compiling for 1.0.1

--- a/crypto/aes/asm/aesni-sha256-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha256-x86_64.pl
@@ -75,7 +75,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/aes/asm/aesni-xts-avx512.pl
+++ b/crypto/aes/asm/aesni-xts-avx512.pl
@@ -59,7 +59,7 @@ if (!$avx512vaes && `$ENV{CC} -v 2>&1`
     }
 }
 
-if (!$avx512vaes && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx512vaes && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avx512vaes = ($1>=11); #icx started with clang 11

--- a/crypto/bn/asm/rsaz-2k-avx512.pl
+++ b/crypto/bn/asm/rsaz-2k-avx512.pl
@@ -64,7 +64,7 @@ if (!$avx512ifma && `$ENV{CC} -v 2>&1`
     }
 }
 
-if (!$avx512ifma && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx512ifma && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avx512ifma = ($1>=11); #icx started with clang 11

--- a/crypto/bn/asm/rsaz-2k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-2k-avxifma.pl
@@ -39,7 +39,7 @@ if (!$avxifma && `$ENV{CC} -v 2>&1`
     $avxifma = ($ver>=16.0);
 }
 
-if (!$avxifma && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avxifma && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avxifma = ($1>=16);

--- a/crypto/bn/asm/rsaz-3k-avx512.pl
+++ b/crypto/bn/asm/rsaz-3k-avx512.pl
@@ -63,7 +63,7 @@ if (!$avx512ifma && `$ENV{CC} -v 2>&1`
     }
 }
 
-if (!$avx512ifma && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx512ifma && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avx512ifma = ($1>=11); #icx started with clang 11

--- a/crypto/bn/asm/rsaz-3k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-3k-avxifma.pl
@@ -38,7 +38,7 @@ if (!$avxifma && `$ENV{CC} -v 2>&1`
     $avxifma = ($ver>=16.0);
 }
 
-if (!$avxifma && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avxifma && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avxifma = ($1>=16);

--- a/crypto/bn/asm/rsaz-4k-avx512.pl
+++ b/crypto/bn/asm/rsaz-4k-avx512.pl
@@ -63,7 +63,7 @@ if (!$avx512ifma && `$ENV{CC} -v 2>&1`
     }
 }
 
-if (!$avx512ifma && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx512ifma && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avx512ifma = ($1>=11); #icx started with clang 11

--- a/crypto/bn/asm/rsaz-4k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-4k-avxifma.pl
@@ -38,7 +38,7 @@ if (!$avxifma && `$ENV{CC} -v 2>&1`
     $avxifma = ($ver>=16.0);
 }
 
-if (!$avxifma && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avxifma && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avxifma = ($1>=16);

--- a/crypto/bn/asm/rsaz-avx2.pl
+++ b/crypto/bn/asm/rsaz-avx2.pl
@@ -73,7 +73,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|based on LLVM) ([0-9
 	$addx = ($ver>=3.03);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$addx = ($1>=11); #icx started with clang 11

--- a/crypto/bn/asm/rsaz-x86_64.pl
+++ b/crypto/bn/asm/rsaz-x86_64.pl
@@ -90,7 +90,7 @@ if (!$addx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([
 	$addx = ($ver>=3.03);
 }
 
-if (!$addx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$addx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$addx = ($1>=11); #icx started with clang 11

--- a/crypto/bn/asm/x86_64-mont.pl
+++ b/crypto/bn/asm/x86_64-mont.pl
@@ -82,7 +82,7 @@ if (!$addx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([
 	$addx = ($ver>=3.03);
 }
 
-if (!$addx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$addx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$addx = ($1>=11); #icx started with clang 11

--- a/crypto/bn/asm/x86_64-mont5.pl
+++ b/crypto/bn/asm/x86_64-mont5.pl
@@ -69,7 +69,7 @@ if (!$addx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([
 	$addx = ($ver>=3.03);
 }
 
-if (!$addx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$addx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$addx = ($1>=11); #icx started with clang 11

--- a/crypto/chacha/asm/chacha-x86.pl
+++ b/crypto/chacha/asm/chacha-x86.pl
@@ -64,8 +64,8 @@ $ymm=1 if ($xmm && !$ymm &&
 		`$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|based on LLVM) ([0-9]+\.[0-9]+)/ &&
 		$2>=3.0);	# first version supporting AVX
 
-$ymm=1 if ($xmm && !$ymm &&
-		`$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__` =~ /#define __clang_major__.([0-9]+)/ &&
+$ymm=1 if ($xmm && !$ymm && $ENV{CC} &&
+		`$ENV{CC} -x c /dev/null -dM -E 2>&1` =~ /#define __clang_major__.([0-9]+)/ &&
 		$1>=11); #icx started with clang 11
 
 $a="eax";

--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -91,7 +91,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -80,7 +80,7 @@ if (!$addx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([
 	$addx = ($ver>=3.03);
 }
 
-if (!$addx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$addx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/ec/asm/x25519-x86_64.pl
+++ b/crypto/ec/asm/x25519-x86_64.pl
@@ -97,7 +97,7 @@ if (!$addx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([
 	$addx = ($ver>=3.03);
 }
 
-if (!$addx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$addx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$addx = ($1>=11); #icx started with clang 11

--- a/crypto/modes/asm/aes-gcm-avx512.pl
+++ b/crypto/modes/asm/aes-gcm-avx512.pl
@@ -72,7 +72,7 @@ if (!$avx512vaes && `$ENV{CC} -v 2>&1`
     }
 }
 
-if (!$avx512vaes && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx512vaes && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
     =~ /#define __clang_major__.([0-9]+)/) {
     if ($1) {
         $avx512vaes = ($1>=11); #icx started with clang 11

--- a/crypto/modes/asm/aesni-gcm-x86_64.pl
+++ b/crypto/modes/asm/aesni-gcm-x86_64.pl
@@ -73,7 +73,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -121,7 +121,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/poly1305/asm/poly1305-x86.pl
+++ b/crypto/poly1305/asm/poly1305-x86.pl
@@ -74,7 +74,7 @@ if ($sse2) {
 		$avx = ($2>=3.0) + ($2>3.0);
 	}
 
-	if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+	if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 		=~ /#define __clang_major__.([0-9]+)/) {
 		if ($1) {
 			$avx = ($1>=11); #icx started with clang 11

--- a/crypto/poly1305/asm/poly1305-x86_64.pl
+++ b/crypto/poly1305/asm/poly1305-x86_64.pl
@@ -95,7 +95,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/sha/asm/sha1-586.pl
+++ b/crypto/sha/asm/sha1-586.pl
@@ -146,7 +146,7 @@ $ymm=1 if ($xmm && !$ymm && $ARGV[0] eq "win32" &&
 $ymm=1 if ($xmm && !$ymm && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|based on LLVM) ([0-9]+\.[0-9]+)/ &&
 		$2>=3.0);	# first version supporting AVX
 
-$ymm=1 if ($xmm && !$ymm && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__` =~ /#define __clang_major__.([0-9]+)/ &&
+$ymm=1 if ($xmm && !$ymm && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1` =~ /#define __clang_major__.([0-9]+)/ &&
 		$1>=11); #icx started with clang 11
 
 $shaext=$xmm;	### set to zero if compiling for 1.0.1

--- a/crypto/sha/asm/sha1-mb-x86_64.pl
+++ b/crypto/sha/asm/sha1-mb-x86_64.pl
@@ -76,7 +76,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/sha/asm/sha1-x86_64.pl
+++ b/crypto/sha/asm/sha1-x86_64.pl
@@ -124,7 +124,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/sha/asm/sha256-586.pl
+++ b/crypto/sha/asm/sha256-586.pl
@@ -99,7 +99,7 @@ if ($xmm && !$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|based on LLV
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if ($xmm && !$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if ($xmm && !$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/sha/asm/sha256-mb-x86_64.pl
+++ b/crypto/sha/asm/sha256-mb-x86_64.pl
@@ -77,7 +77,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -2411,7 +2411,7 @@ $code.=<<___ if($win64);
     # xmm6:xmm9, xmm11:xmm15 need to be maintained for Windows
     # xmm10 not used
     sub \$`9*16`,%rsp
-.cfi_adjust_cfa_offset \$`9*16`
+.cfi_adjust_cfa_offset `9*16`
     vmovdqu %xmm6, 16*0(%rsp)
     vmovdqu %xmm7, 16*1(%rsp)
     vmovdqu %xmm8, 16*2(%rsp)
@@ -2629,7 +2629,7 @@ $code.=<<___ if($win64);
     vmovdqu 16*7(%rsp),%xmm14
     vmovdqu 16*8(%rsp),%xmm15
     add \$`9*16`,%rsp
-.cfi_adjust_cfa_offset \$`-9*16`
+.cfi_adjust_cfa_offset `-9*16`
 ___
 
 $code.=<<___;

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -144,7 +144,7 @@ if (!$avx && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0
 	$avx = ($2>=3.0) + ($2>3.0);
 }
 
-if (!$avx && `$ENV{CC} -x c /dev/null -dM -E|grep __clang_major__`
+if (!$avx && $ENV{CC} && `$ENV{CC} -x c /dev/null -dM -E 2>&1`
 	=~ /#define __clang_major__.([0-9]+)/) {
 	if ($1) {
 		$avx = ($1>=11); #icx started with clang 11

--- a/crypto/sm3/asm/sm3-x86_64.pl
+++ b/crypto/sm3/asm/sm3-x86_64.pl
@@ -114,7 +114,7 @@ ___
 $code.=<<___ if($win64);
     # xmm6:xmm12 need to be maintained for Windows
     sub \$`7*16`,%rsp
-.cfi_adjust_cfa_offset \$`7*16`
+.cfi_adjust_cfa_offset `7*16`
     vmovdqu %xmm6, 16*0(%rsp)
     vmovdqu %xmm7, 16*1(%rsp)
     vmovdqu %xmm8, 16*2(%rsp)
@@ -260,7 +260,7 @@ $code.=<<___ if($win64);
     vmovdqu 16*5(%rsp),%xmm11
     vmovdqu 16*6(%rsp),%xmm12
     add \$`7*16`,%rsp
-.cfi_adjust_cfa_offset \$`-7*16`
+.cfi_adjust_cfa_offset `-7*16`
 ___
   $code .= <<___;
      pop     %rbp


### PR DESCRIPTION
Windows x86 assembly generation currently emits two kinds of spurious diagnostics. Both also occur with Makefile builds and are not caused by Ninja.

The unset `CC` diagnostic was introduced by commit 82124a204a5b from #30313, which added ICX compiler probes to the Perl assembly generators.
On VC-WIN64A, `CC` is not necessarily exported, causing `-x` to be interpreted as the command name.

The CFI expression warnings were introduced independently by commit 196b36f0d0c8 from #26147 for SHA-512 and commit e1eb6fdb3a42 from #26196 for SM3.

This change:

- guards the ICX preprocessor probes when `CC` is not exported;
- captures unsupported compiler diagnostics and matches the Clang version macro directly;
- removes the invalid immediate-value marker from SHA-512 and SM3 CFI offsets.

The generated Windows SHA-512 assembly remains byte-for-byte unchanged.

Fixes #31976

### Testing

- Windows `VC-WIN64A`: all 395 generated-source commands completed without the reported diagnostics.
- Windows `VC-WIN64A`: full strict `/WX` build passed.
- Windows: affected SHA-512, SM3, and RSAZ outputs assembled successfully with NASM.
- Linux Ubuntu x86_64: strict build with `enable-fips enable-lms` passed.
- Linux Ubuntu x86_64: all 4,921 tests passed.