### PR TITLE
Restore Visual Studio 2013 build compatibility

### DIFF
--- a/crypto/bio/bio_print.c
+++ b/crypto/bio/bio_print.c
@@ -47,20 +47,107 @@ int BIO_printf(BIO *bio, const char *format, ...)
  * https://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010
  *
  */
+static int msvc_translate_printf_format(const char *format, const char **out,
+    char **tmp)
+{
+    /* Valid printf conversion specifiers, grouped by category: signed
+     * integers (d i), unsigned (o u x X), floating-point (f F e E g G a A),
+     * misc (c s p n) and MSVC-specific (S Z C). */
+    static const char conv[] = "diouxXfFeEgGaAcspnSZC";
+    const char *p = format;
+    char *dst = NULL, *q = NULL;
+
+    /*
+     * The VS 2013 CRT does not understand the C99 z, t and j length
+     * modifiers. Translate z and t to I (both are pointer-sized on Windows)
+     * and j to I64 (intmax_t is 64 bits). Every input character expands to
+     * at most three output characters (j -> I64), so 3 * length is a safe
+     * bound for the buffer.
+     *
+     * This is done in a single pass: nothing is allocated until the first
+     * modifier is seen, so formats that need no translation return the
+     * original string untouched. EMIT_CHAR() appends a character to the
+     * output once the buffer exists; before that it is a no-op.
+     */
+#define EMIT_CHAR(c)     \
+    do {                 \
+        if (dst != NULL) \
+            *q++ = (c);  \
+    } while (0)
+
+    *out = format;
+    *tmp = NULL;
+
+    while (*p != '\0') {
+        if (*p != '%') { /* literal character */
+            EMIT_CHAR(*p);
+            p++;
+            continue;
+        }
+        p++; /* consume '%' */
+        if (*p == '%') { /* literal "%%" */
+            EMIT_CHAR('%');
+            EMIT_CHAR('%');
+            p++;
+            continue;
+        }
+        EMIT_CHAR('%');
+        while (*p != '\0' && strchr(conv, *p) == NULL) {
+            char c = *p++;
+            if (c != 'z' && c != 't' && c != 'j') { /* verbatim */
+                EMIT_CHAR(c);
+                continue;
+            }
+            if (dst == NULL) { /* first modifier: allocate + flush prefix */
+                size_t len = strlen(format);
+                if (len > (SIZE_MAX - 1) / 3) /* make static analysis happy */
+                    return 0;
+                dst = (char *)OPENSSL_malloc(3 * len + 1);
+                if (dst == NULL)
+                    return 0;
+                q = dst;
+                memcpy(q, format, (size_t)(p - 1 - format));
+                q += p - 1 - format;
+            }
+            EMIT_CHAR('I');
+            if (c == 'j') {
+                EMIT_CHAR('6');
+                EMIT_CHAR('4');
+            }
+        }
+        if (*p != '\0') { /* copy the conversion specifier */
+            EMIT_CHAR(*p);
+            p++;
+        }
+    }
+#undef EMIT_CHAR
+
+    if (dst != NULL) {
+        *q = '\0';
+        *out = dst;
+        *tmp = dst;
+    }
+    return 1;
+}
+
 static int msvc_bio_vprintf(BIO *bio, const char *format, va_list args)
 {
     char buf[512];
-    char *abuf;
+    char *abuf, *fmt_alloc;
+    const char *fmt;
     int ret, sz;
 
-    sz = _vsnprintf_s(buf, sizeof(buf), _TRUNCATE, format, args);
+    if (!msvc_translate_printf_format(format, &fmt, &fmt_alloc))
+        return -1;
+
+    sz = _vsnprintf_s(buf, sizeof(buf), _TRUNCATE, fmt, args);
     if (sz == -1) {
-        sz = _vscprintf(format, args) + 1;
+        sz = _vscprintf(fmt, args) + 1;
         abuf = (char *)OPENSSL_malloc(sz);
         if (abuf == NULL) {
             ret = -1;
         } else {
-            sz = _vsnprintf(abuf, sz, format, args);
+            sz = _vsnprintf(abuf, sz, fmt, args);
             ret = BIO_write(bio, abuf, sz);
             OPENSSL_free(abuf);
         }
@@ -68,6 +155,7 @@ static int msvc_bio_vprintf(BIO *bio, const char *format, va_list args)
         ret = BIO_write(bio, buf, sz);
     }
 
+    OPENSSL_free(fmt_alloc);
     return ret;
 }
 #endif
@@ -82,7 +170,21 @@ int ossl_BIO_snprintf_msvc(char *buf, size_t n, const char *format, ...)
     int ret;
 
     va_start(args, format);
