### PR TITLE
ci: add pilot auto-dispatch entry points for approved PRs

### DIFF
--- a/.github/workflows/ct-validation-daily.yml
+++ b/.github/workflows/ct-validation-daily.yml
@@ -42,21 +42,19 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: 'PR number (leave empty for a bare manual run against the default branch)'
+        description: 'Internal: openssl-ci-bot PR number. Leave empty for a normal manual run.'
         required: false
         type: string
       head_sha:
-        description: 'Exact commit SHA to check out (required when pr is set)'
+        description: 'Internal: openssl-ci-bot commit SHA. Leave empty for a normal manual run.'
         required: false
         type: string
       check_run_id:
-        description: 'Check-run id to report completion back to (required when pr is set)'
+        description: 'Internal: openssl-ci-bot check-run ID. Leave empty for a normal manual run.'
         required: false
         type: string
 
-# Pinned run-name contract with images/openssl-ci-bot/main.py's format_run_name()/
-# parse_run_name() -- the completed-run handler parses check_run_id back out of
-# this exact format string, so keep both sides identical on any change.
+# Keep in sync with openssl-ci-bot's run-name parser.
 run-name: >-
   ${{ github.event.inputs.pr && format('ci-dispatch pr={0} head={1} check_run_id={2}', github.event.inputs.pr, github.event.inputs.head_sha, github.event.inputs.check_run_id) || github.workflow }}
 
@@ -69,17 +67,14 @@ permissions:
 
 jobs:
   validate-dispatch-inputs:
-    # Defense-in-depth on the untrusted-code boundary, in addition to the
-    # dispatching service's own validation: fail closed on malformed inputs
-    # before anything checks out a ref or runs.
-    if: github.repository == 'openssl/openssl' && github.event.inputs.pr != ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate pr / head_sha / check_run_id
-        run: |
-          [[ "${{ github.event.inputs.pr }}" =~ ^[0-9]+$ ]] || { echo "::error::pr must be numeric"; exit 1; }
-          [[ "${{ github.event.inputs.check_run_id }}" =~ ^[0-9]+$ ]] || { echo "::error::check_run_id must be numeric"; exit 1; }
-          [[ "${{ github.event.inputs.head_sha }}" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::head_sha must be a 40-character hex commit SHA"; exit 1; }
+    if: |
+      github.repository == 'openssl/openssl' &&
+      (inputs.pr != '' || inputs.head_sha != '' || inputs.check_run_id != '')
+    uses: ./.github/workflows/validate-dispatch-inputs.yml
+    with:
+      pr: ${{ inputs.pr }}
+      head_sha: ${{ inputs.head_sha }}
+      check_run_id: ${{ inputs.check_run_id }}
 
   ct-validation:
     needs: [validate-dispatch-inputs]
@@ -118,8 +113,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-          # Bare-manual/schedule triggers omit head_sha, in which case checkout
-          # falls back to its own default (github.sha) unchanged.
           ref: ${{ github.event.inputs.head_sha || github.sha }}
 
       - name: Install valgrind

--- a/.github/workflows/ct-validation-daily.yml
+++ b/.github/workflows/ct-validation-daily.yml
@@ -80,7 +80,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     strategy:
       fail-fast: false

--- a/.github/workflows/ct-validation-daily.yml
+++ b/.github/workflows/ct-validation-daily.yml
@@ -40,13 +40,53 @@ on:
   schedule:
     - cron: '45 03 * * *'
   workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number (leave empty for a bare manual run against the default branch)'
+        required: false
+        type: string
+      head_sha:
+        description: 'Exact commit SHA to check out (required when pr is set)'
+        required: false
+        type: string
+      check_run_id:
+        description: 'Check-run id to report completion back to (required when pr is set)'
+        required: false
+        type: string
+
+# Pinned run-name contract with images/openssl-ci-bot/main.py's format_run_name()/
+# parse_run_name() -- the completed-run handler parses check_run_id back out of
+# this exact format string, so keep both sides identical on any change.
+run-name: >-
+  ${{ github.event.inputs.pr && format('ci-dispatch pr={0} head={1} check_run_id={2}', github.event.inputs.pr, github.event.inputs.head_sha, github.event.inputs.check_run_id) || github.workflow }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
+  validate-dispatch-inputs:
+    # Defense-in-depth on the untrusted-code boundary, in addition to the
+    # dispatching service's own validation: fail closed on malformed inputs
+    # before anything checks out a ref or runs.
+    if: github.repository == 'openssl/openssl' && github.event.inputs.pr != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate pr / head_sha / check_run_id
+        run: |
+          [[ "${{ github.event.inputs.pr }}" =~ ^[0-9]+$ ]] || { echo "::error::pr must be numeric"; exit 1; }
+          [[ "${{ github.event.inputs.check_run_id }}" =~ ^[0-9]+$ ]] || { echo "::error::check_run_id must be numeric"; exit 1; }
+          [[ "${{ github.event.inputs.head_sha }}" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::head_sha must be a 40-character hex commit SHA"; exit 1; }
+
   ct-validation:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +118,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          # Bare-manual/schedule triggers omit head_sha, in which case checkout
+          # falls back to its own default (github.sha) unchanged.
+          ref: ${{ github.event.inputs.head_sha || github.sha }}
 
       - name: Install valgrind
         # On Debian/Ubuntu the main 'valgrind' package includes

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     strategy:
       fail-fast: false
@@ -194,7 +194,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -241,7 +241,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -271,7 +271,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -301,7 +301,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -332,7 +332,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -362,7 +362,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -396,7 +396,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -430,7 +430,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     strategy:
       matrix:
@@ -456,7 +456,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -481,7 +481,7 @@ jobs:
     needs: [validate-dispatch-inputs]
     if: |
       github.repository == 'openssl/openssl' &&
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -510,7 +510,7 @@ jobs:
   bn_debug:
     needs: [validate-dispatch-inputs]
     if: |
-      always() &&
+      !cancelled() &&
       (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -12,13 +12,53 @@ on:
   schedule:
     - cron: '30 02 * * *'
   workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number (leave empty for a bare manual run against the default branch)'
+        required: false
+        type: string
+      head_sha:
+        description: 'Exact commit SHA to check out (required when pr is set)'
+        required: false
+        type: string
+      check_run_id:
+        description: 'Check-run id to report completion back to (required when pr is set)'
+        required: false
+        type: string
+
+# Pinned run-name contract with images/openssl-ci-bot/main.py's format_run_name()/
+# parse_run_name() -- the completed-run handler parses check_run_id back out of
+# this exact format string, so keep both sides identical on any change.
+run-name: >-
+  ${{ github.event.inputs.pr && format('ci-dispatch pr={0} head={1} check_run_id={2}', github.event.inputs.pr, github.event.inputs.head_sha, github.event.inputs.check_run_id) || github.workflow }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
+  validate-dispatch-inputs:
+    # Defense-in-depth on the untrusted-code boundary, in addition to the
+    # dispatching service's own validation: fail closed on malformed inputs
+    # before anything checks out a ref or runs.
+    if: github.repository == 'openssl/openssl' && github.event.inputs.pr != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate pr / head_sha / check_run_id
+        run: |
+          [[ "${{ github.event.inputs.pr }}" =~ ^[0-9]+$ ]] || { echo "::error::pr must be numeric"; exit 1; }
+          [[ "${{ github.event.inputs.check_run_id }}" =~ ^[0-9]+$ ]] || { echo "::error::check_run_id must be numeric"; exit 1; }
+          [[ "${{ github.event.inputs.head_sha }}" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::head_sha must be a 40-character hex commit SHA"; exit 1; }
+
   run-checker:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -139,6 +179,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
@@ -155,12 +196,17 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   run-checker-sctp:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: Install Dependencies for sctp option
@@ -197,7 +243,11 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_brotli_dynamic:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - name: install brotli
@@ -208,6 +258,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
@@ -222,7 +273,11 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_zstd_dynamic:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - name: install zstd
@@ -233,6 +288,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
@@ -247,7 +303,11 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_brotli_and_zstd_dynamic:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - name: install brotli and zstd
@@ -259,6 +319,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
@@ -273,13 +334,18 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   malloc_failure_testing:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - name: checkout openssl
       uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: Adjust ASLR for sanitizer
       run: |
         sudo cat /proc/sys/vm/mmap_rnd_bits
@@ -298,7 +364,11 @@ jobs:
         make TESTS="test_memfail" test
 
   enable_brotli_and_asan_ubsan:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - name: install brotli
@@ -309,6 +379,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: Adjust ASLR for sanitizer
@@ -327,7 +398,11 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0
 
   enable_zstd_and_asan_ubsan:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - name: install zstd
@@ -338,6 +413,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: Adjust ASLR for sanitizer
@@ -356,7 +432,11 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0
 
   enable_tfo:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     strategy:
       matrix:
         os: [ubuntu-latest, macos-15, macos-15-intel]
@@ -365,6 +445,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
@@ -377,12 +458,17 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_buildtest:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
@@ -397,12 +483,17 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   memory_sanitizer_slh_dsa:
-    if: github.repository == 'openssl/openssl'
+    needs: [validate-dispatch-inputs]
+    if: |
+      github.repository == 'openssl/openssl' &&
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: Adjust ASLR for sanitizer
@@ -422,11 +513,16 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0
 
   bn_debug:
+    needs: [validate-dispatch-inputs]
+    if: |
+      always() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
     - name: config
       run: ./config --debug --strict-warnings -DBN_DEBUG --banner=Configured -DOPENSSL_NO_SECURE_MEMORY && perl configdata.pm --dump
     - name: make

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -14,21 +14,19 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: 'PR number (leave empty for a bare manual run against the default branch)'
+        description: 'Internal: openssl-ci-bot PR number. Leave empty for a normal manual run.'
         required: false
         type: string
       head_sha:
-        description: 'Exact commit SHA to check out (required when pr is set)'
+        description: 'Internal: openssl-ci-bot commit SHA. Leave empty for a normal manual run.'
         required: false
         type: string
       check_run_id:
-        description: 'Check-run id to report completion back to (required when pr is set)'
+        description: 'Internal: openssl-ci-bot check-run ID. Leave empty for a normal manual run.'
         required: false
         type: string
 
-# Pinned run-name contract with images/openssl-ci-bot/main.py's format_run_name()/
-# parse_run_name() -- the completed-run handler parses check_run_id back out of
-# this exact format string, so keep both sides identical on any change.
+# Keep in sync with openssl-ci-bot's run-name parser.
 run-name: >-
   ${{ github.event.inputs.pr && format('ci-dispatch pr={0} head={1} check_run_id={2}', github.event.inputs.pr, github.event.inputs.head_sha, github.event.inputs.check_run_id) || github.workflow }}
 
@@ -41,17 +39,14 @@ permissions:
 
 jobs:
   validate-dispatch-inputs:
-    # Defense-in-depth on the untrusted-code boundary, in addition to the
-    # dispatching service's own validation: fail closed on malformed inputs
-    # before anything checks out a ref or runs.
-    if: github.repository == 'openssl/openssl' && github.event.inputs.pr != ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate pr / head_sha / check_run_id
-        run: |
-          [[ "${{ github.event.inputs.pr }}" =~ ^[0-9]+$ ]] || { echo "::error::pr must be numeric"; exit 1; }
-          [[ "${{ github.event.inputs.check_run_id }}" =~ ^[0-9]+$ ]] || { echo "::error::check_run_id must be numeric"; exit 1; }
-          [[ "${{ github.event.inputs.head_sha }}" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::head_sha must be a 40-character hex commit SHA"; exit 1; }
+    if: |
+      github.repository == 'openssl/openssl' &&
+      (inputs.pr != '' || inputs.head_sha != '' || inputs.check_run_id != '')
+    uses: ./.github/workflows/validate-dispatch-inputs.yml
+    with:
+      pr: ${{ inputs.pr }}
+      head_sha: ${{ inputs.head_sha }}
+      check_run_id: ${{ inputs.check_run_id }}
 
   run-checker:
     needs: [validate-dispatch-inputs]

--- a/.github/workflows/valgrind-daily.yml
+++ b/.github/workflows/valgrind-daily.yml
@@ -52,7 +52,7 @@ jobs:
       needs: [validate-dispatch-inputs]
       if: |
         github.repository == 'openssl/openssl' &&
-        always() &&
+        !cancelled() &&
         (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/valgrind-daily.yml
+++ b/.github/workflows/valgrind-daily.yml
@@ -14,21 +14,19 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: 'PR number (leave empty for a bare manual run against the default branch)'
+        description: 'Internal: openssl-ci-bot PR number. Leave empty for a normal manual run.'
         required: false
         type: string
       head_sha:
-        description: 'Exact commit SHA to check out (required when pr is set)'
+        description: 'Internal: openssl-ci-bot commit SHA. Leave empty for a normal manual run.'
         required: false
         type: string
       check_run_id:
-        description: 'Check-run id to report completion back to (required when pr is set)'
+        description: 'Internal: openssl-ci-bot check-run ID. Leave empty for a normal manual run.'
         required: false
         type: string
 
-# Pinned run-name contract with images/openssl-ci-bot/main.py's format_run_name()/
-# parse_run_name() -- the completed-run handler parses check_run_id back out of
-# this exact format string, so keep both sides identical on any change.
+# Keep in sync with openssl-ci-bot's run-name parser.
 run-name: >-
   ${{ github.event.inputs.pr && format('ci-dispatch pr={0} head={1} check_run_id={2}', github.event.inputs.pr, github.event.inputs.head_sha, github.event.inputs.check_run_id) || github.workflow }}
 
@@ -41,17 +39,14 @@ permissions:
 
 jobs:
     validate-dispatch-inputs:
-      # Defense-in-depth on the untrusted-code boundary, in addition to the
-      # dispatching service's own validation: fail closed on malformed inputs
-      # before anything checks out a ref or runs.
-      if: github.repository == 'openssl/openssl' && github.event.inputs.pr != ''
-      runs-on: ubuntu-latest
-      steps:
-        - name: Validate pr / head_sha / check_run_id
-          run: |
-            [[ "${{ github.event.inputs.pr }}" =~ ^[0-9]+$ ]] || { echo "::error::pr must be numeric"; exit 1; }
-            [[ "${{ github.event.inputs.check_run_id }}" =~ ^[0-9]+$ ]] || { echo "::error::check_run_id must be numeric"; exit 1; }
-            [[ "${{ github.event.inputs.head_sha }}" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::head_sha must be a 40-character hex commit SHA"; exit 1; }
+      if: |
+        github.repository == 'openssl/openssl' &&
+        (inputs.pr != '' || inputs.head_sha != '' || inputs.check_run_id != '')
+      uses: ./.github/workflows/validate-dispatch-inputs.yml
+      with:
+        pr: ${{ inputs.pr }}
+        head_sha: ${{ inputs.head_sha }}
+        check_run_id: ${{ inputs.check_run_id }}
 
     check-valgrind-suppressions:
       needs: [validate-dispatch-inputs]

--- a/.github/workflows/valgrind-daily.yml
+++ b/.github/workflows/valgrind-daily.yml
@@ -12,17 +12,59 @@ on:
   schedule:
     - cron: '30 02 * * *'
   workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number (leave empty for a bare manual run against the default branch)'
+        required: false
+        type: string
+      head_sha:
+        description: 'Exact commit SHA to check out (required when pr is set)'
+        required: false
+        type: string
+      check_run_id:
+        description: 'Check-run id to report completion back to (required when pr is set)'
+        required: false
+        type: string
+
+# Pinned run-name contract with images/openssl-ci-bot/main.py's format_run_name()/
+# parse_run_name() -- the completed-run handler parses check_run_id back out of
+# this exact format string, so keep both sides identical on any change.
+run-name: >-
+  ${{ github.event.inputs.pr && format('ci-dispatch pr={0} head={1} check_run_id={2}', github.event.inputs.pr, github.event.inputs.head_sha, github.event.inputs.check_run_id) || github.workflow }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
+    validate-dispatch-inputs:
+      # Defense-in-depth on the untrusted-code boundary, in addition to the
+      # dispatching service's own validation: fail closed on malformed inputs
+      # before anything checks out a ref or runs.
+      if: github.repository == 'openssl/openssl' && github.event.inputs.pr != ''
+      runs-on: ubuntu-latest
+      steps:
+        - name: Validate pr / head_sha / check_run_id
+          run: |
+            [[ "${{ github.event.inputs.pr }}" =~ ^[0-9]+$ ]] || { echo "::error::pr must be numeric"; exit 1; }
+            [[ "${{ github.event.inputs.check_run_id }}" =~ ^[0-9]+$ ]] || { echo "::error::check_run_id must be numeric"; exit 1; }
+            [[ "${{ github.event.inputs.head_sha }}" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::head_sha must be a 40-character hex commit SHA"; exit 1; }
+
     check-valgrind-suppressions:
+      needs: [validate-dispatch-inputs]
+      if: |
+        github.repository == 'openssl/openssl' &&
+        always() &&
+        (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v6
           with:
             persist-credentials: false
+            ref: ${{ github.event.inputs.head_sha || github.sha }}
         - name: Install valgrind
           run: |
             sudo apt-get -y update

--- a/.github/workflows/valgrind-daily.yml
+++ b/.github/workflows/valgrind-daily.yml
@@ -51,9 +51,10 @@ jobs:
     check-valgrind-suppressions:
       needs: [validate-dispatch-inputs]
       if: |
-        github.repository == 'openssl/openssl' &&
         !cancelled() &&
-        (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
+        (needs.validate-dispatch-inputs.result == 'success' ||
+         (needs.validate-dispatch-inputs.result == 'skipped' &&
+          inputs.pr == '' && inputs.head_sha == '' && inputs.check_run_id == ''))
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v6

--- a/.github/workflows/validate-dispatch-inputs.yml
+++ b/.github/workflows/validate-dispatch-inputs.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           [[ "$PR" =~ ^[1-9][0-9]*$ ]] || { echo "::error::pr must be a positive integer"; exit 1; }
           [[ "$CHECK_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo "::error::check_run_id must be a positive integer"; exit 1; }
-          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::head_sha must be a 40-character lowercase hex commit SHA"; exit 1; }
+          [[ "$HEAD_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo "::error::head_sha must be a 40-character hex commit SHA"; exit 1; }

--- a/.github/workflows/validate-dispatch-inputs.yml
+++ b/.github/workflows/validate-dispatch-inputs.yml
@@ -1,0 +1,37 @@
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the LICENSE file in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: Validate CI bot dispatch inputs
+
+on:
+  workflow_call:
+    inputs:
+      pr:
+        required: true
+        type: string
+      head_sha:
+        required: true
+        type: string
+      check_run_id:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate pr / head_sha / check_run_id
+        env:
+          PR: ${{ inputs.pr }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          CHECK_RUN_ID: ${{ inputs.check_run_id }}
+        run: |
+          [[ "$PR" =~ ^[1-9][0-9]*$ ]] || { echo "::error::pr must be a positive integer"; exit 1; }
+          [[ "$CHECK_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo "::error::check_run_id must be a positive integer"; exit 1; }
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::head_sha must be a 40-character lowercase hex commit SHA"; exit 1; }


### PR DESCRIPTION
This is a pilot for automatically running selected CI workflows after a PR is approved.

The pilot intentionally includes only three workflows:

- `ct-validation-daily`
- `run-checker-daily`
- `valgrind-daily`

It covers only the automatic on-approval path. The proposed `/ci` comment command for manually requesting CI will be implemented separately.

For bot dispatches, the workflows accept the PR number, exact head SHA, and check-run ID. A shared reusable workflow rejects incomplete or malformed input before checkout. Jobs then check out the specified SHA with read-only permissions and without persisted credentials.

The run name carries the check-run correlation data, and PR-keyed concurrency cancels obsolete runs.

Existing scheduled and Actions-tab manual execution remain unchanged: leave the internal inputs empty to run normally. Existing fork behavior is also preserved.