### PR TITLE
ci: add on-demand + auto-on-approval PR CI, piloted on two workflows

### DIFF
--- a/.github/workflows/aarch64-more-cross-compiles.yml
+++ b/.github/workflows/aarch64-more-cross-compiles.yml
@@ -27,7 +27,7 @@ on:
         description: 'Check-run id to report into (set by the /ci controller)'
         required: false
         default: ''
-  # Auto-on-approval (openssl/project#2027): run when a committer approves.
+  # Run automatically when a committer approves the PR.
   pull_request_review:
     types: [submitted]
 
@@ -41,18 +41,9 @@ permissions:
   contents: read
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # PR CI gate (openssl/project#2027) — metadata only, NEVER checks out PR code.
-  # Decides whether the build jobs run and which commit they check out for the
-  # on-demand (/ci workflow_dispatch) and auto-on-approval (pull_request_review)
-  # paths, leaving schedule/push/pull_request/ordinary-dispatch behaviour
-  # unchanged. On a /ci dispatch it also records the routing metadata that
-  # ci-report.yml uses to complete the check-run.
-  #
-  # SECURITY: do not add `secrets:` or `permissions:` beyond `contents: read`
-  # here or to any build job this gates, and never check out PR code in this
-  # job. "Safe by discipline" — see openssl/project#2027 open item 3.
-  # ---------------------------------------------------------------------------
+  # Decides whether the build jobs run and which commit they build, and records
+  # routing metadata for a /ci dispatch. Metadata only: keep it at
+  # `contents: read` with no secrets, and never check out PR code here.
   authorize:
     runs-on: ubuntu-latest
     permissions:
@@ -118,9 +109,8 @@ jobs:
           path: ci-report-meta.json
           if-no-files-found: error
   cross-compilation-aarch64:
-    # Native opt-in preserved: PR runs when the title/body opts in; push runs on
-    # the '[aarch64 ci]' marker. schedule/manual/approval always run (subject to
-    # the authorize gate, openssl/project#2027).
+    # PR runs when the title/body opts in; push runs on the '[aarch64 ci]'
+    # marker; schedule/manual/approval always run, subject to the authorize gate.
     needs: authorize
     if: >-
       needs.authorize.outputs.run == 'true' &&
@@ -296,8 +286,8 @@ jobs:
                   TESTS="${{ matrix.platform.tests }} -test_afalg" \
                   QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}
     - name: make evp tests
-      # §4b: cross-compile-only runs (approval / manual dispatch) must still run
-      # the EVP tests, or a compile-only green would be misleading.
+      # Approval / manual-dispatch runs must still run the EVP tests, or a
+      # compile-only green would be misleading.
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'workflow_dispatch') && matrix.platform.tests != 'none'
       run: |
         .github/workflows/make-test \

--- a/.github/workflows/aarch64-more-cross-compiles.yml
+++ b/.github/workflows/aarch64-more-cross-compiles.yml
@@ -52,7 +52,7 @@ jobs:
       run: ${{ steps.gate.outputs.run }}
       ref: ${{ steps.gate.outputs.ref }}
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v9.0.0
         id: gate
         with:
           script: |
@@ -103,7 +103,7 @@ jobs:
             core.setOutput('meta', String(meta));
       - name: Upload routing metadata
         if: steps.gate.outputs.meta == 'true'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ci-report-meta
           path: ci-report-meta.json

--- a/.github/workflows/aarch64-more-cross-compiles.yml
+++ b/.github/workflows/aarch64-more-cross-compiles.yml
@@ -41,73 +41,8 @@ permissions:
   contents: read
 
 jobs:
-  # Decides whether the build jobs run and which commit they build, and records
-  # routing metadata for a /ci dispatch. Metadata only: keep it at
-  # `contents: read` with no secrets, and never check out PR code here.
   authorize:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      run: ${{ steps.gate.outputs.run }}
-      ref: ${{ steps.gate.outputs.ref }}
-    steps:
-      - uses: actions/github-script@v9.0.0
-        id: gate
-        with:
-          script: |
-            const fs = require('fs');
-            const eventName = context.eventName;
-            const repoOk = `${context.repo.owner}/${context.repo.repo}` === 'openssl/openssl';
-            let run = false, ref = '', pr = '', headSha = '', checkRunId = '', meta = false;
-            const isCommitter = async (login) => {
-              if (!login) return false;
-              const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
-                { owner: context.repo.owner, repo: context.repo.repo, username: login });
-              return data.permission === 'write' || data.permission === 'admin';
-            };
-            if (eventName === 'schedule') {
-              run = repoOk;
-            } else if (eventName === 'push' || eventName === 'pull_request') {
-              run = true;
-            } else if (eventName === 'workflow_dispatch') {
-              const i = context.payload.inputs || {};
-              if (!i.pr) {
-                run = true;                       // ordinary manual dispatch
-              } else {                            // /ci on-demand dispatch
-                if (!/^\d+$/.test(i.pr) || !/^[0-9a-f]{40}$/.test(i.head_sha)
-                    || !/^\d+$/.test(i.check_run_id)) {
-                  core.setFailed('Invalid /ci dispatch inputs'); return;
-                }
-                run = repoOk; ref = i.head_sha; pr = i.pr; headSha = i.head_sha;
-                checkRunId = i.check_run_id; meta = run;
-              }
-            } else if (eventName === 'pull_request_review') {
-              const rv = context.payload.review, prObj = context.payload.pull_request;
-              const base = prObj.base.ref;
-              // Only base branches whose protection dismisses stale approvals.
-              const baseOk = base === 'master' || base.startsWith('feature/')
-                || base.startsWith('openssl-');
-              if (repoOk && rv.state === 'approved' && baseOk
-                  && rv.commit_id === prObj.head.sha && await isCommitter(rv.user.login)) {
-                run = true; ref = rv.commit_id; headSha = rv.commit_id;
-                pr = String(prObj.number);
-              }
-            }
-            if (meta) {
-              fs.writeFileSync('ci-report-meta.json',
-                JSON.stringify({ pr, head_sha: headSha, check_run_id: checkRunId }));
-            }
-            core.setOutput('run', String(run));
-            core.setOutput('ref', ref);
-            core.setOutput('meta', String(meta));
-      - name: Upload routing metadata
-        if: steps.gate.outputs.meta == 'true'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: ci-report-meta
-          path: ci-report-meta.json
-          if-no-files-found: error
+    uses: ./.github/workflows/ci-authorize.yml
   cross-compilation-aarch64:
     # PR runs when the title/body opts in; push runs on the '[aarch64 ci]'
     # marker; schedule/manual/approval always run, subject to the authorize gate.

--- a/.github/workflows/aarch64-more-cross-compiles.yml
+++ b/.github/workflows/aarch64-more-cross-compiles.yml
@@ -14,19 +14,126 @@ on:
   schedule:
     - cron: '05 03 * * *'
   workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number (set by the /ci controller; empty for an ordinary manual run)'
+        required: false
+        default: ''
+      head_sha:
+        description: 'PR head SHA to build, 40-hex (set by the /ci controller)'
+        required: false
+        default: ''
+      check_run_id:
+        description: 'Check-run id to report into (set by the /ci controller)'
+        required: false
+        default: ''
+  # Auto-on-approval (openssl/project#2027): run when a committer approves.
+  pull_request_review:
+    types: [submitted]
+
+run-name: "${{ (github.event_name == 'workflow_dispatch' && inputs.pr != '') && format('{0} · /ci PR #{1} · {2} · check:{3}', github.workflow, inputs.pr, inputs.head_sha, inputs.check_run_id) || github.workflow }}"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.inputs.pr || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 permissions:
   contents: read
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # PR CI gate (openssl/project#2027) — metadata only, NEVER checks out PR code.
+  # Decides whether the build jobs run and which commit they check out for the
+  # on-demand (/ci workflow_dispatch) and auto-on-approval (pull_request_review)
+  # paths, leaving schedule/push/pull_request/ordinary-dispatch behaviour
+  # unchanged. On a /ci dispatch it also records the routing metadata that
+  # ci-report.yml uses to complete the check-run.
+  #
+  # SECURITY: do not add `secrets:` or `permissions:` beyond `contents: read`
+  # here or to any build job this gates, and never check out PR code in this
+  # job. "Safe by discipline" — see openssl/project#2027 open item 3.
+  # ---------------------------------------------------------------------------
+  authorize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+      ref: ${{ steps.gate.outputs.ref }}
+    steps:
+      - uses: actions/github-script@v8
+        id: gate
+        with:
+          script: |
+            const fs = require('fs');
+            const eventName = context.eventName;
+            const repoOk = `${context.repo.owner}/${context.repo.repo}` === 'openssl/openssl';
+            let run = false, ref = '', pr = '', headSha = '', checkRunId = '', meta = false;
+            const isCommitter = async (login) => {
+              if (!login) return false;
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
+                { owner: context.repo.owner, repo: context.repo.repo, username: login });
+              return data.permission === 'write' || data.permission === 'admin';
+            };
+            if (eventName === 'schedule') {
+              run = repoOk;
+            } else if (eventName === 'push' || eventName === 'pull_request') {
+              run = true;
+            } else if (eventName === 'workflow_dispatch') {
+              const i = context.payload.inputs || {};
+              if (!i.pr) {
+                run = true;                       // ordinary manual dispatch
+              } else {                            // /ci on-demand dispatch
+                if (!/^\d+$/.test(i.pr) || !/^[0-9a-f]{40}$/.test(i.head_sha)
+                    || !/^\d+$/.test(i.check_run_id)) {
+                  core.setFailed('Invalid /ci dispatch inputs'); return;
+                }
+                run = repoOk; ref = i.head_sha; pr = i.pr; headSha = i.head_sha;
+                checkRunId = i.check_run_id; meta = run;
+              }
+            } else if (eventName === 'pull_request_review') {
+              const rv = context.payload.review, prObj = context.payload.pull_request;
+              const base = prObj.base.ref;
+              // Only base branches whose protection dismisses stale approvals.
+              const baseOk = base === 'master' || base.startsWith('feature/')
+                || base.startsWith('openssl-');
+              if (repoOk && rv.state === 'approved' && baseOk
+                  && rv.commit_id === prObj.head.sha && await isCommitter(rv.user.login)) {
+                run = true; ref = rv.commit_id; headSha = rv.commit_id;
+                pr = String(prObj.number);
+              }
+            }
+            if (meta) {
+              fs.writeFileSync('ci-report-meta.json',
+                JSON.stringify({ pr, head_sha: headSha, check_run_id: checkRunId }));
+            }
+            core.setOutput('run', String(run));
+            core.setOutput('ref', ref);
+            core.setOutput('meta', String(meta));
+      - name: Upload routing metadata
+        if: steps.gate.outputs.meta == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-report-meta
+          path: ci-report-meta.json
+          if-no-files-found: error
   cross-compilation-aarch64:
-    # pull request title contains 'aarch64'
-    # pull request title contains 'arm64'
-    # pull request body contains '[aarch64 ci]'
-    # push event commit message contains '[aarch64 ci]'
-    # cron job
-    # manual dispatch
-    if: contains(github.event.pull_request.title, 'aarch64') || contains(github.event.pull_request.title, 'AArch64') || contains(github.event.pull_request.title, 'arm64') || contains(github.event.pull_request.body, '[aarch64 ci]') || contains(github.event.head_commit.message, '[aarch64 ci]') || (github.event_name == 'schedule' && github.repository == 'openssl/openssl') || github.event_name == 'workflow_dispatch'
+    # Native opt-in preserved: PR runs when the title/body opts in; push runs on
+    # the '[aarch64 ci]' marker. schedule/manual/approval always run (subject to
+    # the authorize gate, openssl/project#2027).
+    needs: authorize
+    if: >-
+      needs.authorize.outputs.run == 'true' &&
+      ( ( github.event_name == 'pull_request' &&
+          ( contains(github.event.pull_request.title, 'aarch64')
+            || contains(github.event.pull_request.title, 'AArch64')
+            || contains(github.event.pull_request.title, 'arm64')
+            || contains(github.event.pull_request.body, '[aarch64 ci]') ) )
+        || ( github.event_name == 'push' &&
+             contains(github.event.head_commit.message, '[aarch64 ci]') )
+        || github.event_name == 'schedule'
+        || github.event_name == 'workflow_dispatch'
+        || github.event_name == 'pull_request_review' )
     strategy:
       fail-fast: false
       matrix:
@@ -133,6 +240,7 @@ jobs:
             ${{ matrix.platform.libs }}
     - uses: actions/checkout@v6
       with:
+        ref: ${{ needs.authorize.outputs.ref }}
         persist-credentials: false
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
@@ -188,7 +296,9 @@ jobs:
                   TESTS="${{ matrix.platform.tests }} -test_afalg" \
                   QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}
     - name: make evp tests
-      if: github.event_name == 'pull_request' && matrix.platform.tests != 'none'
+      # §4b: cross-compile-only runs (approval / manual dispatch) must still run
+      # the EVP tests, or a compile-only green would be misleading.
+      if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'workflow_dispatch') && matrix.platform.tests != 'none'
       run: |
         .github/workflows/make-test \
                   TESTS="test_evp*" \

--- a/.github/workflows/aarch64-more-cross-compiles.yml
+++ b/.github/workflows/aarch64-more-cross-compiles.yml
@@ -9,7 +9,8 @@ name: Cross Compile for AArch64 Extensions
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    # 'labeled' carries the auto-on-approval trigger (see the job guard).
+    types: [opened, reopened, edited, synchronize, labeled]
   push:
   schedule:
     - cron: '05 03 * * *'
@@ -27,9 +28,6 @@ on:
         description: 'Check-run id to report into (set by the /ci controller)'
         required: false
         default: ''
-  # Run automatically when a committer approves the PR.
-  pull_request_review:
-    types: [submitted]
 
 run-name: "${{ (github.event_name == 'workflow_dispatch' && inputs.pr != '') && format('{0} · /ci PR #{1} · {2} · check:{3}', github.workflow, inputs.pr, inputs.head_sha, inputs.check_run_id) || github.workflow }}"
 
@@ -44,12 +42,14 @@ jobs:
   authorize:
     uses: ./.github/workflows/ci-authorize.yml
   cross-compilation-aarch64:
-    # PR runs when the title/body opts in; push runs on the '[aarch64 ci]'
-    # marker; schedule/manual/approval always run, subject to the authorize gate.
+    # Ordinary PR runs on title/body opt-in; the 'approval: done' label auto-runs
+    # regardless; push on the '[aarch64 ci]' marker; schedule/manual always run.
     needs: authorize
     if: >-
       needs.authorize.outputs.run == 'true' &&
-      ( ( github.event_name == 'pull_request' &&
+      ( ( github.event_name == 'pull_request' && github.event.action == 'labeled'
+          && github.event.label.name == 'approval: done' )
+        || ( github.event_name == 'pull_request' && github.event.action != 'labeled' &&
           ( contains(github.event.pull_request.title, 'aarch64')
             || contains(github.event.pull_request.title, 'AArch64')
             || contains(github.event.pull_request.title, 'arm64')
@@ -57,8 +57,7 @@ jobs:
         || ( github.event_name == 'push' &&
              contains(github.event.head_commit.message, '[aarch64 ci]') )
         || github.event_name == 'schedule'
-        || github.event_name == 'workflow_dispatch'
-        || github.event_name == 'pull_request_review' )
+        || github.event_name == 'workflow_dispatch' )
     strategy:
       fail-fast: false
       matrix:
@@ -221,9 +220,8 @@ jobs:
                   TESTS="${{ matrix.platform.tests }} -test_afalg" \
                   QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}
     - name: make evp tests
-      # Approval / manual-dispatch runs must still run the EVP tests, or a
-      # compile-only green would be misleading.
-      if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'workflow_dispatch') && matrix.platform.tests != 'none'
+      # PR and /ci dispatch runs must run EVP tests, else a compile-only green misleads.
+      if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && matrix.platform.tests != 'none'
       run: |
         .github/workflows/make-test \
                   TESTS="test_evp*" \

--- a/.github/workflows/ci-authorize.yml
+++ b/.github/workflows/ci-authorize.yml
@@ -39,16 +39,25 @@ jobs:
             const eventName = context.eventName;
             const repoOk = `${context.repo.owner}/${context.repo.repo}` === 'openssl/openssl';
             let run = false, ref = '', pr = '', headSha = '', checkRunId = '', meta = false;
-            const isCommitter = async (login) => {
-              if (!login) return false;
-              const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
-                { owner: context.repo.owner, repo: context.repo.repo, username: login });
-              return data.permission === 'write' || data.permission === 'admin';
-            };
             if (eventName === 'schedule') {
               run = repoOk;
-            } else if (eventName === 'push' || eventName === 'pull_request') {
+            } else if (eventName === 'push') {
               run = true;
+            } else if (eventName === 'pull_request') {
+              if (context.payload.action === 'labeled') {
+                // Auto-run on the 2-approval 'approval: done' label; scope to
+                // base branches whose protection dismisses stale approvals.
+                const prObj = context.payload.pull_request;
+                const label = context.payload.label && context.payload.label.name;
+                const base = prObj.base.ref;
+                const baseOk = base === 'master' || base.startsWith('feature/')
+                  || base.startsWith('openssl-');
+                if (repoOk && label === 'approval: done' && baseOk) {
+                  run = true; ref = prObj.head.sha;
+                }
+              } else {
+                run = true;
+              }
             } else if (eventName === 'workflow_dispatch') {
               const i = context.payload.inputs || {};
               if (!i.pr) {
@@ -60,17 +69,6 @@ jobs:
                 }
                 run = repoOk; ref = i.head_sha; pr = i.pr; headSha = i.head_sha;
                 checkRunId = i.check_run_id; meta = run;
-              }
-            } else if (eventName === 'pull_request_review') {
-              const rv = context.payload.review, prObj = context.payload.pull_request;
-              const base = prObj.base.ref;
-              // Only base branches whose protection dismisses stale approvals.
-              const baseOk = base === 'master' || base.startsWith('feature/')
-                || base.startsWith('openssl-');
-              if (repoOk && rv.state === 'approved' && baseOk
-                  && rv.commit_id === prObj.head.sha && await isCommitter(rv.user.login)) {
-                run = true; ref = rv.commit_id; headSha = rv.commit_id;
-                pr = String(prObj.number);
               }
             }
             if (meta) {

--- a/.github/workflows/ci-authorize.yml
+++ b/.github/workflows/ci-authorize.yml
@@ -1,0 +1,89 @@
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: CI authorize
+# Shared gate deciding whether a caller's build jobs run and which commit they
+# build. Metadata only: contents: read, no secrets, never checks out PR code.
+
+on:
+  workflow_call:
+    outputs:
+      run:
+        description: 'Whether the caller build jobs should run'
+        value: ${{ jobs.authorize.outputs.run }}
+      ref:
+        description: 'The commit the caller build jobs should check out'
+        value: ${{ jobs.authorize.outputs.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+      ref: ${{ steps.gate.outputs.ref }}
+    steps:
+      - uses: actions/github-script@v9.0.0
+        id: gate
+        with:
+          script: |
+            const fs = require('fs');
+            const eventName = context.eventName;
+            const repoOk = `${context.repo.owner}/${context.repo.repo}` === 'openssl/openssl';
+            let run = false, ref = '', pr = '', headSha = '', checkRunId = '', meta = false;
+            const isCommitter = async (login) => {
+              if (!login) return false;
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
+                { owner: context.repo.owner, repo: context.repo.repo, username: login });
+              return data.permission === 'write' || data.permission === 'admin';
+            };
+            if (eventName === 'schedule') {
+              run = repoOk;
+            } else if (eventName === 'push' || eventName === 'pull_request') {
+              run = true;
+            } else if (eventName === 'workflow_dispatch') {
+              const i = context.payload.inputs || {};
+              if (!i.pr) {
+                run = true;                       // ordinary manual dispatch
+              } else {                            // /ci on-demand dispatch
+                if (!/^\d+$/.test(i.pr) || !/^[0-9a-f]{40}$/.test(i.head_sha)
+                    || !/^\d+$/.test(i.check_run_id)) {
+                  core.setFailed('Invalid /ci dispatch inputs'); return;
+                }
+                run = repoOk; ref = i.head_sha; pr = i.pr; headSha = i.head_sha;
+                checkRunId = i.check_run_id; meta = run;
+              }
+            } else if (eventName === 'pull_request_review') {
+              const rv = context.payload.review, prObj = context.payload.pull_request;
+              const base = prObj.base.ref;
+              // Only base branches whose protection dismisses stale approvals.
+              const baseOk = base === 'master' || base.startsWith('feature/')
+                || base.startsWith('openssl-');
+              if (repoOk && rv.state === 'approved' && baseOk
+                  && rv.commit_id === prObj.head.sha && await isCommitter(rv.user.login)) {
+                run = true; ref = rv.commit_id; headSha = rv.commit_id;
+                pr = String(prObj.number);
+              }
+            }
+            if (meta) {
+              fs.writeFileSync('ci-report-meta.json',
+                JSON.stringify({ pr, head_sha: headSha, check_run_id: checkRunId }));
+            }
+            core.setOutput('run', String(run));
+            core.setOutput('ref', ref);
+            core.setOutput('meta', String(meta));
+      - name: Upload routing metadata
+        if: steps.gate.outputs.meta == 'true'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: ci-report-meta
+          path: ci-report-meta.json
+          if-no-files-found: error

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -27,7 +27,7 @@ jobs:
       startsWith(github.event.comment.body, '/ci')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v9.0.0
         with:
           script: |
             const crypto = require('crypto');

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -6,19 +6,8 @@
 # https://www.openssl.org/source/license.html
 
 name: CI command
-# On-demand PR CI controller (openssl/project#2027).
-#
-# A committer comments `/ci <jobs>` on a pull request to run selected
-# time-consuming / non-PR workflows against that PR's code. This controller:
-#   * refuses non-committers (repository write/admin only);
-#   * pins the PR head SHA at command time (immutable, never refs/pull/N/head);
-#   * creates a pending check-run per requested workflow on that SHA; and
-#   * dispatches each workflow with the pinned {pr, head_sha, check_run_id}.
-# Results are completed by the companion `ci-report.yml` on workflow_run.
-#
-# This is a privileged, default-branch event: it NEVER checks out PR code and
-# the comment body is never interpolated into a shell `run:` — it is parsed in
-# github-script and passed through the API only.
+# A committer comments `/ci <jobs>` on a PR to run selected workflows against
+# its code. Results are completed by ci-report.yml. Never checks out PR code.
 
 on:
   issue_comment:
@@ -32,7 +21,6 @@ permissions:
 
 jobs:
   dispatch:
-    # Only PR comments starting with `/ci`.
     if: >-
       github.repository == 'openssl/openssl' &&
       github.event.issue.pull_request &&
@@ -45,15 +33,12 @@ jobs:
             const crypto = require('crypto');
             const { owner, repo } = context.repo;
 
-            // Eligible on-demand workflows: friendly name -> {file, cost (compute-min)}.
-            // Gradual rollout (openssl/project#2027): pilot with a small subset;
-            // add the remaining wired workflows here (and to ci-report.yml's
-            // `workflows:` list, plus re-wire their triggers) as they graduate.
+            // Friendly name -> { workflow file, approx compute-minutes }.
             const WORKFLOWS = {
               'ct-validation':     { file: 'ct-validation-daily.yml',         cost: 12 },
               'aarch64':           { file: 'aarch64-more-cross-compiles.yml', cost: 20 },
             };
-            const NONCE_TTL_MS = 60 * 60 * 1000; // /ci all confirmation window
+            const NONCE_TTL_MS = 60 * 60 * 1000;
 
             const prNum = context.payload.issue.number;
             const comment = context.payload.comment;
@@ -63,7 +48,6 @@ jobs:
             const jobList = () => Object.entries(WORKFLOWS)
               .map(([k, v]) => `- \`${k}\` (~${v.cost} min)`).join('\n');
 
-            // --- Committer gate (repository write/admin) -----------------------
             let level = 'none';
             try {
               const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
@@ -76,9 +60,7 @@ jobs:
               return;
             }
 
-            // --- Parse `/ci <args>` --------------------------------------------
-            // Take the first line only; require the command to be exactly `/ci`
-            // (so `/cite`, `/ci-foo`, … are ignored rather than acted on).
+            // Match `/ci` exactly on the first line, so `/cite` etc. are ignored.
             const line = comment.body.split(/\r?\n/, 1)[0].trim();
             const tokens = line.split(/\s+/);
             if (tokens[0] !== '/ci') return;
@@ -90,7 +72,7 @@ jobs:
               return;
             }
 
-            // --- Pin the PR head SHA at command time ---------------------------
+            // Pin the head SHA now; the run always builds this immutable commit.
             let head_sha;
             try {
               const { data: prData } = await github.rest.pulls.get(
@@ -102,7 +84,7 @@ jobs:
               return;
             }
 
-            // --- `/ci all` cost guard (nonce two-step) -------------------------
+            // `/ci all` is costly, so require a nonce round-trip to confirm.
             const marker = (n) => `ci-all-confirm nonce=${n}`;
             let selected;
             if (args[0] === 'all') {
@@ -117,16 +99,14 @@ jobs:
                   + `<!-- ${marker(nonce)} pr=${prNum} sha=${head_sha} by=${commenter} exp=${exp} -->`);
                 return;
               }
-              // Validate the confirmation nonce against a prior bot warning.
               const nonce = args[2] || '';
               if (!/^[0-9a-f]{16}$/.test(nonce)) {
                 await reply(`@${commenter}: \`/ci all confirm\` needs the nonce from the `
                   + `warning above, e.g. \`/ci all confirm <nonce>\`.`);
                 return;
               }
-              // "List issue comments" is oldest-first; paginate so a warning on
-              // a long PR thread is not missed, then search newest-first. The
-              // trailing space pins the exact nonce (avoids prefix matches).
+              // Paginate (listComments is oldest-first) and match the exact nonce
+              // via its trailing space to avoid prefix matches.
               const comments = await github.paginate(
                 github.rest.issues.listComments,
                 { owner, repo, issue_number: prNum, per_page: 100 });
@@ -153,7 +133,6 @@ jobs:
               selected = [...new Set(args)];
             }
 
