### PR TITLE
add d2i regression test to asn1 decode test suite

### DIFF
--- a/test/asn1_decode_test.c
+++ b/test/asn1_decode_test.c
@@ -427,6 +427,52 @@ err:
     return ret;
 }
 
+/*
+ * Regression test for reading multiple ASN1_INTEGERs written
+ * into a memory BIO. ASN1_item_d2i_bio() must consume exactly the
+ * bytes belonging to each object, since ASN.1 integer uses only 3 bytes.
+ */
+static int test_d2i_bio_concatenated_integers(void)
+{
+    ASN1_INTEGER *int0 = NULL, *int1 = NULL, *int2 = NULL;
+    BIO *writer = NULL, *reader = NULL;
+    char *buf;
+    long len;
+    int ret = 0;
+
+    if (!TEST_ptr(int0 = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(int0, 1)))
+        goto err;
+
+    if (!TEST_ptr(writer = BIO_new(BIO_s_mem()))
+        || !TEST_int_eq(ASN1_item_i2d_bio(ASN1_INTEGER_it(), writer, int0), 1)
+        || !TEST_int_eq(ASN1_item_i2d_bio(ASN1_INTEGER_it(), writer, int0), 1))
+        goto err;
+
+    if (!TEST_int_gt(len = BIO_get_mem_data(writer, &buf), 0)
+        || !TEST_ptr(reader = BIO_new_mem_buf(buf, len)))
+        goto err;
+
+    if (!TEST_ptr(int1 = (ASN1_INTEGER *)ASN1_item_d2i_bio(ASN1_INTEGER_it(),
+                      reader, NULL))
+        || !TEST_int_eq(ASN1_INTEGER_cmp(int0, int1), 0))
+        goto err;
+
+    if (!TEST_ptr(int2 = (ASN1_INTEGER *)ASN1_item_d2i_bio(ASN1_INTEGER_it(),
+                      reader, NULL))
+        || !TEST_int_eq(ASN1_INTEGER_cmp(int0, int2), 0))
+        goto err;
+
+    ret = 1;
+err:
+    ASN1_INTEGER_free(int0);
+    ASN1_INTEGER_free(int1);
+    ASN1_INTEGER_free(int2);
+    BIO_free(reader);
+    BIO_free(writer);
+    return ret;
+}
+
 int setup_tests(void)
 {
 #ifndef OPENSSL_NO_DEPRECATED_3_0
@@ -444,5 +490,6 @@ int setup_tests(void)
     ADD_TEST(test_d2i_read_bio_truncated);
     ADD_TEST(test_d2i_read_bio_indefinite_truncated);
     ADD_TEST(test_d2i_read_bio_partial_header);
+    ADD_TEST(test_d2i_bio_concatenated_integers);
     return 1;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

The MR adds a regression test that was introduced in the reproducer in  [#22704](https://github.com/openssl/openssl/issues/22704). The test is quite simple: adds two integers to BIO and then reads from BIO, checks calls do not fail and compares the integers..
