### PR TITLE
Handle missing CT log store during SCT validation

### DIFF
--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -339,6 +339,9 @@ const CTLOG *CTLOG_STORE_get0_log_by_id(const CTLOG_STORE *store,
 {
     int i;
 
+    if (store == NULL)
+        return NULL;
+
     for (i = 0; i < sk_CTLOG_num(store->logs); ++i) {
         const CTLOG *log = sk_CTLOG_value(store->logs, i);
         if (memcmp(log->log_id, log_id, log_id_len) == 0)

--- a/doc/man3/CTLOG_STORE_get0_log_by_id.pod
+++ b/doc/man3/CTLOG_STORE_get0_log_by_id.pod
@@ -22,6 +22,7 @@ Therefore, it is useful to be able to look up more information about a log
 
 CTLOG_STORE_get0_log_by_id() provides a way to do this. It will find a CTLOG
 in a CTLOG_STORE that has a given LogID.
+If the CTLOG_STORE is NULL, it is treated as empty and no match is found.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/SCT_validate.pod
+++ b/doc/man3/SCT_validate.pod
@@ -54,6 +54,8 @@ A CTLOG_STORE that contains the CT log that issued this SCT.
 
 If the SCT was issued by a log that is not in this CTLOG_STORE, the validation
 status will be SCT_VALIDATION_STATUS_UNKNOWN_LOG.
+If no CTLOG_STORE is provided, the validation status will also be
+SCT_VALIDATION_STATUS_UNKNOWN_LOG.
 
 =back
 

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -550,6 +550,30 @@ end:
     return result;
 }
 
+static int test_sct_validate_no_log_store(void)
+{
+    const unsigned char log_id[CT_V1_HASHLEN] = { 0 };
+    SCT *sct = NULL;
+    CT_POLICY_EVAL_CTX *ct_policy_ctx = NULL;
+    int result = 0;
+
+    if (!TEST_ptr(sct = SCT_new())
+        || !TEST_true(SCT_set_version(sct, SCT_VERSION_V1))
+        || !TEST_true(SCT_set1_log_id(sct, log_id, sizeof(log_id)))
+        || !TEST_ptr(ct_policy_ctx = CT_POLICY_EVAL_CTX_new())
+        || !TEST_int_eq(SCT_validate(sct, ct_policy_ctx), 0)
+        || !TEST_int_eq(SCT_get_validation_status(sct),
+            SCT_VALIDATION_STATUS_UNKNOWN_LOG))
+        goto end;
+
+    result = 1;
+
+end:
+    SCT_free(sct);
+    CT_POLICY_EVAL_CTX_free(ct_policy_ctx);
+    return result;
+}
+
 static int test_ctlog_store_add0_log_validates_sct(void)
 {
     CTLOG_STORE *store = NULL;
@@ -654,6 +678,7 @@ int setup_tests(void)
     ADD_TEST(test_default_ct_policy_eval_ctx_time_is_now);
     ADD_TEST(test_ctlog_from_base64);
     ADD_TEST(test_ctlog_store_add0_log);
+    ADD_TEST(test_sct_validate_no_log_store);
     ADD_TEST(test_ctlog_store_add0_log_validates_sct);
     ADD_TEST(test_ctlog_store_add0_log_null);
 #else


### PR DESCRIPTION
Validating a v1 SCT with a `CT_POLICY_EVAL_CTX` that has no CT log store currently dereferences a NULL pointer in `CTLOG_STORE_get0_log_by_id`.

Although `SCT_validate` documents that the policy context should specify a `CTLOG_STORE`, treat a NULL store like an empty store by returning no matching log. `SCT_validate` already handles this result by returning 0 and setting the validation status to `SCT_VALIDATION_STATUS_UNKNOWN_LOG`, so the SCT is not accepted.

Add a regression test using a v1 SCT with a 32-byte LogID and a fresh policy context without a log store.
Document the NULL-store behavior for both direct `CTLOG_STORE_get0_log_by_id` callers and `SCT_validate`.

Fixes #32026

##### Checklist
- [x] tests are added or updated
- [x] documentation is added or updated

