### PR TITLE
quic: fix BIO ownership in test helper

### DIFF
--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -311,6 +311,8 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
     }
 
     SSL_set_bio(*cssl, cbio, cbio);
+    /* Ownership of cbio is now held by *cssl */
+    cbio = NULL;
 
     if (!TEST_true(SSL_set_blocking_mode(*cssl,
             (flags & QTEST_FLAG_BLOCK) != 0 ? 1 : 0)))


### PR DESCRIPTION
`SSL_set_bio` transfers ownership of `cbio` to the client SSL object. But, `qtest_create_quic_objects` retained the local pointer and released it again from its error path before calling `SSL_free`.

When `cbio` is installed as both the read and write BIO, this consumes one of the two SSL-owned references prematurely. QUIC cleanup then frees the remaining reference and accesses the same freed pointer on the second release, causing the reported use-after-free.

Clear the local `cbio` pointer immediately after ownership is transferred. This fixes the test helper without changing QUIC port or BIO cleanup logic.

Fixes #32084

##### Checklist

- [x] tests are added or updated