### PR TITLE
QUIC: ignore rejected default stream candidates

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2150,6 +2150,23 @@ struct quic_wait_for_stream_args {
 };
 
 QUIC_NEEDS_LOCK
+static QUIC_STREAM *quic_get_incoming_default_stream(QUIC_CONNECTION *qc,
+    uint64_t expect_id)
+{
+    QUIC_STREAM_MAP *qsm = ossl_quic_channel_get_qsm(qc->ch);
+    QUIC_STREAM *qs;
+
+    qs = ossl_quic_stream_map_get_by_id(qsm,
+        expect_id | QUIC_STREAM_DIR_BIDI);
+    if (qs == NULL)
+        qs = ossl_quic_stream_map_get_by_id(qsm,
+            expect_id | QUIC_STREAM_DIR_UNI);
+
+    /* Auto-rejected streams remain in the map until garbage collection. */
+    return qs != NULL && qs->accept_node.next != NULL ? qs : NULL;
+}
+
+QUIC_NEEDS_LOCK
 static int quic_wait_for_stream(void *arg)
 {
     struct quic_wait_for_stream_args *args = arg;
@@ -2160,11 +2177,7 @@ static int quic_wait_for_stream(void *arg)
         return -1;
     }
 
-    args->qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(args->qc->ch),
-        args->expect_id | QUIC_STREAM_DIR_BIDI);
-    if (args->qs == NULL)
-        args->qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(args->qc->ch),
-            args->expect_id | QUIC_STREAM_DIR_UNI);
+    args->qs = quic_get_incoming_default_stream(args->qc, args->expect_id);
 
     if (args->qs != NULL)
         return 1; /* stream now exists */
@@ -2201,17 +2214,12 @@ static int qc_wait_for_default_xso_for_read(QCTX *ctx, int peek)
         ? QUIC_STREAM_INITIATOR_CLIENT
         : QUIC_STREAM_INITIATOR_SERVER;
 
-    qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(qc->ch),
-        expect_id | QUIC_STREAM_DIR_BIDI);
-    if (qs == NULL)
-        qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(qc->ch),
-            expect_id | QUIC_STREAM_DIR_UNI);
+    qs = quic_get_incoming_default_stream(qc, expect_id);
 
     if (qs == NULL) {
         qctx_maybe_autotick(ctx);
 
-        qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(qc->ch),
-            expect_id);
+        qs = quic_get_incoming_default_stream(qc, expect_id);
     }
 
     if (qs == NULL) {

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -52,6 +52,21 @@ err:
     return ok;
 }
 
+DEF_FUNC(check_want_read)
+{
+    int ok = 0;
+    SSL *ssl;
+
+    REQUIRE_SSL(ssl);
+    if (!TEST_int_eq(SSL_get_error(ssl, 0), SSL_ERROR_WANT_READ)
+        || !TEST_int_eq(SSL_want(ssl), SSL_READING))
+        goto err;
+
+    ok = 1;
+err:
+    return ok;
+}
+
 /*
  * Multi-stream test
  */
@@ -144,6 +159,20 @@ DEF_SCRIPT(multi_stream, "multi stream test")
      * (see SSL_set_incoming_stream_policy(3ossl) for details).
      */
     OP_FUNC(check_rejected);
+}
+
+/*
+ * Reject an incoming stream before a default stream has been established.
+ */
+DEF_SCRIPT(reject_before_default_stream, "reject before default stream")
+{
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+    OP_SET_INCOMING_STREAM_POLICY(C, SSL_INCOMING_STREAM_POLICY_REJECT, 42);
+    OP_WRITE_B(S, "unseen");
+    OP_SLEEP(100);
+    OP_READ_FAIL(C);
+    OP_FUNC(check_want_read);
 }
 
 /*
@@ -1468,6 +1497,7 @@ DEF_SCRIPT(script_106, "place holder for multistrem script_106")
 static SCRIPT_INFO *const scripts[] = {
     USE(simple_stream),
     USE(multi_stream),
+    USE(reject_before_default_stream),
     USE(simple_conn),
     USE(simple_thread),
     USE(ssl_poll),


### PR DESCRIPTION
Fixes #31685.

Auto-rejected QUIC streams remain in the stream map until garbage collection, but they are never linked to the incoming accept queue. Connection-level reads treated map presence as sufficient to select a default stream and then tried to remove an unlinked accept node, triggering the `list_remove` assertion (or a NULL dereference with assertions disabled).

This change centralizes incoming default-stream lookup and only returns streams that are still linked to the accept queue. The regression test establishes a local QUIC connection, rejects the peer-created default stream, and verifies that the connection-level read returns `SSL_ERROR_WANT_READ` without exposing the rejected stream.

Testing:
- Negative control on unmodified source: `quic_radix_test` exits 134 at `quic_stream_map.c:list_remove`.
- Patched focused run: all 111 radix scenarios pass.
- Patched QUIC regression run: all 20 test files / 22 tests pass (`test_quic_*`, `test_quicapi`, and `test_quicfaults`).
- `clang-format --style=file --dry-run --Werror` and `git diff --check` pass.