### PR TITLE
Display UTF-8 DirName characters when locale is UTF-8

### DIFF
--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -183,7 +183,7 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
         break;
 
     case GEN_DIRNAME:
-        if (X509_NAME_oneline(gen->d.dirn, oline, sizeof(oline)) == NULL
+        if (X509_NAME_oneline_for_locale(gen->d.dirn, oline, sizeof(oline)) == NULL
             || !X509V3_add_value("DirName", oline, &ret))
             return NULL;
         break;

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "internal/cryptlib.h"
 #include <openssl/objects.h>
 #include <openssl/x509.h>
@@ -22,7 +23,41 @@
 
 #define NAME_ONELINE_MAX (1024 * 1024)
 
-char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
+#ifndef CHARSET_EBCDIC
+# define NAME_ONELINE_DEL 127
+#else
+# define NAME_ONELINE_DEL 7
+#endif
+
+/*
+ * Return 1 if the process locale codeset appears to be UTF-8.
+ * Inspect LC_ALL, then LC_CTYPE, then LANG (first one that is set wins).
+ */
+static int name_oneline_locale_is_utf8(void)
+{
+    static const char *const env_vars[] = {
+        "LC_ALL", "LC_CTYPE", "LANG", NULL
+    };
+    const char *const *var;
+
+    for (var = env_vars; *var != NULL; var++) {
+        const char *val = getenv(*var);
+
+        if (val != NULL)
+            return HAS_CASE_SUFFIX(val, ".UTF-8")
+                || HAS_CASE_SUFFIX(val, ".utf8");
+    }
+    return 0;
+}
+
+/*
+ * Print X509_NAME |a| into |buf|.
+ * If |escape_non_ascii| is non-zero, bytes outside the printable ASCII range
+ * are hex-escaped.  If it is zero, UTF8String values keep non-ASCII UTF-8
+ * bytes unescaped (control characters and DEL are still escaped).
+ */
+static char *x509_name_oneline_int(const X509_NAME *a, char *buf, int len,
+                                   int escape_non_ascii)
 {
     const X509_NAME_ENTRY *ne;
     int i;
@@ -61,6 +96,8 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
     len--; /* space for '\0' */
     l = 0;
     for (i = 0; i < sk_X509_NAME_ENTRY_num(a->entries); i++) {
+        int do_escape = escape_non_ascii;
+
         ne = sk_X509_NAME_ENTRY_value(a->entries, i);
         n = OBJ_obj2nid(ne->object);
         if ((n == NID_undef) || ((s = OBJ_nid2sn(n)) == NULL)) {
@@ -70,6 +107,10 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
         l1 = (int)strlen(s);
 
         type = ne->value->type;
+        /* Only UTF8String may keep non-ASCII bytes unescaped. */
+        if (!do_escape && type != V_ASN1_UTF8STRING)
+            do_escape = 1;
+
         num = ne->value->length;
         if (num > NAME_ONELINE_MAX) {
             ERR_raise(ERR_LIB_X509, X509_R_NAME_TOO_LONG);
@@ -77,7 +118,11 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
         }
         q = ne->value->data;
 #ifdef CHARSET_EBCDIC
-        if (type == V_ASN1_GENERALSTRING || type == V_ASN1_VISIBLESTRING || type == V_ASN1_PRINTABLESTRING || type == V_ASN1_TELETEXSTRING || type == V_ASN1_IA5STRING) {
+        if (type == V_ASN1_GENERALSTRING ||
+            type == V_ASN1_VISIBLESTRING ||
+            type == V_ASN1_PRINTABLESTRING ||
+            type == V_ASN1_TELETEXSTRING ||
+            type == V_ASN1_IA5STRING) {
             if (num > (int)sizeof(ebcdic_buf))
                 num = sizeof(ebcdic_buf);
             ascii2ebcdic(ebcdic_buf, q, num);
@@ -97,8 +142,9 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
                 gs_doit[0] = gs_doit[1] = gs_doit[2] = 0;
                 gs_doit[3] = 1;
             }
-        } else
+        } else {
             gs_doit[0] = gs_doit[1] = gs_doit[2] = gs_doit[3] = 1;
+        }
 
         for (l2 = j = 0; j < num; j++) {
             if (!gs_doit[j & 3])
@@ -106,7 +152,10 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             l2++;
             if (q[j] == '/' || q[j] == '+')
                 l2++; /* char needs to be escaped */
-            else if ((ossl_toascii(q[j]) < ossl_toascii(' ')) || (ossl_toascii(q[j]) > ossl_toascii('~')))
+            else if (ossl_toascii(q[j]) < ossl_toascii(' ') ||
+                     ossl_toascii(q[j]) == ossl_toascii(NAME_ONELINE_DEL) ||
+                     (do_escape &&
+                      ossl_toascii(q[j]) > ossl_toascii('~')))
                 l2 += 3;
         }
 
@@ -122,10 +171,11 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             p = &(b->data[lold]);
         } else if (l > len) {
             break;
-        } else
+        } else {
             p = &(buf[lold]);
+        }
         *(p++) = prev_set == ne->set ? '+' : '/';
-        memcpy(p, s, (unsigned int)l1);
+        memcpy(p, s, (size_t)l1);
         p += l1;
         *(p++) = '=';
 
@@ -138,18 +188,20 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
                 continue;
 #ifndef CHARSET_EBCDIC
             n = q[j];
-            if ((n < ' ') || (n > '~')) {
+            if (n < ' ' || n == NAME_ONELINE_DEL ||
+                (do_escape && n > '~')) {
                 *(p++) = '\\';
                 *(p++) = 'x';
                 p += ossl_to_hex(p, n);
             } else {
                 if (n == '/' || n == '+')
                     *(p++) = '\\';
-                *(p++) = n;
+                *(p++) = (char)n;
             }
 #else
             n = os_toascii[q[j]];
-            if ((n < os_toascii[' ']) || (n > os_toascii['~'])) {
+            if (n < os_toascii[' '] || n == os_toascii[NAME_ONELINE_DEL] ||
+                (do_escape && n > os_toascii['~'])) {
                 *(p++) = '\\';
                 *(p++) = 'x';
                 p += ossl_to_hex(p, n);
@@ -166,8 +218,9 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
     if (b != NULL) {
         p = b->data;
         OPENSSL_free(b);
-    } else
+    } else {
         p = buf;
+    }
     if (i == 0)
         *p = '\0';
     return p;
@@ -176,4 +229,19 @@ buferr:
 end:
     BUF_MEM_free(b);
     return NULL;
+}
+
+char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size)
+{
+    return x509_name_oneline_int(a, buf, size, 1);
+}
+
+/*
+ * Like X509_NAME_oneline(), but when the locale codeset is UTF-8, do not
+ * hex-escape non-ASCII bytes in UTF8String NAME entries.
+ */
+char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int size)
+{
+    return x509_name_oneline_int(a, buf, size,
+                                 name_oneline_locale_is_utf8() ? 0 : 1);
 }

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -150,6 +150,22 @@ Output the nextUpdate field.
 
 =back
 
+=head1 ENVIRONMENT
+
+=over 4
+
+=item B<LANG>, B<LC_CTYPE>, B<LC_ALL>
+
+If any of these is defined with a codeset of C<.UTF-8> or C<.utf8>,
+and the CRL is printed in text form with a UTF8String DirName value,
+non-ASCII UTF-8 characters in the DirName field are shown without
+hex-escaping.
+
+When more than one of these are defined, B<LC_CTYPE> overrides B<LANG>, and
+B<LC_ALL> overrides both B<LC_CTYPE> and B<LANG>.
+
+=back
+
 =head1 EXAMPLES
 
 Convert a CRL file from PEM to DER:
@@ -159,6 +175,10 @@ Convert a CRL file from PEM to DER:
 Output the text form of a DER encoded certificate:
 
  openssl crl -in crl.der -text -noout
+
+Output text form while showing UTF-8 DirName characters without hex-escaping:
+
+ LC_ALL=C.UTF-8 openssl crl -in crl.der -text -noout
 
 =head1 BUGS
 
@@ -179,7 +199,7 @@ Since OpenSSL 3.3, the B<-verify> option will exit with 1 on failure.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/X509_NAME_print_ex.pod
+++ b/doc/man3/X509_NAME_print_ex.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 X509_NAME_print_ex, X509_NAME_print_ex_fp, X509_NAME_print,
-X509_NAME_oneline - X509_NAME printing routines
+X509_NAME_oneline, X509_NAME_oneline_for_locale - X509_NAME printing routines
 
 =head1 SYNOPSIS
 
@@ -14,6 +14,7 @@ X509_NAME_oneline - X509_NAME printing routines
  int X509_NAME_print_ex_fp(FILE *fp, const X509_NAME *nm,
                            int indent, unsigned long flags);
  char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
+ char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int size);
  int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase);
 
 =head1 DESCRIPTION
@@ -27,17 +28,24 @@ except the output is written to FILE pointer I<fp>.
 
 X509_NAME_oneline() prints an ASCII version of I<a> to I<buf>.
 This supports multi-valued RDNs and escapes B</> and B<+> characters in values.
