### PR TITLE
DTLS 1.3 SSL Listener does not currently buffer handshake messages

### DIFF
--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -530,6 +530,7 @@ static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
     size_t num_msg, uint64_t flags,
     size_t *msgs_processed)
 {
+#ifndef OPENSSL_NO_SOCK
     BIO_F_BUFFER_CTX *ctx;
     int ret;
 
@@ -564,4 +565,8 @@ static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
 
     *msgs_processed = 1;
     return 1;
+#else
+    *msgs_processed = 0;
+    return 0;
+#endif
 }

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -84,6 +84,9 @@ static int buffer_free(BIO *a)
     b = (BIO_F_BUFFER_CTX *)a->ptr;
     OPENSSL_free(b->ibuf);
     OPENSSL_free(b->obuf);
+#ifndef OPENSSL_NO_SOCK
+    BIO_ADDR_free(b->peer);
+#endif
     OPENSSL_free(a->ptr);
     a->ptr = NULL;
     a->init = 0;
@@ -498,14 +501,14 @@ static int buffer_send_next(BIO *b, BIO_F_BUFFER_CTX *ctx,
     const char *data, int len)
 {
 #ifndef OPENSSL_NO_SOCK
-    if (ctx->peer_addr_set) {
+    if (ctx->peer != NULL) {
         BIO_MSG msg;
         size_t processed = 0;
 
         memset(&msg, 0, sizeof(msg));
         msg.data = (void *)data;
         msg.data_len = (size_t)len;
-        msg.peer = &ctx->peer;
+        msg.peer = ctx->peer;
 
         /* Datagrams are all-or-nothing: either the whole chunk goes or none. */
         if (!BIO_sendmmsg(b->next_bio, &msg, sizeof(msg), 1, 0, &processed)
@@ -546,11 +549,15 @@ static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
     /*
      * Record the peer address so the flush path knows where to send the
      * accumulated data. There is one buffer BIO per SSL connection, so the
-     * peer is constant for this BIO's lifetime; setting it on every call is
-     * harmless.
+     * peer is constant for this BIO's lifetime.
      */
-    ctx->peer_addr_set = 1;
-    ctx->peer = *msg->peer;
+    if (ctx->peer == NULL) {
+        ctx->peer = BIO_ADDR_new();
+        if (ctx->peer == NULL)
+            return 0;
+    }
+    if (!BIO_ADDR_copy(ctx->peer, msg->peer))
+        return 0;
 
     /*
      * Buffer the message data. buffer_write() takes an int length, so guard

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -23,6 +23,9 @@ static long buffer_callback_ctrl(BIO *h, int cmd, BIO_info_cb *fp);
 static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
     size_t num_msg, uint64_t flags,
     size_t *msgs_processed);
+static int buffer_send_next(BIO *b, BIO_F_BUFFER_CTX *ctx,
+    const char *data, int len);
+
 #define DEFAULT_BUFFER_SIZE 4096
 
 static const BIO_METHOD methods_buffer = {
@@ -191,7 +194,7 @@ start:
         }
         /* we now have a full buffer needing flushing */
         for (;;) {
-            i = BIO_write(b->next_bio, &(ctx->obuf[ctx->obuf_off]),
+            i = buffer_send_next(b, ctx, &(ctx->obuf[ctx->obuf_off]),
                 ctx->obuf_len);
             if (i <= 0) {
                 BIO_copy_next_retry(b);
@@ -215,7 +218,7 @@ start:
 
     /* we now have inl bytes to write */
     while (inl >= ctx->obuf_size) {
-        i = BIO_write(b->next_bio, in, inl);
+        i = buffer_send_next(b, ctx, in, inl);
         if (i <= 0) {
             BIO_copy_next_retry(b);
             if (i < 0)
@@ -377,8 +380,8 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         for (;;) {
             BIO_clear_retry_flags(b);
             if (ctx->obuf_len > 0) {
-                r = BIO_write(b->next_bio,
-                    &(ctx->obuf[ctx->obuf_off]), ctx->obuf_len);
+                r = buffer_send_next(b, ctx, &(ctx->obuf[ctx->obuf_off]),
+                    ctx->obuf_len);
                 BIO_copy_next_retry(b);
                 if (r <= 0)
                     return (long)r;
@@ -482,36 +485,83 @@ static int buffer_puts(BIO *b, const char *str)
 }
 
 /*
- * buffer_sendmmsg - send multiple messages through the buffer BIO.
+ * buffer_send_next - write one chunk of buffered output to the next BIO.
+ *
+ * For listener-created datagram connections a peer address has been recorded
+ * such connections share a single network BIO, so the data must be sent with
+ * BIO_sendmmsg() carrying the explicit peer address rather than BIO_write()
+ *
+ * Returns the number of bytes sent - the full len for the datagram case, which
+ * is all-or-nothing - or 0 / a negative value on a transient or fatal error.
+ */
+static int buffer_send_next(BIO *b, BIO_F_BUFFER_CTX *ctx,
+    const char *data, int len)
+{
+#ifndef OPENSSL_NO_SOCK
+    if (ctx->peer_addr_set) {
+        BIO_MSG msg;
+        size_t processed = 0;
+
+        memset(&msg, 0, sizeof(msg));
+        msg.data = (void *)data;
+        msg.data_len = (size_t)len;
+        msg.peer = &ctx->peer;
+
+        /* Datagrams are all-or-nothing: either the whole chunk goes or none. */
+        if (!BIO_sendmmsg(b->next_bio, &msg, sizeof(msg), 1, 0, &processed)
+            || processed != 1)
+            return -1;
+        return len;
+    }
+#endif
+    return BIO_write(b->next_bio, data, len);
+}
+
+/*
+ * buffer_sendmmsg - accumulate a message into the buffer BIO.
+ *
+ * Listener-created DTLS connections share a single network BIO and so cannot
+ * use BIO_write(). Instead the record layer sends each record via BIO_sendmmsg(),
+ * which lands here. We record the peer address and then buffer the data exactly
+ * like buffer_write() does, so that multiple handshake records accumulate and are
+ * packed into a single datagram when the state machine flushes
  */
 static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
     size_t num_msg, uint64_t flags,
     size_t *msgs_processed)
 {
     BIO_F_BUFFER_CTX *ctx;
+    int ret;
 
     *msgs_processed = 0;
 
-    /*
-     * TODO: DTLS1.3 Look at actually buffering the messages and
-     * this function may then be removed
-     */
     if (b == NULL || b->next_bio == NULL)
         return 0;
 
     ctx = (BIO_F_BUFFER_CTX *)b->ptr;
-    if (ctx == NULL)
+    if (ctx == NULL || msg == NULL || msg->peer == NULL)
         return 0;
 
     /*
-     * Flush any buffered output data before sending messages.
-     * This ensures proper ordering of data on the wire.
+     * Record the peer address so the flush path knows where to send the
+     * accumulated data. There is one buffer BIO per SSL connection, so the
+     * peer is constant for this BIO's lifetime; setting it on every call is
+     * harmless.
      */
-    if (ctx->obuf_len > 0) {
-        if (buffer_ctrl(b, BIO_CTRL_FLUSH, 0, NULL) <= 0)
-            return 0;
-    }
+    ctx->peer_addr_set = 1;
+    ctx->peer = *msg->peer;
 
-    /* Forward the sendmmsg call to the next BIO */
-    return BIO_sendmmsg(b->next_bio, msg, stride, num_msg, flags, msgs_processed);
+    /*
+     * Buffer the message data. buffer_write() takes an int length, so guard
+     * against an oversized datagram (this mirrors buffer_puts()).
+     */
+    if (msg->data_len > INT_MAX)
+        return 0;
+
+    ret = buffer_write(b, msg->data, (int)msg->data_len);
+    if (ret <= 0)
+        return 0;
+
+    *msgs_processed = 1;
+    return 1;
 }

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -259,6 +259,10 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         ctx->ibuf_len = 0;
         ctx->obuf_off = 0;
         ctx->obuf_len = 0;
+#ifndef OPENSSL_NO_SOCK
+        BIO_ADDR_free(ctx->peer);
+        ctx->peer = NULL;
+#endif
         if (b->next_bio == NULL)
             return 0;
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
@@ -361,6 +365,10 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
             ctx->obuf_off = 0;
             ctx->obuf_len = 0;
             ctx->obuf_size = obs;
+#ifndef OPENSSL_NO_SOCK
+            BIO_ADDR_free(ctx->peer);
+            ctx->peer = NULL;
+#endif
         }
         break;
     case BIO_C_DO_STATE_MACHINE:
@@ -494,9 +502,9 @@ static int buffer_puts(BIO *b, const char *str)
 /*
  * buffer_send_next - write one chunk of buffered output to the next BIO.
  *
- * For listener-created datagram connections a peer address has been recorded
+ * For listener-created datagram connections a peer address has been recorded and
  * such connections share a single network BIO, so the data must be sent with
- * BIO_sendmmsg() carrying the explicit peer address rather than BIO_write()
+ * BIO_sendmmsg() carrying the explicit peer address rather than BIO_write().
  *
  * Returns the number of bytes sent - the full len for the datagram case, which
  * is all-or-nothing - or 0 / a negative value on a transient or fatal error.
@@ -531,7 +539,7 @@ static int buffer_send_next(BIO *b, BIO_F_BUFFER_CTX *ctx,
  * use BIO_write(). Instead the record layer sends each record via BIO_sendmmsg(),
  * which lands here. We record the peer address and then buffer the data exactly
  * like buffer_write() does, so that multiple handshake records accumulate and are
- * packed into a single datagram when the state machine flushes
+ * packed into a single datagram when the state machine flushes.
  */
 static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
     size_t num_msg, uint64_t flags,
@@ -547,7 +555,7 @@ static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
         return 0;
 
     ctx = (BIO_F_BUFFER_CTX *)b->ptr;
-    if (ctx == NULL || msg == NULL)
+    if (ctx == NULL || msg == NULL || num_msg == 0)
         return 0;
 
     /*

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -398,6 +398,10 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         BIO_copy_next_retry(b);
+#ifndef OPENSSL_NO_SOCK
+        BIO_ADDR_free(ctx->peer);
+        ctx->peer = NULL;
+#endif
         break;
     case BIO_CTRL_DUP:
         dbio = (BIO *)ptr;
@@ -535,7 +539,7 @@ static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
 {
 #ifndef OPENSSL_NO_SOCK
     BIO_F_BUFFER_CTX *ctx;
-    int ret;
+    size_t i;
 
     *msgs_processed = 0;
 
@@ -543,35 +547,46 @@ static int buffer_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
         return 0;
 
     ctx = (BIO_F_BUFFER_CTX *)b->ptr;
-    if (ctx == NULL || msg == NULL || msg->peer == NULL)
+    if (ctx == NULL || msg == NULL)
         return 0;
 
     /*
-     * Record the peer address so the flush path knows where to send the
-     * accumulated data. There is one buffer BIO per SSL connection, so the
-     * peer is constant for this BIO's lifetime.
+     * Record the peer address on the first write so the flush path knows
+     * where to send the accumulated data. The address is cleared after each
+     * flush so it can be set again for the next batch.
      */
     if (ctx->peer == NULL) {
+        if (msg->peer == NULL)
+            return 0;
         ctx->peer = BIO_ADDR_new();
         if (ctx->peer == NULL)
             return 0;
+        if (!BIO_ADDR_copy(ctx->peer, msg->peer)) {
+            BIO_ADDR_free(ctx->peer);
+            ctx->peer = NULL;
+            return 0;
+        }
     }
-    if (!BIO_ADDR_copy(ctx->peer, msg->peer))
-        return 0;
 
-    /*
-     * Buffer the message data. buffer_write() takes an int length, so guard
-     * against an oversized datagram (this mirrors buffer_puts()).
-     */
-    if (msg->data_len > INT_MAX)
-        return 0;
+    for (i = 0; i < num_msg; i++) {
+        BIO_MSG *m = (BIO_MSG *)((char *)msg + i * stride);
+        int ret;
 
-    ret = buffer_write(b, msg->data, (int)msg->data_len);
-    if (ret <= 0)
-        return 0;
+        /*
+         * Buffer the message data. buffer_write() takes an int length, so
+         * guard against an oversized datagram (this mirrors buffer_puts()).
+         */
+        if (m->data_len > INT_MAX)
+            break;
 
-    *msgs_processed = 1;
-    return 1;
+        ret = buffer_write(b, m->data, (int)m->data_len);
+        if (ret <= 0)
+            break;
+
+        ++(*msgs_processed);
+    }
+
+    return (*msgs_processed > 0) ? 1 : 0;
 #else
     *msgs_processed = 0;
     return 0;

--- a/crypto/bio/bio_local.h
+++ b/crypto/bio/bio_local.h
@@ -96,6 +96,10 @@ typedef struct bio_f_buffer_ctx_struct {
     char *obuf; /* the char array */
     int obuf_len; /* how many bytes are in it */
     int obuf_off; /* write/read offset */
+#ifndef OPENSSL_NO_SOCK
+    BIO_ADDR peer; /* peer address for Listener */
+#endif
+    int peer_addr_set; /* peer address has been set */
 } BIO_F_BUFFER_CTX;
 
 struct bio_st {

--- a/crypto/bio/bio_local.h
+++ b/crypto/bio/bio_local.h
@@ -97,9 +97,8 @@ typedef struct bio_f_buffer_ctx_struct {
     int obuf_len; /* how many bytes are in it */
     int obuf_off; /* write/read offset */
 #ifndef OPENSSL_NO_SOCK
-    BIO_ADDR peer; /* peer address for Listener */
+    BIO_ADDR *peer;
 #endif
-    int peer_addr_set; /* peer address has been set */
 } BIO_F_BUFFER_CTX;
 
 struct bio_st {

--- a/doc/man3/BIO_f_buffer.pod
+++ b/doc/man3/BIO_f_buffer.pod
@@ -92,13 +92,6 @@ first message of the first call after a flush. It remains fixed for the entire
 flush cycle and is cleared automatically after each successful flush so that
 subsequent calls may supply a new peer address.
 
-B<Intended use.> This behaviour is specific to DTLS 1.3 SSL listener
-connections, where multiple SSL objects share a single underlying network BIO
-and must therefore transmit datagrams with an explicit destination address.
-Coalescing the outgoing records reduces the number of datagrams on the wire and
-ensures that all records belonging to a single flight are packed into one
-datagram where possible.
-
 B<Thread safety.> The general BIO_sendmmsg() documentation states that
 concurrent readers and writers on the same BIO are permitted. That guarantee
 does B<not> apply to the buffering BIO implementation. BIO_sendmmsg() on a

--- a/doc/man3/BIO_f_buffer.pod
+++ b/doc/man3/BIO_f_buffer.pod
@@ -70,6 +70,41 @@ whenever any pending data should be written such as when removing a buffering
 BIO using BIO_pop(). BIO_flush() may need to be retried if the ultimate
 source/sink BIO is non blocking.
 
+=head2 BIO_sendmmsg() behaviour
+
+The buffering BIO provides an implementation of BIO_sendmmsg() with behaviour
+that differs significantly from the general BIO_sendmmsg() contract described in
+L<BIO_sendmmsg(3)>.
+
+B<Coalescing, not buffering.> Unlike a caller that might expect N individually
+buffered messages to be replayed as N separate messages on flush, the buffering
+BIO I<concatenates> the payload bytes of all messages into its single write
+buffer. When the buffer is flushed (either because it is full or because
+BIO_flush() is called), all accumulated bytes are delivered to the next BIO as a
+single datagram via BIO_sendmmsg(). The same applies within a single call: if
+B<num_msg> is greater than 1, the payload data of every message in the array is
+appended to the write buffer in order, and they will all be emitted together in
+the next flush. Callers should take care that the total coalesced size does not
+exceed the maximum datagram size of the underlying transport.
+
+B<Peer address.> The destination address is taken from the peer field of the
+first message of the first call after a flush. It remains fixed for the entire
+flush cycle and is cleared automatically after each successful flush so that
+subsequent calls may supply a new peer address.
+
+B<Intended use.> This behaviour is specific to DTLS 1.3 SSL listener
+connections, where multiple SSL objects share a single underlying network BIO
+and must therefore transmit datagrams with an explicit destination address.
+Coalescing the outgoing records reduces the number of datagrams on the wire and
+ensures that all records belonging to a single flight are packed into one
+datagram where possible.
+
+B<Thread safety.> The general BIO_sendmmsg() documentation states that
+concurrent readers and writers on the same BIO are permitted. That guarantee
+does B<not> apply to the buffering BIO implementation. BIO_sendmmsg() on a
+buffering BIO is B<not> thread-safe; callers must not invoke it concurrently on
+the same BIO object.
+
 =head1 RETURN VALUES
 
 BIO_f_buffer() returns the buffering BIO method.
@@ -93,7 +128,7 @@ L<BIO_ctrl(3)>.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/BIO_sendmmsg.pod
+++ b/doc/man3/BIO_sendmmsg.pod
@@ -132,6 +132,11 @@ always process at most one message at a time, for example when OS-level
 functionality to transmit or receive multiple messages at a time is not
 available.
 
+The thread-safety guarantee stated above does not extend to all BIO types.
+The buffering BIO returned by L<BIO_f_buffer(3)> is one example: its
+BIO_sendmmsg() implementation is not thread-safe and its semantics differ
+significantly from those described here; see L<BIO_f_buffer(3)> for details.
+
 =head1 RETURN VALUES
 
 On success, the functions BIO_sendmmsg() and BIO_recvmmsg() return 1 and write
@@ -219,7 +224,7 @@ These functions were added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/BIO_sendmmsg.pod
+++ b/doc/man3/BIO_sendmmsg.pod
@@ -132,10 +132,12 @@ always process at most one message at a time, for example when OS-level
 functionality to transmit or receive multiple messages at a time is not
 available.
 
-The thread-safety guarantee stated above does not extend to all BIO types.
-The buffering BIO returned by L<BIO_f_buffer(3)> is one example: its
-BIO_sendmmsg() implementation is not thread-safe and its semantics differ
-significantly from those described here; see L<BIO_f_buffer(3)> for details.
+The thread-safety guarantee stated above is the default for all BIO types
+that support BIO_sendmmsg() unless stated otherwise in the documentation
+for the BIO. The buffering BIO returned by L<BIO_f_buffer(3)> is one example
+where this guarantee does not apply: its BIO_sendmmsg() implementation is
+not thread-safe and its semantics differ significantly from those described here;
+see L<BIO_f_buffer(3)> for details.
 
 =head1 RETURN VALUES
 

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1938,13 +1938,9 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl)
 
 #ifndef OPENSSL_NO_SOCK
             /*
-             * For DTLS connections created via a listener (where rl->peer is
-             * set), use BIO_sendmmsg() with an explicit peer address. This
-             * allows multiple connections to share the listener's network BIO.
-             *
-             * For non-listener DTLS connections (where rl->peer is not set),
-             * continue using BIO_write() which relies on either a connected
-             * socket or the BIO's stored peer address set via BIO_dgram_set_peer().
+             * For DTLS connections created via a listener we need to
+             * call BIO_sendmmsg() to send the datagrams to the correct
+             * peer address.
              */
             if (rl->isdtls && BIO_ADDR_family(&rl->peer) != AF_UNSPEC) {
                 BIO_MSG msg;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -460,7 +460,7 @@ static int state_machine(SSL_CONNECTION *s, int server)
 #ifndef OPENSSL_NO_SCTP
         if (!SSL_CONNECTION_IS_DTLS(s) || !BIO_dgram_is_sctp(SSL_get_wbio(ssl)))
 #endif
-            if (!SSL_CONNECTION_IS_DTLS13(s) && st->hand_state != TLS_ST_OK) {
+            if (!SSL_CONNECTION_IS_DTLS13(s) || st->hand_state != TLS_ST_OK) {
                 if (!ssl_init_wbio_buffer(s)) {
                     SSLfatal(s, SSL_AD_NO_ALERT, ERR_R_INTERNAL_ERROR);
                     goto end;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -460,11 +460,9 @@ static int state_machine(SSL_CONNECTION *s, int server)
 #ifndef OPENSSL_NO_SCTP
         if (!SSL_CONNECTION_IS_DTLS(s) || !BIO_dgram_is_sctp(SSL_get_wbio(ssl)))
 #endif
-            if (!SSL_CONNECTION_IS_DTLS13(s) || st->hand_state != TLS_ST_OK) {
-                if (!ssl_init_wbio_buffer(s)) {
-                    SSLfatal(s, SSL_AD_NO_ALERT, ERR_R_INTERNAL_ERROR);
-                    goto end;
-                }
+            if (!ssl_init_wbio_buffer(s)) {
+                SSLfatal(s, SSL_AD_NO_ALERT, ERR_R_INTERNAL_ERROR);
+                goto end;
             }
 
         if ((SSL_in_before(ssl))
@@ -632,6 +630,10 @@ static SUB_STATE_RETURN read_state_machine(SSL_CONNECTION *s)
                 if (SSL_CONNECTION_IS_DTLS13(s)
                     && st->hand_state == TLS_ST_OK
                     && s->statem.state != MSG_FLOW_ERROR) {
+                    if (!ssl_free_wbio_buffer(s)) {
+                        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                        return SUB_STATE_ERROR;
+                    }
                     ossl_statem_set_in_init(s, 0);
                     return SUB_STATE_END_HANDSHAKE;
                 }

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -453,9 +453,7 @@ static int state_machine(SSL_CONNECTION *s, int server)
 
         /*
          * Ok, we now need to push on a buffering BIO ...but not with
-         * SCTP. For DTLSv1.3 we also skip this for post-handshake messages
-         * (e.g. NewSessionTicket, KeyUpdate) since we are not in the initial
-         * handshake and re-initialising the write buffer is not appropriate.
+         * SCTP
          */
 #ifndef OPENSSL_NO_SCTP
         if (!SSL_CONNECTION_IS_DTLS(s) || !BIO_dgram_is_sctp(SSL_get_wbio(ssl)))

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -3676,6 +3676,201 @@ end:
     return testresult;
 }
 
+/*
+ * Test DTLS 1.3 SSL Listener handshake message buffering.
+ *
+ * This test verifies that when a DTLS 1.3 SSL Listener sends handshake
+ * messages, multiple records are buffered into a single datagram
+ * rather than being sent as separate datagrams.
+ *
+ * Expected behavior with buffering:
+ *   - At least one datagram contains multiple DTLS records
+ *
+ * Without buffering (the bug this tests for):
+ *   - Each record would be in its own datagram
+ */
+static int test_dtls13_listener_msg_buffering(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *listener = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    BIO_ADDR *client_addr = NULL;
+    int testresult = 0;
+    int retc, rets, err_code;
+    SSL_POLL_ITEM poll_item;
+    struct timeval poll_timeout;
+    size_t poll_result;
+    int abortctr = 0;
+    unsigned char buf[16384];
+    size_t datagram_len;
+    BIO_MSG msg;
+    size_t msgs_processed;
+    int record_count, max_records_in_datagram = 0;
+    BIO *client_rbio;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(),
+            DTLS1_3_VERSION, DTLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    /*
+     * Set NO_QUERY_MTU on the context so connections inherit it.
+     * This prevents the MTU from being queried before we can set it.
+     */
+    SSL_CTX_set_options(sctx, SSL_OP_NO_QUERY_MTU);
+
+    if (!TEST_true(create_dtls_listener_and_client_mem(sctx, cctx,
+            SSL_LISTENER_FLAG_NO_VALIDATE | SSL_LISTENER_FLAG_SINGLE_THREAD,
+            &listener, &clientssl, &client_addr)))
+        goto end;
+
+    SSL_set_connect_state(clientssl);
+
+    retc = SSL_connect(clientssl);
+    err_code = SSL_get_error(clientssl, retc);
+    if (!TEST_true(retc <= 0
+            && (err_code == SSL_ERROR_WANT_READ
+                || err_code == SSL_ERROR_WANT_WRITE)))
+        goto end;
+
+    while (serverssl == NULL) {
+        if (!TEST_int_le(++abortctr, 100))
+            goto end;
+
+        poll_item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+        poll_item.desc.value.ssl = listener;
+        poll_item.events = SSL_POLL_EVENT_IC;
+        poll_item.revents = 0;
+        poll_timeout.tv_sec = 0;
+        poll_timeout.tv_usec = 0;
+
+        if (!TEST_true(SSL_poll(&poll_item, 1, sizeof(poll_item),
+                &poll_timeout, 0, &poll_result)))
+            goto end;
+
+        if (poll_result > 0 && (poll_item.revents & SSL_POLL_EVENT_IC) != 0)
+            serverssl = SSL_accept_connection(listener,
+                SSL_ACCEPT_CONNECTION_NO_BLOCK);
+    }
+
+    if (!TEST_ptr(serverssl))
+        goto end;
+
+    /* Set a large MTU to prevent message fragmentation */
+    SSL_set_mtu(serverssl, 1500);
+
+    abortctr = 0;
+    while (1) {
+        if (!TEST_int_le(++abortctr, 100))
+            goto end;
+
+        rets = SSL_do_handshake(serverssl);
+        err_code = SSL_get_error(serverssl, rets);
+
+        if (rets > 0)
+            break;
+
+        if (err_code == SSL_ERROR_WANT_READ)
+            break;
+
+        if (!TEST_int_eq(err_code, SSL_ERROR_WANT_WRITE))
+            goto end;
+    }
+
+    /*
+     * The server has sent its flight, which should be buffered into one or
+     * more datagrams. We read each datagram and count the DTLS records
+     * within it. With proper buffering, at least one datagram should
+     * contain multiple records.
+     */
+    client_rbio = SSL_get_rbio(clientssl);
+    if (!TEST_ptr(client_rbio))
+        goto end;
+
+    /* Read all available datagrams */
+    while (1) {
+        memset(&msg, 0, sizeof(msg));
+        msg.data = buf;
+        msg.data_len = sizeof(buf);
+
+        if (!BIO_recvmmsg(client_rbio, &msg, sizeof(msg), 1, 0, &msgs_processed)
+            || msgs_processed == 0)
+            break;
+
+        datagram_len = msg.data_len;
+
+        /* Count DTLS records in this datagram */
+        record_count = 0;
+        {
+            size_t offset = 0;
+
+            while (offset < datagram_len) {
+                unsigned char hdr = buf[offset];
+                size_t rec_len, hdr_len;
+
+                /*
+                 * Check that the first three bits are set to 001 to verify
+                 * that the DTLS 1.3 Unified Header is present. Otherwise,
+                 * assume DTLS 1.2 record format.
+                 */
+                if ((hdr & 0xE0) == 0x20) {
+                    /* DTLS 1.3 unified header */
+                    if (offset + 4 > datagram_len)
+                        break;
+
+                    if (hdr & 0x04) {
+                        /* Length field present */
+                        hdr_len = 1 + ((hdr & 0x08) ? 2 : 1);
+                        if (offset + hdr_len + 2 > datagram_len)
+                            break;
+                        rec_len = (buf[offset + hdr_len] << 8)
+                            | buf[offset + hdr_len + 1];
+                        hdr_len += 2;
+                    } else {
+                        /* No length field - record extends to end of datagram */
+                        rec_len = datagram_len - offset - 1
+                            - ((hdr & 0x08) ? 2 : 1);
+                        hdr_len = 1 + ((hdr & 0x08) ? 2 : 1);
+                    }
+
+                    offset += hdr_len + rec_len;
+                } else if (hdr >= 20 && hdr <= 25) {
+                    /* DTLS 1.2 style record header (13 bytes) */
+                    if (offset + 13 > datagram_len)
+                        break;
+                    rec_len = (buf[offset + 11] << 8) | buf[offset + 12];
+                    offset += 13 + rec_len;
+                } else {
+                    break;
+                }
+
+                record_count++;
+            }
+        }
+
+        if (record_count > max_records_in_datagram)
+            max_records_in_datagram = record_count;
+    }
+
+    /*
+     * The key assertion: with buffering enabled, at least one datagram should
+     * contain multiple records.
+     */
+    if (!TEST_int_gt(max_records_in_datagram, 1))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_free(listener);
+    BIO_ADDR_free(client_addr);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
@@ -3744,6 +3939,9 @@ int setup_tests(void)
     ADD_TEST(test_dtls_poll_listener_multiple_events);
     ADD_TEST(test_dtls_poll_conn_event_ec);
     ADD_TEST(test_dtls_poll_null_item);
+
+    /* Message buffering test */
+    ADD_TEST(test_dtls13_listener_msg_buffering);
 #endif /* OPENSSL_NO_DTLS1_3 */
 
     /* Time callback tests */


### PR DESCRIPTION
Now when a buffer BIO is created for the initial DTLS handshake from an SSL listener messages are now buffered until a flush is called.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
