### PR TITLE
Fix build on macOS with -D_XOPEN_SOURCE=1 -D_POSIX_C_SOURCE=200809L

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -7,6 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/crypto/async/async_local.h
+++ b/crypto/async/async_local.h
@@ -16,6 +16,8 @@
 
 #if defined(__APPLE__) && defined(__MACH__) && !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE /* Otherwise incomplete ucontext_t structure */
+#endif
+#if defined(__APPLE__) && defined(__MACH__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 

--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -11,6 +11,10 @@
 #define _GNU_SOURCE
 #endif
 
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
 /*
  * VC configurations may define UNICODE, to indicate to the C RTL that
  * WCHAR functions are preferred.

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -550,8 +550,9 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     long ret = 1;
     int *ip;
     bio_dgram_data *data = NULL;
-#ifndef __DJGPP__
-    /* There are currently no cases where this is used on djgpp/watt32. */
+#if !defined(__DJGPP__) && (defined(IP_MTU_DISCOVER) || defined(IP_MTU) \
+    || defined(IP_DONTFRAG) || defined(IP_DONTFRAGMENT) \
+    || defined(IPV6_DONTFRAG) || defined(IPV6_MTU_DISCOVER))
     int sockopt_val = 0;
 #endif
     int d_errno;

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -550,8 +550,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     long ret = 1;
     int *ip;
     bio_dgram_data *data = NULL;
-#ifndef __DJGPP__
-    /* There are currently no cases where this is used on djgpp/watt32. */
+#if !defined(__DJGPP__) && (defined(IP_MTU_DISCOVER) || defined(IP_MTU) || defined(IP_DONTFRAG) || defined(IP_DONTFRAGMENT) || defined(IPV6_DONTFRAG) || defined(IPV6_MTU_DISCOVER))
     int sockopt_val = 0;
 #endif
     int d_errno;

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -15,6 +15,9 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE /* make sure dladdr is declared */
 #endif
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
 
 #include "dso_local.h"
 #include "internal/e_os.h"

--- a/test/radix/quic_radix.c
+++ b/test/radix/quic_radix.c
@@ -6,6 +6,9 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
 /* clang-format off */
 #include "terp.c"
 #include "quic_bindings.c"


### PR DESCRIPTION
  Building with strict POSIX feature macros (`-D_XOPEN_SOURCE=1
  -D_POSIX_C_SOURCE=200809L`) on macOS causes multiple compilation failures
  because these settings suppress macOS-specific extensions that expose
  networking constants, deprecated-but-needed POSIX APIs, and dynamic
  linker interfaces.

  This PR fixes five affected files:

  - **crypto/bio/bss_dgram.c**: `sockopt_val` is unused when platform-specific
    socket options (IP_MTU_DISCOVER, IP_DONTFRAG, etc.) are unavailable.
    Tighten the `#if` guard around its declaration to match the conditions
    where it is actually used.

  - **crypto/async/async_local.h**: The pragma suppressing
    `-Wdeprecated-declarations` for `setcontext`/`swapcontext` was nested
    inside a `!defined(_XOPEN_SOURCE)` check. When `_XOPEN_SOURCE` is
    defined externally, the pragma was skipped and the deprecation warning
    became a hard error under `-Werror`. Move it to apply unconditionally
    on Apple platforms.

  - **crypto/bio/bio_addr.c**: Add `_DARWIN_C_SOURCE` to expose
    `NI_MAXHOST`, `NI_MAXSERV`, and `INADDR_LOOPBACK`.

  - **crypto/dso/dso_dlfcn.c**: Add `_DARWIN_C_SOURCE` to expose `Dl_info`
    and `dladdr` (`_GNU_SOURCE` only helps on glibc/Linux).

  - **test/radix/quic_radix.c**: Add `_DARWIN_C_SOURCE` to expose
    `INADDR_LOOPBACK` used in the included `quic_ops.c`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
