### PR TITLE
Rename `ASN1_STRING_length_ex`, `ASN1_STRING_set_data`, and `ASN1_STRING_set_string`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -133,7 +133,7 @@ OpenSSL Releases
 
  *  `ASN1_STRING_set()` and `ASN1_STRING_length()` have been
     deprecated. The replacement functions `ASN1_STRING_set_data()` or
-    `ASN1_STRING_set_string()`, and `ASN1_STRING_length_ex()` should be
+    `ASN1_STRING_set_string()`, and `ASN1_STRING_get_length()` should be
     used in their place. This prepares the ASN1_STRING type to support
     modern size_t length values in the future.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -132,8 +132,8 @@ OpenSSL Releases
    *Bob Beck*
 
  *  `ASN1_STRING_set()` and `ASN1_STRING_length()` have been
-    deprecated. The replacement functions `ASN1_STRING_set_data()` or
-    `ASN1_STRING_set_string()`, and `ASN1_STRING_get_length()` should be
+    deprecated. The replacement functions `ASN1_STRING_set1_data()` or
+    `ASN1_STRING_set1_string()`, and `ASN1_STRING_get_length()` should be
     used in their place. This prepares the ASN1_STRING type to support
     modern size_t length values in the future.
 

--- a/apps/asn1parse.c
+++ b/apps/asn1parse.c
@@ -273,7 +273,7 @@ int asn1parse_main(int argc, char **argv)
             }
             /* hmm... this is a little evil but it works */
             tmpbuf = ASN1_STRING_get0_data(at->value.asn1_string);
-            tmplen = ASN1_STRING_length_ex(at->value.asn1_string);
+            tmplen = ASN1_STRING_get_length(at->value.asn1_string);
             if (tmplen > INT_MAX) {
                 BIO_puts(bio_err, "ASN.1 string length exceeds INT_MAX\n");
                 ERR_print_errors(bio_err);

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1077,7 +1077,7 @@ end_of_options:
             X509 *xi = sk_X509_value(cert_sk, i);
             const ASN1_INTEGER *serialNumber = X509_get0_serialNumber(xi);
             const unsigned char *psn = ASN1_STRING_get0_data(serialNumber);
-            const size_t snl = ASN1_STRING_length_ex(serialNumber);
+            const size_t snl = ASN1_STRING_get_length(serialNumber);
             const size_t filen_len = 2 * (snl > 0 ? snl : 1) + sizeof(".pem");
             char *n = new_cert + outdirlen;
 
@@ -1523,7 +1523,7 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
             goto end;
         }
         if (type != V_ASN1_BMPSTRING && type != V_ASN1_UTF8STRING) {
-            size_t tmp = ASN1_STRING_length_ex(str);
+            size_t tmp = ASN1_STRING_get_length(str);
             if (tmp > INT_MAX)
                 goto end;
             j = ASN1_PRINTABLE_type(ASN1_STRING_get0_data(str), (int)tmp);
@@ -1903,9 +1903,9 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
     /* We now just add it to the database as DB_TYPE_VAL('V') */
     row[DB_type] = OPENSSL_strdup("V");
     tm = X509_get0_notAfter(ret);
-    row[DB_exp_date] = app_malloc(ASN1_STRING_length_ex(tm) + 1, "row expdate");
-    memcpy(row[DB_exp_date], ASN1_STRING_get0_data(tm), ASN1_STRING_length_ex(tm));
-    row[DB_exp_date][ASN1_STRING_length_ex(tm)] = '\0';
+    row[DB_exp_date] = app_malloc(ASN1_STRING_get_length(tm) + 1, "row expdate");
+    memcpy(row[DB_exp_date], ASN1_STRING_get0_data(tm), ASN1_STRING_get_length(tm));
+    row[DB_exp_date][ASN1_STRING_get_length(tm)] = '\0';
     row[DB_rev_date] = NULL;
     row[DB_file] = OPENSSL_strdup("unknown");
     if ((row[DB_type] == NULL) || (row[DB_file] == NULL)
@@ -2139,9 +2139,9 @@ static int do_revoke(X509 *x509, CA_DB *db, REVINFO_TYPE rev_type,
         /* We now just add it to the database as DB_TYPE_REV('V') */
         row[DB_type] = OPENSSL_strdup("V");
         tm = X509_get0_notAfter(x509);
-        row[DB_exp_date] = app_malloc(ASN1_STRING_length_ex(tm) + 1, "row exp_data");
-        memcpy(row[DB_exp_date], ASN1_STRING_get0_data(tm), ASN1_STRING_length_ex(tm));
-        row[DB_exp_date][ASN1_STRING_length_ex(tm)] = '\0';
+        row[DB_exp_date] = app_malloc(ASN1_STRING_get_length(tm) + 1, "row exp_data");
+        memcpy(row[DB_exp_date], ASN1_STRING_get0_data(tm), ASN1_STRING_get_length(tm));
+        row[DB_exp_date][ASN1_STRING_get_length(tm)] = '\0';
         row[DB_rev_date] = NULL;
         row[DB_file] = OPENSSL_strdup("unknown");
 
@@ -2409,7 +2409,7 @@ static char *make_revocation_str(REVINFO_TYPE rev_type, const char *rev_arg)
     if (!revtm)
         return NULL;
 
-    i = ASN1_STRING_length_ex(revtm) + 1;
+    i = ASN1_STRING_get_length(revtm) + 1;
 
     if (reason)
         i += strlen(reason) + 1;
@@ -2516,7 +2516,7 @@ static int old_entry_print(const ASN1_OBJECT *obj, const ASN1_STRING *str)
         BIO_printf(bio_err, "ASN.1 %2d:'", ASN1_STRING_type(str));
 
     p = (const char *)ASN1_STRING_get0_data(str);
-    for (j = ASN1_STRING_length_ex(str); j > 0; j--) {
+    for (j = ASN1_STRING_get_length(str); j > 0; j--) {
         if ((*p >= ' ') && (*p <= '~'))
             BIO_printf(bio_err, "%c", *p);
         else if (*p & 0x80)

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2140,7 +2140,7 @@ static int add_certProfile(OSSL_CMP_CTX *ctx, const char *name)
         return 0;
     if ((utf8string = ASN1_UTF8STRING_new()) == NULL)
         goto err;
-    if (!ASN1_STRING_set_string(utf8string, name)) {
+    if (!ASN1_STRING_set1_string(utf8string, name)) {
         ASN1_STRING_free(utf8string);
         goto err;
     }
@@ -2215,7 +2215,7 @@ static int handle_opt_geninfo(OSSL_CMP_CTX *ctx)
             else
                 *end++ = '\0';
             if ((text = ASN1_UTF8STRING_new()) == NULL
-                || !ASN1_STRING_set_string(text, ptr))
+                || !ASN1_STRING_set1_string(text, ptr))
                 goto oom;
             ptr = end;
             ASN1_TYPE_set(type, V_ASN1_UTF8STRING, text);

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1584,7 +1584,7 @@ static void receipt_request_print(CMS_ContentInfo *cms)
             CMS_ReceiptRequest_get0_values(rr, &scid, &allorfirst,
                 &rlist, &rto);
             BIO_puts(bio_err, "  Signed Content ID:\n");
-            idlen = ASN1_STRING_length_ex(scid);
+            idlen = ASN1_STRING_get_length(scid);
             if (idlen > INT_MAX)
                 idlen = INT_MAX;
             id = (const char *)ASN1_STRING_get0_data(scid);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2833,7 +2833,7 @@ static const char *get_dp_url(DIST_POINT *dp)
     for (i = 0; i < sk_GENERAL_NAME_num(gens); i++) {
         gen = sk_GENERAL_NAME_value(gens, i);
         uri = GENERAL_NAME_get0_value(gen, &gtype);
-        if (gtype == GEN_URI && ASN1_STRING_length_ex(uri) > 6) {
+        if (gtype == GEN_URI && ASN1_STRING_get_length(uri) > 6) {
             const char *uptr = (const char *)ASN1_STRING_get0_data(uri);
 
             if (IS_HTTP(uptr)) /* can/should not use HTTPS here */
@@ -3722,7 +3722,7 @@ int has_stdin_waiting(void)
 int corrupt_signature(ASN1_STRING *signature)
 {
     const unsigned char *valid = ASN1_STRING_get0_data(signature);
-    size_t length = ASN1_STRING_length_ex(signature);
+    size_t length = ASN1_STRING_get_length(signature);
     unsigned char *s = OPENSSL_memdup(valid, length);
 
     if (s == NULL)

--- a/apps/lib/cmp_mock_srv.c
+++ b/apps/lib/cmp_mock_srv.c
@@ -360,7 +360,7 @@ static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
                     ERR_raise(ERR_LIB_CMP, ERR_R_PASSED_INVALID_ARGUMENT);
                     return NULL;
                 }
-                if (((len = ASN1_STRING_length_ex(str)) != sizeof("profile1") - 1)
+                if (((len = ASN1_STRING_get_length(str)) != sizeof("profile1") - 1)
                     || memcmp(data, "profile1", len) != 0) {
                     ERR_raise(ERR_LIB_CMP, CMP_R_UNEXPECTED_CERTPROFILE);
                     return NULL;

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -833,7 +833,7 @@ int pkcs12_main(int argc, char **argv)
                     ASN1_INTEGER_get(pbkdf2_param->iter));
                 BIO_printf(bio_err, "Key length: %ld, Salt length: %d\n",
                     ASN1_INTEGER_get(pbkdf2_param->keylength),
-                    (int)ASN1_STRING_length_ex(pbkdf2_param->salt->value.octet_string));
+                    (int)ASN1_STRING_get_length(pbkdf2_param->salt->value.octet_string));
                 if (pbkdf2_param->prf == NULL) {
                     prfnid = NID_hmacWithSHA1;
                 } else {
@@ -847,8 +847,8 @@ int pkcs12_main(int argc, char **argv)
             BIO_printf(bio_err, ", Iteration %ld\n",
                 tmaciter != NULL ? ASN1_INTEGER_get(tmaciter) : 1L);
             BIO_printf(bio_err, "MAC length: %ld, salt length: %ld\n",
-                tmac != NULL ? (long)ASN1_STRING_length_ex(tmac) : 0L,
-                tsalt != NULL ? (long)ASN1_STRING_length_ex(tsalt) : 0L);
+                tmac != NULL ? (long)ASN1_STRING_get_length(tmac) : 0L,
+                tsalt != NULL ? (long)ASN1_STRING_get_length(tsalt) : 0L);
         }
     }
 
@@ -1231,7 +1231,7 @@ static int alg_print(const X509_ALGOR *alg)
             }
             BIO_printf(bio_err, ", Salt length: %d, Cost(N): %ld, "
                                 "Block size(r): %ld, Parallelism(p): %ld",
-                (int)ASN1_STRING_length_ex(kdf->salt),
+                (int)ASN1_STRING_get_length(kdf->salt),
                 ASN1_INTEGER_get(kdf->costParameter),
                 ASN1_INTEGER_get(kdf->blockSize),
                 ASN1_INTEGER_get(kdf->parallelizationParameter));
@@ -1282,25 +1282,25 @@ void print_attribute(BIO *out, const ASN1_TYPE *av)
     switch (av->type) {
     case V_ASN1_BMPSTRING:
         value = OPENSSL_uni2asc(ASN1_STRING_get0_data(av->value.bmpstring),
-            (int)ASN1_STRING_length_ex(av->value.bmpstring));
+            (int)ASN1_STRING_get_length(av->value.bmpstring));
         BIO_printf(out, "%s\n", value);
         OPENSSL_free(value);
         break;
 
     case V_ASN1_UTF8STRING:
-        BIO_printf(out, "%.*s\n", (int)ASN1_STRING_length_ex(av->value.utf8string),
+        BIO_printf(out, "%.*s\n", (int)ASN1_STRING_get_length(av->value.utf8string),
             ASN1_STRING_get0_data(av->value.utf8string));
         break;
 
     case V_ASN1_OCTET_STRING:
         hex_print(out, ASN1_STRING_get0_data(av->value.octet_string),
-            (int)ASN1_STRING_length_ex(av->value.octet_string));
+            (int)ASN1_STRING_get_length(av->value.octet_string));
         BIO_puts(out, "\n");
         break;
 
     case V_ASN1_BIT_STRING:
         hex_print(out, ASN1_STRING_get0_data(av->value.bit_string),
-            (int)ASN1_STRING_length_ex(av->value.bit_string));
+            (int)ASN1_STRING_get_length(av->value.bit_string));
         BIO_puts(out, "\n");
         break;
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3082,7 +3082,7 @@ re_start:
             BIO_puts(bio_err, "ASN1_generate_nconf failed\n");
             goto end;
         }
-        ssl_request_len = ASN1_STRING_length_ex(atyp->value.sequence);
+        ssl_request_len = ASN1_STRING_get_length(atyp->value.sequence);
         if (ssl_request_len > INT_MAX) {
             NCONF_free(cnf);
             ASN1_TYPE_free(atyp);

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -155,7 +155,7 @@ int spkac_main(int argc, char **argv)
         if (spki == NULL)
             goto end;
         if (challenge != NULL
-            && !ASN1_STRING_set_string(spki->spkac->challenge,
+            && !ASN1_STRING_set1_string(spki->spkac->challenge,
                 challenge))
             goto end;
         if (!NETSCAPE_SPKI_set_pubkey(spki, pkey)) {

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -583,7 +583,7 @@ static ASN1_INTEGER *create_nonce(int bits)
     if ((nonce = ASN1_INTEGER_new()) == NULL)
         goto err;
 
-    if (!ASN1_STRING_set_data(nonce, buf, len))
+    if (!ASN1_STRING_set1_data(nonce, buf, len))
         goto err;
 
     ret = nonce;

--- a/crypto/asn1/a_int.c
+++ b/crypto/asn1/a_int.c
@@ -316,7 +316,7 @@ ASN1_INTEGER *ossl_c2i_ASN1_INTEGER(ASN1_INTEGER **a, const unsigned char **pp,
     } else
         ret = *a;
 
-    if (ASN1_STRING_set_data(ret, NULL, r) == 0) {
+    if (ASN1_STRING_set1_data(ret, NULL, r) == 0) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
         goto err;
     }
@@ -371,7 +371,7 @@ static int asn1_string_set_int64(ASN1_STRING *a, int64_t r, int itype)
         off = asn1_put_uint64(tbuf, r);
         a->type &= ~V_ASN1_NEG;
     }
-    return ASN1_STRING_set_data(a, tbuf + off, (sizeof(tbuf) - off));
+    return ASN1_STRING_set1_data(a, tbuf + off, (sizeof(tbuf) - off));
 }
 
 static int asn1_string_get_uint64(uint64_t *pr, const ASN1_STRING *a,
@@ -399,7 +399,7 @@ static int asn1_string_set_uint64(ASN1_STRING *a, uint64_t r, int itype)
 
     a->type = itype;
     off = asn1_put_uint64(tbuf, r);
-    return ASN1_STRING_set_data(a, tbuf + off, (sizeof(tbuf) - off));
+    return ASN1_STRING_set1_data(a, tbuf + off, (sizeof(tbuf) - off));
 }
 
 /*
@@ -503,7 +503,7 @@ static ASN1_STRING *bn_to_asn1_string(const BIGNUM *bn, ASN1_STRING *ai,
     if (len == 0)
         len = 1;
 
-    if (ASN1_STRING_set_data(ret, NULL, len) == 0) {
+    if (ASN1_STRING_set1_data(ret, NULL, len) == 0) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
         goto err;
     }

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -171,7 +171,7 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
     }
     /* If both the same type just copy across */
     if (inform == outform) {
-        if (!ASN1_STRING_set_data(dest, in, len)) {
+        if (!ASN1_STRING_set1_data(dest, in, len)) {
             if (free_out) {
                 ASN1_STRING_free(dest);
                 *out = NULL;

--- a/crypto/asn1/a_octet.c
+++ b/crypto/asn1/a_octet.c
@@ -30,6 +30,6 @@ int ASN1_OCTET_STRING_set(ASN1_OCTET_STRING *x, const unsigned char *d,
         return 0;
     }
     if (len == -1)
-        return ASN1_STRING_set_string(x, (const char *)d);
-    return ASN1_STRING_set_data(x, d, len);
+        return ASN1_STRING_set1_string(x, (const char *)d);
+    return ASN1_STRING_set1_data(x, d, len);
 }

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -271,7 +271,7 @@ ASN1_TIME *ossl_asn1_time_from_tm(ASN1_TIME *s, struct tm *ts, int type)
     if (tmps == NULL)
         return NULL;
 
-    if (!ASN1_STRING_set_data(tmps, NULL, len))
+    if (!ASN1_STRING_set1_data(tmps, NULL, len))
         goto err;
 
     tmps->type = type;

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -651,7 +651,7 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
             goto bad_str;
         }
-        if (!ASN1_STRING_set_string(atmp->value.asn1_string, str)) {
+        if (!ASN1_STRING_set1_string(atmp->value.asn1_string, str)) {
             ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
             goto bad_str;
         }
@@ -706,7 +706,7 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             atmp->value.asn1_string->length = rdlen;
             atmp->value.asn1_string->type = utype;
         } else if (format == ASN1_GEN_FORMAT_ASCII) {
-            if (!ASN1_STRING_set_string(atmp->value.asn1_string, str)) {
+            if (!ASN1_STRING_set1_string(atmp->value.asn1_string, str)) {
                 ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
                 goto bad_str;
             }

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -512,7 +512,7 @@ int ASN1_STRING_length(const ASN1_STRING *x)
 }
 #endif
 
-size_t ASN1_STRING_length_ex(const ASN1_STRING *x)
+size_t ASN1_STRING_get_length(const ASN1_STRING *x)
 {
     return (size_t)x->length;
 }
@@ -552,7 +552,7 @@ char *ossl_sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text,
         current = sk_ASN1_UTF8STRING_value(text, i);
         if (i > 0)
             length += sep_len;
-        length += ASN1_STRING_length_ex(current);
+        length += ASN1_STRING_get_length(current);
         if (max_len != 0 && length > max_len)
             return NULL;
     }
@@ -562,7 +562,7 @@ char *ossl_sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text,
     p = result;
     for (i = 0; i < sk_ASN1_UTF8STRING_num(text); i++) {
         current = sk_ASN1_UTF8STRING_value(text, i);
-        length = ASN1_STRING_length_ex(current);
+        length = ASN1_STRING_get_length(current);
         if (i > 0 && sep_len > 0) {
             strncpy(p, sep, sep_len + 1); /* using + 1 to silence gcc warning */
             p += sep_len;

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -381,7 +381,7 @@ void ASN1_STRING_set0(ASN1_STRING *str, void *data, int len)
     str->length = len;
 }
 
-int ASN1_STRING_set_data(ASN1_STRING *str, const uint8_t *data, size_t len_in)
+int ASN1_STRING_set1_data(ASN1_STRING *str, const uint8_t *data, size_t len_in)
 {
     if (str->type == V_ASN1_BIT_STRING) {
         ERR_raise(ERR_LIB_ASN1, ASN1_R_ILLEGAL_BITSTRING_FORMAT);
@@ -395,9 +395,9 @@ int ASN1_STRING_set_data(ASN1_STRING *str, const uint8_t *data, size_t len_in)
     return ossl_asn1_string_set_internal(str, data, (int)len_in, /*add_nul_byte=*/0);
 }
 
-int ASN1_STRING_set_string(ASN1_STRING *str, const char *c_string)
+int ASN1_STRING_set1_string(ASN1_STRING *str, const char *c_string)
 {
-    return ASN1_STRING_set_data(str, (const uint8_t *)c_string,
+    return ASN1_STRING_set1_data(str, (const uint8_t *)c_string,
         strlen(c_string));
 }
 

--- a/crypto/asn1/evp_asn1.c
+++ b/crypto/asn1/evp_asn1.c
@@ -42,7 +42,7 @@ int ASN1_TYPE_get_octetstring(const ASN1_TYPE *a, unsigned char *data, int max_l
         return -1;
     }
     p = ASN1_STRING_get0_data(a->value.octet_string);
-    tmp = ASN1_STRING_length_ex(a->value.octet_string);
+    tmp = ASN1_STRING_get_length(a->value.octet_string);
     if (tmp > INT_MAX) {
         ERR_raise(ERR_LIB_ASN1, ASN1_R_TOO_LARGE);
         return -1;
@@ -82,7 +82,7 @@ static int asn1_type_get_int_oct(ASN1_OCTET_STRING *oct, int32_t anum,
     if (num != NULL)
         *num = anum;
 
-    tmp = ASN1_STRING_length_ex(oct);
+    tmp = ASN1_STRING_get_length(oct);
 
     if (tmp > INT_MAX)
         tmp = INT_MAX;

--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -173,7 +173,7 @@ static X509_ALGOR *pkcs5_scrypt_set(const unsigned char *salt, int saltlen,
         saltlen = PKCS5_DEFAULT_PBE2_SALT_LEN;
 
     /* This will either copy salt or grow the buffer */
-    if (ASN1_STRING_set_data(sparam->salt, salt, saltlen) == 0) {
+    if (ASN1_STRING_set1_data(sparam->salt, salt, saltlen) == 0) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
         goto err;
     }

--- a/crypto/asn1/p8_pkey.c
+++ b/crypto/asn1/p8_pkey.c
@@ -72,13 +72,13 @@ int PKCS8_pkey_get0(const ASN1_OBJECT **ppkalg,
     const unsigned char **pk, int *ppklen,
     const X509_ALGOR **pa, const PKCS8_PRIV_KEY_INFO *p8)
 {
-    if (ASN1_STRING_length_ex(p8->pkey) > INT_MAX)
+    if (ASN1_STRING_get_length(p8->pkey) > INT_MAX)
         return 0;
     if (ppkalg)
         *ppkalg = p8->pkeyalg->algorithm;
     if (pk) {
         *pk = ASN1_STRING_get0_data(p8->pkey);
-        *ppklen = (int)ASN1_STRING_length_ex(p8->pkey);
+        *ppklen = (int)ASN1_STRING_get_length(p8->pkey);
     }
     if (pa)
         *pa = p8->pkeyalg;

--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -983,7 +983,7 @@ static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, long len,
             ASN1_STRING_set0(stmp, (unsigned char *)cont /* UGLY CAST! */, ilen);
             *free_cont = 0;
         } else {
-            if (!ASN1_STRING_set_data(stmp, cont, len)) {
+            if (!ASN1_STRING_set1_data(stmp, cont, len)) {
                 ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
                 ASN1_STRING_free(stmp);
                 *pval = NULL;

--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -206,7 +206,7 @@ static X509_ALGOR *pbmac_algor(const OSSL_CMP_CTX *ctx)
         goto err;
     if ((pbm_der_len = i2d_OSSL_CRMF_PBMPARAMETER(pbm, &pbm_der)) < 0)
         goto err;
-    if (!ASN1_STRING_set_data(pbm_str, pbm_der, pbm_der_len))
+    if (!ASN1_STRING_set1_data(pbm_str, pbm_der, pbm_der_len))
         goto err;
     alg = ossl_X509_ALGOR_from_nid(NID_id_PasswordBasedMAC,
         V_ASN1_SEQUENCE, pbm_str);

--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -73,11 +73,11 @@ ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
 
         pbm_str = (ASN1_STRING *)ppval;
         pbm_str_uc = ASN1_STRING_get0_data(pbm_str);
-        if (ASN1_STRING_length_ex(pbm_str) > INT_MAX) {
+        if (ASN1_STRING_get_length(pbm_str) > INT_MAX) {
             ERR_raise(ERR_LIB_CMP, CMP_R_WRONG_ALGORITHM_OID);
             goto end;
         }
-        pbm = d2i_OSSL_CRMF_PBMPARAMETER(NULL, &pbm_str_uc, (long)ASN1_STRING_length_ex(pbm_str));
+        pbm = d2i_OSSL_CRMF_PBMPARAMETER(NULL, &pbm_str_uc, (long)ASN1_STRING_get_length(pbm_str));
         if (pbm == NULL) {
             ERR_raise(ERR_LIB_CMP, CMP_R_WRONG_ALGORITHM_OID);
             goto end;
@@ -85,7 +85,7 @@ ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
 
         if (!OSSL_CRMF_pbm_new(ctx->libctx, ctx->propq,
                 pbm, prot_part_der, prot_part_der_len,
-                ASN1_STRING_get0_data(ctx->secretValue), ASN1_STRING_length_ex(ctx->secretValue),
+                ASN1_STRING_get0_data(ctx->secretValue), ASN1_STRING_get_length(ctx->secretValue),
                 &protection, &sig_len))
             goto end;
 

--- a/crypto/cmp/cmp_status.c
+++ b/crypto/cmp/cmp_status.c
@@ -214,7 +214,7 @@ static char *snprint_PKIStatusInfo_parts(int status, int fail_info,
         for (i = 0; i < n_status_strings; i++) {
             text = sk_ASN1_UTF8STRING_value(status_strings, i);
             printed_chars = BIO_snprintf(write_ptr, bufsize, "\"%.*s\"%s",
-                (int)ASN1_STRING_length_ex(text),
+                (int)ASN1_STRING_get_length(text),
                 ASN1_STRING_get0_data(text),
                 i < n_status_strings - 1 ? ", " : "");
             ADVANCE_BUFFER;

--- a/crypto/cmp/cmp_status.c
+++ b/crypto/cmp/cmp_status.c
@@ -275,7 +275,7 @@ OSSL_CMP_PKISI *OSSL_CMP_STATUSINFO_new(int status, int fail_info,
 
     if (text != NULL) {
         if ((utf8_text = ASN1_UTF8STRING_new()) == NULL
-            || !ASN1_STRING_set_string(utf8_text, text))
+            || !ASN1_STRING_set1_string(utf8_text, text))
             goto err;
         if ((si->statusString = sk_ASN1_UTF8STRING_new_null()) == NULL)
             goto err;

--- a/crypto/cmp/cmp_util.c
+++ b/crypto/cmp/cmp_util.c
@@ -227,7 +227,7 @@ int ossl_cmp_sk_ASN1_UTF8STRING_push_str(STACK_OF(ASN1_UTF8STRING) *sk,
         return 0;
     if ((utf8string = ASN1_UTF8STRING_new()) == NULL)
         return 0;
-    if (!ASN1_STRING_set_data(utf8string, (const uint8_t *)text, len))
+    if (!ASN1_STRING_set1_data(utf8string, (const uint8_t *)text, len))
         goto err;
     if (!sk_ASN1_UTF8STRING_push(sk, utf8string))
         goto err;

--- a/crypto/cms/cms_dd.c
+++ b/crypto/cms/cms_dd.c
@@ -92,7 +92,7 @@ int ossl_cms_DigestedData_do_final(const CMS_ContentInfo *cms, BIO *chain,
         else
             r = 1;
     } else {
-        if (!ASN1_STRING_set_data(dd->digest, md, mdlen))
+        if (!ASN1_STRING_set1_data(dd->digest, md, mdlen))
             goto err;
         r = 1;
     }

--- a/crypto/cms/cms_dh.c
+++ b/crypto/cms/cms_dh.c
@@ -43,7 +43,7 @@ static int dh_cms_set_peerkey(EVP_PKEY_CTX *pctx,
         goto err;
 
     /* Get public key */
-    plen = ASN1_STRING_length_ex(pubkey);
+    plen = ASN1_STRING_get_length(pubkey);
     if (plen > INT_MAX)
         goto err;
     p = ASN1_STRING_get0_data(pubkey);
@@ -121,7 +121,7 @@ static int dh_cms_set_shared_info(EVP_PKEY_CTX *pctx, CMS_RecipientInfo *ri)
         goto err;
 
     p = ASN1_STRING_get0_data(parameter);
-    plen = ASN1_STRING_length_ex(parameter);
+    plen = ASN1_STRING_get_length(parameter);
     if (plen > INT_MAX)
         goto err;
     kekalg = d2i_X509_ALGOR(NULL, &p, (int)plen);
@@ -153,7 +153,7 @@ static int dh_cms_set_shared_info(EVP_PKEY_CTX *pctx, CMS_RecipientInfo *ri)
         goto err;
 
     if (ukm != NULL) {
-        dukmlen = ASN1_STRING_length_ex(ukm);
+        dukmlen = ASN1_STRING_get_length(ukm);
         if (dukmlen > INT_MAX)
             goto err;
         dukm = OPENSSL_memdup(ASN1_STRING_get0_data(ukm), (int)dukmlen);
@@ -307,7 +307,7 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri)
         goto err;
 
     if (ukm != NULL) {
-        dukmlen = ASN1_STRING_length_ex(ukm);
+        dukmlen = ASN1_STRING_get_length(ukm);
         if (dukmlen > INT_MAX)
             goto err;
         dukm = OPENSSL_memdup(ASN1_STRING_get0_data(ukm), dukmlen);

--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -106,7 +106,7 @@ static int ecdh_cms_set_peerkey(EVP_PKEY_CTX *pctx,
             goto err;
     }
     /* We have parameters now set public key */
-    plen = ASN1_STRING_length_ex(pubkey);
+    plen = ASN1_STRING_get_length(pubkey);
     if (plen > INT_MAX)
         goto err;
     p = ASN1_STRING_get0_data(pubkey);
@@ -189,7 +189,7 @@ static int ecdh_cms_set_shared_info(EVP_PKEY_CTX *pctx, CMS_RecipientInfo *ri)
         return 0;
 
     p = ASN1_STRING_get0_data(parameter);
-    plen = ASN1_STRING_length_ex(parameter);
+    plen = ASN1_STRING_get_length(parameter);
     if (plen > INT_MAX)
         goto err;
     kekalg = d2i_X509_ALGOR(NULL, &p, (int)plen);

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -286,7 +286,7 @@ BIO *CMS_EnvelopedData_decrypt(CMS_EnvelopedData *env, BIO *detached_data,
     }
 
     if (secret != NULL
-        && (secret_len = ASN1_STRING_length_ex(secret)) > INT_MAX)
+        && (secret_len = ASN1_STRING_get_length(secret)) > INT_MAX)
         return NULL;
 
     if ((ci = CMS_ContentInfo_new_ex(libctx, propq)) == NULL

--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -131,7 +131,7 @@ CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     if (id)
         ASN1_STRING_set0(rr->signedContentIdentifier, id, idlen);
     else {
-        if (!ASN1_STRING_set_data(rr->signedContentIdentifier, NULL, 32)) {
+        if (!ASN1_STRING_set1_data(rr->signedContentIdentifier, NULL, 32)) {
             ERR_raise(ERR_LIB_CMS, ERR_R_ASN1_LIB);
             goto err;
         }

--- a/crypto/cms/cms_kemri.c
+++ b/crypto/cms/cms_kemri.c
@@ -388,7 +388,7 @@ int ossl_cms_RecipientInfo_kemri_decrypt(const CMS_ContentInfo *cms,
         goto err;
 
     kem_ct = ASN1_STRING_get0_data(kemri->kemct);
-    kem_ct_len = ASN1_STRING_length_ex(kemri->kemct);
+    kem_ct_len = ASN1_STRING_get_length(kemri->kemct);
 
     if (EVP_PKEY_decapsulate(kemri->pctx, NULL, &kem_secret_len, kem_ct, kem_ct_len) <= 0)
         return 0;

--- a/crypto/cms/cms_rsa.c
+++ b/crypto/cms/cms_rsa.c
@@ -90,7 +90,7 @@ static int rsa_cms_decrypt(CMS_RecipientInfo *ri)
         }
 
         label = ASN1_STRING_get0_data(parameter);
-        labellen = ASN1_STRING_length_ex(parameter);
+        labellen = ASN1_STRING_get_length(parameter);
         if (labellen > INT_MAX)
             goto err;
     }

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -304,7 +304,7 @@ static int ossl_cms_add1_signing_cert(CMS_SignerInfo *si,
 
     p = pp;
     i2d_ESS_SIGNING_CERT(sc, &p);
-    if (!(seq = ASN1_STRING_new()) || !ASN1_STRING_set_data(seq, pp, len)) {
+    if (!(seq = ASN1_STRING_new()) || !ASN1_STRING_set1_data(seq, pp, len)) {
         ASN1_STRING_free(seq);
         OPENSSL_free(pp);
         return 0;
@@ -329,7 +329,7 @@ static int ossl_cms_add1_signing_cert_v2(CMS_SignerInfo *si,
 
     p = pp;
     i2d_ESS_SIGNING_CERT_V2(sc, &p);
-    if (!(seq = ASN1_STRING_new()) || !ASN1_STRING_set_data(seq, pp, len)) {
+    if (!(seq = ASN1_STRING_new()) || !ASN1_STRING_set1_data(seq, pp, len)) {
         ASN1_STRING_free(seq);
         OPENSSL_free(pp);
         return 0;

--- a/crypto/ct/ct_oct.c
+++ b/crypto/ct/ct_oct.c
@@ -381,7 +381,7 @@ STACK_OF(SCT) *d2i_SCT_LIST(STACK_OF(SCT) **a, const unsigned char **pp,
         return NULL;
 
     p = ASN1_STRING_get0_data(oct);
-    if ((sk = o2i_SCT_LIST(a, &p, ASN1_STRING_length_ex(oct))) != NULL)
+    if ((sk = o2i_SCT_LIST(a, &p, ASN1_STRING_get_length(oct))) != NULL)
         *pp += len;
 
     ASN1_OCTET_STRING_free(oct);

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -966,7 +966,7 @@ EC_KEY *d2i_ECPrivateKey(EC_KEY **a, const unsigned char **in, long len)
 
     if (priv_key->privateKey) {
         ASN1_OCTET_STRING *pkey = priv_key->privateKey;
-        size_t pkey_len = ASN1_STRING_length_ex(pkey);
+        size_t pkey_len = ASN1_STRING_get_length(pkey);
         if (pkey_len > INT_MAX)
             goto err;
         if (EC_KEY_oct2priv(ret, ASN1_STRING_get0_data(pkey), (int)pkey_len) == 0)
@@ -991,7 +991,7 @@ EC_KEY *d2i_ECPrivateKey(EC_KEY **a, const unsigned char **in, long len)
         size_t pub_oct_len;
 
         pub_oct = ASN1_STRING_get0_data(priv_key->publicKey);
-        pub_oct_len = ASN1_STRING_length_ex(priv_key->publicKey);
+        pub_oct_len = ASN1_STRING_get_length(priv_key->publicKey);
         if (pub_oct_len > INT_MAX)
             goto err;
         if (!EC_KEY_oct2key(ret, pub_oct, (int)pub_oct_len, NULL)) {

--- a/crypto/ec/ecx_backend.c
+++ b/crypto/ec/ecx_backend.c
@@ -239,7 +239,7 @@ ECX_KEY *ossl_ecx_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     } else {
         size_t tmp;
         p = ASN1_STRING_get0_data(oct);
-        tmp = ASN1_STRING_length_ex(oct);
+        tmp = ASN1_STRING_get_length(oct);
         if (tmp > INT_MAX)
             goto err;
         plen = (int)tmp;

--- a/crypto/ocsp/ocsp_ext.c
+++ b/crypto/ocsp/ocsp_ext.c
@@ -360,7 +360,7 @@ X509_EXTENSION *OCSP_crlID_new(const char *url, long *n, char *tim)
     if (url) {
         if ((cid->crlUrl = ASN1_IA5STRING_new()) == NULL)
             goto err;
-        if (!(ASN1_STRING_set_string(cid->crlUrl, url)))
+        if (!(ASN1_STRING_set1_string(cid->crlUrl, url)))
             goto err;
     }
     if (n) {
@@ -446,7 +446,7 @@ X509_EXTENSION *OCSP_url_svcloc_new(const X509_NAME *issuer, const char **urls)
             goto err;
         if ((ia5 = ASN1_IA5STRING_new()) == NULL)
             goto err;
-        if (!ASN1_STRING_set_string((ASN1_STRING *)ia5, *urls))
+        if (!ASN1_STRING_set1_string((ASN1_STRING *)ia5, *urls))
             goto err;
         /* ad->location is allocated inside ACCESS_DESCRIPTION_new */
         ad->location->type = GEN_URI;

--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -301,7 +301,7 @@ int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OSSL_LIB_CTX *libctx,
         if (!X509_pubkey_digest(cert, sha1, md, NULL))
             goto err;
 
-        ret = (ASN1_STRING_length_ex(respid->value.byKey) == SHA_DIGEST_LENGTH)
+        ret = (ASN1_STRING_get_length(respid->value.byKey) == SHA_DIGEST_LENGTH)
             && (memcmp(ASN1_STRING_get0_data(respid->value.byKey), md,
                     SHA_DIGEST_LENGTH)
                 == 0);

--- a/crypto/pkcs12/p12_mutl.c
+++ b/crypto/pkcs12/p12_mutl.c
@@ -350,7 +350,7 @@ int PKCS12_verify_mac(PKCS12 *p12, const char *pass, int passlen)
         }
     }
     X509_SIG_get0(p12->mac->dinfo, NULL, &macoct);
-    if ((maclen != ASN1_STRING_length_ex(macoct))
+    if ((maclen != ASN1_STRING_get_length(macoct))
         || CRYPTO_memcmp(mac, ASN1_STRING_get0_data(macoct), maclen) != 0)
         return 0;
 

--- a/crypto/pkcs7/pk7_attr.c
+++ b/crypto/pkcs7/pk7_attr.c
@@ -30,7 +30,7 @@ int PKCS7_add_attrib_smimecap(PKCS7_SIGNER_INFO *si,
     }
     seq->length = ASN1_item_i2d((ASN1_VALUE *)cap, &seq->data,
         ASN1_ITEM_rptr(X509_ALGORS));
-    if (ASN1_STRING_length_ex(seq) == 0 || ASN1_STRING_get0_data(seq) == NULL) {
+    if (ASN1_STRING_get_length(seq) == 0 || ASN1_STRING_get0_data(seq) == NULL) {
         ASN1_STRING_free(seq);
         return 1;
     }
@@ -52,7 +52,7 @@ STACK_OF(X509_ALGOR) *PKCS7_get_smimecap(PKCS7_SIGNER_INFO *si)
     if (cap == NULL || (cap->type != V_ASN1_SEQUENCE))
         return NULL;
     p = ASN1_STRING_get0_data(cap->value.sequence);
-    len = ASN1_STRING_length_ex(cap->value.sequence);
+    len = ASN1_STRING_get_length(cap->value.sequence);
     if (len > INT_MAX)
         return NULL;
     return (STACK_OF(X509_ALGOR) *)

--- a/crypto/pkcs7/pk7_attr.c
+++ b/crypto/pkcs7/pk7_attr.c
@@ -132,7 +132,7 @@ int PKCS7_add1_attrib_digest(PKCS7_SIGNER_INFO *si,
     os = ASN1_OCTET_STRING_new();
     if (os == NULL)
         return 0;
-    if (!ASN1_STRING_set_data(os, md, mdlen)
+    if (!ASN1_STRING_set1_data(os, md, mdlen)
         || !PKCS7_add_signed_attribute(si, NID_pkcs9_messageDigest,
             V_ASN1_OCTET_STRING, os)) {
         ASN1_OCTET_STRING_free(os);

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -74,13 +74,13 @@ static ASN1_OCTET_STRING *pkcs7_get1_data(PKCS7 *p7)
     if (PKCS7_type_is_other(p7) && (p7->d.other != NULL)
         && (p7->d.other->type == V_ASN1_SEQUENCE)
         && (p7->d.other->value.sequence != NULL)
-        && (ASN1_STRING_length_ex(p7->d.other->value.sequence) > 0)) {
+        && (ASN1_STRING_get_length(p7->d.other->value.sequence) > 0)) {
         const unsigned char *data = ASN1_STRING_get0_data(p7->d.other->value.sequence);
         long len;
         int inf, tag, class;
         size_t tmp;
 
-        tmp = ASN1_STRING_length_ex(p7->d.other->value.sequence);
+        tmp = ASN1_STRING_get_length(p7->d.other->value.sequence);
         if (tmp > INT_MAX)
             return NULL;
         os = ASN1_OCTET_STRING_new();
@@ -201,7 +201,7 @@ static int pkcs7_decrypt_rinfo(unsigned char **pek, int *peklen,
         goto err;
 
     ret = evp_pkey_decrypt_alloc(pctx, &ek, &eklen, fixlen,
-        ASN1_STRING_get0_data(ri->enc_key), ASN1_STRING_length_ex(ri->enc_key));
+        ASN1_STRING_get0_data(ri->enc_key), ASN1_STRING_get_length(ri->enc_key));
     if (ret <= 0)
         goto err;
 
@@ -374,7 +374,7 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
     if (bio == NULL) {
         if (PKCS7_is_detached(p7)) {
             bio = BIO_new(BIO_s_null());
-        } else if (os != NULL && ASN1_STRING_length_ex(os) > 0) {
+        } else if (os != NULL && ASN1_STRING_get_length(os) > 0) {
             /*
              * bio needs a copy of os->data instead of a pointer because
              * the data will be used after os has been freed
@@ -383,7 +383,7 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
             if (bio != NULL) {
                 BIO_set_mem_eof_return(bio, 0);
                 const unsigned char *os_data = ASN1_STRING_get0_data(os);
-                size_t os_len = ASN1_STRING_length_ex(os);
+                size_t os_len = ASN1_STRING_get_length(os);
                 if (os_len > INT_MAX || BIO_write(bio, os_data, (int)os_len) != (int)os_len) {
                     BIO_free_all(bio);
                     bio = NULL;
@@ -659,7 +659,7 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
     if (in_bio != NULL) {
         bio = in_bio;
     } else {
-        size_t data_body_len = ASN1_STRING_length_ex(data_body);
+        size_t data_body_len = ASN1_STRING_get_length(data_body);
         if (data_body_len > INT_MAX)
             goto err;
         if (data_body_len > 0)
@@ -1115,7 +1115,7 @@ int PKCS7_signatureVerify(BIO *bio, PKCS7 *p7, PKCS7_SIGNER_INFO *si,
             ERR_raise(ERR_LIB_PKCS7, PKCS7_R_UNABLE_TO_FIND_MESSAGE_DIGEST);
             goto err;
         }
-        if ((ASN1_STRING_length_ex(message_digest) != md_len)
+        if ((ASN1_STRING_get_length(message_digest) != md_len)
             || (memcmp(ASN1_STRING_get0_data(message_digest), md_dat, md_len))) {
             ERR_raise(ERR_LIB_PKCS7, PKCS7_R_DIGEST_FAILURE);
             ret = -1;
@@ -1147,7 +1147,7 @@ int PKCS7_signatureVerify(BIO *bio, PKCS7 *p7, PKCS7_SIGNER_INFO *si,
     }
 
     const unsigned char *sig_data = ASN1_STRING_get0_data(os);
-    size_t sig_len = ASN1_STRING_length_ex(os);
+    size_t sig_len = ASN1_STRING_get_length(os);
     if (sig_len > INT_MAX) {
         ret = -1;
         goto err;

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -201,7 +201,7 @@ static int pkcs7_copy_existing_digest(PKCS7 *p7, PKCS7_SIGNER_INFO *si)
 
     if (osdig != NULL) {
         size_t len;
-        len = ASN1_STRING_length_ex(osdig);
+        len = ASN1_STRING_get_length(osdig);
         if (len > INT_MAX)
             goto err;
         return PKCS7_add1_attrib_digest(si, ASN1_STRING_get0_data(osdig), (int)len);

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -78,7 +78,7 @@ int ossl_sm2_plaintext_size(const unsigned char *ct, size_t ct_size,
         return 0;
     }
 
-    *pt_size = ASN1_STRING_length_ex(sm2_ctext->C2);
+    *pt_size = ASN1_STRING_get_length(sm2_ctext->C2);
     SM2_Ciphertext_free(sm2_ctext);
 
     return 1;
@@ -326,11 +326,11 @@ int ossl_sm2_decrypt(const EC_KEY *key,
         goto done;
     }
 
-    msg_len = ASN1_STRING_length_ex(sm2_ctext->C2);
+    msg_len = ASN1_STRING_get_length(sm2_ctext->C2);
     if (msg_len > INT_MAX)
         goto done;
 
-    c3_len = ASN1_STRING_length_ex(sm2_ctext->C3);
+    c3_len = ASN1_STRING_get_length(sm2_ctext->C3);
     if (c3_len > INT_MAX || c3_len != (size_t)hash_size) {
         ERR_raise(ERR_LIB_SM2, SM2_R_INVALID_ENCODING);
         goto done;

--- a/crypto/ts/ts_asn1.c
+++ b/crypto/ts/ts_asn1.c
@@ -231,7 +231,7 @@ TS_TST_INFO *PKCS7_to_TS_TST_INFO(PKCS7 *token)
     }
     tst_info_der = tst_info_wrapper->value.octet_string;
     p = ASN1_STRING_get0_data(tst_info_der);
-    len = ASN1_STRING_length_ex(tst_info_der);
+    len = ASN1_STRING_get_length(tst_info_der);
     if (len > INT_MAX) {
         ERR_raise(ERR_LIB_TS, TS_R_BAD_TYPE);
         return NULL;

--- a/crypto/ts/ts_lib.c
+++ b/crypto/ts/ts_lib.c
@@ -86,7 +86,7 @@ int TS_MSG_IMPRINT_print_bio(BIO *bio, TS_MSG_IMPRINT *a)
     BIO_printf(bio, "Message data:\n");
     msg = a->hashed_msg;
     BIO_dump_indent(bio, (const char *)ASN1_STRING_get0_data(msg),
-        (int)ASN1_STRING_length_ex(msg), 4);
+        (int)ASN1_STRING_get_length(msg), 4);
 
     return 1;
 }

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -487,7 +487,7 @@ static int ts_RESP_check_request(TS_RESP_CTX *ctx)
         return 0;
     }
     digest = msg_imprint->hashed_msg;
-    if (ASN1_STRING_length_ex(digest) != (size_t)md_size) {
+    if (ASN1_STRING_get_length(digest) != (size_t)md_size) {
         TS_RESP_CTX_set_status_info(ctx, TS_STATUS_REJECTION,
             "Bad message digest.");
         TS_RESP_CTX_add_failure_info(ctx, TS_INFO_BAD_DATA_FORMAT);

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -298,7 +298,7 @@ int TS_RESP_CTX_set_status_info(TS_RESP_CTX *ctx,
     }
     if (text) {
         if ((utf8_text = ASN1_UTF8STRING_new()) == NULL
-            || !ASN1_STRING_set_string(utf8_text, text)) {
+            || !ASN1_STRING_set1_string(utf8_text, text)) {
             ERR_raise(ERR_LIB_TS, ERR_R_ASN1_LIB);
             goto err;
         }
@@ -645,7 +645,7 @@ static int ossl_ess_add1_signing_cert(PKCS7_SIGNER_INFO *si,
 
     p = pp;
     i2d_ESS_SIGNING_CERT(sc, &p);
-    if ((seq = ASN1_STRING_new()) == NULL || !ASN1_STRING_set_data(seq, pp, len)) {
+    if ((seq = ASN1_STRING_new()) == NULL || !ASN1_STRING_set1_data(seq, pp, len)) {
         ASN1_STRING_free(seq);
         OPENSSL_free(pp);
         return 0;
@@ -676,7 +676,7 @@ static int ossl_ess_add1_signing_cert_v2(PKCS7_SIGNER_INFO *si,
 
     p = pp;
     i2d_ESS_SIGNING_CERT_V2(sc, &p);
-    if ((seq = ASN1_STRING_new()) == NULL || !ASN1_STRING_set_data(seq, pp, len)) {
+    if ((seq = ASN1_STRING_new()) == NULL || !ASN1_STRING_set1_data(seq, pp, len)) {
         ASN1_STRING_free(seq);
         OPENSSL_free(pp);
         return 0;

--- a/crypto/ts/ts_rsp_verify.c
+++ b/crypto/ts/ts_rsp_verify.c
@@ -213,7 +213,7 @@ static ESS_SIGNING_CERT *ossl_ess_get_signing_cert(const PKCS7_SIGNER_INFO *si)
     if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
         return NULL;
     p = ASN1_STRING_get0_data(attr->value.sequence);
-    len = ASN1_STRING_length_ex(attr->value.sequence);
+    len = ASN1_STRING_get_length(attr->value.sequence);
     if (len > INT_MAX)
         return NULL;
     return d2i_ESS_SIGNING_CERT(NULL, &p, (int)len);
@@ -229,7 +229,7 @@ static ESS_SIGNING_CERT_V2 *ossl_ess_get_signing_cert_v2(const PKCS7_SIGNER_INFO
     if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
         return NULL;
     p = ASN1_STRING_get0_data(attr->value.sequence);
-    len = ASN1_STRING_length_ex(attr->value.sequence);
+    len = ASN1_STRING_get_length(attr->value.sequence);
     if (len > INT_MAX)
         return NULL;
     return d2i_ESS_SIGNING_CERT_V2(NULL, &p, (int)len);
@@ -504,7 +504,7 @@ static int ts_check_imprints(X509_ALGOR *algor_a,
             goto err;
     }
 
-    len = ASN1_STRING_length_ex(b->hashed_msg);
+    len = ASN1_STRING_get_length(b->hashed_msg);
     if (len > INT_MAX)
         goto err;
 

--- a/crypto/ts/ts_verify_ctx.c
+++ b/crypto/ts/ts_verify_ctx.c
@@ -163,7 +163,7 @@ TS_VERIFY_CTX *TS_REQ_to_TS_VERIFY_CTX(TS_REQ *req, TS_VERIFY_CTX *ctx)
     if ((ret->md_alg = X509_ALGOR_dup(md_alg)) == NULL)
         goto err;
     msg = imprint->hashed_msg;
-    tmp = ASN1_STRING_length_ex(msg);
+    tmp = ASN1_STRING_get_length(msg);
     if (tmp > INT_MAX)
         goto err;
     ret->imprint_len = (unsigned int)tmp;

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -244,7 +244,7 @@ int X509_ocspid_print(BIO *bp, const X509 *x)
         goto err;
 
     if (!EVP_Digest(ASN1_STRING_get0_data(keybstr),
-            ASN1_STRING_length_ex(keybstr), SHA1md, NULL, md, NULL))
+            ASN1_STRING_get_length(keybstr), SHA1md, NULL, md, NULL))
         goto err;
     for (i = 0; i < SHA_DIGEST_LENGTH; i++) {
         if (BIO_printf(bp, "%02X", SHA1md[i]) <= 0)

--- a/crypto/x509/v3_akid.c
+++ b/crypto/x509/v3_akid.c
@@ -186,7 +186,7 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
             && !(same_issuer && !ss)) {
             ikeyid = X509V3_EXT_d2i(ext);
             /* Ignore empty keyids in the issuer cert */
-            if (ASN1_STRING_length_ex(ikeyid) == 0) {
+            if (ASN1_STRING_get_length(ikeyid) == 0) {
                 ASN1_OCTET_STRING_free(ikeyid);
                 ikeyid = NULL;
             }

--- a/crypto/x509/v3_cpols.c
+++ b/crypto/x509/v3_cpols.c
@@ -208,7 +208,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
                 goto err;
             }
-            if (!ASN1_STRING_set_string(qual->d.cpsuri, cnf->value)) {
+            if (!ASN1_STRING_set1_string(qual->d.cpsuri, cnf->value)) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
                 goto err;
             }
@@ -324,7 +324,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
             if (tag_len != 0)
                 value += tag_len + 1;
             len = (int)strlen(value);
-            if (!ASN1_STRING_set_data(not->exptext, (uint8_t *)value, len)) {
+            if (!ASN1_STRING_set1_data(not->exptext, (uint8_t *)value, len)) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
                 goto err;
             }
@@ -343,7 +343,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
                 nref->organization->type = V_ASN1_IA5STRING;
             else
                 nref->organization->type = V_ASN1_VISIBLESTRING;
-            if (!ASN1_STRING_set_string(nref->organization, cnf->value)) {
+            if (!ASN1_STRING_set1_string(nref->organization, cnf->value)) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
                 goto err;
             }

--- a/crypto/x509/v3_ia5.c
+++ b/crypto/x509/v3_ia5.c
@@ -52,7 +52,7 @@ ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
         ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
         return NULL;
     }
-    if (!ASN1_STRING_set_string((ASN1_STRING *)ia5, str)) {
+    if (!ASN1_STRING_set1_string((ASN1_STRING *)ia5, str)) {
         ASN1_IA5STRING_free(ia5);
         return NULL;
     }

--- a/crypto/x509/v3_ist.c
+++ b/crypto/x509/v3_ist.c
@@ -52,28 +52,28 @@ static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_
         if (strcmp(cnf->name, "signTool") == 0) {
             if (ist->signTool == NULL
                 || cnf->value == NULL
-                || !ASN1_STRING_set_string(ist->signTool, cnf->value)) {
+                || !ASN1_STRING_set1_string(ist->signTool, cnf->value)) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
                 goto err;
             }
         } else if (strcmp(cnf->name, "cATool") == 0) {
             if (ist->cATool == NULL
                 || cnf->value == NULL
-                || !ASN1_STRING_set_string(ist->cATool, cnf->value)) {
+                || !ASN1_STRING_set1_string(ist->cATool, cnf->value)) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
                 goto err;
             }
         } else if (strcmp(cnf->name, "signToolCert") == 0) {
             if (ist->signToolCert == NULL
                 || cnf->value == NULL
-                || !ASN1_STRING_set_string(ist->signToolCert, cnf->value)) {
+                || !ASN1_STRING_set1_string(ist->signToolCert, cnf->value)) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
                 goto err;
             }
         } else if (strcmp(cnf->name, "cAToolCert") == 0) {
             if (ist->cAToolCert == NULL
                 || cnf->value == NULL
-                || !ASN1_STRING_set_string(ist->cAToolCert, cnf->value)) {
+                || !ASN1_STRING_set1_string(ist->cAToolCert, cnf->value)) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
                 goto err;
             }

--- a/crypto/x509/v3_lib.c
+++ b/crypto/x509/v3_lib.c
@@ -175,7 +175,7 @@ void *X509V3_EXT_d2i(const X509_EXTENSION *ext)
         return NULL;
     extvalue = X509_EXTENSION_get_data(ext);
     p = ASN1_STRING_get0_data(extvalue);
-    extlen = ASN1_STRING_length_ex(extvalue);
+    extlen = ASN1_STRING_get_length(extvalue);
     if (extlen > INT_MAX)
         return NULL;
     if (method->it)

--- a/crypto/x509/v3_prn.c
+++ b/crypto/x509/v3_prn.c
@@ -80,7 +80,7 @@ int X509V3_EXT_print(BIO *out, const X509_EXTENSION *ext, unsigned long flag,
 
     extoct = X509_EXTENSION_get_data(ext);
     p = ASN1_STRING_get0_data(extoct);
-    extlen = ASN1_STRING_length_ex(extoct);
+    extlen = ASN1_STRING_get_length(extoct);
     if (extlen > INT_MAX)
         return 0;
 

--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -576,7 +576,7 @@ GENERAL_NAME *a2i_GENERAL_NAME(GENERAL_NAME *out,
 
     if (is_string) {
         if ((gen->d.ia5 = ASN1_IA5STRING_new()) == NULL
-            || !ASN1_STRING_set_string(gen->d.ia5, value)) {
+            || !ASN1_STRING_set1_string(gen->d.ia5, value)) {
             ASN1_IA5STRING_free(gen->d.ia5);
             gen->d.ia5 = NULL;
             ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);

--- a/crypto/x509/v3_utf8.c
+++ b/crypto/x509/v3_utf8.c
@@ -55,7 +55,7 @@ ASN1_UTF8STRING *s2i_ASN1_UTF8STRING(X509V3_EXT_METHOD *method,
         ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
         return NULL;
     }
-    if (!ASN1_STRING_set_string(utf8, str)) {
+    if (!ASN1_STRING_set1_string(utf8, str)) {
         ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
         ASN1_UTF8STRING_free(utf8);
         return NULL;

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -365,7 +365,7 @@ int X509_ATTRIBUTE_set1_data(X509_ATTRIBUTE *attr, int attrtype,
         atype = stmp->type;
     } else if (len != -1) {
         if ((stmp = ASN1_STRING_type_new(attrtype)) == NULL
-            || !ASN1_STRING_set_data(stmp, data, len)) {
+            || !ASN1_STRING_set1_data(stmp, data, len)) {
             ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
             goto err;
         }

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -335,9 +335,9 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
     if (len < -1)
         return 0;
     if (len == -1)
-        i = ASN1_STRING_set_string(ne->value, (const char *)bytes);
+        i = ASN1_STRING_set1_string(ne->value, (const char *)bytes);
     else
-        i = ASN1_STRING_set_data(ne->value, bytes, (size_t)len);
+        i = ASN1_STRING_set1_data(ne->value, bytes, (size_t)len);
     if (!i)
         return 0;
     if (type != V_ASN1_UNDEF) {

--- a/crypto/x509/x_x509a.c
+++ b/crypto/x509/x_x509a.c
@@ -72,7 +72,7 @@ int X509_alias_set1(X509 *x, const unsigned char *name, int len)
 
     if (aux->alias == NULL && (aux->alias = ASN1_UTF8STRING_new()) == NULL)
         return 0;
-    return ASN1_STRING_set_data(aux->alias, name, len_s);
+    return ASN1_STRING_set1_data(aux->alias, name, len_s);
 }
 
 int X509_keyid_set1(X509 *x, const unsigned char *id, int len)
@@ -101,7 +101,7 @@ int X509_keyid_set1(X509 *x, const unsigned char *id, int len)
     if (aux->keyid == NULL
         && (aux->keyid = ASN1_OCTET_STRING_new()) == NULL)
         return 0;
-    return ASN1_STRING_set_data(aux->keyid, id, len_s);
+    return ASN1_STRING_set1_data(aux->keyid, id, len_s);
 }
 
 const unsigned char *X509_alias_get0(const X509 *x, int *len)

--- a/doc/man3/ASN1_STRING_length.pod
+++ b/doc/man3/ASN1_STRING_length.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-ASN1_STRING_set_data, ASN1_STRING_set_string, ASN1_STRING_length_ex,
+ASN1_STRING_set_data, ASN1_STRING_set_string, ASN1_STRING_get_length,
 ASN1_STRING_dup, ASN1_STRING_cmp, ASN1_STRING_set, ASN1_STRING_length,
 ASN1_STRING_type, ASN1_STRING_get0_data,
 ASN1_STRING_to_UTF8 - ASN1_STRING utility functions
@@ -25,7 +25,7 @@ ASN1_STRING_to_UTF8 - ASN1_STRING utility functions
 
  int ASN1_STRING_set_string(ASN1_STRING *str, const char *data);
 
- size_t ASN1_STRING_length_ex(const ASN1_STRING *x);
+ size_t ASN1_STRING_get_length(const ASN1_STRING *x);
 
 The following functions have been deprecated since OpenSSL 4.1, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
@@ -129,7 +129,7 @@ L<ERR_get_error(3)>
 
 =head1 HISTORY
 
-ASN1_STRING_set_data(), ASN1_STRING_set_string(), and ASN1_STRING_length_ex()
+ASN1_STRING_set_data(), ASN1_STRING_set_string(), and ASN1_STRING_get_length()
 were added in OpenSSL 4.1.
 
 =head1 COPYRIGHT

--- a/doc/man3/ASN1_STRING_length.pod
+++ b/doc/man3/ASN1_STRING_length.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-ASN1_STRING_set_data, ASN1_STRING_set_string, ASN1_STRING_get_length,
+ASN1_STRING_set1_data, ASN1_STRING_set1_string, ASN1_STRING_get_length,
 ASN1_STRING_dup, ASN1_STRING_cmp, ASN1_STRING_set, ASN1_STRING_length,
 ASN1_STRING_type, ASN1_STRING_get0_data,
 ASN1_STRING_to_UTF8 - ASN1_STRING utility functions
@@ -21,9 +21,9 @@ ASN1_STRING_to_UTF8 - ASN1_STRING utility functions
 
  int ASN1_STRING_to_UTF8(unsigned char **out, const ASN1_STRING *in);
 
- int ASN1_STRING_set_data(ASN1_STRING *str, const uint8_t *data, size_t len);
+ int ASN1_STRING_set1_data(ASN1_STRING *str, const uint8_t *data, size_t len);
 
- int ASN1_STRING_set_string(ASN1_STRING *str, const char *data);
+ int ASN1_STRING_set1_string(ASN1_STRING *str, const char *data);
 
  size_t ASN1_STRING_get_length(const ASN1_STRING *x);
 
@@ -56,13 +56,13 @@ freed or re-used.  If I<data> is not NULL, I<len> bytes are copied
 from the memory pointed to by I<data> to I<str>. If I<len> is -1 then
 the length is determined by strlen(data).
 
-ASN1_STRING_set_data() allocates memory for string I<str> to hold
+ASN1_STRING_set1_data() allocates memory for string I<str> to hold
 I<len> bytes of data. Any previously allocated memory owned by I<str>
 will be freed or re-used.  If I<data> is not NULL, I<len> bytes are
 copied from the memory pointed to by I<data> to I<str>. It is an error
 to use this function on a string of type B<ASN1_BIT_STRING>.
 
-ASN1_STRING_set_string() allocates memory for the string I<str> and makes
+ASN1_STRING_set1_string() allocates memory for the string I<str> and makes
 a copy of the characters from I<cstring>. Any previously
 allocated memory owned by I<str> will be freed or re-used.  I<cstring>
 must point to a valid NUL-terminated C string, and must not be
@@ -99,8 +99,8 @@ be ASCII, for a BMPString two bytes per character in big endian
 format, and for a UTF8String it will be in UTF8 format.
 
 Similar care should be taken to ensure the data is in the correct
-format when calling ASN1_STRING_set(), ASN1_STRING_set_data(), or
-ASN1_STRING_set_string().
+format when calling ASN1_STRING_set(), ASN1_STRING_set1_data(), or
+ASN1_STRING_set1_string().
 
 =head1 RETURN VALUES
 
@@ -115,8 +115,8 @@ error occurred.
 ASN1_STRING_cmp() returns an integer greater than, equal to, or less than 0,
 according to whether I<a> is greater than, equal to, or less than I<b>.
 
-ASN1_STRING_set(), ASN1_STRING_set_data(), and
-ASN1_STRING_set_string() return 1 on success or 0 on error or failure.
+ASN1_STRING_set(), ASN1_STRING_set1_data(), and
+ASN1_STRING_set1_string() return 1 on success or 0 on error or failure.
 
 ASN1_STRING_type() returns the type of I<x>.
 
@@ -129,7 +129,7 @@ L<ERR_get_error(3)>
 
 =head1 HISTORY
 
-ASN1_STRING_set_data(), ASN1_STRING_set_string(), and ASN1_STRING_get_length()
+ASN1_STRING_set1_data(), ASN1_STRING_set1_string(), and ASN1_STRING_get_length()
 were added in OpenSSL 4.1.
 
 =head1 COPYRIGHT

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -541,14 +541,14 @@ int ASN1_STRING_cmp(const ASN1_STRING *a, const ASN1_STRING *b);
  * make its data void *
  */
 #if !defined(OPENSSL_NO_DEPRECATED_4_1)
-OSSL_DEPRECATEDIN_4_1_FOR(" Use ASN1_STRING_set_data() or ASN1_STRING_set_string() instead.")
+OSSL_DEPRECATEDIN_4_1_FOR(" Use ASN1_STRING_set1_data() or ASN1_STRING_set1_string() instead.")
 int ASN1_STRING_set(ASN1_STRING *str, const void *data, int len);
 OSSL_DEPRECATEDIN_4_1_FOR(" Use ASN1_STRING_get_length() instead.")
 int ASN1_STRING_length(const ASN1_STRING *x);
 #endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 void ASN1_STRING_set0(ASN1_STRING *str, void *data, int len);
-int ASN1_STRING_set_data(ASN1_STRING *str, const uint8_t *data, size_t len);
-int ASN1_STRING_set_string(ASN1_STRING *str, const char *cstring);
+int ASN1_STRING_set1_data(ASN1_STRING *str, const uint8_t *data, size_t len);
+int ASN1_STRING_set1_string(ASN1_STRING *str, const char *cstring);
 size_t ASN1_STRING_get_length(const ASN1_STRING *x);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 void ASN1_STRING_length_set(ASN1_STRING *x, int n);

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -543,13 +543,13 @@ int ASN1_STRING_cmp(const ASN1_STRING *a, const ASN1_STRING *b);
 #if !defined(OPENSSL_NO_DEPRECATED_4_1)
 OSSL_DEPRECATEDIN_4_1_FOR(" Use ASN1_STRING_set_data() or ASN1_STRING_set_string() instead.")
 int ASN1_STRING_set(ASN1_STRING *str, const void *data, int len);
-OSSL_DEPRECATEDIN_4_1_FOR(" Use ASN1_STRING_length_ex() instead.")
+OSSL_DEPRECATEDIN_4_1_FOR(" Use ASN1_STRING_get_length() instead.")
 int ASN1_STRING_length(const ASN1_STRING *x);
 #endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 void ASN1_STRING_set0(ASN1_STRING *str, void *data, int len);
 int ASN1_STRING_set_data(ASN1_STRING *str, const uint8_t *data, size_t len);
 int ASN1_STRING_set_string(ASN1_STRING *str, const char *cstring);
-size_t ASN1_STRING_length_ex(const ASN1_STRING *x);
+size_t ASN1_STRING_get_length(const ASN1_STRING *x);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 void ASN1_STRING_length_set(ASN1_STRING *x, int n);
 #endif

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3629,7 +3629,7 @@ static int tls_process_cke_gost(SSL_CONNECTION *s, PACKET *pkt)
         goto err;
     }
 
-    inlen = ASN1_STRING_length_ex(pKX->kxBlob->value.sequence);
+    inlen = ASN1_STRING_get_length(pKX->kxBlob->value.sequence);
     if (inlen > INT_MAX)
         goto err;
 

--- a/test/asn1_string_test.c
+++ b/test/asn1_string_test.c
@@ -416,7 +416,7 @@ asn1_string_new_not_owned_test(void)
     if (!TEST_mem_eq(data, sizeof(data), data2, sizeof(data2)))
         goto err;
 
-    if (!TEST_size_t_eq(ASN1_STRING_length_ex(tmp), strlen("muppet")))
+    if (!TEST_size_t_eq(ASN1_STRING_get_length(tmp), strlen("muppet")))
         goto err;
 
     if (!TEST_mem_eq(ASN1_STRING_get0_data(tmp), strlen("muppet"), "muppet", strlen("muppet")))
@@ -436,13 +436,13 @@ asn1_string_new_not_owned_test(void)
     if (!TEST_mem_eq(data, sizeof(data), data2, sizeof(data2)))
         goto err;
 
-    if (!TEST_size_t_eq(ASN1_STRING_length_ex(tmp), 4))
+    if (!TEST_size_t_eq(ASN1_STRING_get_length(tmp), 4))
         goto err;
 
     if (!TEST_mem_eq(ASN1_STRING_get0_data(tmp), strlen("puppet"), "puppet", strlen("puppet")))
         goto err;
 
-    memset((uint8_t *)ASN1_STRING_get0_data(tmp), 'z', ASN1_STRING_length_ex(tmp));
+    memset((uint8_t *)ASN1_STRING_get0_data(tmp), 'z', ASN1_STRING_get_length(tmp));
 
     if (!TEST_mem_eq(data, sizeof(data), data2, sizeof(data2)))
         goto err;
@@ -498,7 +498,7 @@ asn1_string_set_data_test(void)
 
     data = ASN1_STRING_get0_data(str);
 
-    if (!TEST_size_t_eq(ASN1_STRING_length_ex(str), 6))
+    if (!TEST_size_t_eq(ASN1_STRING_get_length(str), 6))
         goto err;
 
     if (!TEST_int_eq(memcmp("hoobla", data, strlen("hoobla")), 0))
@@ -509,7 +509,7 @@ asn1_string_set_data_test(void)
 
     data = ASN1_STRING_get0_data(str);
 
-    if (!TEST_size_t_eq(ASN1_STRING_length_ex(str), 7))
+    if (!TEST_size_t_eq(ASN1_STRING_get_length(str), 7))
         goto err;
 
     if (!TEST_int_eq(strcmp("hoobla", (char *)data), 0))
@@ -534,13 +534,13 @@ asn1_string_set_string_test(void)
     if (!TEST_true(ASN1_STRING_set_string(str, "foo")))
         goto err;
 
-    if (!TEST_size_t_eq(ASN1_STRING_length_ex(str), 3))
+    if (!TEST_size_t_eq(ASN1_STRING_get_length(str), 3))
         goto err;
 
     if (!TEST_true(ASN1_STRING_set_string(str, "hoob\0la")))
         goto err;
 
-    if (!TEST_size_t_eq(ASN1_STRING_length_ex(str), 4))
+    if (!TEST_size_t_eq(ASN1_STRING_get_length(str), 4))
         goto err;
 
     success = 1;

--- a/test/asn1_string_test.c
+++ b/test/asn1_string_test.c
@@ -410,7 +410,7 @@ asn1_string_new_not_owned_test(void)
     if (!TEST_ptr(tmp = ASN1_STRING_new_not_owned(V_ASN1_OCTET_STRING, data, sizeof(data))))
         goto err;
 
-    if (!TEST_true(ASN1_STRING_set_string(tmp, "muppet")))
+    if (!TEST_true(ASN1_STRING_set1_string(tmp, "muppet")))
         goto err;
 
     if (!TEST_mem_eq(data, sizeof(data), data2, sizeof(data2)))
@@ -484,16 +484,16 @@ asn1_string_set_data_test(void)
     if (!TEST_ptr(str = ASN1_STRING_new()))
         goto err;
 
-    if (!TEST_false(ASN1_STRING_set_data(str, (uint8_t *)"hoobla", -1)))
+    if (!TEST_false(ASN1_STRING_set1_data(str, (uint8_t *)"hoobla", -1)))
         goto err;
 
-    if (!TEST_false(ASN1_STRING_set_data(str, (uint8_t *)"hoobla", (size_t)INT_MAX + 1)))
+    if (!TEST_false(ASN1_STRING_set1_data(str, (uint8_t *)"hoobla", (size_t)INT_MAX + 1)))
         goto err;
 
-    if (!TEST_true(ASN1_STRING_set_data(str, NULL, 10)))
+    if (!TEST_true(ASN1_STRING_set1_data(str, NULL, 10)))
         goto err;
 
-    if (!TEST_true(ASN1_STRING_set_data(str, (uint8_t *)"hoobla", strlen("hoobla"))))
+    if (!TEST_true(ASN1_STRING_set1_data(str, (uint8_t *)"hoobla", strlen("hoobla"))))
         goto err;
 
     data = ASN1_STRING_get0_data(str);
@@ -504,7 +504,7 @@ asn1_string_set_data_test(void)
     if (!TEST_int_eq(memcmp("hoobla", data, strlen("hoobla")), 0))
         goto err;
 
-    if (!TEST_true(ASN1_STRING_set_data(str, (uint8_t *)"hoobla", strlen("hoobla") + 1)))
+    if (!TEST_true(ASN1_STRING_set1_data(str, (uint8_t *)"hoobla", strlen("hoobla") + 1)))
         goto err;
 
     data = ASN1_STRING_get0_data(str);
@@ -531,13 +531,13 @@ asn1_string_set_string_test(void)
     if (!TEST_ptr(str = ASN1_STRING_new()))
         goto err;
 
-    if (!TEST_true(ASN1_STRING_set_string(str, "foo")))
+    if (!TEST_true(ASN1_STRING_set1_string(str, "foo")))
         goto err;
 
     if (!TEST_size_t_eq(ASN1_STRING_get_length(str), 3))
         goto err;
 
-    if (!TEST_true(ASN1_STRING_set_string(str, "hoob\0la")))
+    if (!TEST_true(ASN1_STRING_set1_string(str, "hoob\0la")))
         goto err;
 
     if (!TEST_size_t_eq(ASN1_STRING_get_length(str), 4))

--- a/test/cmp_hdr_test.c
+++ b/test/cmp_hdr_test.c
@@ -252,7 +252,7 @@ static int execute_HDR_push0_freeText_test(CMP_HDR_TEST_FIXTURE *fixture)
     if (!TEST_ptr(text))
         return 0;
 
-    if (!ASN1_STRING_set_string(text, "A free text"))
+    if (!ASN1_STRING_set1_string(text, "A free text"))
         goto err;
 
     if (!TEST_int_eq(ossl_cmp_hdr_push0_freeText(fixture->hdr, text), 1))
@@ -285,7 +285,7 @@ static int execute_HDR_push1_freeText_test(CMP_HDR_TEST_FIXTURE *fixture)
     if (!TEST_ptr(text))
         goto err;
 
-    if (!ASN1_STRING_set_string(text, "A free text"))
+    if (!ASN1_STRING_set1_string(text, "A free text"))
         goto err;
 
     if (!TEST_int_eq(ossl_cmp_hdr_push1_freeText(fixture->hdr, text), 1))

--- a/test/helpers/pkcs12.c
+++ b/test/helpers/pkcs12.c
@@ -468,21 +468,21 @@ static int check_asn1_string(const ASN1_TYPE *av, const char *txt)
     switch (av->type) {
     case V_ASN1_BMPSTRING:
         value = OPENSSL_uni2asc(ASN1_STRING_get0_data(av->value.bmpstring),
-            (int)ASN1_STRING_length_ex(av->value.bmpstring));
+            (int)ASN1_STRING_get_length(av->value.bmpstring));
         if (!TEST_str_eq(txt, (char *)value))
             goto err;
         break;
 
     case V_ASN1_UTF8STRING:
         if (!TEST_mem_eq(txt, strlen(txt), ASN1_STRING_get0_data(av->value.utf8string),
-                ASN1_STRING_length_ex(av->value.utf8string)))
+                ASN1_STRING_get_length(av->value.utf8string)))
             goto err;
         break;
 
     case V_ASN1_OCTET_STRING:
         if (!TEST_mem_eq(txt, strlen(txt),
                 (char *)ASN1_STRING_get0_data(av->value.octet_string),
-                ASN1_STRING_length_ex(av->value.octet_string)))
+                ASN1_STRING_get_length(av->value.octet_string)))
             goto err;
         break;
 

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -1282,7 +1282,7 @@ static XORKEY *xor_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
         plen = 0;
     } else {
         p = ASN1_STRING_get0_data(oct);
-        plen = (int)ASN1_STRING_length_ex(oct);
+        plen = (int)ASN1_STRING_get_length(oct);
     }
 
     xork = xor_key_op(palg, p, plen, KEY_OP_PRIVATE,

--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -149,7 +149,7 @@ static int set_altname(X509 *crt, ...)
         ia5 = ASN1_IA5STRING_new();
         if (ia5 == NULL)
             goto out;
-        if (!ASN1_STRING_set_string(ia5, name))
+        if (!ASN1_STRING_set1_string(ia5, name))
             goto out;
         switch (type) {
         case GEN_EMAIL:

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -162,7 +162,7 @@ static int test_a2i_ipaddress(int idx)
         }
     } else {
         if (!TEST_ptr(ip)
-            || !TEST_size_t_eq(ASN1_STRING_length_ex(ip), len)
+            || !TEST_size_t_eq(ASN1_STRING_get_length(ip), len)
             || !TEST_mem_eq(ASN1_STRING_get0_data(ip), len,
                 a2i_ipaddress_tests[idx].data, len)) {
             good = 0;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5726,4 +5726,4 @@ EVP_KDF_CTX_get0_kdf                    ?	4_1_0	EXIST::FUNCTION:
 EVP_KDF_CTX_get1_kdf                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_data                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_string                  ?	4_1_0	EXIST::FUNCTION:
-ASN1_STRING_length_ex                   ?	4_1_0	EXIST::FUNCTION:
+ASN1_STRING_get_length                  ?	4_1_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5724,6 +5724,6 @@ OPENSSL_sk_set_copy_thunks              ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_new_not_owned               ?	4_1_0	EXIST::FUNCTION:
 EVP_KDF_CTX_get0_kdf                    ?	4_1_0	EXIST::FUNCTION:
 EVP_KDF_CTX_get1_kdf                    ?	4_1_0	EXIST::FUNCTION:
-ASN1_STRING_set_data                    ?	4_1_0	EXIST::FUNCTION:
-ASN1_STRING_set_string                  ?	4_1_0	EXIST::FUNCTION:
+ASN1_STRING_set1_data                   ?	4_1_0	EXIST::FUNCTION:
+ASN1_STRING_set1_string                 ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_get_length                  ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
There is already a recently[1] introduced `ASN1_BIT_STRING_get_length()`;  the setters, while creating a copy of the provided data, don't signal that in their names per current naming conventions.  Update the names to `ASN1_STRING_get_length`, `ASN1_STRING_set1_data`, and `ASN1_STRING_set1_string`, respectively.

[1] https://github.com/openssl/openssl/pull/29387

Complements: 28179061bfcd "Prepare a now opaque ASN1_STRING for the size_t rapture."