### PR TITLE
x509: reject negative CRL numbers under X509_STRICT

### DIFF
--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -229,6 +229,8 @@ const char *X509_verify_cert_error_string(long n)
         return "Authority Key Identifier issuer and serial number must be paired";
     case X509_V_ERR_DUPLICATE_EXTENSION:
         return "Certificate includes more than one instance of a particular extension";
+    case X509_V_ERR_NEGATIVE_CRL_NUMBER:
+        return "CRL Number or Base CRL Number is negative";
 
         /*
          * Entries must be kept consistent with include/openssl/x509_vfy.h.in

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2045,8 +2045,7 @@ static int check_crl(X509_STORE_CTX *ctx, X509_CRL *crl)
     ctx->current_crl = crl;
 
     /*
-     * RFC 5280 5.2.3 / 5.2.4: CRLNumber and BaseCRLNumber are INTEGER (0..MAX).
-     * Only enforce under X509_V_FLAG_X509_STRICT.
+     * Reject negative CRLNumber / BaseCRLNumber under X509_V_FLAG_X509_STRICT.
      */
     if ((ctx->param->flags & X509_V_FLAG_X509_STRICT) != 0
         && ((crl->crl_number != NULL

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2044,6 +2044,18 @@ static int check_crl(X509_STORE_CTX *ctx, X509_CRL *crl)
 
     ctx->current_crl = crl;
 
+    /*
+     * RFC 5280 5.2.3 / 5.2.4: CRLNumber and BaseCRLNumber are INTEGER (0..MAX).
+     * Only enforce under X509_V_FLAG_X509_STRICT.
+     */
+    if ((ctx->param->flags & X509_V_FLAG_X509_STRICT) != 0
+        && ((crl->crl_number != NULL
+             && crl->crl_number->type == V_ASN1_NEG_INTEGER)
+            || (crl->base_crl_number != NULL
+                && crl->base_crl_number->type == V_ASN1_NEG_INTEGER))
+        && !verify_cb_crl(ctx, X509_V_ERR_NEGATIVE_CRL_NUMBER))
+        return 0;
+
     /* If we have an alternative CRL issuer cert use that */
     if (ctx->current_issuer != NULL) {
         issuer = ctx->current_issuer;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2017,8 +2017,7 @@ static int check_crl(X509_STORE_CTX *ctx, X509_CRL *crl)
     ctx->current_crl = crl;
 
     /*
-     * RFC 5280 5.2.3 / 5.2.4: CRLNumber and BaseCRLNumber are INTEGER (0..MAX).
-     * Only enforce under X509_V_FLAG_X509_STRICT.
+     * Reject negative CRLNumber / BaseCRLNumber under X509_V_FLAG_X509_STRICT.
      */
     if ((ctx->param->flags & X509_V_FLAG_X509_STRICT) != 0
         && ((crl->crl_number != NULL

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2016,6 +2016,18 @@ static int check_crl(X509_STORE_CTX *ctx, X509_CRL *crl)
 
     ctx->current_crl = crl;
 
+    /*
+     * RFC 5280 5.2.3 / 5.2.4: CRLNumber and BaseCRLNumber are INTEGER (0..MAX).
+     * Only enforce under X509_V_FLAG_X509_STRICT.
+     */
+    if ((ctx->param->flags & X509_V_FLAG_X509_STRICT) != 0
+        && ((crl->crl_number != NULL
+             && crl->crl_number->type == V_ASN1_NEG_INTEGER)
+            || (crl->base_crl_number != NULL
+                && crl->base_crl_number->type == V_ASN1_NEG_INTEGER))
+        && !verify_cb_crl(ctx, X509_V_ERR_NEGATIVE_CRL_NUMBER))
+        return 0;
+
     /* If we have an alternative CRL issuer cert use that */
     if (ctx->current_issuer != NULL) {
         issuer = ctx->current_issuer;

--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -522,6 +522,11 @@ Authority Key Identifier issuer and serial number must be paired.
 
 Certificate includes more than one instance of a particular extension.
 
+=item B<X509_V_ERR_NEGATIVE_CRL_NUMBER: CRL Number or Base CRL Number is negative>
+
+The CRL Number or Base CRL Number extension contains a negative integer.
+This is only reported when B<X509_V_FLAG_X509_STRICT> is set.
+
 =back
 
 =head1 NOTES

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -386,8 +386,7 @@ supported can be performed in the verification callback.
 
 The B<X509_V_FLAG_X509_STRICT> flag disables workarounds for some broken
 certificates and makes the verification strictly apply B<X509> rules.
-Among other checks, a negative CRL Number or Base CRL Number (RFC 5280
-sections 5.2.3 and 5.2.4) is rejected with
+Among other checks, a negative CRL Number or Base CRL Number is rejected with
 B<X509_V_ERR_NEGATIVE_CRL_NUMBER>.
 
 B<X509_V_FLAG_ALLOW_PROXY_CERTS> enables proxy certificate verification.

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -296,6 +296,9 @@ verification callback.
 The B<X509_V_FLAG_X509_STRICT> flag disables workarounds for some
 broken certificates and makes verification strictly apply B<X509>
 rules.
+Among other checks, a negative CRL Number or Base CRL Number (RFC 5280
+sections 5.2.3 and 5.2.4) is rejected with
+B<X509_V_ERR_NEGATIVE_CRL_NUMBER>.
 
 B<X509_V_FLAG_ALLOW_PROXY_CERTS> enables proxy certificate verification.
 By default, proxy certificates are not accepted.

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -386,6 +386,9 @@ supported can be performed in the verification callback.
 
 The B<X509_V_FLAG_X509_STRICT> flag disables workarounds for some broken
 certificates and makes the verification strictly apply B<X509> rules.
+Among other checks, a negative CRL Number or Base CRL Number (RFC 5280
+sections 5.2.3 and 5.2.4) is rejected with
+B<X509_V_ERR_NEGATIVE_CRL_NUMBER>.
 
 B<X509_V_FLAG_ALLOW_PROXY_CERTS> enables proxy certificate verification.
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -296,8 +296,7 @@ verification callback.
 The B<X509_V_FLAG_X509_STRICT> flag disables workarounds for some
 broken certificates and makes verification strictly apply B<X509>
 rules.
-Among other checks, a negative CRL Number or Base CRL Number (RFC 5280
-sections 5.2.3 and 5.2.4) is rejected with
+Among other checks, a negative CRL Number or Base CRL Number is rejected with
 B<X509_V_ERR_NEGATIVE_CRL_NUMBER>.
 
 B<X509_V_FLAG_ALLOW_PROXY_CERTS> enables proxy certificate verification.

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -338,6 +338,7 @@ void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 #define X509_V_ERR_AKID_ISSUER_SERIAL_NOT_PAIRED 103
 
 #define X509_V_ERR_DUPLICATE_EXTENSION 104
+#define X509_V_ERR_NEGATIVE_CRL_NUMBER 105
 
 /* Certificate verify flags */
 #ifndef OPENSSL_NO_DEPRECATED_1_1_0

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -1615,7 +1615,7 @@ static X509_CRL *make_signed_delta_crl(X509 *issuer, EVP_PKEY *pkey,
         || !TEST_int_gt(X509_CRL_add1_ext_i2d(crl, NID_crl_number, num, 0, 0), 0)
         || !TEST_ptr(base_num = ASN1_INTEGER_new())
         || !TEST_true(ASN1_INTEGER_set(base_num, base_number))
-        /* deltaCRLIndicator is critical per RFC 5280 5.2.4 */
+        /* deltaCRLIndicator is typically marked critical */
         || !TEST_int_gt(X509_CRL_add1_ext_i2d(crl, NID_delta_crl, base_num, 1, 0),
                         0)
         || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
@@ -1637,8 +1637,8 @@ err:
 }
 
 /*
- * RFC 5280 requires a non-negative cRLNumber. OpenSSL only enforces this during
- * certificate verification when X509_V_FLAG_X509_STRICT is set.
+ * Negative cRLNumber values are rejected during certificate verification when
+ * X509_V_FLAG_X509_STRICT is set.
  */
 static int test_crl_negative_number(void)
 {

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -8,11 +8,14 @@
  */
 
 #include <time.h>
+#include <openssl/asn1.h>
 #include <openssl/bio.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 
 #include "testutil.h"
 
@@ -1531,6 +1534,195 @@ static int test_crl_number(void)
     return test;
 }
 
+/*
+ * Build a v2 CRL for |issuer|, signed with |pkey|, with cRLNumber set to
+ * |crl_number|. Re-decodes the result so cached extension fields are filled.
+ */
+static X509_CRL *make_signed_crl_with_number(X509 *issuer, EVP_PKEY *pkey,
+    long crl_number)
+{
+    X509_CRL *crl = NULL, *decoded = NULL;
+    ASN1_TIME *last = NULL, *next = NULL;
+    ASN1_INTEGER *num = NULL;
+    unsigned char *der = NULL;
+    const unsigned char *p;
+    int derlen;
+
+    if (!TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(X509_CRL_set_version(crl, X509_CRL_VERSION_2))
+        || !TEST_true(X509_CRL_set_issuer_name(crl,
+                          X509_get_subject_name(issuer)))
+        || !TEST_ptr(last = ASN1_TIME_set(NULL, kVerify - 86400))
+        || !TEST_ptr(next = ASN1_TIME_set(NULL, kVerify + 30 * 86400))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, last))
+        || !TEST_true(X509_CRL_set1_nextUpdate(crl, next))
+        || !TEST_ptr(num = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(num, crl_number))
+        || !TEST_int_gt(X509_CRL_add1_ext_i2d(crl, NID_crl_number, num, 0, 0), 0)
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
+        || !TEST_int_gt(derlen = i2d_X509_CRL(crl, &der), 0))
+        goto err;
+
+    p = der;
+    if (!TEST_ptr(decoded = d2i_X509_CRL(NULL, &p, derlen)))
+        goto err;
+
+err:
+    OPENSSL_free(der);
+    ASN1_INTEGER_free(num);
+    ASN1_TIME_free(last);
+    ASN1_TIME_free(next);
+    X509_CRL_free(crl);
+    return decoded;
+}
+
+/*
+ * Build a delta CRL compatible with |base|: same issuer/AKID/IDP, with the
+ * given cRLNumber and BaseCRLNumber (deltaCRLIndicator). Re-decodes so
+ * crl->base_crl_number is populated.
+ */
+static X509_CRL *make_signed_delta_crl(X509 *issuer, EVP_PKEY *pkey,
+    X509_CRL *base, long crl_number, long base_number)
+{
+    X509_CRL *crl = NULL, *decoded = NULL;
+    ASN1_TIME *last = NULL, *next = NULL;
+    ASN1_INTEGER *num = NULL, *base_num = NULL;
+    X509_EXTENSION *akid_ext = NULL;
+    unsigned char *der = NULL;
+    const unsigned char *p;
+    int derlen, idx;
+
+    /*
+     * Copy the base AKID extension verbatim. check_delta_base() compares the
+     * raw extension encoding, so re-encoding via AUTHORITY_KEYID may not match.
+     */
+    idx = X509_CRL_get_ext_by_NID(base, NID_authority_key_identifier, -1);
+    if (!TEST_int_ge(idx, 0)
+        || !TEST_ptr(akid_ext = X509_CRL_get_ext(base, idx)))
+        return NULL;
+
+    if (!TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(X509_CRL_set_version(crl, X509_CRL_VERSION_2))
+        || !TEST_true(X509_CRL_set_issuer_name(crl,
+                          X509_get_subject_name(issuer)))
+        || !TEST_ptr(last = ASN1_TIME_set(NULL, kVerify - 86400))
+        || !TEST_ptr(next = ASN1_TIME_set(NULL, kVerify + 30 * 86400))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, last))
+        || !TEST_true(X509_CRL_set1_nextUpdate(crl, next))
+        || !TEST_true(X509_CRL_add_ext(crl, akid_ext, -1))
+        || !TEST_ptr(num = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(num, crl_number))
+        || !TEST_int_gt(X509_CRL_add1_ext_i2d(crl, NID_crl_number, num, 0, 0), 0)
+        || !TEST_ptr(base_num = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(base_num, base_number))
+        /* deltaCRLIndicator is critical per RFC 5280 5.2.4 */
+        || !TEST_int_gt(X509_CRL_add1_ext_i2d(crl, NID_delta_crl, base_num, 1, 0),
+                        0)
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
+        || !TEST_int_gt(derlen = i2d_X509_CRL(crl, &der), 0))
+        goto err;
+
+    p = der;
+    if (!TEST_ptr(decoded = d2i_X509_CRL(NULL, &p, derlen)))
+        goto err;
+
+err:
+    OPENSSL_free(der);
+    ASN1_INTEGER_free(num);
+    ASN1_INTEGER_free(base_num);
+    ASN1_TIME_free(last);
+    ASN1_TIME_free(next);
+    X509_CRL_free(crl);
+    return decoded;
+}
+
+/*
+ * RFC 5280 requires a non-negative cRLNumber. OpenSSL only enforces this during
+ * certificate verification when X509_V_FLAG_X509_STRICT is set.
+ */
+static int test_crl_negative_number(void)
+{
+    X509 *root = NULL;
+    X509 *leaf = NULL;
+    EVP_PKEY *root_pkey = NULL;
+    X509_CRL *neg_crl = NULL;
+    X509_CRL *pos_crl = NULL;
+    STACK_OF(X509_CRL) *crls;
+    int test;
+
+    test = TEST_ptr(root = X509_from_strings(kRoot))
+        && TEST_ptr(leaf = X509_from_strings(kLeaf))
+        && TEST_ptr(root_pkey = PKEY_from_strings(kRootPrivateKey))
+        && TEST_ptr(neg_crl = make_signed_crl_with_number(root, root_pkey, -36))
+        && TEST_ptr(pos_crl = make_signed_crl_with_number(root, root_pkey, 1))
+        /* Without X509_STRICT, a negative CRL number is accepted. */
+        && TEST_ptr(crls = make_CRL_stack(neg_crl, NULL))
+        && TEST_int_eq(verify(leaf, root, crls, X509_V_FLAG_CRL_CHECK, kVerify),
+                       X509_V_OK)
+        /* With X509_STRICT, a negative CRL number is rejected. */
+        && TEST_ptr(crls = make_CRL_stack(neg_crl, NULL))
+        && TEST_int_eq(verify(leaf, root, crls,
+                              X509_V_FLAG_CRL_CHECK | X509_V_FLAG_X509_STRICT,
+                              kVerify),
+                       X509_V_ERR_NEGATIVE_CRL_NUMBER)
+        /* A non-negative CRL number still verifies under X509_STRICT. */
+        && TEST_ptr(crls = make_CRL_stack(pos_crl, NULL))
+        && TEST_int_eq(verify(leaf, root, crls,
+                              X509_V_FLAG_CRL_CHECK | X509_V_FLAG_X509_STRICT,
+                              kVerify),
+                       X509_V_OK);
+
+    X509_CRL_free(neg_crl);
+    X509_CRL_free(pos_crl);
+    EVP_PKEY_free(root_pkey);
+    X509_free(root);
+    X509_free(leaf);
+    return test;
+}
+
+/*
+ * Same strictness check for Base CRL Number (deltaCRLIndicator). A lone delta
+ * never reaches check_crl(); it is only considered after a freshest-capable
+ * base CRL is selected under X509_V_FLAG_USE_DELTAS (see get_delta_sk()).
+ *
+ * kCrlDeltaBase has cRLNumber 4096 and a Freshest CRL extension; the synthetic
+ * delta uses cRLNumber 4097 and a negative BaseCRLNumber.
+ */
+static int test_crl_negative_base_number(void)
+{
+    X509 *root = NULL;
+    X509 *leaf = NULL;
+    EVP_PKEY *root_pkey = NULL;
+    X509_CRL *base = NULL;
+    X509_CRL *delta = NULL;
+    STACK_OF(X509_CRL) *crls;
+    unsigned long flags = X509_V_FLAG_CRL_CHECK
+        | X509_V_FLAG_EXTENDED_CRL_SUPPORT | X509_V_FLAG_USE_DELTAS;
+    int test;
+
+    test = TEST_ptr(root = X509_from_strings(kRoot))
+        && TEST_ptr(leaf = X509_from_strings(kLeaf))
+        && TEST_ptr(root_pkey = PKEY_from_strings(kRootPrivateKey))
+        && TEST_ptr(base = CRL_from_strings(kCrlDeltaBase))
+        && TEST_ptr(delta = make_signed_delta_crl(root, root_pkey, base, 4097,
+                                                  -36))
+        /* Without X509_STRICT, a negative Base CRL Number is accepted. */
+        && TEST_ptr(crls = make_CRL_stack(base, delta))
+        && TEST_int_eq(verify(leaf, root, crls, flags, kVerify), X509_V_OK)
+        /* With X509_STRICT, reject via the base_crl_number branch. */
+        && TEST_ptr(crls = make_CRL_stack(base, delta))
+        && TEST_int_eq(verify(leaf, root, crls,
+                              flags | X509_V_FLAG_X509_STRICT, kVerify),
+                       X509_V_ERR_NEGATIVE_CRL_NUMBER);
+
+    X509_CRL_free(delta);
+    X509_CRL_free(base);
+    EVP_PKEY_free(root_pkey);
+    X509_free(root);
+    X509_free(leaf);
+    return test;
+}
+
 static int test_crl_idp_asn1_wrong_tag(void)
 {
     X509_CRL *crl;
@@ -2014,6 +2206,8 @@ int setup_tests(void)
     ADD_TEST(test_crl_delta_indicator);
     ADD_TEST(test_crl_delta_valid);
     ADD_TEST(test_crl_number);
+    ADD_TEST(test_crl_negative_number);
+    ADD_TEST(test_crl_negative_base_number);
     ADD_TEST(test_crl_idp_asn1_wrong_tag);
     ADD_TEST(test_crl_idp_asn1_wrong_tag2);
     ADD_TEST(test_crl_idp_onlyca_onlyattr);

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -1587,7 +1587,7 @@ static X509_CRL *make_signed_delta_crl(X509 *issuer, EVP_PKEY *pkey,
     X509_CRL *crl = NULL, *decoded = NULL;
     ASN1_TIME *last = NULL, *next = NULL;
     ASN1_INTEGER *num = NULL, *base_num = NULL;
-    X509_EXTENSION *akid_ext = NULL;
+    const X509_EXTENSION *akid_ext = NULL;
     unsigned char *der = NULL;
     const unsigned char *p;
     int derlen, idx;


### PR DESCRIPTION
Reject negative CRL Number / Base CRL Number during certificate verification when X509_V_FLAG_X509_STRICT is set. Parsing and openssl crl -text are unchanged.

Fixes #27085.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
