### PR TITLE
Update SSL_CTX_set1_curves.pod for OpenSSL 3.5 additions

### DIFF
--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -402,6 +402,9 @@ SSL_set1_groups_list() was added in OpenSSL 3.3.
 
 Support for B<ML-KEM> was added in OpenSSL 3.5.
 
+OpenSSL 3.5 also introduced support for group tuples, the C<*> keyshare prediction prefix,
+the C</> tuple separator, the C<DEFAULT> pseudo-group, and the C<-> prefix.
+
 OpenSSL 3.5 also introduced support for three I<hybrid> ECDH PQ key exchange
 TLS groups: B<X25519MLKEM768>, B<SecP256r1MLKEM768> and
 B<SecP384r1MLKEM1024>.

--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -402,7 +402,7 @@ SSL_set1_groups_list() was added in OpenSSL 3.3.
 
 Support for B<ML-KEM> was added in OpenSSL 3.5.
 
-OpenSSL 3.5 also introduced support for group tuples, the C<*> keyshare prediction prefix,
+OpenSSL 3.5 also introduced support for group tuples, the C<*> keyshare prediction prefix, 
 the C</> tuple separator, the C<DEFAULT> pseudo-group, and the C<-> prefix.
 
 OpenSSL 3.5 also introduced support for three I<hybrid> ECDH PQ key exchange


### PR DESCRIPTION
Added documentation of the addition of group tuples in openSSL 3.5 in HISTORY section of SSL_CTX_set1_curves.pod.

Fixes #32004 

CLA: trivial
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
