### PR TITLE
docs: clarify raw RSA migration

### DIFF
--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -2428,8 +2428,11 @@ See L</Deprecated low-level encryption functions>
 
 RSA_private_encrypt(), RSA_public_decrypt()
 
-This is equivalent to doing sign and verify recover operations (with a padding
-mode of none). See L</Deprecated low-level signing functions>.
+These are equivalent to L<EVP_PKEY_sign(3)> and
+L<EVP_PKEY_verify_recover(3)> operations, respectively. For compatibility
+with the legacy low-level operations, do not configure a signature digest and
+use the same padding mode as the legacy call (B<RSA_PKCS1_PADDING> or
+B<RSA_NO_PADDING>). See L</Deprecated low-level signing functions>.
 
 =item *
 


### PR DESCRIPTION
The migration guide currently states that `RSA_private_encrypt` and `RSA_public_decrypt` map to sign and verify-recover operations only with no padding. This is too restrictive because the legacy operations also support PKCS#1 v1.5 padding, which must be preserved when compatibility with existing outputs is required.

Document the direct mappings to `EVP_PKEY_sign` and `EVP_PKEY_verify_recover`, and clarify that reproducing the legacy raw RSA behavior requires using the same supported RSA padding mode without configuring a signature digest.

Related to #31989.

##### Checklist

- [x] documentation is added or updated