### PR TITLE
Allow adding untrusted intermediates to cert stores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -283,6 +283,13 @@ OpenSSL Releases
 
    *Dimitri John Ledkov*
 
+ * Added `X509_STORE_add_untrusted_cert()` and
+   `X509_STORE_get1_untrusted_certs()`.  This allows adding untrusted
+   intermediate certificates to a certificate store to help with building
+   chains to an existing trust anchor.
+
+   *Tim Perry*
+
 OpenSSL 4.0
 -----------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -344,6 +344,13 @@ OpenSSL Releases
 
    *Dimitri John Ledkov*
 
+ * Added `X509_STORE_add_untrusted_cert()` and
+   `X509_STORE_get1_untrusted_certs()`.  This allows adding untrusted
+   intermediate certificates to a certificate store to help with building
+   chains to an existing trust anchor.
+
+   *Tim Perry*
+
 OpenSSL 4.0
 -----------
 

--- a/crypto/x509/x509_local.h
+++ b/crypto/x509/x509_local.h
@@ -147,6 +147,11 @@ struct x509_store_st {
      * compatibility.
      */
     STACK_OF(X509_OBJECT) *objs;
+    /*
+     * Certificates available as candidate issuers for chain building during
+     * verification, but never usable as trust anchors.
+     */
+    STACK_OF(X509) *untrusted;
     /* These are external lookup methods */
     STACK_OF(X509_LOOKUP) *get_cert_methods;
     X509_VERIFY_PARAM *param;
@@ -192,6 +197,7 @@ int ossl_x509_signing_allowed(const X509 *issuer, const X509 *subject);
 int ossl_x509_store_ctx_get_by_subject(const X509_STORE_CTX *ctx, X509_LOOKUP_TYPE type,
     const X509_NAME *name, X509_OBJECT *ret);
 __owur int ossl_x509_store_read_lock(X509_STORE *xs);
+int ossl_x509_store_get1_untrusted(X509_STORE *xs, STACK_OF(X509) **out);
 STACK_OF(X509_OBJECT) *ossl_x509_store_ht_get_by_name(const X509_STORE *store,
     const X509_NAME *xn);
 int ossl_x509_check_rfc822(X509 *x, const char *chk, size_t chklen,

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -274,6 +274,7 @@ void X509_STORE_free(X509_STORE *xs)
     }
     sk_X509_LOOKUP_free(sk);
     sk_X509_OBJECT_pop_free(xs->objs, X509_OBJECT_free);
+    sk_X509_pop_free(xs->untrusted, X509_free);
 
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_X509_STORE, xs, &xs->ex_data);
     X509_VERIFY_PARAM_free(xs->param);
@@ -598,6 +599,70 @@ int X509_STORE_add_crl(X509_STORE *xs, X509_CRL *x)
         return 0;
     }
     return 1;
+}
+
+int X509_STORE_add_untrusted_cert(X509_STORE *xs, const X509 *x)
+{
+    int ret;
+
+    if (xs == NULL || x == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    if (!X509_STORE_lock(xs)) {
+        ERR_raise(ERR_LIB_X509, ERR_R_CRYPTO_LIB);
+        return 0;
+    }
+    if (xs->untrusted == NULL
+        && (xs->untrusted = sk_X509_new_null()) == NULL) {
+        X509_STORE_unlock(xs);
+        ERR_raise(ERR_LIB_X509, ERR_R_CRYPTO_LIB);
+        return 0;
+    }
+    ret = X509_add_cert(xs->untrusted, x, X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP);
+    X509_STORE_unlock(xs);
+    if (!ret)
+        ERR_raise(ERR_LIB_X509, ERR_R_X509_LIB);
+    return ret;
+}
+
+int ossl_x509_store_get1_untrusted(X509_STORE *xs, STACK_OF(X509) **out)
+{
+    STACK_OF(X509) *sk = NULL;
+
+    *out = NULL;
+    if (!ossl_x509_store_read_lock(xs)) {
+        ERR_raise(ERR_LIB_X509, ERR_R_CRYPTO_LIB);
+        return 0;
+    }
+    if (sk_X509_num(xs->untrusted) > 0) {
+        if ((sk = sk_X509_new_null()) == NULL
+            || !X509_add_certs(sk, xs->untrusted, X509_ADD_FLAG_UP_REF)) {
+            X509_STORE_unlock(xs);
+            sk_X509_pop_free(sk, X509_free);
+            ERR_raise(ERR_LIB_X509, ERR_R_CRYPTO_LIB);
+            return 0;
+        }
+    }
+    X509_STORE_unlock(xs);
+    *out = sk;
+    return 1;
+}
+
+STACK_OF(X509) *X509_STORE_get1_untrusted_certs(const X509_STORE *xs)
+{
+    STACK_OF(X509) *sk = NULL;
+
+    if (xs == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+        return NULL;
+    }
+    if (!ossl_x509_store_get1_untrusted((X509_STORE *)xs, &sk))
+        return NULL;
+
+    if (sk == NULL && (sk = sk_X509_new_null()) == NULL)
+        ERR_raise(ERR_LIB_X509, ERR_R_CRYPTO_LIB);
+    return sk;
 }
 
 int X509_OBJECT_up_ref_count(X509_OBJECT *a)

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3674,6 +3674,7 @@ static int build_chain(X509_STORE_CTX *ctx)
     SSL_DANE *dane = ctx->dane;
     int num = sk_X509_num(ctx->chain);
     STACK_OF(X509) *sk_untrusted = NULL;
+    STACK_OF(X509) *sk_store_untrusted = NULL;
     unsigned int search;
     int may_trusted = 0;
     int may_alternate = 0;
@@ -3690,6 +3691,17 @@ static int build_chain(X509_STORE_CTX *ctx)
 #define S_DOUNTRUSTED (1 << 0) /* Search untrusted chain */
 #define S_DOTRUSTED (1 << 1) /* Search trusted store */
 #define S_DOALTERNATE (1 << 2) /* Retry with pruned alternate chain */
+
+    /*
+     * Snapshot store-level untrusted certificates to use as chain candidates,
+     * in addition to the ctx-level untrusted stack.
+     */
+    if (ctx->store != NULL
+        && !ossl_x509_store_get1_untrusted(ctx->store, &sk_store_untrusted)) {
+        ctx->error = X509_V_ERR_STORE_LOOKUP;
+        return -1;
+    }
+
     /*
      * Set up search policy, untrusted if possible, trusted-first if enabled,
      * which is the default.
@@ -3698,7 +3710,9 @@ static int build_chain(X509_STORE_CTX *ctx)
      * and alternate chains are not disabled, try building an alternate chain
      * if no luck with untrusted first.
      */
-    search = ctx->untrusted != NULL ? S_DOUNTRUSTED : 0;
+    search = (ctx->untrusted != NULL || sk_X509_num(sk_store_untrusted) > 0)
+        ? S_DOUNTRUSTED
+        : 0;
     if (DANETLS_HAS_PKIX(dane) || !DANETLS_HAS_DANE(dane)) {
         if (search == 0 || (ctx->param->flags & X509_V_FLAG_TRUSTED_FIRST) != 0)
             search |= S_DOTRUSTED;
@@ -3729,6 +3743,15 @@ static int build_chain(X509_STORE_CTX *ctx)
      * multiple passes over it, while free to remove elements as we go.
      */
     if (!X509_add_certs(sk_untrusted, ctx->untrusted, X509_ADD_FLAG_DEFAULT)) {
+        ERR_raise(ERR_LIB_X509, ERR_R_X509_LIB);
+        goto memerr;
+    }
+
+    /*
+     * Append the store-level untrusted certificates after the peer-presented
+     * ones, so ctx-level candidates are tried first.
+     */
+    if (!X509_add_certs(sk_untrusted, sk_store_untrusted, X509_ADD_FLAG_DEFAULT)) {
         ERR_raise(ERR_LIB_X509, ERR_R_X509_LIB);
         goto memerr;
     }
@@ -3949,6 +3972,7 @@ static int build_chain(X509_STORE_CTX *ctx)
         }
     }
     sk_X509_free(sk_untrusted);
+    sk_X509_pop_free(sk_store_untrusted, X509_free);
 
     if (trust < 0) /* internal error */
         return trust;
@@ -4004,11 +4028,13 @@ int_err:
     ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
     ctx->error = X509_V_ERR_UNSPECIFIED;
     sk_X509_free(sk_untrusted);
+    sk_X509_pop_free(sk_store_untrusted, X509_free);
     return -1;
 
 memerr:
     ctx->error = X509_V_ERR_OUT_OF_MEM;
     sk_X509_free(sk_untrusted);
+    sk_X509_pop_free(sk_store_untrusted, X509_free);
     return -1;
 }
 
@@ -4039,7 +4065,7 @@ STACK_OF(X509) *X509_build_chain(const X509 *target, STACK_OF(X509) *certs,
     }
     ctx->num_untrusted = 1;
 
-    if (!build_chain(ctx) && finish_chain)
+    if (build_chain(ctx) <= 0 && finish_chain)
         goto err;
 
     /* result list to store the up_ref'ed certificates */

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3702,6 +3702,7 @@ static int build_chain(X509_STORE_CTX *ctx)
     SSL_DANE *dane = ctx->dane;
     int num = sk_X509_num(ctx->chain);
     STACK_OF(X509) *sk_untrusted = NULL;
+    STACK_OF(X509) *sk_store_untrusted = NULL;
     unsigned int search;
     int may_trusted = 0;
     int may_alternate = 0;
@@ -3718,6 +3719,17 @@ static int build_chain(X509_STORE_CTX *ctx)
 #define S_DOUNTRUSTED (1 << 0) /* Search untrusted chain */
 #define S_DOTRUSTED (1 << 1) /* Search trusted store */
 #define S_DOALTERNATE (1 << 2) /* Retry with pruned alternate chain */
+
+    /*
+     * Snapshot store-level untrusted certificates to use as chain candidates,
+     * in addition to the ctx-level untrusted stack.
+     */
+    if (ctx->store != NULL
+        && !ossl_x509_store_get1_untrusted(ctx->store, &sk_store_untrusted)) {
+        ctx->error = X509_V_ERR_STORE_LOOKUP;
+        return -1;
+    }
+
     /*
      * Set up search policy, untrusted if possible, trusted-first if enabled,
      * which is the default.
@@ -3726,7 +3738,9 @@ static int build_chain(X509_STORE_CTX *ctx)
      * and alternate chains are not disabled, try building an alternate chain
      * if no luck with untrusted first.
      */
-    search = ctx->untrusted != NULL ? S_DOUNTRUSTED : 0;
+    search = (ctx->untrusted != NULL || sk_X509_num(sk_store_untrusted) > 0)
+        ? S_DOUNTRUSTED
+        : 0;
     if (DANETLS_HAS_PKIX(dane) || !DANETLS_HAS_DANE(dane)) {
         if (search == 0 || (ctx->param->flags & X509_V_FLAG_TRUSTED_FIRST) != 0)
             search |= S_DOTRUSTED;
@@ -3757,6 +3771,15 @@ static int build_chain(X509_STORE_CTX *ctx)
      * multiple passes over it, while free to remove elements as we go.
      */
     if (!X509_add_certs(sk_untrusted, ctx->untrusted, X509_ADD_FLAG_DEFAULT)) {
+        ERR_raise(ERR_LIB_X509, ERR_R_X509_LIB);
+        goto memerr;
+    }
+
+    /*
+     * Append the store-level untrusted certificates after the peer-presented
+     * ones, so ctx-level candidates are tried first.
+     */
+    if (!X509_add_certs(sk_untrusted, sk_store_untrusted, X509_ADD_FLAG_DEFAULT)) {
         ERR_raise(ERR_LIB_X509, ERR_R_X509_LIB);
         goto memerr;
     }
@@ -3977,6 +4000,7 @@ static int build_chain(X509_STORE_CTX *ctx)
         }
     }
     sk_X509_free(sk_untrusted);
+    sk_X509_pop_free(sk_store_untrusted, X509_free);
 
     if (trust < 0) /* internal error */
         return trust;
@@ -4032,11 +4056,13 @@ int_err:
     ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
     ctx->error = X509_V_ERR_UNSPECIFIED;
     sk_X509_free(sk_untrusted);
+    sk_X509_pop_free(sk_store_untrusted, X509_free);
     return -1;
 
 memerr:
     ctx->error = X509_V_ERR_OUT_OF_MEM;
     sk_X509_free(sk_untrusted);
+    sk_X509_pop_free(sk_store_untrusted, X509_free);
     return -1;
 }
 
@@ -4067,7 +4093,7 @@ STACK_OF(X509) *X509_build_chain(const X509 *target, STACK_OF(X509) *certs,
     }
     ctx->num_untrusted = 1;
 
-    if (!build_chain(ctx) && finish_chain)
+    if (build_chain(ctx) <= 0 && finish_chain)
         goto err;
 
     /* result list to store the up_ref'ed certificates */

--- a/doc/man3/X509_STORE_add_cert.pod
+++ b/doc/man3/X509_STORE_add_cert.pod
@@ -3,7 +3,9 @@
 =head1 NAME
 
 X509_STORE,
-X509_STORE_add_cert, X509_STORE_add_crl, X509_STORE_set_depth,
+X509_STORE_add_cert, X509_STORE_add_crl,
+X509_STORE_add_untrusted_cert, X509_STORE_get1_untrusted_certs,
+X509_STORE_set_depth,
 X509_STORE_set_flags, X509_STORE_set_purpose, X509_STORE_set_trust,
 X509_STORE_add_lookup,
 X509_STORE_load_file_ex, X509_STORE_load_file, X509_STORE_load_path,
@@ -20,6 +22,8 @@ X509_STORE_load_locations_ex, X509_STORE_load_locations
 
  int X509_STORE_add_cert(X509_STORE *xs, const X509 *x);
  int X509_STORE_add_crl(X509_STORE *xs, X509_CRL *x);
+ int X509_STORE_add_untrusted_cert(X509_STORE *xs, const X509 *x);
+ STACK_OF(X509) *X509_STORE_get1_untrusted_certs(const X509_STORE *xs);
  int X509_STORE_set_depth(X509_STORE *store, int depth);
  int X509_STORE_set_flags(X509_STORE *xs, unsigned long flags);
  int X509_STORE_set_purpose(X509_STORE *xs, int purpose);
@@ -84,6 +88,23 @@ added in this way.  The added object's reference count is incremented by one,
 hence the caller retains ownership of the object and needs to free it when it
 is no longer needed.
 
+X509_STORE_add_untrusted_cert() adds certificate I<x> to a separate set of
+B<untrusted> certificates held by the B<X509_STORE>.  During any verification
+performed against the store, these are available as candidate issuers for
+chain construction, similarly to the untrusted certificates passed to an
+individual B<X509_STORE_CTX>.  Adding a certificate to this set does not make
+it trusted: it is used only to help build the chain, even under
+B<X509_V_FLAG_PARTIAL_CHAIN>.  Such certificates also remain invisible to
+trust-store lookup and enumeration such as X509_STORE_get1_all_certs().
+This function is suitable for preloading known intermediate CA certificates so
+that peers presenting an incomplete chain can still be verified.  The caller
+retains ownership of I<x> and needs to free it when it is no longer needed.
+
+X509_STORE_get1_untrusted_certs() returns a snapshot of the untrusted
+certificates previously added with X509_STORE_add_untrusted_cert().  A new
+stack is returned with the reference count of each certificate incremented by
+one; the caller must free it with OSSL_STACK_OF_X509_free().
+
 X509_STORE_set_depth(), X509_STORE_set_flags(), X509_STORE_set_purpose(),
 X509_STORE_set_trust(), and X509_STORE_set1_param() set the default values
 for the corresponding values used in certificate chain validation.  Their
@@ -141,7 +162,8 @@ context I<libctx> and property query I<propq>.
 
 =head1 RETURN VALUES
 
-X509_STORE_add_cert(), X509_STORE_add_crl(), X509_STORE_set_depth(),
+X509_STORE_add_cert(), X509_STORE_add_crl(),
+X509_STORE_add_untrusted_cert(), X509_STORE_set_depth(),
 X509_STORE_set_flags(), X509_STORE_set_purpose(), X509_STORE_set_trust(),
 X509_STORE_load_file_ex(), X509_STORE_load_file(),
 X509_STORE_load_path(),
@@ -152,6 +174,9 @@ return 1 on success or 0 on failure.
 
 X509_STORE_add_lookup() returns the found or created
 L<X509_LOOKUP(3)>, or NULL on error.
+
+X509_STORE_get1_untrusted_certs() returns a newly allocated stack of
+certificates, which is empty if none have been added, or NULL on error.
 
 =head1 SEE ALSO
 
@@ -166,6 +191,9 @@ L<X509_STORE_get0_param(3)>
 The functions X509_STORE_set_default_paths_ex(),
 X509_STORE_load_file_ex(), X509_STORE_load_store_ex() and
 X509_STORE_load_locations_ex() were added in OpenSSL 3.0.
+
+The functions X509_STORE_add_untrusted_cert() and
+X509_STORE_get1_untrusted_certs() were added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -623,6 +623,8 @@ X509_LOOKUP_get_by_alias_fn X509_LOOKUP_meth_get_get_by_alias(
 
 int X509_STORE_add_cert(X509_STORE *xs, const X509 *x);
 int X509_STORE_add_crl(X509_STORE *xs, X509_CRL *x);
+int X509_STORE_add_untrusted_cert(X509_STORE *xs, const X509 *x);
+STACK_OF(X509) *X509_STORE_get1_untrusted_certs(const X509_STORE *xs);
 
 int X509_STORE_CTX_get_by_subject(const X509_STORE_CTX *vs,
     X509_LOOKUP_TYPE type,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -661,6 +661,95 @@ end:
     return testresult;
 }
 
+/*
+ * Verify that intermediate certificates preloaded into the client's cert store
+ * with X509_STORE_add_untrusted_cert() can be used to complete an incomplete
+ * server chain during a TLS handshake.
+ */
+static int test_store_add_untrusted_tls(void)
+{
+    /* server key and (leaf-only) cert, plus the missing intermediates */
+    char *skey = test_mk_file_path(certsdir, "leaf.key");
+    char *leaf = test_mk_file_path(certsdir, "leaf.pem");
+    char *int2 = test_mk_file_path(certsdir, "subinterCA.pem");
+    char *int1 = test_mk_file_path(certsdir, "interCA.pem");
+    char *root = test_mk_file_path(certsdir, "rootCA.pem");
+    X509 *crt1 = NULL, *crt2 = NULL;
+    X509_STORE *cstore = NULL;
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_VERSION, 0,
+            &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    /* The server presents only its leaf certificate (an incomplete chain). */
+    if (!TEST_int_eq(SSL_CTX_use_certificate_chain_file(sctx, leaf), 1)
+        || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, skey,
+                            SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        goto end;
+
+    /* The client trusts only the root and requires server verification. */
+    if (!TEST_true(SSL_CTX_load_verify_locations(cctx, root, NULL)))
+        goto end;
+    SSL_CTX_set_verify(cctx, SSL_VERIFY_PEER, NULL);
+
+    /* Without the intermediates the chain cannot be built, so it fails. */
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+            &clientssl, NULL, NULL)))
+        goto end;
+    if (!TEST_false(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_int_eq(SSL_get_verify_result(clientssl),
+            X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY))
+        goto end;
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    serverssl = clientssl = NULL;
+
+    /* Preload the missing intermediates into the client's cert store. */
+    if (!TEST_ptr(cstore = SSL_CTX_get_cert_store(cctx))
+        || !TEST_ptr((crt1 = load_cert_pem(int1, libctx)))
+        || !TEST_ptr((crt2 = load_cert_pem(int2, libctx)))
+        || !TEST_true(X509_STORE_add_untrusted_cert(cstore, crt1))
+        || !TEST_true(X509_STORE_add_untrusted_cert(cstore, crt2)))
+        goto end;
+
+    /* The handshake now succeeds with the chain completed via the store. */
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+            &clientssl, NULL, NULL)))
+        goto end;
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE)))
+        goto end;
+
+    /* The verified chain must include both intermediates and the root. */
+    if (!TEST_int_eq(sk_X509_num(SSL_get0_verified_chain(clientssl)), 4))
+        goto end;
+
+    testresult = 1;
+
+end:
+    X509_free(crt1);
+    X509_free(crt2);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    OPENSSL_free(skey);
+    OPENSSL_free(leaf);
+    OPENSSL_free(int2);
+    OPENSSL_free(int1);
+    OPENSSL_free(root);
+
+    return testresult;
+}
+
 static int test_ssl_build_cert_chain(void)
 {
     int ret = 0;
@@ -15452,6 +15541,7 @@ int setup_tests(void)
     ADD_TEST(test_keylog_no_master_key);
 #endif
     ADD_TEST(test_client_cert_verify_cb);
+    ADD_TEST(test_store_add_untrusted_tls);
     ADD_TEST(test_ssl_build_cert_chain);
     ADD_TEST(test_ssl_ctx_build_cert_chain);
 #ifndef OPENSSL_NO_TLS1_2

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -661,6 +661,95 @@ end:
     return testresult;
 }
 
+/*
+ * Verify that intermediate certificates preloaded into the client's cert store
+ * with X509_STORE_add_untrusted_cert() can be used to complete an incomplete
+ * server chain during a TLS handshake.
+ */
+static int test_store_add_untrusted_tls(void)
+{
+    /* server key and (leaf-only) cert, plus the missing intermediates */
+    char *skey = test_mk_file_path(certsdir, "leaf.key");
+    char *leaf = test_mk_file_path(certsdir, "leaf.pem");
+    char *int2 = test_mk_file_path(certsdir, "subinterCA.pem");
+    char *int1 = test_mk_file_path(certsdir, "interCA.pem");
+    char *root = test_mk_file_path(certsdir, "rootCA.pem");
+    X509 *crt1 = NULL, *crt2 = NULL;
+    X509_STORE *cstore = NULL;
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_VERSION, 0,
+            &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    /* The server presents only its leaf certificate (an incomplete chain). */
+    if (!TEST_int_eq(SSL_CTX_use_certificate_chain_file(sctx, leaf), 1)
+        || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, skey,
+                            SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        goto end;
+
+    /* The client trusts only the root and requires server verification. */
+    if (!TEST_true(SSL_CTX_load_verify_locations(cctx, root, NULL)))
+        goto end;
+    SSL_CTX_set_verify(cctx, SSL_VERIFY_PEER, NULL);
+
+    /* Without the intermediates the chain cannot be built, so it fails. */
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+            &clientssl, NULL, NULL)))
+        goto end;
+    if (!TEST_false(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_int_eq(SSL_get_verify_result(clientssl),
+            X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY))
+        goto end;
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    serverssl = clientssl = NULL;
+
+    /* Preload the missing intermediates into the client's cert store. */
+    if (!TEST_ptr(cstore = SSL_CTX_get_cert_store(cctx))
+        || !TEST_ptr((crt1 = load_cert_pem(int1, libctx)))
+        || !TEST_ptr((crt2 = load_cert_pem(int2, libctx)))
+        || !TEST_true(X509_STORE_add_untrusted_cert(cstore, crt1))
+        || !TEST_true(X509_STORE_add_untrusted_cert(cstore, crt2)))
+        goto end;
+
+    /* The handshake now succeeds with the chain completed via the store. */
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+            &clientssl, NULL, NULL)))
+        goto end;
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE)))
+        goto end;
+
+    /* The verified chain must include both intermediates and the root. */
+    if (!TEST_int_eq(sk_X509_num(SSL_get0_verified_chain(clientssl)), 4))
+        goto end;
+
+    testresult = 1;
+
+end:
+    X509_free(crt1);
+    X509_free(crt2);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    OPENSSL_free(skey);
+    OPENSSL_free(leaf);
+    OPENSSL_free(int2);
+    OPENSSL_free(int1);
+    OPENSSL_free(root);
+
+    return testresult;
+}
+
 static int test_ssl_build_cert_chain(void)
 {
     int ret = 0;
@@ -15646,6 +15735,7 @@ int setup_tests(void)
     ADD_TEST(test_keylog_no_master_key);
 #endif
     ADD_TEST(test_client_cert_verify_cb);
+    ADD_TEST(test_store_add_untrusted_tls);
     ADD_TEST(test_ssl_build_cert_chain);
     ADD_TEST(test_ssl_ctx_build_cert_chain);
 #ifndef OPENSSL_NO_TLS1_2

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -25,6 +25,7 @@ static char *bad_f = NULL;
 static char *req_f = NULL;
 static char *sroot_cert = NULL;
 static char *ca_cert = NULL;
+static char *ca_expired_cert = NULL;
 static char *ee_cert = NULL;
 
 #define load_cert_from_file(file) load_cert_pem(file, NULL)
@@ -766,6 +767,224 @@ static int test_purpose_any(void)
     return do_test_purpose(X509_PURPOSE_ANY, 1);
 }
 
+/*
+ * Verify ee-cert against a store, exercising X509_STORE_add_untrusted_cert().
+ * add_root:          add sroot-cert (the trust anchor) to the trust store.
+ * store_untrusted_f: cert added via X509_STORE_add_untrusted_cert (or NULL).
+ * peer_untrusted_f:  cert presented as a ctx-level untrusted cert (or NULL).
+ * flags:             extra verify flags (e.g. X509_V_FLAG_PARTIAL_CHAIN).
+ * expected:          expected X509_verify_cert() return.
+ * expected_err:      expected error, checked only on failure (else X509_V_OK).
+ */
+static int do_test_store_untrusted(int add_root, const char *store_untrusted_f,
+    const char *peer_untrusted_f,
+    unsigned long flags, int expected,
+    int expected_err)
+{
+    int ret = 0, npeer;
+    X509 *root = NULL, *store_ca = NULL, *peer_ca = NULL, *ee = NULL;
+    STACK_OF(X509) *peer = NULL;
+    X509_STORE *store = NULL;
+    X509_STORE_CTX *ctx = NULL;
+
+    if (!TEST_ptr(ee = load_cert_from_file(ee_cert))
+        || !TEST_ptr(store = X509_STORE_new()))
+        goto err;
+
+    if (add_root) {
+        if (!TEST_ptr(root = load_cert_from_file(sroot_cert))
+            || !TEST_true(X509_STORE_add_cert(store, root)))
+            goto err;
+    }
+
+    if (store_untrusted_f != NULL) {
+        if (!TEST_ptr(store_ca = load_cert_from_file(store_untrusted_f))
+            || !TEST_true(X509_STORE_add_untrusted_cert(store, store_ca)))
+            goto err;
+    }
+
+    if (peer_untrusted_f != NULL) {
+        if (!TEST_ptr(peer = sk_X509_new_null())
+            || !TEST_ptr(peer_ca = load_cert_from_file(peer_untrusted_f))
+            || !TEST_true(sk_X509_push(peer, peer_ca)))
+            goto err;
+        peer_ca = NULL;
+    }
+
+    if (!TEST_ptr(ctx = X509_STORE_CTX_new())
+        || !TEST_true(X509_STORE_CTX_init(ctx, store, ee, peer)))
+        goto err;
+
+    if (flags != 0)
+        X509_STORE_CTX_set_flags(ctx, flags);
+
+    npeer = sk_X509_num(peer);
+    if (!TEST_int_eq(X509_verify_cert(ctx), expected)
+        || !TEST_int_eq(X509_STORE_CTX_get_error(ctx),
+            expected == 1 ? X509_V_OK : expected_err))
+        goto err;
+
+    /* The merge must not leak store certs onto the ctx untrusted stack. */
+    if (!TEST_ptr_eq(X509_STORE_CTX_get0_untrusted(ctx), peer)
+        || !TEST_int_eq(sk_X509_num(peer), npeer))
+        goto err;
+
+    ret = 1;
+err:
+    X509_STORE_CTX_free(ctx);
+    X509_STORE_free(store);
+    OSSL_STACK_OF_X509_free(peer);
+    X509_free(ee);
+    X509_free(root);
+    X509_free(store_ca);
+    X509_free(peer_ca);
+    return ret;
+}
+
+/* Leaf-only chain fails when the intermediate is not available anywhere. */
+static int test_store_untrusted_missing(void)
+{
+    return do_test_store_untrusted(1, NULL, NULL, 0, 0,
+        X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY);
+}
+
+/* Adding the intermediate via the new API completes the chain. */
+static int test_store_untrusted_added(void)
+{
+    return do_test_store_untrusted(1, ca_cert, NULL, 0, 1, X509_V_OK);
+}
+
+/* Store-level untrusted intermediate present, but the root is not trusted. */
+static int test_store_untrusted_no_root(void)
+{
+    return do_test_store_untrusted(0, ca_cert, NULL, 0, 0,
+        X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY);
+}
+
+/*
+ * Key negative test: a store-level untrusted cert must never act as a trust
+ * anchor, so it must not terminate a chain even under PARTIAL_CHAIN.
+ */
+static int test_store_untrusted_no_root_partial(void)
+{
+    return do_test_store_untrusted(0, ca_cert, NULL, X509_V_FLAG_PARTIAL_CHAIN,
+        0,
+        X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY);
+}
+
+/*
+ * Peer presents an expired intermediate; the store holds a valid
+ * same-subject/same-key reissue, which the builder prefers over the expired
+ * one when selecting ee-cert's issuer.
+ */
+static int test_store_untrusted_reissued(void)
+{
+    return do_test_store_untrusted(1, ca_cert, ca_expired_cert, 0, 1,
+        X509_V_OK);
+}
+
+/* Without the valid reissue, only the expired peer intermediate is available. */
+static int test_store_untrusted_reissued_missing(void)
+{
+    return do_test_store_untrusted(1, NULL, ca_expired_cert, 0, 0,
+        X509_V_ERR_CERT_HAS_EXPIRED);
+}
+
+/* Getter round-trip: get1 semantics, empty store, and post-add contents. */
+static int test_store_untrusted_getter(void)
+{
+    int ret = 0;
+    X509 *ca = NULL, *ee = NULL;
+    X509_STORE *store = NULL;
+    STACK_OF(X509) *got = NULL, *all = NULL;
+
+    if (!TEST_ptr(store = X509_STORE_new()))
+        goto err;
+
+    /* An empty store yields an empty stack, not NULL. */
+    if (!TEST_ptr(got = X509_STORE_get1_untrusted_certs(store))
+        || !TEST_int_eq(sk_X509_num(got), 0))
+        goto err;
+    sk_X509_pop_free(got, X509_free);
+    got = NULL;
+
+    if (!TEST_ptr(ca = load_cert_from_file(ca_cert))
+        || !TEST_ptr(ee = load_cert_from_file(ee_cert))
+        || !TEST_true(X509_STORE_add_untrusted_cert(store, ca))
+        || !TEST_true(X509_STORE_add_untrusted_cert(store, ee)))
+        goto err;
+
+    if (!TEST_ptr(got = X509_STORE_get1_untrusted_certs(store))
+        || !TEST_int_eq(sk_X509_num(got), 2)
+        || !TEST_int_ge(sk_X509_find(got, ca), 0)
+        || !TEST_int_ge(sk_X509_find(got, ee), 0))
+        goto err;
+
+    /* Untrusted certs must stay invisible to trust-store enumeration. */
+    if (!TEST_ptr(all = X509_STORE_get1_all_certs(store))
+        || !TEST_int_eq(sk_X509_num(all), 0))
+        goto err;
+
+    ret = 1;
+err:
+    sk_X509_pop_free(got, X509_free);
+    OSSL_STACK_OF_X509_free(all);
+    X509_STORE_free(store);
+    X509_free(ca);
+    X509_free(ee);
+    return ret;
+}
+
+/*
+ * A cert added to the shared store after a ctx has been created is picked up
+ * by subsequent verifications using that store.
+ */
+static int test_store_untrusted_add_after_ctx(void)
+{
+    int ret = 0;
+    X509 *root = NULL, *ca = NULL, *ee = NULL;
+    X509_STORE *store = NULL;
+    X509_STORE_CTX *ctx = NULL;
+
+    if (!TEST_ptr(ee = load_cert_from_file(ee_cert))
+        || !TEST_ptr(root = load_cert_from_file(sroot_cert))
+        || !TEST_ptr(ca = load_cert_from_file(ca_cert))
+        || !TEST_ptr(store = X509_STORE_new())
+        || !TEST_true(X509_STORE_add_cert(store, root)))
+        goto err;
+
+    if (!TEST_ptr(ctx = X509_STORE_CTX_new())
+        || !TEST_true(X509_STORE_CTX_init(ctx, store, ee, NULL)))
+        goto err;
+
+    /* Without the intermediate, verification fails. */
+    if (!TEST_int_eq(X509_verify_cert(ctx), 0)
+        || !TEST_int_eq(X509_STORE_CTX_get_error(ctx),
+            X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY))
+        goto err;
+
+    /* Add the intermediate to the shared store after ctx creation. */
+    if (!TEST_true(X509_STORE_add_untrusted_cert(store, ca)))
+        goto err;
+
+    /* A subsequent verification against the same store now succeeds. */
+    X509_STORE_CTX_free(ctx);
+    ctx = NULL;
+    if (!TEST_ptr(ctx = X509_STORE_CTX_new())
+        || !TEST_true(X509_STORE_CTX_init(ctx, store, ee, NULL))
+        || !TEST_int_eq(X509_verify_cert(ctx), 1))
+        goto err;
+
+    ret = 1;
+err:
+    X509_STORE_CTX_free(ctx);
+    X509_STORE_free(store);
+    X509_free(ee);
+    X509_free(root);
+    X509_free(ca);
+    return ret;
+}
+
 OPT_TEST_DECLARE_USAGE("certs-dir\n")
 
 int setup_tests(void)
