### PR TITLE
DTLS 1.3 Don't reset the handshake seq number after connection finish

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1504,9 +1504,16 @@ WORK_STATE tls_finish_handshake(SSL_CONNECTION *s, ossl_unused WORK_STATE wst,
 
         if (SSL_CONNECTION_IS_DTLS(s)) {
             /* done with handshaking */
-            s->d1->handshake_read_seq = 0;
-            s->d1->handshake_write_seq = 0;
-            s->d1->next_handshake_write_seq = 0;
+            /*
+             * In DTLS 1.3, we must not reset the handshake sequence numbers
+             * because post-handshake messages like NewSessionTicket need to
+             * continue the sequence numbering from where the handshake left off.
+             */
+            if (!SSL_CONNECTION_IS_DTLS13(s)) {
+                s->d1->handshake_read_seq = 0;
+                s->d1->handshake_write_seq = 0;
+                s->d1->next_handshake_write_seq = 0;
+            }
             dtls1_clear_received_buffer(s);
         }
     }

--- a/test/recipes/70-test_dtls13epoch.t
+++ b/test/recipes/70-test_dtls13epoch.t
@@ -42,10 +42,12 @@ my $proxy = TLSProxy::Proxy->new_dtls(
     (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE})
 );
 
-plan tests => 1;
+plan tests => 2;
 
 my $epoch_check_failed;
 my $latest_epoch;
+my $nst_seq_check_failed;
+my $nst_msgseq;
 
 #Test 1: Check that epoch is incremented as expected during a handshake
 $epoch_check_failed = 0;
@@ -55,9 +57,28 @@ $proxy->clientflags("-min_protocol DTLSv1.3 -max_protocol DTLSv1.3 -groups ?X255
 $proxy->filter(\&current_record_epoch_filter);
 TLSProxy::Message->successondata(1);
 SKIP: {
-    skip "TLS Proxy did not start", 1 if !$proxy->start();
+    skip "TLS Proxy did not start", 2 if !$proxy->start();
     ok(!$epoch_check_failed
        && $latest_epoch == 3, "Epoch changes correctly during handshake");
+
+    #Test 2: Check that NewSessionTicket has the correct handshake sequence number
+    # In DTLS 1.3, post-handshake messages like NewSessionTicket should continue
+    # the handshake sequence numbering (not reset to 0)
+    $nst_seq_check_failed = 0;
+    $nst_msgseq = -1;
+    foreach my $message (@{$proxy->message_list}) {
+        if ($message->mt == TLSProxy::Message::MT_NEW_SESSION_TICKET) {
+            $nst_msgseq = $message->msgseq;
+            # The NewSessionTicket should have a sequence number > 0
+            if ($nst_msgseq == 0) {
+                print "NewSessionTicket has incorrect sequence number 0 (should be > 0)\n";
+                $nst_seq_check_failed = 1;
+            }
+            last;
+        }
+    }
+    ok(!$nst_seq_check_failed && $nst_msgseq > 0,
+       "NewSessionTicket has correct handshake sequence number ($nst_msgseq)");
 }
 
 sub current_record_epoch_filter


### PR DESCRIPTION
In DTLS 1.3 the handshake sequence number is not reset to 0 after the connection is establish. This means New Session tickets will not send out with a handshake seq of 0. Instead it will pick up where it left off.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
