### PR TITLE
DOCS: Fix derive_skey provider documentation

### DIFF
--- a/doc/man7/provider-kdf.pod
+++ b/doc/man7/provider-kdf.pod
@@ -341,7 +341,10 @@ It is defined as per RFC 7292 section B.3.
 OSSL_FUNC_kdf_newctx() and OSSL_FUNC_kdf_dupctx() should return the newly created
 provider side KDF context, or NULL on failure.
 
-OSSL_FUNC_kdf_derive(), OSSL_FUNC_kdf_derive_skey(), OSSL_FUNC_kdf_get_params(),
+OSSL_FUNC_kdf_derive_skey() should return the newly created opaque
+provider-side key object, or NULL on failure.
+
+OSSL_FUNC_kdf_derive(), OSSL_FUNC_kdf_get_params(),
 OSSL_FUNC_kdf_get_ctx_params(), OSSL_FUNC_kdf_set_ctx_params() and
 OSSL_FUNC_kdf_set_skey() should return 1 for success or 0 on error.
 

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -28,9 +28,10 @@ provider-keyexch - The keyexch library E<lt>-E<gt> provider functions
  int OSSL_FUNC_keyexch_set_peer(void *ctx, void *provkey);
  int OSSL_FUNC_keyexch_derive(void *ctx, unsigned char *secret, size_t *secretlen,
                               size_t outlen);
- int OSSL_FUNC_keyexch_derive_skey(void *ctx, const char *key_type, void *provctx,
-                                   OSSL_FUNC_skeymgmt_import_fn *import,
-                                   size_t keylen, const OSSL_PARAM params[]);
+ void *OSSL_FUNC_keyexch_derive_skey(void *ctx, const char *key_type,
+                                     void *provctx,
+                                     OSSL_FUNC_skeymgmt_import_fn *import,
+                                     size_t keylen, const OSSL_PARAM params[]);
 
  /* Key Exchange parameters */
  int OSSL_FUNC_keyexch_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
@@ -115,10 +116,10 @@ OSSL_FUNC_keyexch_init() initialises a key exchange operation given a provider s
 exchange context in the I<ctx> parameter, and a pointer to a provider key object
 in the I<provkey> parameter.
 The I<params>, if not NULL, should be set on the context in a manner similar to
-using OSSL_FUNC_keyexch_set_params().
+using OSSL_FUNC_keyexch_set_ctx_params().
 The key object should have been previously
 generated, loaded or imported into the provider using the key management
-(OSSL_OP_KEYMGMT) operation (see provider-keymgmt(7)>.
+(OSSL_OP_KEYMGMT) operation (see L<provider-keymgmt(7)>.
 
 OSSL_FUNC_keyexch_set_peer() is called to supply the peer's public key (in the
 I<provkey> parameter) to be used when deriving the shared secret.
@@ -126,7 +127,7 @@ It is also passed a previously initialised key exchange context in the I<ctx>
 parameter.
 The key object should have been previously generated, loaded or imported into
 the provider using the key management (OSSL_OP_KEYMGMT) operation (see
-provider-keymgmt(7)>.
+L<provider-keymgmt(7)>.
 
 OSSL_FUNC_keyexch_derive() performs the actual key exchange itself by deriving a shared
 secret.
@@ -143,7 +144,7 @@ uses an opaque object for storing the derived key. It accepts I<key_type>
 parameter to give a hint to the provider what type of the key (e.g. generic or
 AES) would be generated and I<import> function from the B<EVP_SKEYMGMT> object
 to be associated with the key. The B<EVP_SKEYMGMT> object comes from the same
-provider as the KDF itself.
+provider as the key exchange implementation.
 
 =head2 Key Exchange Parameters Functions
 
@@ -253,10 +254,12 @@ to return 0.
 OSSL_FUNC_keyexch_newctx() and OSSL_FUNC_keyexch_dupctx() should return the newly created
 provider side key exchange context, or NULL on failure.
 
-OSSL_FUNC_keyexch_init(), OSSL_FUNC_keyexch_set_peer(), OSSL_FUNC_keyexch_derive(),
-OSSL_FUNC_keyexch_derive_skey(),
-OSSL_FUNC_keyexch_set_params(), and OSSL_FUNC_keyexch_get_params() should return 1 for success
-or 0 on error.
+OSSL_FUNC_keyexch_derive_skey() should return the newly created opaque
+provider-side key object, or NULL on failure.
+
+OSSL_FUNC_keyexch_init(), OSSL_FUNC_keyexch_set_peer(),
+OSSL_FUNC_keyexch_derive(), OSSL_FUNC_keyexch_set_ctx_params(), and
+OSSL_FUNC_keyexch_get_ctx_params() should return 1 for success or 0 on error.
 
 OSSL_FUNC_keyexch_settable_ctx_params() and OSSL_FUNC_keyexch_gettable_ctx_params() should
 always return a constant L<OSSL_PARAM(3)> array.


### PR DESCRIPTION
### Current behavior
The `provider-keyexch(7)` synopsis documents `OSSL_FUNC_keyexch_derive_skey()` with an `int` return type:
```
int OSSL_FUNC_keyexch_derive_skey(void *ctx, const char *key_type, void *provctx,
                                  OSSL_FUNC_skeymgmt_import_fn *import,
                                  size_t keylen, const OSSL_PARAM params[]);
```
However, the provider dispatch interface defines it as returning `void *`:
```
OSSL_CORE_MAKE_FUNC(void *, keyexch_derive_skey, (void *ctx, const char *key_type, void *provctx, OSSL_FUNC_skeymgmt_import_fn *import, size_t keylen, const OSSL_PARAM params[]))
```

The KEYEXCH and KDF manuals also incorrectly describe `derive_skey()` as returning 1 or 0.

Additionally, `provider-keyexch(7)` contains stale function names, malformed links, and an incorrect reference to the KDF provider.

### Scope of changes
- Correct the `OSSL_FUNC_keyexch_derive_skey()` return type.
- Correct the KEYEXCH and KDF `derive_skey()` return-value descriptions.
- Replace stale function names.
- Fix malformed links and the incorrect KDF reference.

Complements:
- 7d42bec "Implement EVP_PKEY_derive_SKEY"
- b5d0d06 "Implement EVP_KDF_derive_SKEY"
- c4aa517 "Add key_type to the derive_skey function"

Documentation-only change.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated