### PR TITLE
CT: prevent OOB reads for v1 LogIDs with invalid length

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Enforce the CT v1 LogID length (`CT_V1_HASHLEN`) in the public SCT and
+   CT log-store APIs, fixing over-reads from short or oversized LogIDs.
+
+   *Mounir IDRASSI*
+
  * Fixed TLS 1.3 external PSK connections being wrongly rejected when
    the client sets a non-empty session ID context.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Enforce the CT v1 LogID length (`CT_V1_HASHLEN`) in the public SCT and
+   CT log-store APIs, fixing over-reads from short or oversized LogIDs.
+
+   *Mounir IDRASSI*
+
  * Repeated fields in the `basicConstraints`, `basicAttConstraints`,
    and `policyConstraints` X.509v3 extension configurations are now rejected
    instead of silently using the last value.

--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -339,9 +339,12 @@ const CTLOG *CTLOG_STORE_get0_log_by_id(const CTLOG_STORE *store,
 {
     int i;
 
+    if (store == NULL || log_id == NULL || log_id_len != CT_V1_HASHLEN)
+        return NULL;
+
     for (i = 0; i < sk_CTLOG_num(store->logs); ++i) {
         const CTLOG *log = sk_CTLOG_value(store->logs, i);
-        if (memcmp(log->log_id, log_id, log_id_len) == 0)
+        if (memcmp(log->log_id, log_id, CT_V1_HASHLEN) == 0)
             return log;
     }
 

--- a/crypto/ct/ct_sct.c
+++ b/crypto/ct/ct_sct.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -54,6 +54,12 @@ int SCT_set_version(SCT *sct, sct_version_t version)
         ERR_raise(ERR_LIB_CT, CT_R_UNSUPPORTED_VERSION);
         return 0;
     }
+    if ((sct->log_id == NULL && sct->log_id_len != 0)
+        || (sct->log_id != NULL
+            && sct->log_id_len != CT_V1_HASHLEN)) {
+        ERR_raise(ERR_LIB_CT, CT_R_INVALID_LOG_ID_LENGTH);
+        return 0;
+    }
     sct->version = version;
     sct->validation_status = SCT_VALIDATION_STATUS_NOT_SET;
     return 1;
@@ -77,21 +83,21 @@ int SCT_set_log_entry_type(SCT *sct, ct_log_entry_type_t entry_type)
 
 int SCT_set0_log_id(SCT *sct, unsigned char *log_id, size_t log_id_len)
 {
-    if (sct->version == SCT_VERSION_V1 && log_id_len != CT_V1_HASHLEN) {
+    if (log_id != NULL && log_id_len != CT_V1_HASHLEN) {
         ERR_raise(ERR_LIB_CT, CT_R_INVALID_LOG_ID_LENGTH);
         return 0;
     }
 
     OPENSSL_free(sct->log_id);
     sct->log_id = log_id;
-    sct->log_id_len = log_id_len;
+    sct->log_id_len = (log_id != NULL) ? log_id_len : 0;
     sct->validation_status = SCT_VALIDATION_STATUS_NOT_SET;
     return 1;
 }
 
 int SCT_set1_log_id(SCT *sct, const unsigned char *log_id, size_t log_id_len)
 {
-    if (sct->version == SCT_VERSION_V1 && log_id_len != CT_V1_HASHLEN) {
+    if (log_id != NULL && log_id_len != CT_V1_HASHLEN) {
         ERR_raise(ERR_LIB_CT, CT_R_INVALID_LOG_ID_LENGTH);
         return 0;
     }
@@ -239,7 +245,16 @@ int SCT_is_complete(const SCT *sct)
     case SCT_VERSION_NOT_SET:
         return 0;
     case SCT_VERSION_V1:
-        return sct->log_id != NULL && SCT_signature_is_complete(sct);
+        /*
+         * i2o_SCT() copies a fixed CT_V1_HASHLEN bytes from sct->log_id, so a
+         * v1 SCT is only complete when the LogID is present and exactly
+         * CT_V1_HASHLEN bytes long.  This protects the serializer sink against
+         * future construction paths or partial mutation even if the setters
+         * and SCT_set_version() guards are bypassed.
+         */
+        return sct->log_id != NULL
+            && sct->log_id_len == CT_V1_HASHLEN
+            && SCT_signature_is_complete(sct);
     default:
         return sct->sct != NULL; /* Just need cached encoding */
     }

--- a/doc/man3/CTLOG_STORE_get0_log_by_id.pod
+++ b/doc/man3/CTLOG_STORE_get0_log_by_id.pod
@@ -23,6 +23,11 @@ Therefore, it is useful to be able to look up more information about a log
 CTLOG_STORE_get0_log_by_id() provides a way to do this. It will find a CTLOG
 in a CTLOG_STORE that has a given LogID.
 
+The LogID of a v1 CT log is a fixed-length SHA-256 hash (see RFC 6962),
+so B<log_id_len> must be B<CT_V1_HASHLEN> (32) bytes for a lookup to
+succeed.  Any other length, or a NULL B<store> or B<log_id>, is rejected
+and the function returns NULL without performing a lookup.
+
 =head1 RETURN VALUES
 
 B<CTLOG_STORE_get0_log_by_id> returns a CTLOG with the given LogID, if it
@@ -39,7 +44,7 @@ The CTLOG_STORE_get0_log_by_id() function was added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SCT_new.pod
+++ b/doc/man3/SCT_new.pod
@@ -90,7 +90,9 @@ it using:
 
 SCT_set_version() to set the SCT version.
 
-Only SCT_VERSION_V1 is currently supported.
+Only B<SCT_VERSION_V1> is currently supported.
+If an incompatible LogID has already been set (see B<SCT_set0_log_id>
+below), the call fails and leaves the SCT version unchanged.
 
 =item *
 
@@ -104,6 +106,8 @@ B<CT_LOG_ENTRY_TYPE_PRECERT> for a pre-certificate.
 SCT_set0_log_id() or SCT_set1_log_id() to set the LogID of the CT log that the SCT came from.
 
 The former takes ownership, whereas the latter makes a copy.
+If B<log_id> is not NULL, B<log_id_len> must be B<CT_V1_HASHLEN> (32) bytes.
+Passing NULL clears the LogID and B<log_id_len> is ignored.
 See RFC 6962, Section 3.2 for the definition of LogID.
 
 =item *
@@ -190,12 +194,15 @@ SCT_set_source() will not refuse unknown values.
 =head1 RETURN VALUES
 
 SCT_set_version() returns 1 if the specified version is supported, 0 otherwise.
+It also returns 0 if the current LogID is incompatible with the requested
+version, leaving the version unchanged.
 
 SCT_set_log_entry_type() returns 1 if the specified log entry type is supported, 0 otherwise.
 
-SCT_set0_log_id() and B<SCT_set1_log_id> return 1 if the specified LogID is a
-valid SHA-256 hash, 0 otherwise. Additionally, B<SCT_set1_log_id> returns 0 if
-malloc fails.
+B<SCT_set0_log_id> and B<SCT_set1_log_id> return 1 on success and 0 on
+failure.  If B<log_id> is not NULL, B<log_id_len> must be B<CT_V1_HASHLEN>.
+Passing NULL clears the LogID and B<log_id_len> is ignored.  Additionally,
+B<SCT_set1_log_id> returns 0 if malloc fails.
 
 B<SCT_set_signature_nid> returns 1 if the specified NID is supported, 0 otherwise.
 
@@ -216,7 +223,7 @@ These functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016-2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/ct.h.in
+++ b/include/openssl/ct.h.in
@@ -1,7 +1,7 @@
 /*
  * {- join("\n * ", @autowarntext) -}
  *
- * Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -178,7 +178,8 @@ sct_version_t SCT_get_version(const SCT *sct);
 
 /*
  * Set the version of an SCT.
- * Returns 1 on success, 0 if the version is unrecognized.
+ * Returns 1 on success, 0 if the version is unrecognized or the current
+ * LogID is incompatible with the version.
  */
 __owur int SCT_set_version(SCT *sct, sct_version_t version);
 
@@ -202,13 +203,17 @@ size_t SCT_get0_log_id(const SCT *sct, unsigned char **log_id);
 
 /*
  * Set the log ID of an SCT to point directly to the *log_id specified.
- * The SCT takes ownership of the specified pointer.
+ * If log_id is not NULL, log_id_len must be CT_V1_HASHLEN.
+ * The SCT takes ownership of the specified pointer on success.
+ * Passing NULL clears the LogID and log_id_len is ignored.
  * Returns 1 on success, 0 otherwise.
  */
 __owur int SCT_set0_log_id(SCT *sct, unsigned char *log_id, size_t log_id_len);
 
 /*
  * Set the log ID of an SCT.
+ * If log_id is not NULL, log_id_len must be CT_V1_HASHLEN.
+ * Passing NULL clears the LogID and log_id_len is ignored.
  * This makes a copy of the log_id.
  * Returns 1 on success, 0 otherwise.
  */
@@ -509,6 +514,7 @@ __owur int CTLOG_STORE_add0_log(CTLOG_STORE *store, CTLOG *log);
 
 /*
  * Finds a CT log in the store based on its log ID.
+ * The log_id_len must be CT_V1_HASHLEN.
  * Returns the CT log, or NULL if no match is found.
  */
 const CTLOG *CTLOG_STORE_get0_log_by_id(const CTLOG_STORE *store,

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -21,6 +21,7 @@
 #include <openssl/crypto.h>
 
 #ifndef OPENSSL_NO_CT
+#include "../crypto/ct/ct_local.h" /* for struct sct_st */
 
 /* Used when declaring buffers to read text files into */
 #define CT_TEST_MAX_FILE_SIZE 8096
@@ -633,6 +634,180 @@ end:
     CTLOG_free(log);
     return result;
 }
+
+static int test_ctlog_store_get0_log_by_id_length(void)
+{
+    CTLOG_STORE *store = NULL;
+    CTLOG *log = NULL;
+    const uint8_t *log_id = NULL;
+    size_t log_id_len = 0;
+    unsigned char oversized_id[CT_V1_HASHLEN + 1];
+    int result = 0;
+    const char pkey_base64[] = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmXg8sUUzwBYaWrRb+V0IopzQ6o3U"
+                               "yEJ04r5ZrRXGdpYM8K+hB0pXrGRLI0eeWz+3skXrS0IO83AhA3GpRL6s6w==";
+
+    if (!TEST_ptr(store = CTLOG_STORE_new()))
+        goto end;
+    if (!TEST_true(CTLOG_new_from_base64(&log, pkey_base64, "test")))
+        goto end;
+
+    CTLOG_get0_log_id(log, &log_id, &log_id_len);
+    if (!TEST_size_t_eq(log_id_len, CT_V1_HASHLEN))
+        goto end;
+
+    memcpy(oversized_id, log_id, CT_V1_HASHLEN);
+    oversized_id[CT_V1_HASHLEN] = 0;
+
+    if (!TEST_true(CTLOG_STORE_add0_log(store, log)))
+        goto end;
+    log = NULL;
+
+    /* A correctly-sized lookup must still match. */
+    if (!TEST_ptr(CTLOG_STORE_get0_log_by_id(store, log_id, log_id_len)))
+        goto end;
+
+    /* An oversized length must not read past the stored 32-byte log_id. */
+    if (!TEST_ptr_null(CTLOG_STORE_get0_log_by_id(store, oversized_id,
+            sizeof(oversized_id))))
+        goto end;
+
+    /* A zero length must not match the first stored log. */
+    if (!TEST_ptr_null(CTLOG_STORE_get0_log_by_id(store, log_id, 0)))
+        goto end;
+
+    /* A short length must not produce a prefix match. */
+    if (!TEST_ptr_null(CTLOG_STORE_get0_log_by_id(store, log_id,
+            CT_V1_HASHLEN / 2)))
+        goto end;
+
+    /* A NULL log_id must not be dereferenced. */
+    if (!TEST_ptr_null(CTLOG_STORE_get0_log_by_id(store, NULL,
+            CT_V1_HASHLEN)))
+        goto end;
+
+    /* A NULL store must return NULL. */
+    if (!TEST_ptr_null(CTLOG_STORE_get0_log_by_id(NULL, log_id, log_id_len)))
+        goto end;
+
+    result = 1;
+
+end:
+    CTLOG_STORE_free(store);
+    CTLOG_free(log);
+    return result;
+}
+
+static int test_sct_log_id_setters_enforce_length(void)
+{
+    SCT *sct = NULL;
+    unsigned char valid_id[CT_V1_HASHLEN];
+    unsigned char oversized_id[CT_V1_HASHLEN + 1];
+    unsigned char short_id = 0xAB;
+    unsigned char *heap_id = NULL;
+    unsigned char *log_id = NULL;
+    int result = 0;
+
+    memset(oversized_id, 0, sizeof(oversized_id));
+    memset(valid_id, 0, sizeof(valid_id));
+
+    if (!TEST_ptr(sct = SCT_new()))
+        goto end;
+
+    if (!TEST_false(SCT_set1_log_id(sct, &short_id, sizeof(short_id)))
+        || !TEST_size_t_eq(SCT_get0_log_id(sct, &log_id), 0)
+        || !TEST_ptr_null(log_id))
+        goto end;
+
+    heap_id = OPENSSL_memdup(oversized_id, sizeof(oversized_id));
+    if (!TEST_ptr(heap_id))
+        goto end;
+    if (!TEST_false(SCT_set0_log_id(sct, heap_id, sizeof(oversized_id)))) {
+        heap_id = NULL; /* ownership transferred unexpectedly */
+        goto end;
+    }
+    OPENSSL_free(heap_id);
+    heap_id = NULL;
+
+    if (!TEST_size_t_eq(SCT_get0_log_id(sct, &log_id), 0)
+        || !TEST_ptr_null(log_id))
+        goto end;
+
+    if (!TEST_true(SCT_set1_log_id(sct, valid_id, sizeof(valid_id)))
+        || !TEST_size_t_eq(SCT_get0_log_id(sct, &log_id), sizeof(valid_id))
+        || !TEST_mem_eq(log_id, CT_V1_HASHLEN, valid_id, sizeof(valid_id))
+        || !TEST_true(SCT_set_version(sct, SCT_VERSION_V1)))
+        goto end;
+
+    if (!TEST_false(SCT_set1_log_id(sct, oversized_id, sizeof(oversized_id)))
+        || !TEST_size_t_eq(SCT_get0_log_id(sct, &log_id), sizeof(valid_id))
+        || !TEST_mem_eq(log_id, CT_V1_HASHLEN, valid_id, sizeof(valid_id)))
+        goto end;
+
+    if (!TEST_ptr(heap_id = OPENSSL_memdup(&short_id, sizeof(short_id))))
+        goto end;
+    if (!TEST_false(SCT_set0_log_id(sct, heap_id, sizeof(short_id)))) {
+        heap_id = NULL; /* ownership transferred unexpectedly */
+        goto end;
+    }
+    OPENSSL_free(heap_id);
+    heap_id = NULL;
+
+    if (!TEST_size_t_eq(SCT_get0_log_id(sct, &log_id), sizeof(valid_id))
+        || !TEST_mem_eq(log_id, CT_V1_HASHLEN, valid_id, sizeof(valid_id)))
+        goto end;
+
+    if (!TEST_true(SCT_set1_log_id(sct, NULL, 0))
+        || !TEST_size_t_eq(SCT_get0_log_id(sct, &log_id), 0)
+        || !TEST_ptr_null(log_id))
+        goto end;
+
+    result = 1;
+
+end:
+    OPENSSL_free(heap_id);
+    SCT_free(sct);
+    return result;
+}
+
+static int test_sct_log_id_length_sink_guards(void)
+{
+    SCT *sct = NULL;
+    unsigned char short_id = 0x42;
+    unsigned char sigbuf[4] = { 1, 2, 3, 4 };
+    unsigned char *out = NULL;
+    int result = 0;
+
+    if (!TEST_ptr(sct = SCT_new()))
+        goto end;
+
+    sct->log_id = OPENSSL_memdup(&short_id, sizeof(short_id));
+    if (!TEST_ptr(sct->log_id))
+        goto end;
+    sct->log_id_len = sizeof(short_id);
+
+    if (!TEST_false(SCT_set_version(sct, SCT_VERSION_V1))
+        || !TEST_int_eq(SCT_get_version(sct), SCT_VERSION_NOT_SET))
+        goto end;
+
+    /*
+     * Simulate an internal construction path that bypassed the public
+     * setters. i2o_SCT() must refuse the SCT before its fixed CT_V1_HASHLEN
+     * memcpy.
+     */
+    sct->version = SCT_VERSION_V1;
+    if (!TEST_true(SCT_set_signature_nid(sct, NID_sha256WithRSAEncryption))
+        || !TEST_true(SCT_set1_signature(sct, sigbuf, sizeof(sigbuf)))
+        || !TEST_int_eq(i2o_SCT(sct, &out), -1)
+        || !TEST_ptr_null(out))
+        goto end;
+
+    result = 1;
+
+end:
+    OPENSSL_free(out);
+    SCT_free(sct);
+    return result;
+}
 #endif
 
 int setup_tests(void)
@@ -656,6 +831,9 @@ int setup_tests(void)
     ADD_TEST(test_ctlog_store_add0_log);
     ADD_TEST(test_ctlog_store_add0_log_validates_sct);
     ADD_TEST(test_ctlog_store_add0_log_null);
+    ADD_TEST(test_ctlog_store_get0_log_by_id_length);
+    ADD_TEST(test_sct_log_id_setters_enforce_length);
+    ADD_TEST(test_sct_log_id_length_sink_guards);
 #else
     printf("No CT support\n");
 #endif


### PR DESCRIPTION
Fixes #32068 

> **Note**: this PR overlaps with #32030 in `CTLOG_STORE_get0_log_by_id` and related tests and documentation. I'm opening it for early visibility and review of the LogID length handling.
> I will rebase and resolve the small overlap once #32030 is merged.

This PR tightens CT v1 LogID length handling so public SCT construction and CT log lookup paths cannot pass unexpected LogID lengths into fixed length reads.

A CT v1 LogID is exactly `CT_V1_HASHLEN` bytes. Before this change, `SCT_set0_log_id()` and `SCT_set1_log_id` only rejected wrong length LogIDs after the SCT version was already set to `SCT_VERSION_V1`. This allowed applications to install a short LogID before setting the version, then serialize a v1 SCT through `i2o_SCT`, which copies `CT_V1_HASHLEN` bytes from `sct->log_id`.

`CTLOG_STORE_get0_log_by_id` also used the caller supplied length when comparing against the fixed length LogID stored in each `CTLOG`, allowing oversized reads and zero or short length matches.

This PR addresses those cases by:

- rejecting non NULL SCT LogIDs whose length is not `CT_V1_HASHLEN`
- checking the LogID pointer and length pair when setting `SCT_VERSION_V1`
- requiring the exact v1 LogID length before a v1 SCT is considered complete
- making CT log lookup fail cleanly for NULL inputs and non `CT_V1_HASHLEN` lengths
- documenting the tightened API behavior
- adding tests for setter rejection, serializer guarding, and lookup length handling

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
