### PR TITLE
Fix issues found by asan/ubsan fuzzer CI

### DIFF
--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -142,7 +142,9 @@ static int do_buf(const unsigned char *buf, int buflen,
     const unsigned char *p, *q;
     uint32_t c;
 
-    if (buflen <= 0)
+    if (buflen < 0)
+        return -1;
+    if (buflen == 0)
         return 0;
     p = buf;
     q = buf + buflen;
@@ -238,7 +240,9 @@ static int do_hex_dump(char_io *io_ch, void *arg, unsigned char *buf,
     unsigned char *p, *q;
     char hextmp[2];
 
-    if (buflen <= 0)
+    if (buflen < 0)
+        return -1;
+    if (buflen == 0)
         return 0;
     if (arg) {
         p = buf;

--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -142,6 +142,8 @@ static int do_buf(const unsigned char *buf, int buflen,
     const unsigned char *p, *q;
     uint32_t c;
 
+    if (buflen <= 0)
+        return 0;
     p = buf;
     q = buf + buflen;
     outlen = 0;
@@ -236,6 +238,8 @@ static int do_hex_dump(char_io *io_ch, void *arg, unsigned char *buf,
     unsigned char *p, *q;
     char hextmp[2];
 
+    if (buflen <= 0)
+        return 0;
     if (arg) {
         p = buf;
         q = buf + buflen;

--- a/crypto/ocsp/v3_ocsp.c
+++ b/crypto/ocsp/v3_ocsp.c
@@ -143,7 +143,7 @@ static void *ocsp_nonce_new(void)
 static int i2d_ocsp_nonce(const void *a, unsigned char **pp)
 {
     const ASN1_OCTET_STRING *os = a;
-    if (pp && os->length > 0) {
+    if (pp != NULL && os->length > 0) {
         memcpy(*pp, os->data, os->length);
         *pp += os->length;
     }

--- a/crypto/ocsp/v3_ocsp.c
+++ b/crypto/ocsp/v3_ocsp.c
@@ -143,7 +143,7 @@ static void *ocsp_nonce_new(void)
 static int i2d_ocsp_nonce(const void *a, unsigned char **pp)
 {
     const ASN1_OCTET_STRING *os = a;
-    if (pp) {
+    if (pp && os->length > 0) {
         memcpy(*pp, os->data, os->length);
         *pp += os->length;
     }
@@ -164,7 +164,8 @@ static void *d2i_ocsp_nonce(void *a, const unsigned char **pp, long length)
     if (!ASN1_OCTET_STRING_set(os, *pp, length))
         goto err;
 
-    *pp += length;
+    if (length > 0)
+        *pp += length;
 
     if (pos)
         *pos = os;

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -404,7 +404,7 @@ static int asn1_string_canon(ASN1_STRING *out, const ASN1_STRING *in)
 
     out->type = V_ASN1_UTF8STRING;
     out->length = ASN1_STRING_to_UTF8(&out->data, in);
-    if (out->length == -1)
+    if (out->length <= 0)
         return 0;
 
     to = out->data;

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -404,8 +404,10 @@ static int asn1_string_canon(ASN1_STRING *out, const ASN1_STRING *in)
 
     out->type = V_ASN1_UTF8STRING;
     out->length = ASN1_STRING_to_UTF8(&out->data, in);
-    if (out->length <= 0)
+    if (out->length < 0)
         return 0;
+    if (out->length == 0)
+        return 1;
 
     to = out->data;
     from = to;


### PR DESCRIPTION
Since 28179061bf a zero-length ASN1_STRING has data == NULL in
fuzzing builds instead of a 1-byte allocation. Several call sites
did pointer arithmetic or memcpy on the data pointer before any
length check, which is undefined behaviour for NULL even with a
zero offset and aborts the fuzz targets under UBSan:

- asn1_string_canon: skip canonicalisation of empty values
- do_buf, do_hex_dump: return early on an empty buffer
- i2d_ocsp_nonce: skip the memcpy for an empty nonce

The loops at these sites were already no-ops for zero length, so
there is no behaviour change outside sanitizer builds.

Assisted-By: Claude:claude-fable-5

Signed-off-by: Norbert Pocs <norbertp@openssl.org>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