+Non-ASCII bytes are always hex-escaped.
 If I<buf> is B<NULL> then a buffer is dynamically allocated and returned, and
 I<size> is ignored.
 Otherwise, at most I<size> bytes will be written, including the ending '\0',
 and I<buf> is returned.
+
+X509_NAME_oneline_for_locale() behaves like X509_NAME_oneline(), except that
+when the process locale codeset is UTF-8 (as indicated by B<LC_ALL>,
+B<LC_CTYPE> or B<LANG> ending in C<.UTF-8> or C<.utf8>) and a NAME entry
+value is of type UTF8String, non-ASCII UTF-8 bytes are not hex-escaped.
 
 X509_NAME_print() prints out I<name> to I<bp> on a single line.
 The I<obase> parameter is ignored and retained only for API compatibility.
 
 =head1 NOTES
 
-The functions X509_NAME_oneline() and X509_NAME_print()
+The functions X509_NAME_oneline(), X509_NAME_oneline_for_locale() and
+X509_NAME_print()
 produce a non standard output form, they don't handle multi-character fields and
 have various quirks and inconsistencies.
 Their use is strongly discouraged in new applications and they could
@@ -107,7 +115,8 @@ in fact it calls X509_NAME_print() internally.
 
 =head1 RETURN VALUES
 
-X509_NAME_oneline() returns a valid string on success or NULL on error.
+X509_NAME_oneline() and X509_NAME_oneline_for_locale() return a valid string on
+success or NULL on error.
 
 X509_NAME_print() returns 1 on success or 0 on error.
 
@@ -119,9 +128,13 @@ Otherwise, it returns -1 on error or other values on success.
 
 L<ASN1_STRING_print_ex(3)>
 
+=head1 HISTORY
+
+X509_NAME_oneline_for_locale() was added in OpenSSL 4.1.0.
+
 =head1 COPYRIGHT
 
-Copyright 2002-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2002-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -625,6 +625,7 @@ DECLARE_ASN1_FUNCTIONS(NETSCAPE_CERT_SEQUENCE)
 X509_INFO *X509_INFO_new(void);
 void X509_INFO_free(X509_INFO *a);
 char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
+char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int size);
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0

--- a/test/build.info
+++ b/test/build.info
@@ -72,7 +72,7 @@ IF[{- !$disabled{tests} -}]
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
           provfetchtest prov_config_test libctx_config_test rand_test \
           ca_internals_test bio_tfo_test membio_test bio_dgram_test list_test \
-          fips_version_test x509_test hpke_test pairwise_fail_test \
+          fips_version_test x509_test x509_name_oneline_test hpke_test pairwise_fail_test \
           nodefltctxtest evp_xof_test x509_load_cert_file_test bio_meth_test \
           x509_acert_test x509_req_test strtoultest bio_pw_callback_test \
           engine_stubs_test base64_simdutf_test bio_eof_test ech_test
@@ -744,6 +744,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[x509_test]=x509_test.c
   INCLUDE[x509_test]=../include ../apps/include
   DEPEND[x509_test]=../libcrypto libtestutil.a
+
+  SOURCE[x509_name_oneline_test]=x509_name_oneline_test.c
+  INCLUDE[x509_name_oneline_test]=../include ../apps/include
+  DEPEND[x509_name_oneline_test]=../libcrypto libtestutil.a
 
   SOURCE[recordlentest]=recordlentest.c helpers/ssltestlib.c
   INCLUDE[recordlentest]=../include ../apps/include

