### PR TITLE
Fix access to no-store provider query data after unquery

### DIFF
--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -462,6 +462,10 @@ static int decoder_same_algorithm(const OSSL_DECODER *a, const OSSL_DECODER *b)
     if (a == b)
         return 1;
 
+    /*
+     * algodef is retained only for cacheable query results, where its pointer
+     * remains a stable identity.  No-store methods leave algodef NULL.
+     */
     if (a->base.algodef != NULL && b->base.algodef != NULL)
         return a->base.algodef == b->base.algodef;
 

--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -457,6 +457,27 @@ static void collect_all_decoders(OSSL_DECODER *decoder, void *arg)
         OSSL_DECODER_free(decoder);
 }
 
+static int decoder_same_algorithm(const OSSL_DECODER *a, const OSSL_DECODER *b)
+{
+    if (a == b)
+        return 1;
+
+    if (a->base.algodef != NULL && b->base.algodef != NULL)
+        return a->base.algodef == b->base.algodef;
+
+    if (a->base.prov != b->base.prov || a->base.id == 0
+        || a->base.id != b->base.id)
+        return 0;
+
+    /* Property definitions are unordered, so require them to match both ways. */
+    return ossl_property_match_count(a->base.parsed_propdef,
+               b->base.parsed_propdef)
+        >= 0
+        && ossl_property_match_count(b->base.parsed_propdef,
+               a->base.parsed_propdef)
+        >= 0;
+}
+
 static void collect_extra_decoder(OSSL_DECODER *decoder, void *arg)
 {
     struct collect_extra_decoder_data_st *data = arg;
@@ -488,7 +509,7 @@ static void collect_extra_decoder(OSSL_DECODER *decoder, void *arg)
         for (j = data->w_prev_start; j < data->w_new_end; j++) {
             OSSL_DECODER_INSTANCE *check_inst = sk_OSSL_DECODER_INSTANCE_value(data->ctx->decoder_insts, j);
 
-            if (decoder->base.algodef == check_inst->decoder->base.algodef) {
+            if (decoder_same_algorithm(decoder, check_inst->decoder)) {
                 /* We found it, so don't do anything more */
                 OSSL_TRACE_BEGIN(DECODER)
                 {

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -244,6 +244,11 @@ void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
         ossl_decoder_free(decoder);
         return NULL;
     }
+    /*
+     * Cacheable query data remains valid until provider teardown and may be
+     * retained.  For a no-store result, leave algodef NULL and copy below the
+     * metadata needed after unquery.
+     */
     if (no_store == 0) {
         decoder->base.algodef = algodef;
     } else {

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -36,6 +36,8 @@ static void ossl_decoder_free(void *data)
     if (ref > 0)
         return;
     OPENSSL_free(decoder->base.name);
+    OPENSSL_free(decoder->base.propdef);
+    OPENSSL_free(decoder->base.description);
     ossl_property_free(decoder->base.parsed_propdef);
     ossl_provider_free(decoder->base.prov);
     CRYPTO_FREE_REF(&decoder->base.refcnt);
@@ -242,9 +244,19 @@ void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
         ossl_decoder_free(decoder);
         return NULL;
     }
-    decoder->base.algodef = algodef;
+    if (no_store == 0) {
+        decoder->base.algodef = algodef;
+    } else {
+        if ((algodef->property_definition != NULL
+                && (decoder->base.propdef = OPENSSL_strdup(algodef->property_definition)) == NULL)
+            || (algodef->algorithm_description != NULL
+                && (decoder->base.description = OPENSSL_strdup(algodef->algorithm_description)) == NULL)) {
+            ossl_decoder_free(decoder);
+            return NULL;
+        }
+    }
     if ((decoder->base.parsed_propdef
-            = ossl_parse_property(libctx, algodef->property_definition))
+            = ossl_parse_property(libctx, no_store == 0 ? algodef->property_definition : decoder->base.propdef))
         == NULL) {
         ossl_decoder_free(decoder);
         return NULL;
@@ -496,7 +508,9 @@ const char *OSSL_DECODER_get0_properties(const OSSL_DECODER *decoder)
         return 0;
     }
 
-    return decoder->base.algodef->property_definition;
+    return decoder->base.algodef != NULL
+        ? decoder->base.algodef->property_definition
+        : decoder->base.propdef;
 }
 
 const OSSL_PROPERTY_LIST *
@@ -527,7 +541,9 @@ const char *OSSL_DECODER_get0_name(const OSSL_DECODER *decoder)
 
 const char *OSSL_DECODER_get0_description(const OSSL_DECODER *decoder)
 {
-    return decoder->base.algodef->algorithm_description;
+    return decoder->base.algodef != NULL
+        ? decoder->base.algodef->algorithm_description
+        : decoder->base.description;
 }
 
 int OSSL_DECODER_is_a(const OSSL_DECODER *decoder, const char *name)

--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -26,7 +26,8 @@ struct ossl_endecode_base_st {
     int id;
     int no_store;
     char *name;
-    const OSSL_ALGORITHM *algodef; /* For cacheable algorithm definitions */
+    /* Retained only for cacheable provider query results */
+    const OSSL_ALGORITHM *algodef;
     char *propdef;
     char *description;
     OSSL_PROPERTY_LIST *parsed_propdef;

--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -26,7 +26,9 @@ struct ossl_endecode_base_st {
     int id;
     int no_store;
     char *name;
-    const OSSL_ALGORITHM *algodef;
+    const OSSL_ALGORITHM *algodef; /* For cacheable algorithm definitions */
+    char *propdef;
+    char *description;
     OSSL_PROPERTY_LIST *parsed_propdef;
 
     CRYPTO_REF_COUNT refcnt;

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -237,6 +237,11 @@ static void *encoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
         ossl_encoder_free(encoder);
         return NULL;
     }
+    /*
+     * Cacheable query data remains valid until provider teardown and may be
+     * retained.  For a no-store result, leave algodef NULL and copy below the
+     * metadata needed after unquery.
+     */
     if (no_store == 0) {
         encoder->base.algodef = algodef;
     } else {

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -37,6 +37,8 @@ static void ossl_encoder_free(void *data)
     if (ref > 0)
         return;
     OPENSSL_free(encoder->base.name);
+    OPENSSL_free(encoder->base.propdef);
+    OPENSSL_free(encoder->base.description);
     ossl_property_free(encoder->base.parsed_propdef);
     ossl_provider_free(encoder->base.prov);
     CRYPTO_FREE_REF(&encoder->base.refcnt);
@@ -235,9 +237,19 @@ static void *encoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
         ossl_encoder_free(encoder);
         return NULL;
     }
-    encoder->base.algodef = algodef;
+    if (no_store == 0) {
+        encoder->base.algodef = algodef;
+    } else {
+        if ((algodef->property_definition != NULL
+                && (encoder->base.propdef = OPENSSL_strdup(algodef->property_definition)) == NULL)
+            || (algodef->algorithm_description != NULL
+                && (encoder->base.description = OPENSSL_strdup(algodef->algorithm_description)) == NULL)) {
+            ossl_encoder_free(encoder);
+            return NULL;
+        }
+    }
     if ((encoder->base.parsed_propdef
-            = ossl_parse_property(libctx, algodef->property_definition))
+            = ossl_parse_property(libctx, no_store == 0 ? algodef->property_definition : encoder->base.propdef))
         == NULL) {
         ossl_encoder_free(encoder);
         return NULL;
@@ -495,7 +507,9 @@ const char *OSSL_ENCODER_get0_properties(const OSSL_ENCODER *encoder)
         return 0;
     }
 
-    return encoder->base.algodef->property_definition;
+    return encoder->base.algodef != NULL
+        ? encoder->base.algodef->property_definition
+        : encoder->base.propdef;
 }
 
 const OSSL_PROPERTY_LIST *
@@ -526,7 +540,9 @@ const char *OSSL_ENCODER_get0_name(const OSSL_ENCODER *encoder)
 
 const char *OSSL_ENCODER_get0_description(const OSSL_ENCODER *encoder)
 {
-    return encoder->base.algodef->algorithm_description;
+    return encoder->base.algodef != NULL
+        ? encoder->base.algodef->algorithm_description
+        : encoder->base.description;
 }
 
 int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name)

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2006-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -28,6 +28,8 @@ static void evp_asym_cipher_free(void *data)
     if (i > 0)
         return;
     OPENSSL_free(cipher->type_name);
