### PR TITLE
Rework how to fetch components in the drbg

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -597,7 +597,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
     EVP_RAND_CTX *ctx;
     OSSL_PARAM params[9], *p = params;
     const OSSL_PARAM *settables;
-    const char *prov_name;
     char *name, *cipher;
     int use_df = 1;
 
@@ -609,7 +608,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
         ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_FETCH_DRBG);
         return NULL;
     }
-    prov_name = ossl_provider_name(EVP_RAND_get0_provider(rand));
     ctx = EVP_RAND_CTX_new(rand, parent);
     EVP_RAND_free(rand);
     if (ctx == NULL) {
@@ -627,9 +625,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
         && OSSL_PARAM_locate_const(settables, OSSL_DRBG_PARAM_DIGEST))
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_DIGEST,
             dgbl->rng_digest, 0);
-    if (prov_name != NULL)
-        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_PROV_PARAM_CORE_PROV_NAME,
-            (char *)prov_name, 0);
     if (dgbl->rng_propq != NULL)
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_PROPERTIES,
             dgbl->rng_propq, 0);

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -632,7 +632,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
     EVP_RAND_CTX *ctx;
     OSSL_PARAM params[9], *p = params;
     const OSSL_PARAM *settables;
-    const char *prov_name;
     char *name, *cipher;
     int use_df = 1;
 
@@ -644,7 +643,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
         ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_FETCH_DRBG);
         return NULL;
     }
-    prov_name = ossl_provider_name(EVP_RAND_get0_provider(rand));
     ctx = EVP_RAND_CTX_new(rand, parent);
     EVP_RAND_free(rand);
     if (ctx == NULL) {
@@ -662,9 +660,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
         && OSSL_PARAM_locate_const(settables, OSSL_DRBG_PARAM_DIGEST))
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_DIGEST,
             dgbl->rng_digest, 0);
-    if (prov_name != NULL)
-        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_PROV_PARAM_CORE_PROV_NAME,
-            (char *)prov_name, 0);
     if (dgbl->rng_propq != NULL)
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_PROPERTIES,
             dgbl->rng_propq, 0);

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -743,14 +743,16 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
         propquery = (const char *)p->propq->data;
     }
 
+#ifndef FIPS_MODULE
     if (p->prov != NULL) {
         if (p->prov->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
         if ((prov = ossl_provider_find(libctx,
-                 (const char *)p->prov->data, 1))
+                 p->prov->data, 1))
             == NULL)
             return 0;
     }
