### PR TITLE
test: add precise Valgrind suppression for direct provider init path

### DIFF
--- a/util/valgrind.suppression
+++ b/util/valgrind.suppression
@@ -126,6 +126,16 @@
    ...
 }
 {
+   provider_activate_strdup_without_provider_init
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:OSSL_provider_init
+   fun:provider_activate
+   ...
+}
+{
    false_positive_conditional_check
    Memcheck:Cond
    fun:bcmp


### PR DESCRIPTION
The Valgrind suppression check can report reachable allocations from `test_internal_provider` when tests run with `OSSL_USE_VALGRIND=yes`.
This is expected for that workflow because `test/testutil/main.c` intentionally skips `OPENSSL_cleanup` under Valgrind to validate the suppression file shipped with OpenSSL.

The existing `provider_activate_strdup` suppression covers the provider activation stack that goes through:

```
OSSL_provider_init
provider_init
provider_activate
```

The internal test provider can also use a direct activation stack:

```
OSSL_provider_init
provider_activate
```

Add a second precise suppression for that direct stack instead of broadening the existing block with an ellipsis between `OSSL_provider_init` and `provider_activate`. This keeps the suppression scoped to the two known stack shapes.

Verification:

```
./Configure -DOPENSSL_VALGRIND_TEST
make -j12
make TESTS=test_internal_provider OSSL_USE_VALGRIND=yes test
/tmp/pr32077-review.NwbbWT/parse_valgrind_suppressions.sh \
    /tmp/pr32077-review.NwbbWT/pr-482-valgrind/test-runs/test_internal_provider/valgrind.log.1.*
```
