### PR TITLE
apps: fix and test skeyutl -skeyopt handling

### DIFF
--- a/apps/skeyutl.c
+++ b/apps/skeyutl.c
@@ -102,6 +102,9 @@ int skeyutl_main(int argc, char **argv)
             goto end;
         params = app_params_new_from_opts(skeyopts,
             EVP_SKEYMGMT_get0_gen_settable_params(mgmt));
+        /* A NULL return is an error only if key options were given */
+        if (skeyopts != NULL && params == NULL)
+            goto end;
 
         skey = EVP_SKEY_generate(app_get0_libctx(),
             skeymgmt ? skeymgmt : EVP_CIPHER_name(cipher),

--- a/test/fake_cipherprov.c
+++ b/test/fake_cipherprov.c
@@ -96,6 +96,27 @@ static void *fake_skeymgmt_generate(void *provctx, const OSSL_PARAM *params)
     return ctx;
 }
 
+static const char *fake_skeymgmt_get_key_id(void *keydata)
+{
+    PROV_CIPHER_FAKE_CTX *ctx = (PROV_CIPHER_FAKE_CTX *)keydata;
+
+    if (ctx == NULL || ctx->key_name[0] == '\0')
+        return NULL;
+
+    return ctx->key_name;
+}
+
+static const OSSL_PARAM fake_skeymgmt_known_settable_params[] = {
+    OSSL_PARAM_utf8_string(FAKE_CIPHER_PARAM_KEY_NAME, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, NULL, 0),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *fake_skeymgmt_settable_params(ossl_unused void *provctx)
+{
+    return fake_skeymgmt_known_settable_params;
+}
+
 static int fake_skeymgmt_export(void *keydata, int selection,
     OSSL_CALLBACK *param_callback, void *cbarg)
 {
@@ -126,6 +147,11 @@ static const OSSL_DISPATCH fake_skeymgmt_funcs[] = {
     { OSSL_FUNC_SKEYMGMT_GENERATE, (void (*)(void))fake_skeymgmt_generate },
     { OSSL_FUNC_SKEYMGMT_IMPORT, (void (*)(void))fake_skeymgmt_import },
     { OSSL_FUNC_SKEYMGMT_EXPORT, (void (*)(void))fake_skeymgmt_export },
+    { OSSL_FUNC_SKEYMGMT_GET_KEY_ID, (void (*)(void))fake_skeymgmt_get_key_id },
+    { OSSL_FUNC_SKEYMGMT_IMP_SETTABLE_PARAMS,
+        (void (*)(void))fake_skeymgmt_settable_params },
+    { OSSL_FUNC_SKEYMGMT_GEN_SETTABLE_PARAMS,
+        (void (*)(void))fake_skeymgmt_settable_params },
     OSSL_DISPATCH_END
 };
 

--- a/test/recipes/20-test_skeyutl.t
+++ b/test/recipes/20-test_skeyutl.t
@@ -18,7 +18,7 @@ setup("test_skeyutl");
 # when module support is enabled.
 my $fake_cipher = !disabled('module');
 
-plan tests => 14 + ($fake_cipher ? 2 : 0);
+plan tests => 14 + ($fake_cipher ? 8 : 0);
 
 # Helper: run skeyutl expecting a non-zero (failure) exit code, and optionally
 # check that stderr matches a regular expression.
@@ -96,4 +96,29 @@ if ($fake_cipher) {
     ok($status, "skeyutl -genkey with fake-cipher provider succeeds");
     ok(grep(/opaque key/, @out),
        "skeyutl -genkey reports the generated opaque key");
+
+    # -skeyopt values are passed to the key generation.  The fake-cipher
+    # provider names the generated key after its key_name parameter, so the
+    # option shows up in the reported key id.
+    my $rawopt = 'hexraw-bytes:00112233445566778899aabbccddeeff';
+    @out = run(app(['openssl', 'skeyutl', @prov, '-genkey',
+                    '-skeymgmt', 'fake_cipher',
+                    '-skeyopt', 'key_name:testkey',
+                    '-skeyopt', $rawopt]),
+               capture => 1, statusvar => \$status);
+    ok($status, "skeyutl -genkey with -skeyopt succeeds");
+    ok(grep(/opaque key identified by testkey/, @out),
+       "skeyutl -genkey applies the -skeyopt key name");
+
+    # An option not settable by the key management is rejected
+    skeyutl_fails("skeyutl -genkey with an unknown -skeyopt fails",
+                  qr/Parameter unknown 'nosuchopt:1'/,
+                  @prov, '-genkey', '-skeymgmt', 'fake_cipher',
+                  '-skeyopt', 'nosuchopt:1');
+
+    # A -skeyopt without the opt:value separator is rejected
+    skeyutl_fails("skeyutl -genkey with a malformed -skeyopt fails",
+                  qr/Parameter error 'key_name'/,
+                  @prov, '-genkey', '-skeymgmt', 'fake_cipher',
+                  '-skeyopt', 'key_name');
 }


### PR DESCRIPTION
skeyutl ignored the NULL returned by app_params_new_from_opts() when a key option could not be converted, so it generated the key without the requested options, printing a parameter error but still exiting with success. Bail out instead, the way mac, kdf and enc do.

No provider advertises settable skeymgmt generation parameters, so the fake cipher provider gets a settable parameter table and reports the key name as key id, which makes the working path testable. Test recipe coverage for -skeyopt is added on top.

The first commit is self-contained and can be backported without the test changes.