-            // --- Create a check per job and dispatch on the pinned SHA ---------
             const dispatched = [];
             for (const key of selected) {
               const { file } = WORKFLOWS[key];
@@ -169,8 +148,6 @@ jobs:
                 },
               });
               try {
-                // return_run_details (GitHub, 2026-02-19) surfaces the run id/url
-                // synchronously so the check can link straight to the run.
                 const res = await github.rest.actions.createWorkflowDispatch({
                   owner, repo, workflow_id: file, ref: 'master',
                   inputs: { pr: String(prNum), head_sha, check_run_id: String(cr.id) },

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -1,0 +1,196 @@
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: CI command
+# On-demand PR CI controller (openssl/project#2027).
+#
+# A committer comments `/ci <jobs>` on a pull request to run selected
+# time-consuming / non-PR workflows against that PR's code. This controller:
+#   * refuses non-committers (repository write/admin only);
+#   * pins the PR head SHA at command time (immutable, never refs/pull/N/head);
+#   * creates a pending check-run per requested workflow on that SHA; and
+#   * dispatches each workflow with the pinned {pr, head_sha, check_run_id}.
+# Results are completed by the companion `ci-report.yml` on workflow_run.
+#
+# This is a privileged, default-branch event: it NEVER checks out PR code and
+# the comment body is never interpolated into a shell `run:` — it is parsed in
+# github-script and passed through the API only.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  checks: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  dispatch:
+    # Only PR comments starting with `/ci`.
+    if: >-
+      github.repository == 'openssl/openssl' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/ci')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const crypto = require('crypto');
+            const { owner, repo } = context.repo;
+
+            // Eligible on-demand workflows: friendly name -> {file, cost (compute-min)}.
+            // Gradual rollout (openssl/project#2027): pilot with a small subset;
+            // add the remaining wired workflows here (and to ci-report.yml's
+            // `workflows:` list, plus re-wire their triggers) as they graduate.
+            const WORKFLOWS = {
+              'ct-validation':     { file: 'ct-validation-daily.yml',         cost: 12 },
+              'aarch64':           { file: 'aarch64-more-cross-compiles.yml', cost: 20 },
+            };
+            const NONCE_TTL_MS = 60 * 60 * 1000; // /ci all confirmation window
+
+            const prNum = context.payload.issue.number;
+            const comment = context.payload.comment;
+            const commenter = comment.user.login;
+            const reply = (body) => github.rest.issues.createComment(
+              { owner, repo, issue_number: prNum, body });
+            const jobList = () => Object.entries(WORKFLOWS)
+              .map(([k, v]) => `- \`${k}\` (~${v.cost} min)`).join('\n');
+
+            // --- Committer gate (repository write/admin) -----------------------
+            let level = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
+                { owner, repo, username: commenter });
+              level = data.permission;
+            } catch (e) { level = 'none'; }
+            if (level !== 'write' && level !== 'admin') {
+              await reply(`@${commenter}: \`/ci\` is restricted to OpenSSL committers `
+                + `(repository write access). No workflows were dispatched.`);
+              return;
+            }
+
+            // --- Parse `/ci <args>` --------------------------------------------
+            // Take the first line only; require the command to be exactly `/ci`
+            // (so `/cite`, `/ci-foo`, … are ignored rather than acted on).
+            const line = comment.body.split(/\r?\n/, 1)[0].trim();
+            const tokens = line.split(/\s+/);
+            if (tokens[0] !== '/ci') return;
+            const args = tokens.slice(1);
+
+            if (args.length === 0) {
+              await reply(`@${commenter}: usage \`/ci <job…>\` or \`/ci all\`. `
+                + `Valid jobs:\n${jobList()}`);
+              return;
+            }
+
+            // --- Pin the PR head SHA at command time ---------------------------
+            let head_sha;
+            try {
+              const { data: prData } = await github.rest.pulls.get(
+                { owner, repo, pull_number: prNum });
+              head_sha = prData.head.sha;
+            } catch (e) {
+              await reply(`@${commenter}: could not read PR #${prNum} `
+                + `(${e && e.message || e}). No workflows were dispatched.`);
+              return;
+            }
+
+            // --- `/ci all` cost guard (nonce two-step) -------------------------
+            const marker = (n) => `ci-all-confirm nonce=${n}`;
+            let selected;
+            if (args[0] === 'all') {
+              const total = Object.values(WORKFLOWS).reduce((a, v) => a + v.cost, 0);
+              if (args[1] !== 'confirm') {
+                const nonce = crypto.randomBytes(8).toString('hex');
+                const exp = Date.now() + NONCE_TTL_MS;
+                await reply(
+                  `@${commenter}: \`/ci all\` dispatches **${Object.keys(WORKFLOWS).length} `
+                  + `workflows** (~**${total} compute-min** per PR). To confirm, comment:\n\n`
+                  + `\`/ci all confirm ${nonce}\`\n\n_(valid for 60 minutes)_\n`
+                  + `<!-- ${marker(nonce)} pr=${prNum} sha=${head_sha} by=${commenter} exp=${exp} -->`);
+                return;
+              }
+              // Validate the confirmation nonce against a prior bot warning.
+              const nonce = args[2] || '';
+              if (!/^[0-9a-f]{16}$/.test(nonce)) {
+                await reply(`@${commenter}: \`/ci all confirm\` needs the nonce from the `
+                  + `warning above, e.g. \`/ci all confirm <nonce>\`.`);
+                return;
+              }
+              // "List issue comments" is oldest-first; paginate so a warning on
+              // a long PR thread is not missed, then search newest-first. The
+              // trailing space pins the exact nonce (avoids prefix matches).
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: prNum, per_page: 100 });
+              const warn = comments.reverse().find(c =>
+                c.user.type === 'Bot' && c.body.includes(`${marker(nonce)} `));
+              const fields = warn && Object.fromEntries(
+                [...warn.body.matchAll(/(\w+)=(\S+?)(?=\s|-->|$)/g)].map(m => [m[1], m[2]]));
+              if (!warn || !fields
+                  || fields.by !== commenter
+                  || fields.sha !== head_sha
+                  || Number(fields.exp) < Date.now()) {
+                await reply(`@${commenter}: no matching, unexpired \`/ci all\` confirmation for `
+                  + `the current head (\`${head_sha.slice(0, 12)}\`). Re-run \`/ci all\`.`);
+                return;
+              }
+              selected = Object.keys(WORKFLOWS);
+            } else {
+              const unknown = args.filter(a => !(a in WORKFLOWS));
+              if (unknown.length) {
+                await reply(`@${commenter}: unknown job(s): ${unknown.map(u => `\`${u}\``).join(', ')}. `
+                  + `Valid jobs:\n${jobList()}`);
+                return;
+              }
+              selected = [...new Set(args)];
+            }
+
+            // --- Create a check per job and dispatch on the pinned SHA ---------
+            const dispatched = [];
+            for (const key of selected) {
+              const { file } = WORKFLOWS[key];
+              const { data: cr } = await github.rest.checks.create({
+                owner, repo,
+                name: `CI on-demand: ${key}`,
+                head_sha,
+                status: 'queued',
+                external_id: `ci-ondemand:${prNum}:${key}:${comment.id}`,
+                output: {
+                  title: 'Queued',
+                  summary: `Dispatched by @${commenter} via \`/ci\` against \`${head_sha.slice(0, 12)}\`.`,
+                },
+              });
+              try {
+                // return_run_details (GitHub, 2026-02-19) surfaces the run id/url
+                // synchronously so the check can link straight to the run.
+                const res = await github.rest.actions.createWorkflowDispatch({
+                  owner, repo, workflow_id: file, ref: 'master',
+                  inputs: { pr: String(prNum), head_sha, check_run_id: String(cr.id) },
+                  return_run_details: true,
+                });
+                const runUrl = res && res.data && res.data.run_url;
+                if (runUrl) {
+                  await github.rest.checks.update(
+                    { owner, repo, check_run_id: cr.id, details_url: runUrl });
+                }
+                dispatched.push(`\`${key}\``);
+              } catch (e) {
+                await github.rest.checks.update({
+                  owner, repo, check_run_id: cr.id,
+                  status: 'completed', conclusion: 'failure',
+                  output: { title: 'Dispatch failed', summary: String(e && e.message || e) },
+                });
+              }
+            }
+            if (dispatched.length) {
+              await reply(`@${commenter}: dispatched ${dispatched.join(', ')} against `
+                + `\`${head_sha.slice(0, 12)}\`. Results will appear in the Checks tab.`);
+            }

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Download routing metadata
         id: meta
         continue-on-error: true