+    if (cipher->no_store != 0)
+        OPENSSL_free((char *)cipher->description);
     ossl_provider_free(cipher->prov);
     CRYPTO_FREE_REF(&cipher->refcnt);
     OPENSSL_free(cipher);
@@ -358,7 +360,12 @@ static void *evp_asym_cipher_from_algorithm(int name_id,
     cipher->no_store = no_store;
     if ((cipher->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL)
         goto err;
-    cipher->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        cipher->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (cipher->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        goto err;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -860,7 +860,12 @@ static void *evp_md_from_algorithm(int name_id,
     if ((md->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL)
         goto err;
 
-    md->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        md->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (md->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        goto err;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
@@ -998,6 +1003,8 @@ static void evp_md_free(void *m)
         return;
 
     OPENSSL_free(md->type_name);
+    if ((md->flags & EVP_MD_FLAG_NO_STORE) != 0)
+        OPENSSL_free((char *)md->description);
     ossl_provider_free(md->prov);
     CRYPTO_FREE_REF(&md->refcnt);
     OPENSSL_free(md);

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1393,7 +1393,12 @@ static void *evp_cipher_from_algorithm(const int name_id,
     if ((cipher->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL)
         goto err;
 
-    cipher->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        cipher->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (cipher->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        goto err;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
@@ -1586,6 +1591,8 @@ int EVP_CIPHER_up_ref(EVP_CIPHER *cipher)
 void evp_cipher_free_int(EVP_CIPHER *cipher)
 {
     OPENSSL_free(cipher->type_name);
+    if ((cipher->flags & EVP_CIPH_FLAG_NO_STORE) != 0)
+        OPENSSL_free((char *)cipher->description);
     ossl_provider_free(cipher->prov);
     CRYPTO_FREE_REF(&cipher->refcnt);
     OPENSSL_free(cipher);

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -72,9 +72,29 @@ static void evp_rand_free(void *vrand)
     if (ref > 0)
         return;
     OPENSSL_free(rand->type_name);
+    if (rand->no_store != 0) {
+        OPENSSL_free((char *)rand->description);
+        OPENSSL_free((OSSL_DISPATCH *)rand->dispatch);
+    }
     ossl_provider_free(rand->prov);
     CRYPTO_FREE_REF(&rand->refcnt);
     OPENSSL_free(rand);
+}
+
+static OSSL_DISPATCH *evp_rand_dup_dispatch(const OSSL_DISPATCH *fns)
+{
+    const OSSL_DISPATCH *p = fns;
+    size_t n;
+
+    for (; p->function_id != 0; p++)
+        continue;
+
+    n = (size_t)(p - fns) + 1;
+    if (n > SIZE_MAX / sizeof(*fns)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+    return OPENSSL_memdup(fns, n * sizeof(*fns));
 }
 
 static void *evp_rand_new(void)
@@ -136,8 +156,22 @@ static void *evp_rand_from_algorithm(int name_id,
         evp_rand_free(rand);
         return NULL;
     }
-    rand->description = algodef->algorithm_description;
-    rand->dispatch = fns;
+    if (no_store == 0) {
+        rand->description = algodef->algorithm_description;
+        rand->dispatch = fns;
+    } else {
+        if (algodef->algorithm_description != NULL
+            && (rand->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+            evp_rand_free(rand);
+            return NULL;
+        }
+        if ((rand->dispatch = evp_rand_dup_dispatch(fns)) == NULL) {
+            evp_rand_free(rand);
+            return NULL;
+        }
+        fns = rand->dispatch;
+    }
+
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
         case OSSL_FUNC_RAND_NEWCTX:

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -30,6 +30,8 @@ static void evp_keyexch_free(void *data)
     if (i > 0)
         return;
     OPENSSL_free(exchange->type_name);
+    if (exchange->no_store != 0)
+        OPENSSL_free((char *)exchange->description);
     ossl_provider_free(exchange->prov);
     CRYPTO_FREE_REF(&exchange->refcnt);
     OPENSSL_free(exchange);
@@ -79,7 +81,12 @@ static void *evp_keyexch_from_algorithm(int name_id,
     exchange->no_store = no_store;
     if ((exchange->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL)
         goto err;
-    exchange->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        exchange->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (exchange->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        goto err;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -38,6 +38,8 @@ static void evp_kdf_free(void *vkdf)
     if (ref > 0)
         return;
     OPENSSL_free(kdf->type_name);
+    if (kdf->no_store != 0)
+        OPENSSL_free((char *)kdf->description);
     ossl_provider_free(kdf->prov);
     CRYPTO_FREE_REF(&kdf->refcnt);
     OPENSSL_free(kdf);
@@ -73,7 +75,12 @@ static void *evp_kdf_from_algorithm(int name_id,
     if ((kdf->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL)
         goto err;
 
-    kdf->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        kdf->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (kdf->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        goto err;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -29,6 +29,8 @@ static void evp_kem_free(void *data)
     if (i > 0)
         return;
     OPENSSL_free(kem->type_name);
+    if (kem->no_store != 0)
+        OPENSSL_free((char *)kem->description);
     ossl_provider_free(kem->prov);
     CRYPTO_FREE_REF(&kem->refcnt);
     OPENSSL_free(kem);
@@ -334,7 +336,12 @@ static void *evp_kem_from_algorithm(int name_id, const OSSL_ALGORITHM *algodef,
 
     if ((kem->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL)
         goto err;
-    kem->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        kem->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (kem->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        goto err;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -29,6 +29,8 @@ static void evp_keymgmt_free(void *data)
     if (ref > 0)
         return;
     OPENSSL_free(keymgmt->type_name);
+    if (keymgmt->no_store != 0)
+        OPENSSL_free((char *)keymgmt->description);
     ossl_provider_free(keymgmt->prov);
     CRYPTO_FREE_REF(&keymgmt->refcnt);
     OPENSSL_free(keymgmt);
@@ -98,7 +100,13 @@ static void *keymgmt_from_algorithm(int name_id,
         evp_keymgmt_free(keymgmt);
         return NULL;
     }
-    keymgmt->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        keymgmt->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (keymgmt->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        evp_keymgmt_free(keymgmt);
+        return NULL;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -37,6 +37,8 @@ static void evp_mac_free(void *vmac)
     if (ref > 0)
         return;
     OPENSSL_free(mac->type_name);
+    if (mac->no_store != 0)
+        OPENSSL_free((char *)mac->description);
     ossl_provider_free(mac->prov);
     CRYPTO_FREE_REF(&mac->refcnt);
     OPENSSL_free(mac);
@@ -72,7 +74,12 @@ static void *evp_mac_from_algorithm(int name_id,
     if ((mac->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL)
         goto err;
 
-    mac->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        mac->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (mac->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        goto err;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -31,6 +31,8 @@ static void evp_signature_free(void *data)
     if (i > 0)
         return;
     OPENSSL_free(signature->type_name);
+    if (signature->no_store != 0)
+        OPENSSL_free((char *)signature->description);
     ossl_provider_free(signature->prov);
     CRYPTO_FREE_REF(&signature->refcnt);
     OPENSSL_free(signature);
@@ -88,7 +90,12 @@ static void *evp_signature_from_algorithm(int name_id,
     signature->no_store = no_store;
     if ((signature->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL)
         goto err;
-    signature->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        signature->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (signature->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        goto err;
+    }
     desc = signature->description != NULL ? signature->description : "";
 
     for (; fns->function_id != 0; fns++) {

--- a/crypto/evp/skeymgmt_meth.c
+++ b/crypto/evp/skeymgmt_meth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2025-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -76,7 +76,13 @@ static void *skeymgmt_from_algorithm(int name_id,
         evp_skeymgmt_free(skeymgmt);
         return NULL;
     }
-    skeymgmt->description = algodef->algorithm_description;
+    if (no_store == 0) {
+        skeymgmt->description = algodef->algorithm_description;
+    } else if (algodef->algorithm_description != NULL
+        && (skeymgmt->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL) {
+        evp_skeymgmt_free(skeymgmt);
+        return NULL;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
@@ -151,6 +157,8 @@ static void evp_skeymgmt_free(void *s)
     if (ref > 0)
         return;
     OPENSSL_free(skeymgmt->type_name);
+    if (skeymgmt->no_store != 0)
+        OPENSSL_free((char *)skeymgmt->description);
     ossl_provider_free(skeymgmt->prov);
     CRYPTO_FREE_REF(&skeymgmt->refcnt);
     OPENSSL_free(skeymgmt);

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -38,6 +38,10 @@ static void free_loader(void *method)
             return;
         ossl_provider_free(loader->prov);
         CRYPTO_FREE_REF(&loader->refcnt);
+    }
+    if (loader != NULL && loader->no_store != 0) {
+        OPENSSL_free((char *)loader->propdef);
+        OPENSSL_free((char *)loader->description);
     }
     OPENSSL_free(loader);
 }
@@ -198,9 +202,18 @@ static void *loader_from_algorithm(int scheme_id, const OSSL_ALGORITHM *algodef,
     if ((loader = new_loader(prov)) == NULL)
         return NULL;
     loader->scheme_id = scheme_id;
-    loader->propdef = algodef->property_definition;
-    loader->description = algodef->algorithm_description;
     loader->no_store = no_store;
+    if (no_store == 0) {
+        loader->propdef = algodef->property_definition;
+        loader->description = algodef->algorithm_description;
+    } else if ((algodef->property_definition != NULL
+                   && (loader->propdef = OPENSSL_strdup(algodef->property_definition))
+                       == NULL)
+        || (algodef->algorithm_description != NULL
+            && (loader->description = OPENSSL_strdup(algodef->algorithm_description)) == NULL)) {
+        free_loader(loader);
+        return NULL;
+    }
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -19,7 +19,7 @@ OSSL_METHOD_CONSTRUCT_METHOD, ossl_method_construct
                 const char *name, const char *propdef, void *data);
      /* Construct a new method */
      void *(*construct)(const OSSL_ALGORITHM *algodef, OSSL_PROVIDER *prov,
-                        void *data);
+                        void *data, int no_store);
      /* Destruct a method */
      void (*destruct)(void *method, void *data);
  };
@@ -59,6 +59,9 @@ passed by ossl_method_construct()).
 If I<prov> is not NULL, only that provider is considered, which is
 useful in the case a method must be found in that particular
 provider.
+If I<force_cache> is nonzero, the constructed method is placed in the
+permanent store even if the provider requested otherwise.  This does not alter
+the lifetime of the provider's query data.
 
 This function assumes that the subsystem method creator implements
 reference counting and acts accordingly (i.e. it will call the
@@ -119,14 +122,19 @@ This function is expected to increment the I<method>'s reference count.
 
 =item construct()
 
-Constructs a subsystem method for the given I<name> and the given
-dispatch table I<fns>.
+Constructs a subsystem method from the algorithm definition I<algodef>.
 
 The associated provider object I<prov> is passed as well, to make
 it possible for the subsystem constructor to keep a reference, which
 is recommended.
 If such a reference is kept, the I<provider object> reference counter
 must be incremented, using ossl_provider_up_ref().
+
+I<no_store> indicates whether the provider permits references to I<algodef> and
+its associated data to be retained.  If it is nonzero, construct() must copy
+any such data that the method will use after construction.  If it is zero,
+construct() may retain references to that data, which the provider must keep
+valid until teardown.
 
 This function is expected to set the method's reference count to 1.
 
@@ -148,7 +156,7 @@ This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2019-2021 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use this
 file except in compliance with the License.  You can obtain a copy in the file

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -273,11 +273,17 @@ well as the caller supplied argument I<arg>.
 ossl_provider_query_operation() calls the provider's
 I<query_operation> function, if the provider has one.
 It should return an array of I<OSSL_ALGORITHM> for the given
-I<operation_id>.
+I<operation_id>.  If I<*no_cache> is set to 0, the returned array and its
+associated data may be retained and must remain valid until provider teardown.
+If I<*no_cache> is set to 1, they must not be accessed after the corresponding
+ossl_provider_unquery_operation() call.
 
 ossl_provider_unquery_operation() informs the provider that the result of
-ossl_provider_query_operation() is no longer going to be directly accessed and
-that all relevant information has been copied.
+ossl_provider_query_operation() is no longer directly required for the current
+query.  For a result returned with I<*no_cache> set to 1, all relevant
+information has been copied and the provider may release the returned array
+and its associated data.  For a result returned with I<*no_cache> set to 0,
+this call does not shorten their required lifetime.
 
 ossl_provider_random_bytes() queries the provider, I<prov>, randomness
 source for I<n> bytes of entropy which are returned in the buffer
@@ -400,7 +406,7 @@ The functions described here were all added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -184,12 +184,22 @@ beforehand in order to display diagnostics for the running self tests.
 OSSL_PROVIDER_query_operation() calls the provider's I<query_operation>
 function (see L<provider(7)>), if the provider has one. It returns an
 array of I<OSSL_ALGORITHM> for the given I<operation_id> terminated by an all
-NULL OSSL_ALGORITHM entry. This is considered a low-level function that most
-applications should not need to call.
+NULL OSSL_ALGORITHM entry.  The provider sets I<*no_cache> to 0 if references
+to the array and its associated data may be retained, or to 1 otherwise.  If
+I<*no_cache> is 0, that data must remain valid until provider teardown.  If
+I<*no_cache> is 1, callers must treat the data as short-lived and must not
+access it after the corresponding OSSL_PROVIDER_unquery_operation() call.
+This is considered a low-level function that most applications should not
+need to call.
 
 OSSL_PROVIDER_unquery_operation() calls the provider's I<unquery_operation>
-function (see L<provider(7)>), if the provider has one.  This is considered a
-low-level function that most applications should not need to call.
+function (see L<provider(7)>), if the provider has one.  It informs the
+provider that the current direct use of I<algs> is complete.  For a result
+returned with I<*no_cache> set to 1, the provider may release the array and
+its associated data in this call.  For a result returned with I<*no_cache>
+set to 0, this call does not shorten their required lifetime.  This is
+considered a low-level function that most applications should not need to
+call.
 
 OSSL_PROVIDER_get0_provider_ctx() returns the provider context for the given
 provider. The provider context is an opaque handle set by the provider itself
@@ -198,10 +208,6 @@ and is passed back to the provider by libcrypto in various function calls.
 OSSL_PROVIDER_get0_dispatch() returns the provider's dispatch table as it was
 returned in the I<out> parameter from the provider's init function. See
 L<provider-base(7)>.
-
-If it is permissible to cache references to this array then I<*no_store> is set
-to 0 or 1 otherwise. If the array is not cacheable then it is assumed to
-have a short lifetime.
 
 OSSL_PROVIDER_get0_name() returns the name of the given provider.
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -115,7 +115,7 @@ provider-base
  int provider_get_params(void *provctx, OSSL_PARAM params[]);
  const OSSL_ALGORITHM *provider_query_operation(void *provctx,
                                                 int operation_id,
-                                                const int *no_store);
+                                                int *no_store);
  void provider_unquery_operation(void *provctx, int operation_id,
                                  const OSSL_ALGORITHM *algs);
  const OSSL_ITEM *provider_get_reason_strings(void *provctx);
@@ -444,15 +444,18 @@ It should indicate if the core may store a reference to this array by
 setting I<*no_store> to 0 (core may store a reference) or 1 (core may
 not store a reference).  If I<*no_store> is set to 0, the returned array
 and its associated strings and dispatch tables must remain valid until
-provider teardown.  If I<*no_store> is set to 1, the provider may release
-them when provider_unquery_operation() is called for that array.
+provider_teardown() is called.  If I<*no_store> is set to 1, the core will
+not access the returned array or its associated data after calling
+provider_unquery_operation(), and the provider may release them in that call.
 
 provider_unquery_operation() informs the provider that the result of a
-provider_query_operation() is no longer directly required.  When I<*no_store>
-was set to 1 for that result, the core has copied the information and function
-pointers that it needs and will no longer access the returned array or its
-associated data.  The I<operation_id> should match that passed to
-provider_query_operation(), and I<algs> should be its return value.
+provider_query_operation() is no longer directly required for the current
+query.  When I<*no_store> was set to 1 for that result, the core has copied the
+information and function pointers that it needs and will no longer access the
+returned array or its associated data.  When I<*no_store> was set to 0, this
+notification does not shorten the lifetime requirement described above.  The
+I<operation_id> should match that passed to provider_query_operation(), and
+I<algs> should be its return value.
 
 provider_get_reason_strings() should return a constant L<OSSL_ITEM(3)>
 array that provides reason strings for reason codes the provider may

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -438,16 +438,21 @@ can handle.
 provider_get_params() should process the L<OSSL_PARAM(3)> array
 I<params>, setting the values of the parameters it understands.
 
-provider_query_operation() should return a constant L<OSSL_ALGORITHM(3)>
-that corresponds to the given I<operation_id>.
+provider_query_operation() should return an array of L<OSSL_ALGORITHM(3)>
+entries corresponding to the given I<operation_id>.
 It should indicate if the core may store a reference to this array by
 setting I<*no_store> to 0 (core may store a reference) or 1 (core may
-not store a reference).
+not store a reference).  If I<*no_store> is set to 0, the returned array
+and its associated strings and dispatch tables must remain valid until
+provider teardown.  If I<*no_store> is set to 1, the provider may release
+them when provider_unquery_operation() is called for that array.
 
 provider_unquery_operation() informs the provider that the result of a
-provider_query_operation() is no longer directly required and that the function
-pointers have been copied.  The I<operation_id> should match that passed to
-provider_query_operation() and I<algs> should be its return value.
+provider_query_operation() is no longer directly required.  When I<*no_store>
+was set to 1 for that result, the core has copied the information and function
+pointers that it needs and will no longer access the returned array or its
+associated data.  The I<operation_id> should match that passed to
+provider_query_operation(), and I<algs> should be its return value.
 
 provider_get_reason_strings() should return a constant L<OSSL_ITEM(3)>
 array that provides reason strings for reason codes the provider may

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -80,17 +80,34 @@ and has the following signature:
 
  const OSSL_ALGORITHM *provider_query_operation(void *provctx,
                                                 int operation_id,
-                                                const int *no_store);
+                                                int *no_store);
 
 I<provctx> is the provider specific context that was passed back by
 the initialization function.
 
 I<operation_id> is an operation identity (see L</Operations> below).
 
-I<no_store> is a flag back to the OpenSSL libraries which, when
-nonzero, signifies that the OpenSSL libraries will not store a
-reference to the returned data in their internal store of
-implementations.
+I<no_store> is an output flag that controls whether the OpenSSL libraries may
+retain references to the returned array and its associated data.  If
+I<*no_store> is zero, the provider must keep the array, its strings, and its
+dispatch tables valid until provider teardown.  If I<*no_store> is nonzero,
+the OpenSSL libraries will not retain references to that data after the
+corresponding provider_unquery_operation() call, and the provider may then
+release it.  See L<provider-base(7)> for further details.
+
+The provider may also offer a function referred to with the number
+B<OSSL_FUNC_PROVIDER_UNQUERY_OPERATION>, with the following signature:
+
+ void provider_unquery_operation(void *provctx, int operation_id,
+                                 const OSSL_ALGORITHM *algs);
+
+I<operation_id> must match the value passed to provider_query_operation(), and
+I<algs> must be the array that it returned.  This callback informs the provider
+that the current query processing is complete.  If I<*no_store> was nonzero for
+that result, the OpenSSL libraries have copied the information they need, will
+no longer access the returned array or its associated data, and the provider
+may release them.  If I<*no_store> was zero, this callback does not shorten the
+lifetime requirement described above.
 
 The returned L<OSSL_ALGORITHM(3)> is the foundation of any OpenSSL
 library API that uses providers for their implementation, most
@@ -275,7 +292,7 @@ introduced in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2019-2022 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/test/provfetchtest.c
+++ b/test/provfetchtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2021-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,10 +11,26 @@
 #include <openssl/provider.h>
 #include <openssl/decoder.h>
 #include <openssl/encoder.h>
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
 #include <openssl/store.h>
 #include <openssl/rand.h>
 #include <openssl/core_names.h>
+#include <stdint.h>
 #include "testutil.h"
+
+static int use_dynamic_no_cache;
+static int reverse_decoder_properties;
+static int decoder_query_count;
+static uintptr_t released_decoder_propdef;
+static uintptr_t released_encoder_propdef;
+static uintptr_t released_store_propdef;
+static uintptr_t released_rand_dispatch;
+static uintptr_t released_description[OSSL_OP__HIGHEST + 1];
+static int released_algorithm_count[OSSL_OP__HIGHEST + 1];
+static uintptr_t rand_parent_dispatch;
+static int rand_parent_dispatch_count;
+static int rand_parent_dispatch_valid;
 
 static int dummy_decoder_decode(void *ctx, OSSL_CORE_BIO *cin, int selection,
     OSSL_CALLBACK *object_cb, void *object_cbarg,
@@ -23,7 +39,18 @@ static int dummy_decoder_decode(void *ctx, OSSL_CORE_BIO *cin, int selection,
     return 0;
 }
 
+static void *dummy_decoder_newctx(void *provctx)
+{
+    return provctx;
+}
+
+static void dummy_decoder_freectx(void *ctx)
+{
+}
+
 static const OSSL_DISPATCH dummy_decoder_functions[] = {
+    { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))dummy_decoder_newctx },
+    { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))dummy_decoder_freectx },
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))dummy_decoder_decode },
     OSSL_DISPATCH_END
 };
@@ -42,7 +69,7 @@ static int dummy_encoder_encode(void *ctx, OSSL_CORE_BIO *out,
 }
 
 static const OSSL_DISPATCH dummy_encoder_functions[] = {
-    { OSSL_FUNC_DECODER_DECODE, (void (*)(void))dummy_encoder_encode },
+    { OSSL_FUNC_ENCODER_ENCODE, (void (*)(void))dummy_encoder_encode },
     OSSL_DISPATCH_END
 };
 
@@ -86,9 +113,231 @@ static const OSSL_ALGORITHM dummy_store[] = {
     { NULL, NULL, NULL }
 };
 
+static void *dummy_evp_newctx(void *provctx)
+{
+    return provctx;
+}
+
+static void dummy_evp_freectx(void *ctx)
+{
+}
+
+static int dummy_digest_get_params(OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_BLOCK_SIZE);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 1))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SIZE);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 1))
+        return 0;
+    return 1;
+}
+
+static int dummy_digest_digest(void *provctx, const unsigned char *in,
+    size_t inl, unsigned char *out, size_t *outl, size_t outsz)
+{
+    *outl = 0;
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_digest_functions[] = {
+    { OSSL_FUNC_DIGEST_GET_PARAMS, (void (*)(void))dummy_digest_get_params },
+    { OSSL_FUNC_DIGEST_DIGEST, (void (*)(void))dummy_digest_digest },
+    OSSL_DISPATCH_END
+};
+
+static int dummy_cipher_get_params(OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_BLOCK_SIZE);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 1))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 1))
+        return 0;
+    return 1;
+}
+
+static int dummy_cipher_cipher(void *ctx, unsigned char *out, size_t *outl,
+    size_t outsize, const unsigned char *in, size_t inl)
+{
+    *outl = 0;
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_cipher_functions[] = {
+    { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))dummy_evp_newctx },
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))dummy_cipher_cipher },
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))dummy_evp_freectx },
+    { OSSL_FUNC_CIPHER_GET_PARAMS, (void (*)(void))dummy_cipher_get_params },
+    OSSL_DISPATCH_END
+};
+
+static int dummy_mac_init(void *ctx, const unsigned char *key, size_t keylen,
+    const OSSL_PARAM params[])
+{
+    return 1;
+}
+
+static int dummy_mac_update(void *ctx, const unsigned char *in, size_t inl)
+{
+    return 1;
+}
+
+static int dummy_mac_final(void *ctx, unsigned char *out, size_t *outl,
+    size_t outsize)
+{
+    *outl = 0;
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_mac_functions[] = {
+    { OSSL_FUNC_MAC_NEWCTX, (void (*)(void))dummy_evp_newctx },
+    { OSSL_FUNC_MAC_FREECTX, (void (*)(void))dummy_evp_freectx },
+    { OSSL_FUNC_MAC_INIT, (void (*)(void))dummy_mac_init },
+    { OSSL_FUNC_MAC_UPDATE, (void (*)(void))dummy_mac_update },
+    { OSSL_FUNC_MAC_FINAL, (void (*)(void))dummy_mac_final },
+    OSSL_DISPATCH_END
+};
+
+static int dummy_kdf_derive(void *ctx, unsigned char *key, size_t keylen,
+    const OSSL_PARAM params[])
+{
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_kdf_functions[] = {
+    { OSSL_FUNC_KDF_NEWCTX, (void (*)(void))dummy_evp_newctx },
+    { OSSL_FUNC_KDF_FREECTX, (void (*)(void))dummy_evp_freectx },
+    { OSSL_FUNC_KDF_DERIVE, (void (*)(void))dummy_kdf_derive },
+    OSSL_DISPATCH_END
+};
+
+static int dummy_keymgmt_has(const void *keydata, int selection)
+{
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_keymgmt_functions[] = {
+    { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))dummy_evp_newctx },
+    { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))dummy_evp_freectx },
+    { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))dummy_keymgmt_has },
+    OSSL_DISPATCH_END
+};
+
+static void *dummy_skeymgmt_import(void *provctx, int selection,
+    const OSSL_PARAM params[])
+{
+    return provctx;
+}
+
+static int dummy_skeymgmt_export(void *keydata, int selection,
+    OSSL_CALLBACK *param_cb, void *cbarg)
+{
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_skeymgmt_functions[] = {
+    { OSSL_FUNC_SKEYMGMT_FREE, (void (*)(void))dummy_evp_freectx },
+    { OSSL_FUNC_SKEYMGMT_IMPORT, (void (*)(void))dummy_skeymgmt_import },
+    { OSSL_FUNC_SKEYMGMT_EXPORT, (void (*)(void))dummy_skeymgmt_export },
+    OSSL_DISPATCH_END
+};
+
+static void *dummy_signature_newctx(void *provctx, const char *propq)
+{
+    return provctx;
+}
+
+static int dummy_pkey_init(void *ctx, void *provkey,
+    const OSSL_PARAM params[])
+{
+    return 1;
+}
+
+static int dummy_pkey_output(void *ctx, unsigned char *out, size_t *outlen,
+    size_t outsize, const unsigned char *in, size_t inlen)
+{
+    *outlen = 0;
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_signature_functions[] = {
+    { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))dummy_signature_newctx },
+    { OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void))dummy_pkey_init },
+    { OSSL_FUNC_SIGNATURE_SIGN, (void (*)(void))dummy_pkey_output },
+    { OSSL_FUNC_SIGNATURE_FREECTX, (void (*)(void))dummy_evp_freectx },
+    OSSL_DISPATCH_END
+};
+
+static const OSSL_DISPATCH dummy_asym_cipher_functions[] = {
+    { OSSL_FUNC_ASYM_CIPHER_NEWCTX, (void (*)(void))dummy_evp_newctx },
+    { OSSL_FUNC_ASYM_CIPHER_ENCRYPT_INIT, (void (*)(void))dummy_pkey_init },
+    { OSSL_FUNC_ASYM_CIPHER_ENCRYPT, (void (*)(void))dummy_pkey_output },
+    { OSSL_FUNC_ASYM_CIPHER_FREECTX, (void (*)(void))dummy_evp_freectx },
+    OSSL_DISPATCH_END
+};
+
+static int dummy_kem_encapsulate(void *ctx, unsigned char *out,
+    size_t *outlen, unsigned char *secret, size_t *secretlen)
+{
+    *outlen = 0;
+    *secretlen = 0;
+    return 1;
+}
+
+static int dummy_kem_decapsulate(void *ctx, unsigned char *out,
+    size_t *outlen, const unsigned char *in, size_t inlen)
+{
+    *outlen = 0;
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_kem_functions[] = {
+    { OSSL_FUNC_KEM_NEWCTX, (void (*)(void))dummy_evp_newctx },
+    { OSSL_FUNC_KEM_ENCAPSULATE_INIT, (void (*)(void))dummy_pkey_init },
+    { OSSL_FUNC_KEM_ENCAPSULATE, (void (*)(void))dummy_kem_encapsulate },
+    { OSSL_FUNC_KEM_DECAPSULATE_INIT, (void (*)(void))dummy_pkey_init },
+    { OSSL_FUNC_KEM_DECAPSULATE, (void (*)(void))dummy_kem_decapsulate },
+    { OSSL_FUNC_KEM_FREECTX, (void (*)(void))dummy_evp_freectx },
+    OSSL_DISPATCH_END
+};
+
+static int dummy_keyexch_derive(void *ctx, unsigned char *secret,
+    size_t *secretlen, size_t outlen)
+{
+    *secretlen = 0;
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_keyexch_functions[] = {
+    { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))dummy_evp_newctx },
+    { OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))dummy_pkey_init },
+    { OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))dummy_keyexch_derive },
+    { OSSL_FUNC_KEYEXCH_FREECTX, (void (*)(void))dummy_evp_freectx },
+    OSSL_DISPATCH_END
+};
+
 static void *dummy_rand_newctx(void *provctx, void *parent,
     const OSSL_DISPATCH *parent_calls)
 {
+    const OSSL_DISPATCH *fns;
+
+    if (use_dynamic_no_cache && parent_calls != NULL) {
+        rand_parent_dispatch = (uintptr_t)parent_calls;
+        rand_parent_dispatch_count++;
+        if (rand_parent_dispatch == released_rand_dispatch)
+            return NULL;
+
+        for (fns = parent_calls; fns->function_id != 0; fns++) {
+            if (fns->function_id == OSSL_FUNC_RAND_GENERATE)
+                rand_parent_dispatch_valid = 1;
+        }
+    }
+
     return provctx;
 }
 
