### PR TITLE
CMS: Guard against int overflow in cms_kek_cipher()

### DIFF
--- a/crypto/cms/cms_kemri.c
+++ b/crypto/cms/cms_kemri.c
@@ -270,6 +270,9 @@ static int cms_kek_cipher(unsigned char **pout, size_t *poutlen,
         return 0;
     }
 
+    if (inlen > INT_MAX)
+        return 0;
+
     if (!kdf_derive(kek, keklen, ss, sslen, kemri))
         goto err;
 


### PR DESCRIPTION
Mirror the check from cms_kari.c in cms_kemri.c.