-        uses: actions/download-artifact@v6.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ci-report-meta
           run-id: ${{ github.event.workflow_run.id }}
@@ -39,7 +39,7 @@ jobs:
           path: meta
 
       - name: Complete the check-run
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -1,0 +1,113 @@
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: CI result reporter
+# Completes the pending check-runs created by `ci-command.yml` for the
+# on-demand `/ci` path (openssl/project#2027).
+#
+# `issue_comment`-dispatched runs execute in default-branch context and do not
+# attach to the PR head SHA, so a reporter is required (the auto-on-approval
+# `pull_request_review` path surfaces natively in the Checks tab and needs no
+# reporter). Each dispatched workflow carries its routing metadata — {pr,
+# head_sha, check_run_id} — in a `ci-report-meta` artifact written by its
+# trusted `authorize` job, and redundantly in the trusted `run-name` set at
+# dispatch. This reporter runs on workflow_run.completed, so it always fires
+# with the authoritative conclusion (even on cancellation); if the run was
+# cancelled while still queued (no artifact yet), it recovers check_run_id from
+# the run-name so the check never hangs.
+#
+# NEVER checks out or executes PR code.
+
+on:
+  workflow_run:
+    # Gradual rollout (openssl/project#2027): only the piloted workflows are
+    # listed here. Add a workflow's `name:` when it graduates from pilot (and
+    # add it to ci-command.yml's WORKFLOWS map + re-wire its triggers).
+    workflows:
+      - "Constant-time validation (daily)"
+      - "Cross Compile for AArch64 Extensions"
+    types:
+      - completed
+
+permissions:
+  checks: write
+  actions: read
+
+jobs:
+  report:
+    # Only report on-demand (/ci) runs; ordinary schedule/manual dispatches and
+    # the native pull_request_review runs carry no routing artifact.
+    if: github.event.workflow_run.event == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download routing metadata
+        id: meta
+        continue-on-error: true
+        uses: actions/download-artifact@v6.0.0
+        with:
+          name: ci-report-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: meta
+
+      - name: Complete the check-run
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+
+            // Primary: routing metadata from the trusted `authorize` job's
+            // artifact. Fallback: the trusted `run-name` (display_title) set at
+            // dispatch, so a run cancelled while still queued — before
+            // `authorize` ran and uploaded the artifact — is still mapped back
+            // to its check and completed (openssl/project#2027 §5, orphan case).
+            let meta = {};
+            try {
+              meta = JSON.parse(fs.readFileSync('meta/ci-report-meta.json', 'utf8'));
+            } catch (e) {
+              core.info(`No ci-report-meta.json artifact (${e}); falling back to run-name.`);
+            }
+            const title = run.display_title || run.name || '';
+            let checkRunId = Number(meta.check_run_id);
+            if (!Number.isInteger(checkRunId) || checkRunId <= 0) {
+              const m = /check:(\d+)/.exec(title);
+              if (m) checkRunId = Number(m[1]);
+            }
+            if (!Number.isInteger(checkRunId) || checkRunId <= 0) {
+              core.info('No valid check_run_id from artifact or run-name; nothing to report.');
+              return;
+            }
+            const prMatch = /\/ci PR #(\d+)/.exec(title);
+            const pr = meta.pr || (prMatch && prMatch[1]) || '?';
+            const shaMatch = /· ([0-9a-f]{40}) ·/.exec(title);
+            const headSha = meta.head_sha || (shaMatch && shaMatch[1]) || '';
+
+            // Map every workflow_run conclusion to a settable check conclusion so
+            // no check ever hangs. `stale` is not client-settable; null/unknown
+            // are a defensive neutral.
+            const SETTABLE = new Set([
+              'success', 'failure', 'cancelled', 'timed_out',
+              'neutral', 'skipped', 'action_required',
+            ]);
+            const conclusion = SETTABLE.has(run.conclusion) ? run.conclusion : 'neutral';
+
+            await github.rest.checks.update({
+              owner, repo,
+              check_run_id: checkRunId,
+              status: 'completed',
+              conclusion,
+              details_url: run.html_url,
+              output: {
+                title: `${run.name}: ${run.conclusion || 'unknown'}`,
+                summary: `On-demand run for PR #${pr}`
+                  + (headSha ? ` (\`${String(headSha).slice(0, 12)}\`)` : '')
+                  + ` completed with conclusion \`${run.conclusion || 'unknown'}\`.\n\n`
+                  + `[View run](${run.html_url})`,
+              },
+            });

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   report:
-    # Only /ci dispatches carry routing metadata; skip schedule/manual/review.
+    # Only /ci dispatches need reporting here; other paths report natively.
     if: github.event.workflow_run.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -6,27 +6,12 @@
 # https://www.openssl.org/source/license.html
 
 name: CI result reporter
