### PR TITLE
test: fix flaky -md and -iter mismatch checks in 20-test_enc.t

### DIFF
--- a/test/recipes/20-test_enc.t
+++ b/test/recipes/20-test_enc.t
@@ -154,9 +154,14 @@ plan tests => 10 + (scalar @ciphers)*2;
             "decrypt with -md sha1");
          ok(compare_text($test, "md.clear") == 0,
             "decrypted output matches the original");
+         # A mismatching digest derives a different key.  The decryption
+         # usually fails on the padding check, but with a random salt the
+         # garbage last block carries valid padding roughly once in 256 runs,
+         # in which case it succeeds and produces garbage instead.
          ok(!run(app([$cmd, "enc", "-aes-128-cbc", "-md", "sha256", "-d", "-k", "test",
-                      "-in", "md.cipher", "-out", "md_mismatch.clear"])),
-            "decrypt fails when -md does not match the one used to encrypt");
+                      "-in", "md.cipher", "-out", "md_mismatch.clear"]))
+            || compare_text($test, "md_mismatch.clear") != 0,
+            "decrypt does not recover the plaintext when -md does not match");
      };
 
      subtest "-iter sets the PBKDF2 iteration count" => sub {
@@ -170,8 +175,12 @@ plan tests => 10 + (scalar @ciphers)*2;
             "decrypt with -iter 5");
          ok(compare_text($test, "iter.clear") == 0,
             "decrypted output matches the original");
+         # As with -md above, a mismatching iteration count derives a
+         # different key, so the decryption either fails on the padding check
+         # or, for about one salt in 256, succeeds and yields garbage.
          ok(!run(app([$cmd, "enc", "-aes-128-cbc", "-iter", "6", "-d", "-k", "test",
-                      "-in", "iter.cipher", "-out", "iter_mismatch.clear"])),
-            "decrypt fails when -iter does not match the one used to encrypt");
+                      "-in", "iter.cipher", "-out", "iter_mismatch.clear"]))
+            || compare_text($test, "iter_mismatch.clear") != 0,
+            "decrypt does not recover the plaintext when -iter does not match");
      };
 }

--- a/test/recipes/20-test_enc.t
+++ b/test/recipes/20-test_enc.t
@@ -156,8 +156,8 @@ plan tests => 10 + (scalar @ciphers)*2;
             "decrypted output matches the original");
          # A mismatching digest derives a different key.  The decryption
          # usually fails on the padding check, but with a random salt the
-         # garbage last block carries valid padding roughly once in 256 runs,
-         # in which case it succeeds and produces garbage instead.
+         # garbage last block occasionally happens to look like valid
+         # padding, in which case it succeeds and produces garbage instead.
          ok(!run(app([$cmd, "enc", "-aes-128-cbc", "-md", "sha256", "-d", "-k", "test",
                       "-in", "md.cipher", "-out", "md_mismatch.clear"]))
             || compare_text($test, "md_mismatch.clear") != 0,
@@ -177,7 +177,8 @@ plan tests => 10 + (scalar @ciphers)*2;
             "decrypted output matches the original");
          # As with -md above, a mismatching iteration count derives a
          # different key, so the decryption either fails on the padding check
-         # or, for about one salt in 256, succeeds and yields garbage.
+         # or, when the garbage happens to look like valid padding, succeeds
+         # and yields garbage.
          ok(!run(app([$cmd, "enc", "-aes-128-cbc", "-iter", "6", "-d", "-k", "test",
                       "-in", "iter.cipher", "-out", "iter_mismatch.clear"]))
             || compare_text($test, "iter_mismatch.clear") != 0,


### PR DESCRIPTION
The subtests added in f26d632a0e assert that "openssl enc -d" exits
non-zero when the key derivation parameters do not match.  enc has no
MAC, so a wrong key is not detectable as such; the only signal is
whether the garbage happens to form valid PKCS#7 padding, which
openssl-enc(1) documents as passing better than one time in 256.  With
a random salt the tests thus failed about 0.4% of the time.

Assert instead that mismatching parameters do not recover the
plaintext: the decryption must either fail or produce differing output.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
