### PR TITLE
Fix data race in `check_pc_flood` radix test

### DIFF
--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -456,10 +456,17 @@ static int mutcbk_inject_frames(const QUIC_PKT_HDR *hdrin,
     /*
      * make injection callback a one shot event,
      * callback is invoked for every packet we
-     * want to modify only one packet here.
+     * want to modify only one packet here. Returning 0 tells the QTX the
+     * packet send itself failed (tearing down the connection), so once
+     * we're done mutating we must pass subsequent packets through
+     * unmodified instead.
      */
-    if (mutctx->mutctx_done)
-        return 0;
+    if (mutctx->mutctx_done) {
+        *hdrout = (QUIC_PKT_HDR *)hdrin;
+        *iovecout = iovecin;
+        *numout = numin;
+        return 1;
+    }
 
     mutctx->mutctx_done = 1;
 


### PR DESCRIPTION
Fix `mutcbk_inject_frames` after mutation

`mutcbk_inject_frames` returned 0 once its one-time mutation was applied, which tells the QTX the packet send failed and tears down the connection instead of continuing the test with unmutated packets. Now, it passes subsequent packets through unmodified by returning the input header, iovec, and count unchanged.

Fixes https://github.com/openssl/project/issues/2036

##### Checklist

- [ ] documentation is added or updated
- [x] tests are added or updated
