### PR TITLE
DOCS: Fix KEM init function documentation

### DIFF
--- a/doc/man7/provider-kem.pod
+++ b/doc/man7/provider-kem.pod
@@ -32,7 +32,8 @@ provider-kem - The kem library E<lt>-E<gt> provider functions
                                unsigned char *secret, size_t *secretlen);
 
  /* Decapsulation */
- int OSSL_FUNC_kem_decapsulate_init(void *ctx, void *provkey);
+ int OSSL_FUNC_kem_decapsulate_init(void *ctx, void *provkey,
+                                    const OSSL_PARAM params[]);
  int OSSL_FUNC_kem_auth_decapsulate_init(void *ctx, void *provkey,
                                          void *provauthkey,
                                          const OSSL_PARAM params[]);
@@ -129,13 +130,13 @@ context in the I<ctx> parameter and return the duplicate copy.
 
 OSSL_FUNC_kem_encapsulate_init() initialises a context for an asymmetric
 encapsulation given a provider side asymmetric kem context in the I<ctx>
-parameter, a pointer to a provider key object in the I<provkey> parameter and
-the I<name> of the algorithm.
+parameter, a pointer to a provider key object in the I<provkey> parameter.
+
 The I<params>, if not NULL, should be set on the context in a manner similar to
 using OSSL_FUNC_kem_set_ctx_params().
 The key object should have been previously generated, loaded or imported into
 the provider using the key management (OSSL_OP_KEYMGMT) operation (see
-provider-keymgmt(7)>.
+L<provider-keymgmt(7)>.
 
 OSSL_FUNC_kem_auth_encapsulate_init() is similar to
 OSSL_FUNC_kem_encapsulate_init(), but also passes an additional authentication
@@ -159,11 +160,13 @@ written to I<*secretlen>.
 
 OSSL_FUNC_kem_decapsulate_init() initialises a context for an asymmetric
 decapsulation given a provider side asymmetric kem context in the I<ctx>
-parameter, a pointer to a provider key object in the I<provkey> parameter, and
-a I<name> of the algorithm.
+parameter, a pointer to a provider key object in the I<provkey> parameter.
+
+The I<params>, if not NULL, should be set on the context in a manner similar to
+using OSSL_FUNC_kem_set_ctx_params().
 The key object should have been previously generated, loaded or imported into
 the provider using the key management (OSSL_OP_KEYMGMT) operation (see
-provider-keymgmt(7)>.
+L<provider-keymgmt(7)>.
 
 OSSL_FUNC_kem_auth_decapsulate_init() is similar to
 OSSL_FUNC_kem_decapsulate_init(), but also passes an additional authentication


### PR DESCRIPTION
### Current behavior
The `provider-kem(7)` synopsis documents `OSSL_FUNC_kem_decapsulate_init(`) without the params argument:
```
int OSSL_FUNC_kem_decapsulate_init(void *ctx, void *provkey);
```

However, the provider dispatch interface defines it as:
```
OSSL_CORE_MAKE_FUNC(int, kem_decapsulate_init, (void *ctx, void *provkey, const OSSL_PARAM params[]))
```
The descriptions of both `OSSL_FUNC_kem_encapsulate_init()` and `OSSL_FUNC_kem_decapsulate_init()` also refer to a nonexistent `name` argument.

### Scope of changes
- Add the missing params argument to the documented `OSSL_FUNC_kem_decapsulate_init()` signature.
- Document how the initialization parameters are applied.
- Remove stale references to the `name` argument.
- Fix the malformed `provider-keymgmt(7)` link.

The `name` references are remnants of an earlier KEM API design.

Complements: 78c44b05945b "Add HPKE DHKEM provider support for EC, X25519 and X448."

Documentation-only change.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated