### PR TITLE
Fix clean target find/-prune precedence bug

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -660,8 +660,8 @@ clean: libclean ## Clean the workspace, keep the configuration
 	           -o -path './python-ecdsa' \
 	           -o -path './tlsfuzzer' \
 	           -o -path './tlslite-ng' \
-	           -o -path './wycheproof' \
-	           -prune \) \
+	           -o -path './wycheproof' \) \
+	        -prune \
 	        -o \! -type d \
 	           \( -name '*{- platform->depext() -}' \
 	              -o -name '*{- platform->objext() -}' \


### PR DESCRIPTION
The `Makefile` `clean` target has a `find`/`-prune` bug. Only the *last* path in its submodule-exclusion list is actually protected from recursion, so `make clean` can delete symlinks inside the earlier-listed submodules (`cloudflare-quiche`, `pkcs11-provider`, etc.)

Fixes https://github.com/openssl/openssl/issues/32005

##### Checklist

- [ ] documentation is added or updated
- [ ] tests are added or updated