@@ -785,6 +1004,7 @@ int setup_tests(void)
         || !TEST_ptr(req_f = test_mk_file_path(certs_dir, "sm2-csr.pem"))
         || !TEST_ptr(sroot_cert = test_mk_file_path(certs_dir, "sroot-cert.pem"))
         || !TEST_ptr(ca_cert = test_mk_file_path(certs_dir, "ca-cert.pem"))
+        || !TEST_ptr(ca_expired_cert = test_mk_file_path(certs_dir, "ca-expired.pem"))
         || !TEST_ptr(ee_cert = test_mk_file_path(certs_dir, "ee-cert.pem")))
         goto err;
 
@@ -800,6 +1020,14 @@ int setup_tests(void)
     ADD_TEST(test_purpose_any);
     ADD_TEST(test_multiname_selfsigned);
     ADD_TEST(test_vpm_input_validation);
+    ADD_TEST(test_store_untrusted_missing);
+    ADD_TEST(test_store_untrusted_added);
+    ADD_TEST(test_store_untrusted_no_root);
+    ADD_TEST(test_store_untrusted_no_root_partial);
+    ADD_TEST(test_store_untrusted_reissued);
+    ADD_TEST(test_store_untrusted_reissued_missing);
+    ADD_TEST(test_store_untrusted_getter);
+    ADD_TEST(test_store_untrusted_add_after_ctx);
     return 1;
 err:
     cleanup_tests();