-# Completes the pending check-runs created by `ci-command.yml` for the
-# on-demand `/ci` path (openssl/project#2027).
-#
-# `issue_comment`-dispatched runs execute in default-branch context and do not
-# attach to the PR head SHA, so a reporter is required (the auto-on-approval
-# `pull_request_review` path surfaces natively in the Checks tab and needs no
-# reporter). Each dispatched workflow carries its routing metadata — {pr,
-# head_sha, check_run_id} — in a `ci-report-meta` artifact written by its
-# trusted `authorize` job, and redundantly in the trusted `run-name` set at
-# dispatch. This reporter runs on workflow_run.completed, so it always fires
-# with the authoritative conclusion (even on cancellation); if the run was
-# cancelled while still queued (no artifact yet), it recovers check_run_id from
-# the run-name so the check never hangs.
-#
-# NEVER checks out or executes PR code.
+# Completes the check-runs created by ci-command.yml for the `/ci` path, which
+# dispatches in default-branch context and so cannot report against the PR head
+# itself. Never checks out or executes PR code.
 
 on:
   workflow_run:
-    # Gradual rollout (openssl/project#2027): only the piloted workflows are
-    # listed here. Add a workflow's `name:` when it graduates from pilot (and
-    # add it to ci-command.yml's WORKFLOWS map + re-wire its triggers).
     workflows:
       - "Constant-time validation (daily)"
       - "Cross Compile for AArch64 Extensions"
@@ -39,8 +24,7 @@ permissions:
 
 jobs:
   report:
-    # Only report on-demand (/ci) runs; ordinary schedule/manual dispatches and
-    # the native pull_request_review runs carry no routing artifact.
+    # Only /ci dispatches carry routing metadata; skip schedule/manual/review.
     if: github.event.workflow_run.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
@@ -62,11 +46,8 @@ jobs:
             const { owner, repo } = context.repo;
             const run = context.payload.workflow_run;
 
-            // Primary: routing metadata from the trusted `authorize` job's
-            // artifact. Fallback: the trusted `run-name` (display_title) set at
-            // dispatch, so a run cancelled while still queued — before
-            // `authorize` ran and uploaded the artifact — is still mapped back
-            // to its check and completed (openssl/project#2027 §5, orphan case).
+            // Route via the authorize job's artifact; fall back to the run-name
+            // so a run cancelled before authorize uploaded it still completes.
             let meta = {};
             try {
               meta = JSON.parse(fs.readFileSync('meta/ci-report-meta.json', 'utf8'));
@@ -88,9 +69,7 @@ jobs:
             const shaMatch = /· ([0-9a-f]{40}) ·/.exec(title);
             const headSha = meta.head_sha || (shaMatch && shaMatch[1]) || '';
 
-            // Map every workflow_run conclusion to a settable check conclusion so
-            // no check ever hangs. `stale` is not client-settable; null/unknown
-            // are a defensive neutral.
+            // `stale` and null are not client-settable; map them to neutral.
             const SETTABLE = new Set([
               'success', 'failure', 'cancelled', 'timed_out',
               'neutral', 'skipped', 'action_required',

--- a/.github/workflows/ct-validation-daily.yml
+++ b/.github/workflows/ct-validation-daily.yml
@@ -78,7 +78,7 @@ jobs:
       run: ${{ steps.gate.outputs.run }}
       ref: ${{ steps.gate.outputs.ref }}
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v9.0.0
         id: gate
         with:
           script: |
@@ -129,7 +129,7 @@ jobs:
             core.setOutput('meta', String(meta));
       - name: Upload routing metadata
         if: steps.gate.outputs.meta == 'true'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ci-report-meta
           path: ci-report-meta.json

--- a/.github/workflows/ct-validation-daily.yml
+++ b/.github/workflows/ct-validation-daily.yml
@@ -53,9 +53,9 @@ on:
         description: 'Check-run id to report into (set by the /ci controller)'
         required: false
         default: ''
-  # Run automatically when a committer approves the PR.
-  pull_request_review:
-    types: [submitted]
+  # Auto-run on the 2-approval 'approval: done' label.
+  pull_request:
+    types: [labeled]
 
 run-name: "${{ (github.event_name == 'workflow_dispatch' && inputs.pr != '') && format('{0} · /ci PR #{1} · {2} · check:{3}', github.workflow, inputs.pr, inputs.head_sha, inputs.check_run_id) || github.workflow }}"
 

--- a/.github/workflows/ct-validation-daily.yml
+++ b/.github/workflows/ct-validation-daily.yml
@@ -67,73 +67,8 @@ permissions:
   contents: read
 
 jobs:
-  # Decides whether the build jobs run and which commit they build, and records
-  # routing metadata for a /ci dispatch. Metadata only: keep it at
-  # `contents: read` with no secrets, and never check out PR code here.
   authorize:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      run: ${{ steps.gate.outputs.run }}
-      ref: ${{ steps.gate.outputs.ref }}
-    steps:
-      - uses: actions/github-script@v9.0.0
-        id: gate
-        with:
-          script: |
-            const fs = require('fs');
-            const eventName = context.eventName;
-            const repoOk = `${context.repo.owner}/${context.repo.repo}` === 'openssl/openssl';
-            let run = false, ref = '', pr = '', headSha = '', checkRunId = '', meta = false;
-            const isCommitter = async (login) => {
-              if (!login) return false;
-              const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
-                { owner: context.repo.owner, repo: context.repo.repo, username: login });
-              return data.permission === 'write' || data.permission === 'admin';
-            };
-            if (eventName === 'schedule') {
-              run = repoOk;
-            } else if (eventName === 'push' || eventName === 'pull_request') {
-              run = true;
-            } else if (eventName === 'workflow_dispatch') {
-              const i = context.payload.inputs || {};
-              if (!i.pr) {
-                run = true;                       // ordinary manual dispatch
-              } else {                            // /ci on-demand dispatch
-                if (!/^\d+$/.test(i.pr) || !/^[0-9a-f]{40}$/.test(i.head_sha)
-                    || !/^\d+$/.test(i.check_run_id)) {
-                  core.setFailed('Invalid /ci dispatch inputs'); return;
-                }
-                run = repoOk; ref = i.head_sha; pr = i.pr; headSha = i.head_sha;
-                checkRunId = i.check_run_id; meta = run;
-              }
-            } else if (eventName === 'pull_request_review') {
-              const rv = context.payload.review, prObj = context.payload.pull_request;
-              const base = prObj.base.ref;
-              // Only base branches whose protection dismisses stale approvals.
-              const baseOk = base === 'master' || base.startsWith('feature/')
-                || base.startsWith('openssl-');
-              if (repoOk && rv.state === 'approved' && baseOk
-                  && rv.commit_id === prObj.head.sha && await isCommitter(rv.user.login)) {
-                run = true; ref = rv.commit_id; headSha = rv.commit_id;
-                pr = String(prObj.number);
-              }
-            }
-            if (meta) {
-              fs.writeFileSync('ci-report-meta.json',
-                JSON.stringify({ pr, head_sha: headSha, check_run_id: checkRunId }));
-            }
-            core.setOutput('run', String(run));
-            core.setOutput('ref', ref);
-            core.setOutput('meta', String(meta));
-      - name: Upload routing metadata
-        if: steps.gate.outputs.meta == 'true'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: ci-report-meta
-          path: ci-report-meta.json
-          if-no-files-found: error
+    uses: ./.github/workflows/ci-authorize.yml
   ct-validation:
     needs: authorize
     if: github.repository == 'openssl/openssl' && needs.authorize.outputs.run == 'true'

--- a/.github/workflows/ct-validation-daily.yml
+++ b/.github/workflows/ct-validation-daily.yml
@@ -53,7 +53,7 @@ on:
         description: 'Check-run id to report into (set by the /ci controller)'
         required: false
         default: ''
-  # Auto-on-approval (openssl/project#2027): run when a committer approves.
+  # Run automatically when a committer approves the PR.
   pull_request_review:
     types: [submitted]
 
@@ -67,18 +67,9 @@ permissions:
   contents: read
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # PR CI gate (openssl/project#2027) — metadata only, NEVER checks out PR code.
-  # Decides whether the build jobs run and which commit they check out for the
-  # on-demand (/ci workflow_dispatch) and auto-on-approval (pull_request_review)
-  # paths, leaving schedule/push/pull_request/ordinary-dispatch behaviour
-  # unchanged. On a /ci dispatch it also records the routing metadata that
-  # ci-report.yml uses to complete the check-run.
-  #
-  # SECURITY: do not add `secrets:` or `permissions:` beyond `contents: read`
-  # here or to any build job this gates, and never check out PR code in this
-  # job. "Safe by discipline" — see openssl/project#2027 open item 3.
-  # ---------------------------------------------------------------------------
+  # Decides whether the build jobs run and which commit they build, and records
+  # routing metadata for a /ci dispatch. Metadata only: keep it at
+  # `contents: read` with no secrets, and never check out PR code here.
   authorize:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ct-validation-daily.yml
+++ b/.github/workflows/ct-validation-daily.yml
@@ -40,13 +40,112 @@ on:
   schedule:
     - cron: '45 03 * * *'
   workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number (set by the /ci controller; empty for an ordinary manual run)'
+        required: false
+        default: ''
+      head_sha:
+        description: 'PR head SHA to build, 40-hex (set by the /ci controller)'
+        required: false
+        default: ''
+      check_run_id:
+        description: 'Check-run id to report into (set by the /ci controller)'
+        required: false
+        default: ''
+  # Auto-on-approval (openssl/project#2027): run when a committer approves.
+  pull_request_review:
+    types: [submitted]
+
+run-name: "${{ (github.event_name == 'workflow_dispatch' && inputs.pr != '') && format('{0} · /ci PR #{1} · {2} · check:{3}', github.workflow, inputs.pr, inputs.head_sha, inputs.check_run_id) || github.workflow }}"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.inputs.pr || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 permissions:
   contents: read
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # PR CI gate (openssl/project#2027) — metadata only, NEVER checks out PR code.
+  # Decides whether the build jobs run and which commit they check out for the
+  # on-demand (/ci workflow_dispatch) and auto-on-approval (pull_request_review)
+  # paths, leaving schedule/push/pull_request/ordinary-dispatch behaviour
+  # unchanged. On a /ci dispatch it also records the routing metadata that
+  # ci-report.yml uses to complete the check-run.
+  #
+  # SECURITY: do not add `secrets:` or `permissions:` beyond `contents: read`
+  # here or to any build job this gates, and never check out PR code in this
+  # job. "Safe by discipline" — see openssl/project#2027 open item 3.
+  # ---------------------------------------------------------------------------
+  authorize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+      ref: ${{ steps.gate.outputs.ref }}
+    steps:
+      - uses: actions/github-script@v8
+        id: gate
+        with:
+          script: |
+            const fs = require('fs');
+            const eventName = context.eventName;
+            const repoOk = `${context.repo.owner}/${context.repo.repo}` === 'openssl/openssl';
+            let run = false, ref = '', pr = '', headSha = '', checkRunId = '', meta = false;
+            const isCommitter = async (login) => {
+              if (!login) return false;
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
+                { owner: context.repo.owner, repo: context.repo.repo, username: login });
+              return data.permission === 'write' || data.permission === 'admin';
+            };
+            if (eventName === 'schedule') {
+              run = repoOk;
+            } else if (eventName === 'push' || eventName === 'pull_request') {
+              run = true;
+            } else if (eventName === 'workflow_dispatch') {
+              const i = context.payload.inputs || {};
+              if (!i.pr) {
+                run = true;                       // ordinary manual dispatch
+              } else {                            // /ci on-demand dispatch
+                if (!/^\d+$/.test(i.pr) || !/^[0-9a-f]{40}$/.test(i.head_sha)
+                    || !/^\d+$/.test(i.check_run_id)) {
+                  core.setFailed('Invalid /ci dispatch inputs'); return;
+                }
+                run = repoOk; ref = i.head_sha; pr = i.pr; headSha = i.head_sha;
+                checkRunId = i.check_run_id; meta = run;
+              }
+            } else if (eventName === 'pull_request_review') {
+              const rv = context.payload.review, prObj = context.payload.pull_request;
+              const base = prObj.base.ref;
+              // Only base branches whose protection dismisses stale approvals.
+              const baseOk = base === 'master' || base.startsWith('feature/')
+                || base.startsWith('openssl-');
+              if (repoOk && rv.state === 'approved' && baseOk
+                  && rv.commit_id === prObj.head.sha && await isCommitter(rv.user.login)) {
+                run = true; ref = rv.commit_id; headSha = rv.commit_id;
+                pr = String(prObj.number);
+              }
+            }
+            if (meta) {
+              fs.writeFileSync('ci-report-meta.json',
+                JSON.stringify({ pr, head_sha: headSha, check_run_id: checkRunId }));
+            }
+            core.setOutput('run', String(run));
+            core.setOutput('ref', ref);
+            core.setOutput('meta', String(meta));
+      - name: Upload routing metadata
+        if: steps.gate.outputs.meta == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: ci-report-meta
+          path: ci-report-meta.json
+          if-no-files-found: error
   ct-validation:
-    if: github.repository == 'openssl/openssl'
+    needs: authorize
+    if: github.repository == 'openssl/openssl' && needs.authorize.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +176,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ needs.authorize.outputs.ref }}
           persist-credentials: false
 
       - name: Install valgrind


