### PR TITLE
apps: test info options of the list command

### DIFF
--- a/test/recipes/20-test_cli_list.t
+++ b/test/recipes/20-test_cli_list.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2016-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -13,7 +13,7 @@ use OpenSSL::Test qw/:DEFAULT bldtop_file srctop_file bldtop_dir with/;
 use OpenSSL::Test::Utils;
 
 setup("test_cli_list");
-plan tests => 4;
+plan tests => 14;
 my $fipsconf = srctop_file("test", "fips-and-base.cnf");
 my $defaultconf = srctop_file("test", "default.cnf");
 
@@ -30,6 +30,47 @@ sub check_skey_manager_list {
 }
 
 check_skey_manager_list("default");
+
+my @match;
+
+ok(run(app(["openssl", "list", "-commands"], stdout => "commands.txt")),
+   "List standard commands");
+open DATA, "commands.txt";
+@match = grep /\blist\b/, <DATA>;
+close DATA;
+ok(scalar @match > 0, "The list command is among the standard commands");
+
+ok(run(app(["openssl", "list", "-1", "-commands"], stdout => "commands1.txt")),
+   "List standard commands in one column");
+open DATA, "commands1.txt";
+@match = grep /^list$/, <DATA>;
+close DATA;
+ok(scalar @match == 1, "One-column output has one command per line");
+
+SKIP: {
+    skip "Deprecated functionality is disabled", 1
+        if disabled("deprecated");
+
+    ok(run(app(["openssl", "list", "-digest-commands"])),
+       "List digest commands");
+}
+
+ok(run(app(["openssl", "list", "-options", "list"], stdout => "options.txt")),
+   "List options of the list command");
+open DATA, "options.txt";
+@match = grep /^select s$/, <DATA>;
+close DATA;
+ok(scalar @match == 1, "The select option is listed for the list command");
+
+ok(run(app(["openssl", "list", "-disabled"])),
+   "List disabled features, algorithms, and protocols");
+
+ok(run(app(["openssl", "list", "-objects"], stdout => "objects.txt")),
+   "List built-in objects");
+open DATA, "objects.txt";
+@match = grep /^CN = commonName, 2\.5\.4\.3$/, <DATA>;
+close DATA;
+ok(scalar @match == 1, "The commonName OID mapping is listed");
 
 SKIP: {
     my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);


### PR DESCRIPTION
Exercise the previously untested -commands, -1, -digest-commands, -options, -disabled and -objects options in list app.