+#if defined(_MSC_VER) && _MSC_VER < 1900
+    {
+        char *fmt_alloc;
+        const char *fmt;
+
+        if (!msvc_translate_printf_format(format, &fmt, &fmt_alloc)) {
+            ret = -1;
+        } else {
+            ret = _vsnprintf_s(buf, n, _TRUNCATE, fmt, args);
+            OPENSSL_free(fmt_alloc);
+        }
+    }
+#else
     ret = _vsnprintf_s(buf, n, _TRUNCATE, format, args);
+#endif
     va_end(args);
 
     return ret;
@@ -144,14 +246,7 @@ int BIO_snprintf(char *buf, size_t n, const char *format, ...)
     int ret;
 
     va_start(args, format);
-
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    ret = _vsnprintf_s(buf, n, _TRUNCATE, format, args);
-#else
-    ret = vsnprintf(buf, n, format, args);
-    if ((size_t)ret >= n)
-        ret = -1;
-#endif
+    ret = BIO_vsnprintf(buf, n, format, args);
     va_end(args);
 
     return ret;
@@ -159,10 +254,17 @@ int BIO_snprintf(char *buf, size_t n, const char *format, ...)
 
 int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args)
 {
+#if defined(_MSC_VER) && _MSC_VER < 1900
+    char *fmt_alloc;
+    const char *fmt;
+#endif
     int ret;
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
-    ret = _vsnprintf_s(buf, n, _TRUNCATE, format, args);
+    if (!msvc_translate_printf_format(format, &fmt, &fmt_alloc))
+        return -1;
+    ret = _vsnprintf_s(buf, n, _TRUNCATE, fmt, args);
+    OPENSSL_free(fmt_alloc);
 #else
     ret = vsnprintf(buf, n, format, args);
     if ((size_t)ret >= n)

--- a/test/bio_core_test.c
+++ b/test/bio_core_test.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <stdarg.h>
+#include <stddef.h>
 #include <string.h>
 #include <openssl/bio.h>
 #include "testutil.h"
@@ -63,6 +65,18 @@ static const OSSL_DISPATCH biocbs[] = {
     { OSSL_FUNC_BIO_FREE, (void (*)(void))tst_bio_core_free },
     OSSL_DISPATCH_END
 };
+
+static int call_bio_vsnprintf(char *buf, size_t n, const char *format, ...)
+{
+    va_list args;
+    int ret;
+
+    va_start(args, format);
+    ret = BIO_vsnprintf(buf, n, format, args);
+    va_end(args);
+
+    return ret;
+}
 
 static int test_bio_core(void)
 {
@@ -140,6 +154,70 @@ err:
     return testresult;
 }
 
+static int test_bio_printf_c99_length_modifiers(void)
+{
+    static const char expected[] = "zu=12345 zd=-42 zx=3039 td=-7 ju=4294967338 jx=10000002a";
+    static const char long_tail[] = "12345";
+    BIO *bio = NULL;
+    char buf[128];
+    char *memdata = NULL;
+    long memlen;
+    size_t z = (size_t)12345;
+    ossl_ssize_t zs = (ossl_ssize_t)-42;
+    ptrdiff_t t = (ptrdiff_t)-7;
+    ossl_uintmax_t j = (((ossl_uintmax_t)1) << 32) + 42;
+    int expected_len = (int)strlen(expected);
+    size_t long_tail_len = strlen(long_tail);
+    int testresult = 0;
+
+    if (!TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
+                         "zu=%zu zd=%zd zx=%zx td=%td ju=%ju jx=%jx",
+                         z, zs, z, t, j, j),
+            expected_len)
+        || !TEST_str_eq(buf, expected))
+        goto err;
+
+    if (!TEST_int_eq(call_bio_vsnprintf(buf, sizeof(buf),
+                         "zu=%zu zd=%zd zx=%zx td=%td ju=%ju jx=%jx",
+                         z, zs, z, t, j, j),
+            expected_len)
+        || !TEST_str_eq(buf, expected))
+        goto err;
+
+    if (!TEST_ptr(bio = BIO_new(BIO_s_mem()))
+        || !TEST_int_eq(BIO_printf(bio,
+                            "zu=%zu zd=%zd zx=%zx td=%td ju=%ju jx=%jx",
+                            z, zs, z, t, j, j),
+            expected_len))
+        goto err;
+
+    memlen = BIO_get_mem_data(bio, &memdata);
+    if (!TEST_long_eq(memlen, (long)strlen(expected))
+        || !TEST_mem_eq(memdata, (size_t)memlen, expected, strlen(expected)))
+        goto err;
+
+    BIO_free(bio);
+    bio = NULL;
+    memdata = NULL;
+    if (!TEST_ptr(bio = BIO_new(BIO_s_mem()))
+        || !TEST_int_eq(BIO_printf(bio, "%600zu", z), 600))
+        goto err;
+
+    memlen = BIO_get_mem_data(bio, &memdata);
+    if (!TEST_long_eq(memlen, 600)
+        || !TEST_mem_eq(memdata + (size_t)memlen - long_tail_len,
+            long_tail_len, long_tail, long_tail_len))
+        goto err;
+
+    if (!TEST_int_eq(BIO_snprintf(buf, 4, "%zu", z), -1))
+        goto err;
+
+    testresult = 1;
+err:
+    BIO_free(bio);
+    return testresult;
+}
+
 int setup_tests(void)
 {
     if (!test_skip_common_options()) {
@@ -149,5 +227,6 @@ int setup_tests(void)
 
     ADD_TEST(test_bio_core);
     ADD_TEST(test_bio_vprintf_boundary);
+    ADD_TEST(test_bio_printf_c99_length_modifiers);
     return 1;
 }

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -475,7 +475,7 @@ static int mutcbk_inject_frames(const QUIC_PKT_HDR *hdrin,
     grow_allowance -= (hdrin->src_conn_id.id_len < grow_allowance) ? hdrin->src_conn_id.id_len : grow_allowance;
 
     if (grow_allowance == 0) {
-        TEST_info("%s not enough space to inject", __func__);
+        TEST_info("%s not enough space to inject", OPENSSL_FUNC);
         return 0;
     }
     bufsz += grow_allowance;
@@ -486,7 +486,7 @@ static int mutcbk_inject_frames(const QUIC_PKT_HDR *hdrin,
     /* discard const */
     buf = (char *)mutctx->mutctx_iov.buf;
     if (buf == NULL) {
-        TEST_info("%s OPENSSL_malloc() failed", __func__);
+        TEST_info("%s OPENSSL_malloc() failed", OPENSSL_FUNC);
         return 0;
     }
 


### PR DESCRIPTION
Current master doesn't build cleanly with the VS 2013 C compiler because several C files use constructs it rejects in C mode. This PR moves those declarations and initializations into forms accepted by VS 2013 while preserving the existing behavior.

### C89 compilation fixes

VS 2013 compiles C in C89/C90 mode and rejects the following C99 constructs found in current master:

- **C99 aggregate initializers with function calls** in `ikev2kdf.c` (3 instances): `OSSL_PARAM params[] = { fn(...), ... }` is rejected because C89 requires constant expressions in initializer lists for aggregate types. Changed to declare the array and assign elements at runtime.
- **Mixed declarations and code** in `dsa_kmgmt.c`, `ec_kmgmt.c`, `extensions_srvr.c`, and `t1_enc.c`: declarations appearing after statements are rejected by VS 2013. Moved them to the top of their respective blocks.
- **`__func__` predefined identifier** in `quic_tests.c`: not available in VS 2013 C mode. Replaced with `OPENSSL_FUNC`, which resolves to `__FUNCTION__` on MSVC.

### Old-CRT printf format translation

The VS 2013 CRT (`_MSC_VER < 1900`) doesn't understand the C99 `z`, `t` and `j` length modifiers, they are printed literally. A central `msvc_translate_printf_format` helper now translates `z` and `t` to MSVC `I` size modifier (both are pointer-sized on Windows) and `j` to `I64` (intmax_t is 64 bits).

The compatibility path allocates a copied format string only when one of those modifiers is present; formats without them return the original string untouched with zero overhead. This leaves VS 2015 and newer completely unchanged. `BIO_snprintf` is simplified to delegate to `BIO_vsnprintf`, removing a duplicated `#if` block.

### Verification

The entire tree was built and tested with VS 2013 (64-bit, `VC-WIN64A no-shared`):

- Full `nmake` build: success, no compilation errors
- `bio_core_test`: 3/3 pass (including new `test_bio_printf_c99_length_modifiers`)
- `evp_kdf_test`: 61/61 pass (covers `ikev2kdf.c` changes)
- `dsatest` + `dsa_no_digest_size_test`: 8/8 pass (covers `dsa_kmgmt.c`)
- `ecdsatest`: all pass (covers `ec_kmgmt.c`)

The new test exercises `%zu`, `%zd`, `%zx`, `%td`, `%ju`, `%jx` through all three modified entry points (`BIO_snprintf`, `BIO_vsnprintf`, `BIO_printf`), plus the large-output realloc path (`%600zu`) and truncation behavior.

Fixes https://github.com/openssl/openssl/issues/31645

##### Checklist
- [x] tests are added or updated

Assisted-by: OpenCode:GLM-5.2