@@ -175,12 +424,132 @@ static const OSSL_ALGORITHM dummy_rand[] = {
     { NULL, NULL, NULL }
 };
 
+static OSSL_DISPATCH *dummy_dynamic_dispatch(const OSSL_DISPATCH *fns)
+{
+    const OSSL_DISPATCH *p;
+    size_t n;
+
+    for (p = fns; p->function_id != 0; p++)
+        continue;
+
+    n = (size_t)(p - fns) + 1;
+    return OPENSSL_memdup(fns, n * sizeof(*fns));
+}
+
+static OSSL_ALGORITHM *dummy_dynamic_algorithm(const char *names,
+    const char *props, const OSSL_DISPATCH *fns, const char *description)
+{
+    OSSL_ALGORITHM *algs = OPENSSL_zalloc(2 * sizeof(*algs));
+
+    if (algs == NULL)
+        return NULL;
+
+    algs[0].algorithm_names = OPENSSL_strdup(names);
+    algs[0].property_definition = OPENSSL_strdup(props);
+    algs[0].implementation = dummy_dynamic_dispatch(fns);
+    algs[0].algorithm_description = OPENSSL_strdup(description);
+
+    if (algs[0].algorithm_names == NULL
+        || algs[0].property_definition == NULL
+        || algs[0].implementation == NULL
+        || algs[0].algorithm_description == NULL) {
+        OPENSSL_free((char *)algs[0].algorithm_names);
+        OPENSSL_free((char *)algs[0].property_definition);
+        OPENSSL_free((OSSL_DISPATCH *)algs[0].implementation);
+        OPENSSL_free((char *)algs[0].algorithm_description);
+        OPENSSL_free(algs);
+        return NULL;
+    }
+
+    return algs;
+}
+
+static void dummy_free_dynamic_algorithm(const OSSL_ALGORITHM *algs)
+{
+    OSSL_ALGORITHM *a = (OSSL_ALGORITHM *)algs;
+
+    if (a == NULL)
+        return;
+
+    OPENSSL_free((char *)a[0].algorithm_names);
+    OPENSSL_free((char *)a[0].property_definition);
+    OPENSSL_free((OSSL_DISPATCH *)a[0].implementation);
+    OPENSSL_free((char *)a[0].algorithm_description);
+    OPENSSL_free(a);
+}
+
 static const OSSL_ALGORITHM *dummy_query(void *provctx, int operation_id,
     int *no_cache)
 {
     *no_cache = 0;
+    if (use_dynamic_no_cache) {
+        switch (operation_id) {
+        case OSSL_OP_DIGEST:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_digest_functions, "dynamic dummy digest");
+        case OSSL_OP_CIPHER:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_cipher_functions, "dynamic dummy cipher");
+        case OSSL_OP_MAC:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_mac_functions, "dynamic dummy mac");
+        case OSSL_OP_KDF:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_kdf_functions, "dynamic dummy kdf");
+        case OSSL_OP_DECODER:
+            *no_cache = 1;
+            decoder_query_count++;
+            return dummy_dynamic_algorithm("DUMMY:PEM",
+                reverse_decoder_properties ? "input=pem,provider=dummy"
+                                           : "provider=dummy,input=pem",
+                dummy_decoder_functions, "dynamic dummy decoder");
+        case OSSL_OP_ENCODER:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY",
+                "provider=dummy,output=pem", dummy_encoder_functions,
+                "dynamic dummy encoder");
+        case OSSL_OP_STORE:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_store_functions, "dynamic dummy store");
+        case OSSL_OP_RAND:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_rand_functions, "dynamic dummy rand");
+        case OSSL_OP_KEYMGMT:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_keymgmt_functions, "dynamic dummy keymgmt");
+        case OSSL_OP_KEYEXCH:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_keyexch_functions, "dynamic dummy keyexch");
+        case OSSL_OP_SIGNATURE:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_signature_functions, "dynamic dummy signature");
+        case OSSL_OP_ASYM_CIPHER:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_asym_cipher_functions, "dynamic dummy asym cipher");
+        case OSSL_OP_KEM:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_kem_functions, "dynamic dummy kem");
+        case OSSL_OP_SKEYMGMT:
+            *no_cache = 1;
+            return dummy_dynamic_algorithm("DUMMY", "provider=dummy",
+                dummy_skeymgmt_functions, "dynamic dummy skeymgmt");
+        }
+    }
+
     switch (operation_id) {
     case OSSL_OP_DECODER:
+        decoder_query_count++;
         return dummy_decoders;
     case OSSL_OP_ENCODER:
         return dummy_encoders;
@@ -192,8 +561,42 @@ static const OSSL_ALGORITHM *dummy_query(void *provctx, int operation_id,
     return NULL;
 }
 
+static void dummy_unquery(void *provctx, int operation_id,
+    const OSSL_ALGORITHM *algs)
+{
+    if (!use_dynamic_no_cache || algs == NULL)
+        return;
+
+    if (operation_id < 0 || operation_id > OSSL_OP__HIGHEST)
+        return;
+
+    released_description[operation_id]
+        = (uintptr_t)algs[0].algorithm_description;
+    released_algorithm_count[operation_id]++;
+
+    switch (operation_id) {
+    case OSSL_OP_DECODER:
+        released_decoder_propdef = (uintptr_t)algs[0].property_definition;
+        break;
+    case OSSL_OP_ENCODER:
+        released_encoder_propdef = (uintptr_t)algs[0].property_definition;
+        break;
+    case OSSL_OP_STORE:
+        released_store_propdef = (uintptr_t)algs[0].property_definition;
+        break;
+    case OSSL_OP_RAND:
+        released_rand_dispatch = (uintptr_t)algs[0].implementation;
+        break;
+    default:
+        break;
+    }
+
+    dummy_free_dynamic_algorithm(algs);
+}
+
 static const OSSL_DISPATCH dummy_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))dummy_query },
