### PR TITLE
Add PKCS7_verify fuzzer

### DIFF
--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -10,6 +10,7 @@
 
 IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   PROGRAMS{noinst}=asn1 asn1parse bignum bndiv client conf crl server smime
+  PROGRAMS{noinst}=pkcs7_verify
   PROGRAMS{noinst}=pkcs12 punycode pem decoder hashtable acert
   PROGRAMS{noinst}=v3name
   PROGRAMS{noinst}=provider
@@ -138,6 +139,10 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   INCLUDE[smime]=../include {- $ex_inc -}
   DEPEND[smime]=../libcrypto ../libssl {- $ex_lib -}
 
+  SOURCE[pkcs7_verify]=pkcs7_verify.c driver.c
+  INCLUDE[pkcs7_verify]=../include {- $ex_inc -}
+  DEPEND[pkcs7_verify]=../libcrypto {- $ex_lib -}
+
   SOURCE[v3name]=v3name.c driver.c
   INCLUDE[v3name]=../include {- $ex_inc -}
   DEPEND[v3name]=../libcrypto.a {- $ex_lib -}
@@ -187,6 +192,7 @@ IF[{- !$disabled{tests} -}]
   $FUZZTESTSRC=test-corpus.c ../test/mfail/mfail.c
 
   PROGRAMS{noinst}=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test smime-test
+  PROGRAMS{noinst}=pkcs7_verify-test
   PROGRAMS{noinst}=pkcs12-test punycode-test pem-test decoder-test hashtable-test acert-test
   PROGRAMS{noinst}=v3name-test
   PROGRAMS{noinst}=provider-test
@@ -327,6 +333,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[smime-test]=smime.c $FUZZTESTSRC
   INCLUDE[smime-test]=../include ../test/mfail
   DEPEND[smime-test]=../libcrypto.a ../libssl.a
+
+  SOURCE[pkcs7_verify-test]=pkcs7_verify.c $FUZZTESTSRC
+  INCLUDE[pkcs7_verify-test]=../include ../test/mfail
+  DEPEND[pkcs7_verify-test]=../libcrypto.a
 
   SOURCE[v3name-test]=v3name.c $FUZZTESTSRC
   INCLUDE[v3name-test]=../include ../test/mfail

--- a/fuzz/pkcs7_verify.c
+++ b/fuzz/pkcs7_verify.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+#include <limits.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/pkcs7.h>
+#include "fuzzer.h"
+
+int FuzzerInitialize(int *argc, char ***argv)
+{
+    return 1;
+}
+
+int FuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+    BIO *indata = NULL;
+    BIO *out = NULL;
+    PKCS7 *p7 = NULL;
+    const unsigned char *in;
+    size_t consumed;
+    size_t remaining;
+
+    if (len > LONG_MAX)
+        return 0;
+
+    in = buf;
+    p7 = d2i_PKCS7(NULL, &in, (long)len);
+    if (p7 == NULL)
+        goto err;
+
+    consumed = (size_t)(in - buf);
+    remaining = len - consumed;
+    if (remaining > INT_MAX)
+        goto err;
+
+    if (consumed < len) {
+        indata = BIO_new_mem_buf(in, (int)remaining);
+        if (indata == NULL)
+            goto err;
+    }
+
+    out = BIO_new(BIO_s_null());
+    if (out == NULL)
+        goto err;
+
+    PKCS7_verify(p7, NULL, NULL, indata, out, PKCS7_NOVERIFY);
+
+err:
+    BIO_free(out);
+    PKCS7_free(p7);
+    BIO_free(indata);
+    ERR_clear_error();
+    return 0;
+}
+
+void FuzzerCleanup(void)
+{
+}

--- a/test/recipes/99-test_fuzz_pkcs7_verify.t
+++ b/test/recipes/99-test_fuzz_pkcs7_verify.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+my $fuzzer = "pkcs7_verify";
+setup("test_fuzz_${fuzzer}");
+
+plan tests => 2; # one more due to below require_ok(...)
+
+require_ok(srctop_file('test','recipes','fuzz.pl'));
+
+fuzz_ok($fuzzer);


### PR DESCRIPTION
Add a fuzzer for PKCS7_verify()

The fuzzer decodes PKCS7 structures from DER input using
d2i_PKCS7() and passes any trailing bytes to PKCS7_verify() as
detached content.

Motivation :
[CVE-2026-45447](https://openssl-library.org/news/vulnerabilities/index.html#CVE-2026-45447) : Vulnerability could have been caught by fuzzer.

Corpus: https://github.com/openssl/fuzz-corpora/pull/34