+#endif
 
     if (p->cipher != NULL) {
         const char *base = (const char *)p->cipher->data;
@@ -774,12 +776,16 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
         strcpy(ecb + p->cipher->data_size - ecb_str_len, "ECB");
         EVP_CIPHER_free(ctr->cipher_ecb);
         EVP_CIPHER_free(ctr->cipher_ctr);
+        ctr->cipher_ctr = NULL;
+        ctr->cipher_ecb = NULL;
         /*
          * Try to fetch algorithms from our own provider code, fallback
          * to generic fetch only if that fails
          */
         (void)ERR_set_mark();
+#ifndef FIPS_MODULE
         ctr->cipher_ctr = evp_cipher_fetch_from_prov(prov, base, NULL);
+#endif
         if (ctr->cipher_ctr == NULL) {
             (void)ERR_pop_to_mark();
             ctr->cipher_ctr = EVP_CIPHER_fetch(libctx, base, propquery);
@@ -787,7 +793,9 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
             (void)ERR_clear_last_mark();
         }
         (void)ERR_set_mark();
+#ifndef FIPS_MODULE
         ctr->cipher_ecb = evp_cipher_fetch_from_prov(prov, ecb, NULL);
+#endif
         if (ctr->cipher_ecb == NULL) {
             (void)ERR_pop_to_mark();
             ctr->cipher_ecb = EVP_CIPHER_fetch(libctx, ecb, propquery);

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -726,7 +726,6 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
 {
     PROV_DRBG_CTR *ctr = (PROV_DRBG_CTR *)ctx->data;
     OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
-    OSSL_PROVIDER *prov = NULL;
     char *ecb;
     const char *propquery = NULL;
     int i, cipher_init = 0;
@@ -743,17 +742,6 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
         propquery = (const char *)p->propq->data;
     }
 
-#ifndef FIPS_MODULE
-    if (p->prov != NULL) {
-        if (p->prov->data_type != OSSL_PARAM_UTF8_STRING)
-            return 0;
-        if ((prov = ossl_provider_find(libctx,
-                 p->prov->data, 1))
-            == NULL)
-            return 0;
-    }
-#endif
-
     if (p->cipher != NULL) {
         const char *base = (const char *)p->cipher->data;
         size_t ctr_str_len = sizeof("CTR") - 1;
@@ -761,16 +749,13 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
 
         if (p->cipher->data_type != OSSL_PARAM_UTF8_STRING
             || p->cipher->data_size < ctr_str_len) {
-            ossl_provider_free(prov);
             return 0;
         }
         if (OPENSSL_strcasecmp("CTR", base + p->cipher->data_size - ctr_str_len) != 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_REQUIRE_CTR_MODE_CIPHER);
-            ossl_provider_free(prov);
             return 0;
         }
         if ((ecb = OPENSSL_strndup(base, p->cipher->data_size)) == NULL) {
-            ossl_provider_free(prov);
             return 0;
         }
         strcpy(ecb + p->cipher->data_size - ecb_str_len, "ECB");
@@ -782,35 +767,15 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
          * Try to fetch algorithms from our own provider code, fallback
          * to generic fetch only if that fails
          */
-        (void)ERR_set_mark();
-#ifndef FIPS_MODULE
-        ctr->cipher_ctr = evp_cipher_fetch_from_prov(prov, base, NULL);
-#endif
-        if (ctr->cipher_ctr == NULL) {
-            (void)ERR_pop_to_mark();
-            ctr->cipher_ctr = EVP_CIPHER_fetch(libctx, base, propquery);
-        } else {
-            (void)ERR_clear_last_mark();
-        }
-        (void)ERR_set_mark();
-#ifndef FIPS_MODULE
-        ctr->cipher_ecb = evp_cipher_fetch_from_prov(prov, ecb, NULL);
-#endif
-        if (ctr->cipher_ecb == NULL) {
-            (void)ERR_pop_to_mark();
-            ctr->cipher_ecb = EVP_CIPHER_fetch(libctx, ecb, propquery);
-        } else {
-            (void)ERR_clear_last_mark();
-        }
+        ctr->cipher_ctr = EVP_CIPHER_fetch(libctx, base, propquery);
+        ctr->cipher_ecb = EVP_CIPHER_fetch(libctx, ecb, propquery);
         OPENSSL_free(ecb);
         if (ctr->cipher_ctr == NULL || ctr->cipher_ecb == NULL) {
             ERR_raise(ERR_LIB_PROV, PROV_R_UNABLE_TO_FIND_CIPHERS);
-            ossl_provider_free(prov);
             return 0;
         }
         cipher_init = 1;
     }
-    ossl_provider_free(prov);
 
     if (cipher_init && !drbg_ctr_init(ctx))
         return 0;

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -736,11 +736,9 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
         cipher_init = 1;
     }
 
