### PR TITLE
Add note about internal documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -22,5 +22,9 @@ README.md  This file
         Overviews; start with crypto.pod and ssl.pod, for example
         Algorithm specific EVP_PKEY documentation.
 
+Directories above should contain public information and API documentation.
+For internal documentation (like an API included with headers in
+include/internal), use [internal/](internal/) directory.
+
 Formatted versions of the manpages (apps,ssl,crypto) can be found at
         <https://docs.openssl.org/master/>


### PR DESCRIPTION
Document internal subdirectory in doc.

I was never sure, what should go into internal doc dir, so document it.

Correct me if my formulation is wrong :)