### PR DESCRIPTION
Relates to openssl/project#2027.

### What

Adds a mechanism for committers to run selected non-PR workflows against a pull request's code, two ways:

- On demand — comment `/ci <jobs>` on a PR (e.g. `/ci ct-validation aarch64`, or `/ci all`).
- Automatically on approval — the wired workflows run when a committer submits an approving review.

### How it works

Two controllers plus a shared gate:

- **ci-command.yml** — parses `/ci`, gates on repository write/admin permission, pins the PR head SHA at command time, opens a pending check-run per requested job, and dispatches each workflow with `{pr, head_sha, check_run_id}`. It never checks out PR code, and the comment body is only ever passed through the API (never into a shell). `/ci all` requires a nonce confirmation because of its cost.
- **ci-report.yml** — completes those check-runs on `workflow_run.completed`, recovering the routing from a trusted artifact written by the authorize gate, or from the trusted run-name if a run was cancelled while still queued.
- **ci-authorize.yml** — a reusable workflow (`workflow_call`) holding the single copy of the authorize gate (contents: read, no PR checkout). Each wired workflow calls it via `uses:`; it decides whether the build runs and which commit it builds:
  - approval path → the reviewed commit (`review.commit_id`, required to equal the PR head);
  - `/ci` path → the pinned head SHA;
  - schedule / push / ordinary manual dispatch → unchanged behaviour.

### Security model

PR code is treated as untrusted regardless of head repository. It runs only on GitHub-hosted, secret-less runners (contents: read, persist-credentials: false). The privileged controllers and the authorize gate never check out PR code.

### Gradual rollout

This PR wires only ct-validation and aarch64 — both cheap and GitHub-hosted, and together they exercise the full plumbing plus the trickier per-job guards. The remaining eligible workflows stay schedule-only until they graduate (add them to the controller lists and point their authorize job at the shared reusable workflow).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