-    if (p->propq != NULL) {
-        if (p->propq->data_type != OSSL_PARAM_UTF8_STRING)
-            return 0;
-        propquery = (const char *)p->propq->data;
-    }
+#ifndef FIPS_MODULE
+    propquery = "provider=default";
+#endif
 
     if (p->cipher != NULL) {
         const char *base = (const char *)p->cipher->data;

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -738,6 +738,9 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
 
 #ifndef FIPS_MODULE
     propquery = "provider=default";
+    if (p->propq != NULL
+        && p->propq->data_type == OSSL_PARAM_UTF8_STRING)
+        propquery = (const char *)p->propq->data;
 #endif
 
     if (p->cipher != NULL) {

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -738,7 +738,6 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
 {
     PROV_DRBG_CTR *ctr = (PROV_DRBG_CTR *)ctx->data;
     OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
-    OSSL_PROVIDER *prov = NULL;
     char *ecb;
     const char *propquery = NULL;
     int i, cipher_init = 0;
@@ -749,20 +748,12 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
         cipher_init = 1;
     }
 
-    if (p->propq != NULL) {
-        if (p->propq->data_type != OSSL_PARAM_UTF8_STRING)
-            return 0;
+#ifndef FIPS_MODULE
+    propquery = "provider=default";
+    if (p->propq != NULL
+        && p->propq->data_type == OSSL_PARAM_UTF8_STRING)
         propquery = (const char *)p->propq->data;
-    }
-
-    if (p->prov != NULL) {
-        if (p->prov->data_type != OSSL_PARAM_UTF8_STRING)
-            return 0;
-        if ((prov = ossl_provider_find(libctx,
-                 (const char *)p->prov->data, 1))
-            == NULL)
-            return 0;
-    }
+#endif
 
     if (p->cipher != NULL) {
         const char *base = (const char *)p->cipher->data;
@@ -771,50 +762,33 @@ static int drbg_ctr_set_ctx_params_locked(PROV_DRBG *ctx,
 
         if (p->cipher->data_type != OSSL_PARAM_UTF8_STRING
             || p->cipher->data_size < ctr_str_len) {
-            ossl_provider_free(prov);
             return 0;
         }
         if (OPENSSL_strcasecmp("CTR", base + p->cipher->data_size - ctr_str_len) != 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_REQUIRE_CTR_MODE_CIPHER);
-            ossl_provider_free(prov);
             return 0;
         }
         if ((ecb = OPENSSL_strndup(base, p->cipher->data_size)) == NULL) {
-            ossl_provider_free(prov);
             return 0;
         }
         strcpy(ecb + p->cipher->data_size - ecb_str_len, "ECB");
         EVP_CIPHER_free(ctr->cipher_ecb);
         EVP_CIPHER_free(ctr->cipher_ctr);
+        ctr->cipher_ctr = NULL;
+        ctr->cipher_ecb = NULL;
         /*
          * Try to fetch algorithms from our own provider code, fallback
          * to generic fetch only if that fails
          */
-        (void)ERR_set_mark();
-        ctr->cipher_ctr = evp_cipher_fetch_from_prov(prov, base, NULL);
-        if (ctr->cipher_ctr == NULL) {
-            (void)ERR_pop_to_mark();
-            ctr->cipher_ctr = EVP_CIPHER_fetch(libctx, base, propquery);
-        } else {
-            (void)ERR_clear_last_mark();
-        }
-        (void)ERR_set_mark();
-        ctr->cipher_ecb = evp_cipher_fetch_from_prov(prov, ecb, NULL);
-        if (ctr->cipher_ecb == NULL) {
-            (void)ERR_pop_to_mark();
-            ctr->cipher_ecb = EVP_CIPHER_fetch(libctx, ecb, propquery);
-        } else {
-            (void)ERR_clear_last_mark();
-        }
+        ctr->cipher_ctr = EVP_CIPHER_fetch(libctx, base, propquery);
+        ctr->cipher_ecb = EVP_CIPHER_fetch(libctx, ecb, propquery);
         OPENSSL_free(ecb);
         if (ctr->cipher_ctr == NULL || ctr->cipher_ecb == NULL) {
             ERR_raise(ERR_LIB_PROV, PROV_R_UNABLE_TO_FIND_CIPHERS);
-            ossl_provider_free(prov);
             return 0;
         }
         cipher_init = 1;
     }
-    ossl_provider_free(prov);
 
     if (cipher_init && !drbg_ctr_init(ctx))
         return 0;

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -525,10 +525,19 @@ static const OSSL_PARAM *drbg_hash_gettable_ctx_params(ossl_unused void *vctx,
 
 static int drbg_fetch_digest_from_prov(const struct drbg_set_ctx_params_st *p,
     OSSL_LIB_CTX *libctx,
-    EVP_MD **digest)
+    EVP_MD **digest,
+    const char *propq)
 {
     EVP_MD *md = NULL;
     int ret = 0;
+    const char *propquery = NULL;
+
+#ifndef FIPS_MODULE
+    if (propq == NULL)
+        propquery = "provider=default";
+    else
+        propquery = propq;
+#endif
 
     if (digest == NULL)
         return 0;
@@ -541,7 +550,7 @@ static int drbg_fetch_digest_from_prov(const struct drbg_set_ctx_params_st *p,
     if (p->digest->data_type != OSSL_PARAM_UTF8_STRING)
         goto done;
 
-    md = EVP_MD_fetch(libctx, p->digest->data, NULL);
+    md = EVP_MD_fetch(libctx, p->digest->data, propquery);
     if (md) {
         EVP_MD_free(*digest);
         *digest = md;
@@ -564,7 +573,8 @@ static int drbg_hash_set_ctx_params_locked(PROV_DRBG *ctx, const struct drbg_set
 
     /* try to fetch digest from provider */
     (void)ERR_set_mark();
-    if (!drbg_fetch_digest_from_prov(p, libctx, &prov_md)) {
+    if (!drbg_fetch_digest_from_prov(p, libctx, &prov_md,
+            (p->propq != NULL && p->propq->data_type == OSSL_PARAM_UTF8_STRING) ? p->propq->data : NULL)) {
         (void)ERR_pop_to_mark();
         /* fall back to full implementation search */
         if (!ossl_prov_digest_load(&hash->digest, p->digest, p->propq, libctx))

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -525,18 +525,21 @@ static const OSSL_PARAM *drbg_hash_gettable_ctx_params(ossl_unused void *vctx,
 
 static int drbg_fetch_digest_from_prov(const struct drbg_set_ctx_params_st *p,
     OSSL_LIB_CTX *libctx,
-    EVP_MD **digest)
+    EVP_MD **digest,
+    const char *propq)
 {
-    OSSL_PROVIDER *prov = NULL;
     EVP_MD *md = NULL;
     int ret = 0;
+    const char *propquery = NULL;
+
+#ifndef FIPS_MODULE
+    if (propq == NULL)
+        propquery = "provider=default";
+    else
+        propquery = propq;
+#endif
 
     if (digest == NULL)
-        return 0;
-
-    if (p->prov == NULL || p->prov->data_type != OSSL_PARAM_UTF8_STRING)
-        return 0;
-    if ((prov = ossl_provider_find(libctx, (const char *)p->prov->data, 1)) == NULL)
         return 0;
 
     if (p->digest == NULL) {
@@ -547,15 +550,13 @@ static int drbg_fetch_digest_from_prov(const struct drbg_set_ctx_params_st *p,
     if (p->digest->data_type != OSSL_PARAM_UTF8_STRING)
         goto done;
 
-    md = evp_digest_fetch_from_prov(prov, (const char *)p->digest->data, NULL);
+    md = EVP_MD_fetch(libctx, p->digest->data, propquery);
     if (md) {
         EVP_MD_free(*digest);
         *digest = md;
         ret = 1;
     }
-
 done:
-    ossl_provider_free(prov);
     return ret;
 }
 
@@ -572,7 +573,8 @@ static int drbg_hash_set_ctx_params_locked(PROV_DRBG *ctx, const struct drbg_set
 
     /* try to fetch digest from provider */
     (void)ERR_set_mark();
-    if (!drbg_fetch_digest_from_prov(p, libctx, &prov_md)) {
+    if (!drbg_fetch_digest_from_prov(p, libctx, &prov_md,
+            (p->propq != NULL && p->propq->data_type == OSSL_PARAM_UTF8_STRING) ? p->propq->data : NULL)) {
         (void)ERR_pop_to_mark();
         /* fall back to full implementation search */
         if (!ossl_prov_digest_load(&hash->digest, p->digest, p->propq, libctx))

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -534,10 +534,12 @@ static int drbg_fetch_digest_from_prov(const struct drbg_set_ctx_params_st *p,
     if (digest == NULL)
         return 0;
 
+#ifndef FIPS_MODULE
     if (p->prov == NULL || p->prov->data_type != OSSL_PARAM_UTF8_STRING)
         return 0;
     if ((prov = ossl_provider_find(libctx, (const char *)p->prov->data, 1)) == NULL)
         return 0;
+#endif
 
     if (p->digest == NULL) {
         ret = 1;
@@ -547,13 +549,16 @@ static int drbg_fetch_digest_from_prov(const struct drbg_set_ctx_params_st *p,
     if (p->digest->data_type != OSSL_PARAM_UTF8_STRING)
         goto done;
 
+#ifndef FIPS_MODULE
     md = evp_digest_fetch_from_prov(prov, (const char *)p->digest->data, NULL);
+#else
+    md = EVP_MD_fetch(libctx, p->digest->data, NULL);
+#endif
     if (md) {
         EVP_MD_free(*digest);
         *digest = md;
         ret = 1;
     }
-
 done:
     ossl_provider_free(prov);
     return ret;

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -527,19 +527,11 @@ static int drbg_fetch_digest_from_prov(const struct drbg_set_ctx_params_st *p,
     OSSL_LIB_CTX *libctx,
     EVP_MD **digest)
 {
-    OSSL_PROVIDER *prov = NULL;
     EVP_MD *md = NULL;
     int ret = 0;
 
     if (digest == NULL)
         return 0;
-
-#ifndef FIPS_MODULE
-    if (p->prov == NULL || p->prov->data_type != OSSL_PARAM_UTF8_STRING)
-        return 0;
-    if ((prov = ossl_provider_find(libctx, (const char *)p->prov->data, 1)) == NULL)
-        return 0;
-#endif
 
     if (p->digest == NULL) {
         ret = 1;
@@ -549,18 +541,13 @@ static int drbg_fetch_digest_from_prov(const struct drbg_set_ctx_params_st *p,
     if (p->digest->data_type != OSSL_PARAM_UTF8_STRING)
         goto done;
 
-#ifndef FIPS_MODULE
-    md = evp_digest_fetch_from_prov(prov, (const char *)p->digest->data, NULL);
-#else
     md = EVP_MD_fetch(libctx, p->digest->data, NULL);
-#endif
     if (md) {
         EVP_MD_free(*digest);
         *digest = md;
         ret = 1;
     }
 done:
-    ossl_provider_free(prov);
     return ret;
 }
 

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -420,28 +420,16 @@ static int drbg_fetch_algs_from_prov(const struct drbg_set_ctx_params_st *p,
     EVP_MAC_CTX **macctx,
     EVP_MD **digest)
 {
-    OSSL_PROVIDER *prov = NULL;
     EVP_MD *md = NULL;
     int ret = 0;
 
     if (macctx == NULL || digest == NULL)
         return 0;
 
-#ifndef FIPS_MODULE
-    if (p->prov == NULL || p->prov->data_type != OSSL_PARAM_UTF8_STRING)
-        return 0;
-    if ((prov = ossl_provider_find(libctx, (const char *)p->prov->data, 1)) == NULL)
-        return 0;
-#endif
-
     if (p->digest != NULL) {
         if (p->digest->data_type != OSSL_PARAM_UTF8_STRING)
             goto done;
-#ifndef FIPS_MODULE
-        md = evp_digest_fetch_from_prov(prov, (const char *)p->digest->data, NULL);
-#else
         md = EVP_MD_fetch(libctx, p->digest->data, NULL);
-#endif
         if (md) {
             EVP_MD_free(*digest);
             *digest = md;
@@ -456,7 +444,6 @@ static int drbg_fetch_algs_from_prov(const struct drbg_set_ctx_params_st *p,
     ret = 1;
 
 done:
-    ossl_provider_free(prov);
     return ret;
 }
 

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -427,16 +427,21 @@ static int drbg_fetch_algs_from_prov(const struct drbg_set_ctx_params_st *p,
     if (macctx == NULL || digest == NULL)
         return 0;
 
+#ifndef FIPS_MODULE
     if (p->prov == NULL || p->prov->data_type != OSSL_PARAM_UTF8_STRING)
         return 0;
     if ((prov = ossl_provider_find(libctx, (const char *)p->prov->data, 1)) == NULL)
         return 0;
+#endif
 
     if (p->digest != NULL) {
         if (p->digest->data_type != OSSL_PARAM_UTF8_STRING)
             goto done;
-
+#ifndef FIPS_MODULE
         md = evp_digest_fetch_from_prov(prov, (const char *)p->digest->data, NULL);
+#else
+        md = EVP_MD_fetch(libctx, p->digest->data, NULL);
+#endif
         if (md) {
             EVP_MD_free(*digest);
             *digest = md;

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -418,25 +418,26 @@ static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(ossl_unused void *vctx,
 static int drbg_fetch_algs_from_prov(const struct drbg_set_ctx_params_st *p,
     OSSL_LIB_CTX *libctx,
     EVP_MAC_CTX **macctx,
-    EVP_MD **digest)
+    EVP_MD **digest, const char *propq)
 {
-    OSSL_PROVIDER *prov = NULL;
     EVP_MD *md = NULL;
     int ret = 0;
+    const char *propquery = NULL;
+
+#ifndef FIPS_MODULE
+    if (propq == NULL)
+        propquery = "provider=default";
+    else
+        propquery = propq;
+#endif
 
     if (macctx == NULL || digest == NULL)
-        return 0;
-
-    if (p->prov == NULL || p->prov->data_type != OSSL_PARAM_UTF8_STRING)
-        return 0;
-    if ((prov = ossl_provider_find(libctx, (const char *)p->prov->data, 1)) == NULL)
         return 0;
 
     if (p->digest != NULL) {
         if (p->digest->data_type != OSSL_PARAM_UTF8_STRING)
             goto done;
-
-        md = evp_digest_fetch_from_prov(prov, (const char *)p->digest->data, NULL);
+        md = EVP_MD_fetch(libctx, p->digest->data, propquery);
         if (md) {
             EVP_MD_free(*digest);
             *digest = md;
@@ -451,7 +452,6 @@ static int drbg_fetch_algs_from_prov(const struct drbg_set_ctx_params_st *p,
     ret = 1;
 
 done:
-    ossl_provider_free(prov);
     return ret;
 }
 
@@ -468,7 +468,8 @@ static int drbg_hmac_set_ctx_params_locked(PROV_DRBG *ctx, const struct drbg_set
 
     /* try to fetch mac and digest from provider */
     (void)ERR_set_mark();
-    if (!drbg_fetch_algs_from_prov(p, libctx, &hmac->ctx, &prov_md)) {
+    if (!drbg_fetch_algs_from_prov(p, libctx, &hmac->ctx, &prov_md,
+            (p->propq != NULL && p->propq->data_type == OSSL_PARAM_UTF8_STRING) ? p->propq->data : NULL)) {
         (void)ERR_pop_to_mark();
         if (p->digest != NULL) {
             /* fall back to full implementation search */

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -418,10 +418,18 @@ static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(ossl_unused void *vctx,
 static int drbg_fetch_algs_from_prov(const struct drbg_set_ctx_params_st *p,
     OSSL_LIB_CTX *libctx,
     EVP_MAC_CTX **macctx,
-    EVP_MD **digest)
+    EVP_MD **digest, const char *propq)
 {
     EVP_MD *md = NULL;
     int ret = 0;
+    const char *propquery = NULL;
+
+#ifndef FIPS_MODULE
+    if (propq == NULL)
+        propquery = "provider=default";
+    else
+        propquery = propq;
+#endif
 
     if (macctx == NULL || digest == NULL)
         return 0;
@@ -429,7 +437,7 @@ static int drbg_fetch_algs_from_prov(const struct drbg_set_ctx_params_st *p,
     if (p->digest != NULL) {
         if (p->digest->data_type != OSSL_PARAM_UTF8_STRING)
             goto done;
-        md = EVP_MD_fetch(libctx, p->digest->data, NULL);
+        md = EVP_MD_fetch(libctx, p->digest->data, propquery);
         if (md) {
             EVP_MD_free(*digest);
             *digest = md;
@@ -460,7 +468,8 @@ static int drbg_hmac_set_ctx_params_locked(PROV_DRBG *ctx, const struct drbg_set
 
     /* try to fetch mac and digest from provider */
     (void)ERR_set_mark();
-    if (!drbg_fetch_algs_from_prov(p, libctx, &hmac->ctx, &prov_md)) {
+    if (!drbg_fetch_algs_from_prov(p, libctx, &hmac->ctx, &prov_md,
+            (p->propq != NULL && p->propq->data_type == OSSL_PARAM_UTF8_STRING) ? p->propq->data : NULL)) {
         (void)ERR_pop_to_mark();
         if (p->digest != NULL) {
             /* fall back to full implementation search */

--- a/test/fipsidentity.cnf
+++ b/test/fipsidentity.cnf
@@ -1,0 +1,19 @@
+openssl_conf = openssl_init
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+.include fipsmodule.cnf
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+fips = fips_sect
+
+[default_sect]
+activate = yes
+
+[fips_sect]
+identity = fips-identity

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -26,11 +26,12 @@ use platform;
 my $no_check = disabled("fips") || disabled('fips-securitychecks');
 plan skip_all => "Test only supported in a fips build with security checks"
     if $no_check;
-plan tests => 12;
+plan tests => 13;
 
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
 my $fipsconf = srctop_file("test", "fips-and-base.cnf");
 my $defaultconf = srctop_file("test", "default.cnf");
+my $identityconf = srctop_file("test" ,"fips-identity.cnf");
 my $tbs_data = $fipsmodule;
 my $bogus_data = $fipsconf;
 
@@ -279,6 +280,41 @@ SKIP: {
 
         tsignverify($testtext_prefix, $fips_key, $fips_pub_key, $nonfips_key,
                     $nonfips_pub_key);
+    };
+}
+
+SKIP: {
+    skip "FIPS RSA tests because of no rsa in this build", 1
+        if disabled("rsa");
+
+    subtest RSA_identity => sub {
+        my $testtext_prefix = 'RSA';
+        my $fips_key = $testtext_prefix.'.fips.priv.pem';
+        my $fips_pub_key = $testtext_prefix.'.fips.pub.pem';
+        my $nonfips_key = $testtext_prefix.'.nonfips.priv.pem';
+        my $nonfips_pub_key = $testtext_prefix.'.nonfips.pub.pem';
+        my $testtext = '';
+
+        plan tests => 2;
+
+        my $destfips = srctop_file("test-runs", "test_cli_fips", platform->dso("fips-identity"));
+        copy($fipsmodule, $destfips) or die("Couldn't copy file");
+        $ENV{OPENSSL_CONF} = $identityconf;
+        $ENV{OPENSSL_MODULES} = bldtop_dir("test-runs", "test_cli_fips");
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with a non-FIPS algorithm with the default provider';
+        print "Running genpkey";
+        ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA',
+                    '-pkeyopt', 'rsa_keygen_bits:512',
+                    '-out', $nonfips_key])),
+           $testtext);
+
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with a FIPS algorithm';
+        ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA',
+                    '-pkeyopt', 'rsa_keygen_bits:2048',
+                    '-out', $fips_key])),
+           $testtext);
     };
 }
 

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -297,7 +297,7 @@ SKIP: {
 
         plan tests => 2;
 
-        my $destfips = srctop_file("test-runs", "test_cli_fips", platform->dso("fips-identity"));
+        my $destfips = bldtop_file("test-runs", "test_cli_fips", platform->dso("fips-identity"));
         copy($fipsmodule, $destfips) or die("Couldn't copy file");
         $ENV{OPENSSL_CONF} = $identityconf;
         $ENV{OPENSSL_MODULES} = bldtop_dir("test-runs", "test_cli_fips");

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -26,11 +26,12 @@ use platform;
 my $no_check = disabled("fips") || disabled('fips-securitychecks');
 plan skip_all => "Test only supported in a fips build with security checks"
     if $no_check;
-plan tests => 12;
+plan tests => 13;
 
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
 my $fipsconf = srctop_file("test", "fips-and-base.cnf");
 my $defaultconf = srctop_file("test", "default.cnf");
+my $identityconf = srctop_file("test" ,"fips-identity.cnf");
 my $tbs_data = $fipsmodule;
 my $bogus_data = $fipsconf;
 
@@ -279,6 +280,41 @@ SKIP: {
 
         tsignverify($testtext_prefix, $fips_key, $fips_pub_key, $nonfips_key,
                     $nonfips_pub_key);
+    };
+}
+
+SKIP: {
+    skip "FIPS RSA tests because of no rsa in this build", 1
+        if disabled("rsa");
+
+    subtest RSA_identity => sub {
+        my $testtext_prefix = 'RSA';
+        my $fips_key = $testtext_prefix.'.fips.priv.pem';
+        my $fips_pub_key = $testtext_prefix.'.fips.pub.pem';
+        my $nonfips_key = $testtext_prefix.'.nonfips.priv.pem';
+        my $nonfips_pub_key = $testtext_prefix.'.nonfips.pub.pem';
+        my $testtext = '';
+
+        plan tests => 2;
+
+        my $destfips = bldtop_file("test-runs", "test_cli_fips", platform->dso("fips-identity"));
+        copy($fipsmodule, $destfips) or die("Couldn't copy file");
+        $ENV{OPENSSL_CONF} = $identityconf;
+        $ENV{OPENSSL_MODULES} = bldtop_dir("test-runs", "test_cli_fips");
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with a non-FIPS algorithm with the default provider';
+        print "Running genpkey";
+        ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA',
+                    '-pkeyopt', 'rsa_keygen_bits:512',
+                    '-out', $nonfips_key])),
+           $testtext);
+
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with a FIPS algorithm';
+        ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA',
+                    '-pkeyopt', 'rsa_keygen_bits:2048',
+                    '-out', $fips_key])),
+           $testtext);
     };
 }
 

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -300,6 +300,7 @@ SKIP: {
         my $destfips = bldtop_file("test-runs", "test_cli_fips", platform->dso("fips-identity"));
         copy($fipsmodule, $destfips) or die("Couldn't copy file");
         $ENV{OPENSSL_CONF} = $identityconf;
+        my $oldmodules = $ENV{OPENSSL_MODULES};
         $ENV{OPENSSL_MODULES} = bldtop_dir("test-runs", "test_cli_fips");
         $testtext = $testtext_prefix.': '.
             'Generate a key with a non-FIPS algorithm with the default provider';
@@ -315,6 +316,7 @@ SKIP: {
                     '-pkeyopt', 'rsa_keygen_bits:2048',
                     '-out', $fips_key])),
            $testtext);
+        $ENV{OPENSSL_MODULES} = $oldmodules;
     };
 }
 


### PR DESCRIPTION
Commit c9a2ce61118c7f73bc4898eedec64c2bde8bb7a0 introduced some code into the drbg in an effort to get it to select the same provider as is specified for the drbg.  Unfortunately this creates a problem when a user has altered the identity of a predefined provider (in this case fips).

The DRBG is passed a set of parameters when instantiating, which includes the name of the provider.  This provider uses the name that the core knows it as, which may be different than "fips", which the fips provider always referrs to itself as.

The only way I see to fix this is to remove the ossl_provider_find call in drbg_set_ctx_params_locked, which checks to make sure the parameter in the params list is valid.

Instead we should just attempt to fetch each cipher component in the rng from the provider it was initially allocated from.

Fixes a customer issue, who noted that since this was introduced, using identity configurations no longer works.