--- a/test/x509_name_oneline_test.c
+++ b/test/x509_name_oneline_test.c
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/bio.h>
+#include <openssl/x509.h>
+#include "testutil.h"
+
+/* UTF-8 for "Österreich" */
+static const char utf8_o_umlaut[] = "\xC3\x96sterreich";
+
+static X509_NAME *make_utf8_name(void)
+{
+    X509_NAME *nm = X509_NAME_new();
+
+    if (nm == NULL)
+        return NULL;
+    if (!X509_NAME_add_entry_by_NID(nm, NID_countryName, MBSTRING_ASC,
+                                    (unsigned char *)"AT", -1, -1, 0)
+        || !X509_NAME_add_entry_by_NID(nm, NID_organizationName,
+                                      V_ASN1_UTF8STRING,
+                                      (unsigned char *)utf8_o_umlaut, -1,
+                                      -1, 0)) {
+        X509_NAME_free(nm);
+        return NULL;
+    }
+    return nm;
+}
+
+static void restore_env(const char *name, char *saved)
+{
+#if defined(_WIN32)
+    char buf[512];
+
+    if (saved != NULL) {
+        BIO_snprintf(buf, sizeof(buf), "%s=%s", name, saved);
+        _putenv(buf);
+    } else {
+        BIO_snprintf(buf, sizeof(buf), "%s=", name);
+        _putenv(buf);
+    }
+#else
+    if (saved != NULL)
+        setenv(name, saved, 1);
+    else
+        unsetenv(name);
+#endif
+}
+
+static int test_oneline_escapes_non_ascii(void)
+{
+    X509_NAME *nm = NULL;
+    char *out = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(nm = make_utf8_name())
+        || !TEST_ptr(out = X509_NAME_oneline(nm, NULL, 0))
+        || !TEST_ptr(strstr(out, "\\xC3\\x96"))
+        || !TEST_ptr(strstr(out, "sterreich")))
+        goto err;
+    ret = 1;
+err:
+    OPENSSL_free(out);
+    X509_NAME_free(nm);
+    return ret;
+}
+
+static int test_oneline_for_locale_utf8(void)
+{
+    X509_NAME *nm = NULL;
+    char *out = NULL;
+    int ret = 0;
+    char *saved_lc_all = NULL;
+    char *saved_lc_ctype = NULL;
+    char *saved_lang = NULL;
+    const char *tmp;
+
+    if ((tmp = getenv("LC_ALL")) != NULL)
+        saved_lc_all = OPENSSL_strdup(tmp);
+    if ((tmp = getenv("LC_CTYPE")) != NULL)
+        saved_lc_ctype = OPENSSL_strdup(tmp);
+    if ((tmp = getenv("LANG")) != NULL)
+        saved_lang = OPENSSL_strdup(tmp);
+
+#if defined(_WIN32)
+    _putenv("LC_ALL=C.UTF-8");
+    _putenv("LC_CTYPE=");
+    _putenv("LANG=");
+#else
+    setenv("LC_ALL", "C.UTF-8", 1);
+    unsetenv("LC_CTYPE");
+    unsetenv("LANG");
+#endif
+
+    if (!TEST_ptr(nm = make_utf8_name())
+        || !TEST_ptr(out = X509_NAME_oneline_for_locale(nm, NULL, 0))
+        || !TEST_true(strstr(out, "\\xC3\\x96") == NULL)
+        || !TEST_ptr(strstr(out, utf8_o_umlaut)))
+        goto err;
+    ret = 1;
+err:
+    OPENSSL_free(out);
+    X509_NAME_free(nm);
+    restore_env("LC_ALL", saved_lc_all);
+    restore_env("LC_CTYPE", saved_lc_ctype);
+    restore_env("LANG", saved_lang);
+    OPENSSL_free(saved_lc_all);
+    OPENSSL_free(saved_lc_ctype);
+    OPENSSL_free(saved_lang);
+    return ret;
+}
+
+static int test_oneline_for_locale_c(void)
+{
+    X509_NAME *nm = NULL;
+    char *out = NULL;
+    int ret = 0;
+    char *saved_lc_all = NULL;
+    const char *tmp;
+
+    if ((tmp = getenv("LC_ALL")) != NULL)
+        saved_lc_all = OPENSSL_strdup(tmp);
+
+#if defined(_WIN32)
+    _putenv("LC_ALL=C");
+#else
+    setenv("LC_ALL", "C", 1);
+#endif
+
+    if (!TEST_ptr(nm = make_utf8_name())
+        || !TEST_ptr(out = X509_NAME_oneline_for_locale(nm, NULL, 0))
+        || !TEST_ptr(strstr(out, "\\xC3\\x96")))
+        goto err;
+    ret = 1;
+err:
+    OPENSSL_free(out);
+    X509_NAME_free(nm);
+    restore_env("LC_ALL", saved_lc_all);
+    OPENSSL_free(saved_lc_all);
+    return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_oneline_escapes_non_ascii);
+    ADD_TEST(test_oneline_for_locale_utf8);
+    ADD_TEST(test_oneline_for_locale_c);
+    return 1;
+}

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5727,3 +5727,4 @@ EVP_KDF_CTX_get1_kdf                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_data                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_string                  ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_length_ex                   ?	4_1_0	EXIST::FUNCTION:
+X509_NAME_oneline_for_locale            ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
When printing X509 names for CRL/SAN DirName text output, avoid hex-escaping non-ASCII UTF8String bytes if the process locale codeset is UTF-8. Fixes #27207.

Based on approach from PR #27545 by @ar-an-ribe.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