@@ -815,5 +1043,6 @@ void cleanup_tests(void)
     OPENSSL_free(req_f);
     OPENSSL_free(sroot_cert);
     OPENSSL_free(ca_cert);
+    OPENSSL_free(ca_expired_cert);
     OPENSSL_free(ee_cert);
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5727,3 +5727,5 @@ EVP_KDF_CTX_get1_kdf                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_data                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_string                  ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_length_ex                   ?	4_1_0	EXIST::FUNCTION:
+X509_STORE_add_untrusted_cert           ?	4_1_0	EXIST::FUNCTION:
+X509_STORE_get1_untrusted_certs         ?	4_1_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5728,3 +5728,5 @@ ASN1_STRING_set1_data                   ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set1_string                 ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_get_length                  ?	4_1_0	EXIST::FUNCTION:
 CMS_add_standard_smimecap_ex            ?	4_1_0	EXIST::FUNCTION:CMS
+X509_STORE_add_untrusted_cert           ?	4_1_0	EXIST::FUNCTION:
+X509_STORE_get1_untrusted_certs         ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This adds `X509_STORE_add_untrusted_cert()` and `X509_STORE_get1_untrusted_certs()` which allow you to add untrusted intermediate certificates to an X509 store, so they can be used to help complete certificate chains when intermediate certificates are missing.

These certificates are not added as trust anchors - they're used only to help build chains, similarly to the existing `X509_STORE_CTX_set0_untrusted` method, but configured in advance on the cert store itself.

This makes much easier to implement #27016 in userland: with this API available, downstreams can cleanly do either AIA or intermediate cert bundling themselves from outside OpenSSL, by just collecting and adding their own intermediates to the configured certificate store.

I think adding this API would allow closing that issue entirely ("you can now manage untrusted intermediates yourself, use this to implement AIA or bundling downstream") - imo it makes much more sense to expose a store-level API to just prepopulate `sk_untrusted` rather than actually try to integrate AIA support in OpenSSL somehow.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
