### PR TITLE
Update CHANGES/NEWS to mention the HollowByte fix (3.6 backport)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,7 @@ OpenSSL 3.6
 
  * Fixed excessive allocation of the handshake message buffer (aka HollowByte)
 
-   Previously we would allocate a buffer large engough to hold the full size of
+   Previously we would allocate a buffer large enough to hold the full size of
    an incoming handshake message as advertised by the peer. This could be quite
    large (although it is bounded). If the peer then fails to send the full
    handshake message then the endpoint is left waiting for the message to arrive

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,9 +47,9 @@ OpenSSL 3.6
 
  * Fixed excessive allocation of the handshake message buffer (aka HollowByte)
 
-   The init_buf is used to buffer a handshake message from the peer. Previously
-   we would allocate the full size of the advertised handshake message. This
-   could be quite large. If the peer then fails to send the rest of the
+   Previously we would allocate a buffer large engough to hold the full size of
+   an incoming handshake message as advertised by the peer. This could be quite
+   large (although it is bounded). If the peer then fails to send the full
    handshake message then the endpoint is left waiting for the message to arrive
    and the memory is still allocated (i.e. a Slowloris attack). To prevent this
    we incrementally grow the buffer as we receive the data.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,19 @@ OpenSSL 3.6
 
 ### Changes between 3.6.2 and 3.6.3 [9 Jun 2026]
 
+ * Fixed excessive allocation of the handshake message buffer (aka HollowByte)
+
+   The init_buf is used to buffer a handshake message from the peer. Previously
+   we would allocate the full size of the advertised handshake message. This
+   could be quite large. If the peer then fails to send the rest of the
+   handshake message then the endpoint is left waiting for the message to arrive
+   and the memory is still allocated (i.e. a Slowloris attack). To prevent this
+   we incrementally grow the buffer as we receive the data.
+
+   This issue was reported to us by Okta Red Team.
+
+   *Matt Caswell*
+
  * Fixed heap use-after-free in `PKCS7_verify()`.
 
    Severity: High

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,14 +47,15 @@ OpenSSL 3.6
 
  * Fixed excessive allocation of the handshake message buffer (aka HollowByte)
 
-   Previously we would allocate a buffer large enough to hold the full size of
+   Previously, we would allocate a buffer large enough to hold the full size of
    an incoming handshake message as advertised by the peer. This could be quite
-   large (although it is bounded). If the peer then fails to send the full
-   handshake message then the endpoint is left waiting for the message to arrive
-   and the memory is still allocated (i.e. a Slowloris attack). To prevent this
-   we incrementally grow the buffer as we receive the data.
+   large (although it is bounded, e.g. for ClientHello this is approximately
+   128 KiB). If the peer then fails to send the full handshake message, then the
+   endpoint is left waiting for the remainder of the message to arrive and the
+   memory is still allocated (i.e. a Slowloris attack). To prevent this, we
+   incrementally grow the buffer as we receive the data.
 
-   This issue was reported to us by Okta Red Team.
+   This issue was reported by Okta Red Team.
 
    *Matt Caswell*
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -89,6 +89,8 @@ This release incorporates the following bug fixes and mitigations:
     and AES-SIV modes.
     ([CVE-2026-45446])
 
+  * Fixed excessive allocation of the handshake message buffer (aka HollowByte)
+
 ### Major changes between OpenSSL 3.6.1 and OpenSSL 3.6.2 [7 Apr 2026]
 
 OpenSSL 3.6.2 is a security patch release. The most severe CVE fixed in this


### PR DESCRIPTION
Add a previously missing CHANGES.md/NEWS.md entry for the Hollowbyte fix.