+    { OSSL_FUNC_PROVIDER_UNQUERY_OPERATION, (void (*)(void))dummy_unquery },
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
     OSSL_DISPATCH_END
 };
@@ -289,9 +692,327 @@ err:
     return testresult;
 }
 
+static int fetch_dynamic_no_cache_test(int tst)
+{
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    OSSL_PROVIDER *dummyprov = NULL;
+    OSSL_PROVIDER *defaultprov = NULL;
+    OSSL_DECODER *decoder = NULL;
+    OSSL_ENCODER *encoder = NULL;
+    OSSL_STORE_LOADER *loader = NULL;
+    EVP_RAND *rand = NULL;
+    EVP_RAND_CTX *parent_rand_ctx = NULL;
+    EVP_RAND_CTX *rand_ctx = NULL;
+    const char *props = NULL;
+    const char *description = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(libctx))
+        goto err;
+
+    use_dynamic_no_cache = 1;
+    reverse_decoder_properties = 0;
+    decoder_query_count = 0;
+    released_decoder_propdef = 0;
+    released_encoder_propdef = 0;
+    released_store_propdef = 0;
+    released_rand_dispatch = 0;
+    memset(released_description, 0, sizeof(released_description));
+    memset(released_algorithm_count, 0, sizeof(released_algorithm_count));
+    rand_parent_dispatch = 0;
+    rand_parent_dispatch_count = 0;
+    rand_parent_dispatch_valid = 0;
+
+    if (!TEST_true(OSSL_PROVIDER_add_builtin(libctx, "dummy-prov",
+            dummy_provider_init))
+        || !TEST_ptr(defaultprov = OSSL_PROVIDER_load(libctx, "default"))
+        || !TEST_ptr(dummyprov = OSSL_PROVIDER_load(libctx, "dummy-prov")))
+        goto err;
+
+    switch (tst) {
+    case 0:
+        if (!TEST_ptr(decoder = OSSL_DECODER_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        props = OSSL_DECODER_get0_properties(decoder);
+        description = OSSL_DECODER_get0_description(decoder);
+        if (!TEST_int_gt(released_algorithm_count[OSSL_OP_DECODER], 0)
+            || !TEST_uint64_t_ne((uint64_t)(uintptr_t)props,
+                (uint64_t)released_decoder_propdef)
+            || !TEST_uint64_t_ne((uint64_t)(uintptr_t)description,
+                (uint64_t)released_description[OSSL_OP_DECODER])
+            || !TEST_str_eq(props, "provider=dummy,input=pem")
+            || !TEST_str_eq(description, "dynamic dummy decoder"))
+            goto err;
+        break;
+    case 1:
+        if (!TEST_ptr(encoder = OSSL_ENCODER_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        props = OSSL_ENCODER_get0_properties(encoder);
+        description = OSSL_ENCODER_get0_description(encoder);
+        if (!TEST_int_gt(released_algorithm_count[OSSL_OP_ENCODER], 0)
+            || !TEST_uint64_t_ne((uint64_t)(uintptr_t)props,
+                (uint64_t)released_encoder_propdef)
+            || !TEST_uint64_t_ne((uint64_t)(uintptr_t)description,
+                (uint64_t)released_description[OSSL_OP_ENCODER])
+            || !TEST_str_eq(props, "provider=dummy,output=pem")
+            || !TEST_str_eq(description, "dynamic dummy encoder"))
+            goto err;
+        break;
+    case 2:
+        if (!TEST_ptr(loader = OSSL_STORE_LOADER_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        props = OSSL_STORE_LOADER_get0_properties(loader);
+        description = OSSL_STORE_LOADER_get0_description(loader);
+        if (!TEST_int_gt(released_algorithm_count[OSSL_OP_STORE], 0)
+            || !TEST_uint64_t_ne((uint64_t)(uintptr_t)props,
+                (uint64_t)released_store_propdef)
+            || !TEST_uint64_t_ne((uint64_t)(uintptr_t)description,
+                (uint64_t)released_description[OSSL_OP_STORE])
+            || !TEST_str_eq(props, "provider=dummy")
+            || !TEST_str_eq(description, "dynamic dummy store"))
+            goto err;
+        break;
+    case 3:
+        if (!TEST_ptr(rand = EVP_RAND_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        description = EVP_RAND_get0_description(rand);
+        if (!TEST_int_gt(released_algorithm_count[OSSL_OP_RAND], 0)
+            || !TEST_uint64_t_ne((uint64_t)(uintptr_t)description,
+                (uint64_t)released_description[OSSL_OP_RAND])
+            || !TEST_str_eq(description, "dynamic dummy rand")
+            || !TEST_ptr(parent_rand_ctx = EVP_RAND_CTX_new(rand, NULL))
+            || !TEST_ptr(rand_ctx = EVP_RAND_CTX_new(rand, parent_rand_ctx))
+            || !TEST_int_gt(rand_parent_dispatch_count, 0)
+            || !TEST_int_eq(rand_parent_dispatch_valid, 1)
+            || !TEST_uint64_t_ne((uint64_t)rand_parent_dispatch,
+                (uint64_t)released_rand_dispatch))
+            goto err;
+        break;
+    default:
+        goto err;
+    }
+
+    testresult = 1;
+err:
+    OSSL_DECODER_free(decoder);
+    OSSL_ENCODER_free(encoder);
+    OSSL_STORE_LOADER_free(loader);
+    EVP_RAND_CTX_free(rand_ctx);
+    EVP_RAND_CTX_free(parent_rand_ctx);
+    EVP_RAND_free(rand);
+    OSSL_PROVIDER_unload(dummyprov);
+    OSSL_PROVIDER_unload(defaultprov);
+    OSSL_LIB_CTX_free(libctx);
+    use_dynamic_no_cache = 0;
+    reverse_decoder_properties = 0;
+    return testresult;
+}
+
+static const struct {
+    int operation_id;
+    const char *description;
+} dynamic_evp_description_tests[] = {
+    { OSSL_OP_DIGEST, "dynamic dummy digest" },
+    { OSSL_OP_CIPHER, "dynamic dummy cipher" },
+    { OSSL_OP_MAC, "dynamic dummy mac" },
+    { OSSL_OP_KDF, "dynamic dummy kdf" },
+    { OSSL_OP_KEYMGMT, "dynamic dummy keymgmt" },
+    { OSSL_OP_SKEYMGMT, "dynamic dummy skeymgmt" },
+    { OSSL_OP_SIGNATURE, "dynamic dummy signature" },
+    { OSSL_OP_ASYM_CIPHER, "dynamic dummy asym cipher" },
+    { OSSL_OP_KEM, "dynamic dummy kem" },
+    { OSSL_OP_KEYEXCH, "dynamic dummy keyexch" }
+};
+
+static int fetch_dynamic_evp_description_test(int tst)
+{
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    OSSL_PROVIDER *dummyprov = NULL;
+    OSSL_PROVIDER *defaultprov = NULL;
+    EVP_MD *md = NULL;
+    EVP_CIPHER *cipher = NULL;
+    EVP_MAC *mac = NULL;
+    EVP_KDF *kdf = NULL;
+    EVP_KEYMGMT *keymgmt = NULL;
+    EVP_SKEYMGMT *skeymgmt = NULL;
+    EVP_SIGNATURE *signature = NULL;
+    EVP_ASYM_CIPHER *asym_cipher = NULL;
+    EVP_KEM *kem = NULL;
+    EVP_KEYEXCH *keyexch = NULL;
+    const char *description = NULL;
+    int operation_id = dynamic_evp_description_tests[tst].operation_id;
+    int testresult = 0;
+
+    if (!TEST_ptr(libctx))
+        goto err;
+
+    use_dynamic_no_cache = 1;
+    reverse_decoder_properties = 0;
+    decoder_query_count = 0;
+    memset(released_description, 0, sizeof(released_description));
+    memset(released_algorithm_count, 0, sizeof(released_algorithm_count));
+
+    if (!TEST_true(OSSL_PROVIDER_add_builtin(libctx, "dummy-prov",
+            dummy_provider_init))
+        || !TEST_ptr(defaultprov = OSSL_PROVIDER_load(libctx, "default"))
+        || !TEST_ptr(dummyprov = OSSL_PROVIDER_load(libctx, "dummy-prov")))
+        goto err;
+
+    switch (operation_id) {
+    case OSSL_OP_DIGEST:
+        if (!TEST_ptr(md = EVP_MD_fetch(libctx, "DUMMY", "provider=dummy")))
+            goto err;
+        description = EVP_MD_get0_description(md);
+        break;
+    case OSSL_OP_CIPHER:
+        if (!TEST_ptr(cipher = EVP_CIPHER_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        description = EVP_CIPHER_get0_description(cipher);
+        break;
+    case OSSL_OP_MAC:
+        if (!TEST_ptr(mac = EVP_MAC_fetch(libctx, "DUMMY", "provider=dummy")))
+            goto err;
+        description = EVP_MAC_get0_description(mac);
+        break;
+    case OSSL_OP_KDF:
+        if (!TEST_ptr(kdf = EVP_KDF_fetch(libctx, "DUMMY", "provider=dummy")))
+            goto err;
+        description = EVP_KDF_get0_description(kdf);
+        break;
+    case OSSL_OP_KEYMGMT:
+        if (!TEST_ptr(keymgmt = EVP_KEYMGMT_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        description = EVP_KEYMGMT_get0_description(keymgmt);
+        break;
+    case OSSL_OP_SKEYMGMT:
+        if (!TEST_ptr(skeymgmt = EVP_SKEYMGMT_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        description = EVP_SKEYMGMT_get0_description(skeymgmt);
+        break;
+    case OSSL_OP_SIGNATURE:
+        if (!TEST_ptr(signature = EVP_SIGNATURE_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        description = EVP_SIGNATURE_get0_description(signature);
+        break;
+    case OSSL_OP_ASYM_CIPHER:
+        if (!TEST_ptr(asym_cipher = EVP_ASYM_CIPHER_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        description = EVP_ASYM_CIPHER_get0_description(asym_cipher);
+        break;
+    case OSSL_OP_KEM:
+        if (!TEST_ptr(kem = EVP_KEM_fetch(libctx, "DUMMY", "provider=dummy")))
+            goto err;
+        description = EVP_KEM_get0_description(kem);
+        break;
+    case OSSL_OP_KEYEXCH:
+        if (!TEST_ptr(keyexch = EVP_KEYEXCH_fetch(libctx, "DUMMY",
+                          "provider=dummy")))
+            goto err;
+        description = EVP_KEYEXCH_get0_description(keyexch);
+        break;
+    default:
+        goto err;
+    }
+
+    if (!TEST_int_gt(released_algorithm_count[operation_id], 0)
+        || !TEST_uint64_t_ne((uint64_t)(uintptr_t)description,
+            (uint64_t)released_description[operation_id])
+        || !TEST_str_eq(description,
+            dynamic_evp_description_tests[tst].description))
+        goto err;
+
+    testresult = 1;
+err:
+    EVP_MD_free(md);
+    EVP_CIPHER_free(cipher);
+    EVP_MAC_free(mac);
+    EVP_KDF_free(kdf);
+    EVP_KEYMGMT_free(keymgmt);
+    EVP_SKEYMGMT_free(skeymgmt);
+    EVP_SIGNATURE_free(signature);
+    EVP_ASYM_CIPHER_free(asym_cipher);
+    EVP_KEM_free(kem);
+    EVP_KEYEXCH_free(keyexch);
+    OSSL_PROVIDER_unload(dummyprov);
+    OSSL_PROVIDER_unload(defaultprov);
+    OSSL_LIB_CTX_free(libctx);
+    use_dynamic_no_cache = 0;
+    return testresult;
+}
+
+static int decoder_dynamic_no_cache_add_extra_test(void)
+{
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    OSSL_PROVIDER *dummyprov = NULL;
+    OSSL_PROVIDER *defaultprov = NULL;
+    OSSL_DECODER *decoder = NULL;
+    OSSL_DECODER_CTX *decoder_ctx = NULL;
+    int query_count;
+    int testresult = 0;
+
+    if (!TEST_ptr(libctx))
+        goto err;
+
+    use_dynamic_no_cache = 1;
+    reverse_decoder_properties = 0;
+    decoder_query_count = 0;
+    memset(released_description, 0, sizeof(released_description));
+    memset(released_algorithm_count, 0, sizeof(released_algorithm_count));
+
+    if (!TEST_true(OSSL_PROVIDER_add_builtin(libctx, "dummy-prov",
+            dummy_provider_init))
+        || !TEST_ptr(defaultprov = OSSL_PROVIDER_load(libctx, "default"))
+        || !TEST_ptr(dummyprov = OSSL_PROVIDER_load(libctx, "dummy-prov"))
+        || !TEST_ptr(decoder = OSSL_DECODER_fetch(libctx, "DUMMY",
+                         "provider=dummy"))
+        || !TEST_ptr(decoder_ctx = OSSL_DECODER_CTX_new())
+        || !TEST_true(OSSL_DECODER_CTX_add_decoder(decoder_ctx, decoder))
+        || !TEST_int_eq(OSSL_DECODER_CTX_get_num_decoders(decoder_ctx), 1))
+        goto err;
+
+    reverse_decoder_properties = 1;
+    if (!TEST_true(OSSL_DECODER_CTX_add_extra(decoder_ctx, libctx,
+            "provider=dummy"))
+        || !TEST_int_gt(decoder_query_count, 1)
+        || !TEST_int_eq(OSSL_DECODER_CTX_get_num_decoders(decoder_ctx), 1))
+        goto err;
+
+    query_count = decoder_query_count;
+    use_dynamic_no_cache = 0;
+    if (!TEST_true(OSSL_DECODER_CTX_add_extra(decoder_ctx, libctx,
+            "provider=dummy"))
+        || !TEST_int_gt(decoder_query_count, query_count)
+        || !TEST_int_eq(OSSL_DECODER_CTX_get_num_decoders(decoder_ctx), 1))
+        goto err;
+
+    testresult = 1;
+err:
+    OSSL_DECODER_CTX_free(decoder_ctx);
+    OSSL_DECODER_free(decoder);
+    OSSL_PROVIDER_unload(dummyprov);
+    OSSL_PROVIDER_unload(defaultprov);
+    OSSL_LIB_CTX_free(libctx);
+    use_dynamic_no_cache = 0;
+    reverse_decoder_properties = 0;
+    return testresult;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(fetch_test, 8);
+    ADD_ALL_TESTS(fetch_dynamic_no_cache_test, 4);
+    ADD_ALL_TESTS(fetch_dynamic_evp_description_test,
+        OSSL_NELEM(dynamic_evp_description_tests));
+    ADD_TEST(decoder_dynamic_no_cache_add_extra_test);
 
     return 1;
 }


### PR DESCRIPTION
Fixes #32008 

Provider query results returned with *no_store set to 1 are non-cacheable and expected to have a short lifetime. After constructing fetched methods, the core calls `provider_unquery_operation()`, but several method implementations retained pointers into the returned `OSSL_ALGORITHM` data.

If the provider releases that data during unquery, metadata getters can return pointers to freed strings, child RAND context construction can use a freed dispatch table, and decoder chaining can make incorrect duplicate-detection decisions using stale query-result identity.

This PR makes the no-store lifetime rule explicit and updates fetched method construction accordingly.

### Changes

- Copy property definitions and descriptions for no-store encoder, decoder, and STORE methods.
- Copy algorithm descriptions for no-store provider-backed EVP methods.
- Copy the complete no-store EVP_RAND dispatch table, including its terminating OSSL_DISPATCH_END entry.
- Do not retain an OSSL_ALGORITHM * as persistent identity for no-store decoders.
- When either decoder has no persistent algorithm definition, deduplicate using the provider, algorithm
  name-map identity, and semantically equivalent parsed properties.

- Preserve provider-owned metadata pointers and `OSSL_ALGORITHM` pointer identity for cacheable methods.
- Document the lifetime requirements for both cacheable and no-store query results.

### Tests

test/provfetchtest.c now includes a built-in provider that returns heap-allocated no-store algorithm arrays, strings, and dispatch tables, then releases all of them from `provider_unquery_operation()`.

The tests cover:

- encoder, decoder, and STORE property and description getters
- descriptions for all affected provider-backed EVP method types
- child EVP_RAND_CTX construction with a copied parent dispatch table
- decoder duplicate detection across repeated no-store queries
- equivalent decoder properties written in different orders
- transitions between no-store and cacheable decoder results

The test-provider fixture also gains the decoder context callbacks required by the decoder-chain test. Its encoder dispatch entry is corrected to use the encoder-specific symbolic identifier.

### Backport Note

This change targets master. The same retention patterns exist in the 3.x release lines, but those branches do not have the no_store constructor plumbing introduced by commit 8c8a80b00b. Stable-branch backports will therefore require adaptation rather than a direct cherry-pick.

Tested with:

```
make -j4 test/provfetchtest
LD_LIBRARY_PATH=. ./test/provfetchtest
HARNESS_JOBS=1 make test TESTS='test_provfetch test_evp_list_noncache test_encoder_decoder test_store test_rand'
```

Assisted-by: Codex:GPT-5.5
