### PR TITLE
Add aggregate reassembly byte budget for DTLS handshake state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,28 @@ OpenSSL Releases
 
    *Todd Short*
 
+ * Added an aggregate receive-side reassembly byte budget for DTLS handshake
+   state.
+
+   DTLS handshake reassembly was bounded per message but not by aggregate
+   bytes per connection: a stateful DTLS connection could retain up to 11
+   reassembly slots (the current message plus 10 future sequence numbers),
+   each allocating up to `SSL_MAX_CERT_LIST_DEFAULT + ceil(msg_len / 8)`
+   bytes (~1.3 MB per connection at the default certificate list size).
+   An unauthenticated peer could open many simultaneous connections to
+   exhaust memory without completing a handshake.
+
+   A per-connection budget now caps the total bytes held in the receive-side
+   reassembly queue. The budget is derived from the configured
+   `SSL_CTX_set_max_cert_list()` value (`DTLS_MAX_REASSEMBLY_BUDGET_DEFAULT`,
+   ~400 KB at the default) and is never smaller than the largest single
+   handshake message the peer may legally send, so legitimate handshakes are
+   unaffected. Fragments that would exceed the budget are discarded (with the
+   record drained), consistent with existing DTLS handling of out-of-window
+   records; DTLS reliability then covers any retransmission.
+
+   *Saksham Kapoor*
+
  * Added various optimizations for the Elbrus2000 architecture in the
    cryptographic and BN code.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,15 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Added an aggregate reassembly byte budget for DTLS handshake state.
+   The DTLS reassembly path lacked an aggregate byte limit per SSL
+   connection, allowing an attacker to retain up to ~1.3 MB of
+   reassembly state per connection across many connections for
+   unauthenticated memory exhaustion. A configurable
+   `DTLS_MAX_REASSEMBLY_BUDGET` now caps the total.
+
+   *Saksham Kapoor*
+
  * Fixed TLS 1.3 external PSK connections being wrongly rejected when
    the client sets a non-empty session ID context.
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -694,13 +694,16 @@ OSSL_DEPRECATEDIN_3_0 __owur int SRP_Calc_A_param(SSL *s);
 #define SSL_MAX_CERT_LIST_DEFAULT (1024 * 100)
 
 /*
- * Maximum aggregate bytes for DTLS handshake message reassembly state.
- * Each buffered fragment can hold up to ~115 KB. With up to 11 concurrent
- * slots (1 in-order + 10 future), this budget caps the total at ~1.3 MB
- * per SSL connection. Exceeding the budget causes new fragments to be
- * dropped, preventing memory exhaustion attacks.
+ * Maximum aggregate bytes for DTLS handshake message reassembly state
+ * per SSL connection. Set to 4x the default max certificate list size
+ * (~400 KB), allowing approximately 3-4 concurrent full-size fragments.
+ * This is well above legitimate usage (typically 1-2 concurrent fragments
+ * under network reordering) but significantly below the worst-case attack
+ * ceiling of 11 fragments (~1.3 MB). Combined with the existing
+ * sequence-number window limit of 11 slots, this provides defense-in-depth
+ * against memory exhaustion attacks.
  */
-#define DTLS_MAX_REASSEMBLY_BUDGET (115200 * 11)
+#define DTLS_MAX_REASSEMBLY_BUDGET (SSL_MAX_CERT_LIST_DEFAULT * 4)
 
 #define SSL_SESSION_CACHE_MAX_SIZE_DEFAULT (1024 * 20)
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -693,6 +693,15 @@ OSSL_DEPRECATEDIN_3_0 __owur int SRP_Calc_A_param(SSL *s);
 /* 100k max cert list */
 #define SSL_MAX_CERT_LIST_DEFAULT (1024 * 100)
 
+/*
+ * Maximum aggregate bytes for DTLS handshake message reassembly state.
+ * Each buffered fragment can hold up to ~115 KB. With up to 11 concurrent
+ * slots (1 in-order + 10 future), this budget caps the total at ~1.3 MB
+ * per SSL connection. Exceeding the budget causes new fragments to be
+ * dropped, preventing memory exhaustion attacks.
+ */
+#define DTLS_MAX_REASSEMBLY_BUDGET (115200 * 11)
+
 #define SSL_SESSION_CACHE_MAX_SIZE_DEFAULT (1024 * 20)
 
 /*

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -693,6 +693,22 @@ OSSL_DEPRECATEDIN_3_0 __owur int SRP_Calc_A_param(SSL *s);
 /* 100k max cert list */
 #define SSL_MAX_CERT_LIST_DEFAULT (1024 * 100)
 
+/*
+ * Default aggregate bytes for DTLS handshake message reassembly state per
+ * SSL connection, at the default maximum certificate list size. The default
+ * is 4x SSL_MAX_CERT_LIST_DEFAULT (~400 KB), allowing approximately 3-4
+ * concurrent full-size fragments - well above legitimate usage (typically
+ * 1-2 concurrent fragments under network reordering) but significantly
+ * below the worst-case attack ceiling of 11 fragments (~1.3 MB). The
+ * effective per-connection budget is derived from the configured
+ * SSL_CTX_set_max_cert_list() value (see dtls1_reassembly_budget), so it
+ * scales with that setting and is never smaller than the largest single
+ * handshake message the peer may legally send. Combined with the existing
+ * sequence-number window limit of 11 slots, this provides defense-in-depth
+ * against memory exhaustion attacks.
+ */
+#define DTLS_MAX_REASSEMBLY_BUDGET_DEFAULT (SSL_MAX_CERT_LIST_DEFAULT * 4)
+
 #define SSL_SESSION_CACHE_MAX_SIZE_DEFAULT (1024 * 20)
 
 /*

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -110,7 +110,7 @@ void dtls1_clear_received_buffer(SSL_CONNECTION *s)
 
     while ((item = pqueue_pop(s->d1->buffered_messages)) != NULL) {
         frag = (hm_fragment *)item->data;
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
         pitem_free(item);
     }
     s->d1->has_change_cipher_spec = 0;
@@ -134,7 +134,7 @@ void dtls1_clear_sent_buffer(SSL_CONNECTION *s)
             frag->msg_header.saved_retransmit_state.wrlmethod->free(frag->msg_header.saved_retransmit_state.wrl);
         }
 
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(NULL, frag);
         pitem_free(item);
     }
 }

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -134,7 +134,7 @@ void dtls1_clear_sent_buffer(SSL_CONNECTION *s)
             frag->msg_header.saved_retransmit_state.wrlmethod->free(frag->msg_header.saved_retransmit_state.wrl);
         }
 
-        dtls1_hm_fragment_free(s, frag);
+        dtls1_hm_fragment_free(NULL, frag);
         pitem_free(item);
     }
 }

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -110,7 +110,7 @@ void dtls1_clear_received_buffer(SSL_CONNECTION *s)
 
     while ((item = pqueue_pop(s->d1->buffered_messages)) != NULL) {
         frag = (hm_fragment *)item->data;
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
         pitem_free(item);
     }
     s->d1->has_change_cipher_spec = 0;
@@ -134,7 +134,7 @@ void dtls1_clear_sent_buffer(SSL_CONNECTION *s)
             frag->msg_header.saved_retransmit_state.wrlmethod->free(frag->msg_header.saved_retransmit_state.wrl);
         }
 
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
         pitem_free(item);
     }
 }

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1964,6 +1964,8 @@ typedef struct hm_fragment_st {
     struct hm_header_st msg_header;
     unsigned char *fragment;
     unsigned char *reassembly;
+    /* Total bytes allocated for this fragment (frag_len + bitmask) */
+    size_t alloc_bytes;
 } hm_fragment;
 
 typedef struct pqueue_st pqueue;
@@ -2001,6 +2003,8 @@ typedef struct dtls1_state_st {
     pqueue *buffered_messages;
     /* Buffered (sent) handshake records */
     pqueue *sent_messages;
+    /* Current aggregate bytes in DTLS reassembly state */
+    size_t reassembly_bytes;
     size_t link_mtu; /* max on-the-wire DTLS packet size */
     size_t mtu; /* max DTLS packet size */
     struct hm_header_st w_msg_hdr;
@@ -2660,7 +2664,7 @@ __owur int dtls1_is_timer_expired(SSL_CONNECTION *s);
 __owur int dtls_raw_hello_verify_request(WPACKET *pkt, unsigned char *cookie,
     size_t cookie_len);
 __owur size_t dtls1_min_mtu(SSL_CONNECTION *s);
-void dtls1_hm_fragment_free(hm_fragment *frag);
+void dtls1_hm_fragment_free(SSL_CONNECTION *s, hm_fragment *frag);
 __owur int dtls1_query_mtu(SSL_CONNECTION *s);
 
 __owur int tls1_new(SSL *s);

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -150,7 +150,7 @@ static hm_fragment *dtls1_hm_fragment_new(size_t frag_len, int reassembly)
     }
 
     frag->reassembly = bitmask;
-    frag->alloc_bytes = frag_len + RSMBLY_BITMASK_SIZE(frag_len);
+    frag->alloc_bytes = frag_len + (reassembly ? RSMBLY_BITMASK_SIZE(frag_len) : 0);
 
     return frag;
 }
@@ -699,10 +699,10 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
         size_t new_bytes = msg_hdr->msg_len + RSMBLY_BITMASK_SIZE(msg_hdr->msg_len);
         if (s->d1->reassembly_bytes + new_bytes > DTLS_MAX_REASSEMBLY_BUDGET)
             goto err;
-        s->d1->reassembly_bytes += new_bytes;
         frag = dtls1_hm_fragment_new(msg_hdr->msg_len, 1);
         if (frag == NULL)
             goto err;
+        s->d1->reassembly_bytes += new_bytes;
         memcpy(&(frag->msg_header), msg_hdr, sizeof(*msg_hdr));
         frag->msg_header.frag_len = frag->msg_header.msg_len;
         frag->msg_header.frag_off = 0;

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -697,12 +697,22 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
 
     if (item == NULL) {
         size_t new_bytes = msg_hdr->msg_len + RSMBLY_BITMASK_SIZE(msg_hdr->msg_len);
-        if (s->d1->reassembly_bytes + new_bytes > DTLS_MAX_REASSEMBLY_BUDGET)
-            goto err;
+        if (s->d1->reassembly_bytes + new_bytes > DTLS_MAX_REASSEMBLY_BUDGET) {
+            unsigned char devnull[256];
+            while (frag_len) {
+                size_t to_read = frag_len > sizeof(devnull) ? sizeof(devnull) : frag_len;
+                i = ssl->method->ssl_read_bytes(ssl, SSL3_RT_HANDSHAKE, NULL,
+                    devnull, to_read, 0, &readbytes);
+                if (i <= 0)
+                    goto err;
+                frag_len -= readbytes;
+            }
+            return DTLS1_HM_FRAGMENT_RETRY;
+        }
         frag = dtls1_hm_fragment_new(msg_hdr->msg_len, 1);
         if (frag == NULL)
             goto err;
-        s->d1->reassembly_bytes += new_bytes;
+        s->d1->reassembly_bytes += frag->alloc_bytes;
         memcpy(&(frag->msg_header), msg_hdr, sizeof(*msg_hdr));
         frag->msg_header.frag_len = frag->msg_header.msg_len;
         frag->msg_header.frag_off = 0;
@@ -833,9 +843,24 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
         if (frag_len > dtls1_max_handshake_message_len(s))
             goto err;
 
+        if (s->d1->reassembly_bytes + frag_len > DTLS_MAX_REASSEMBLY_BUDGET) {
+            unsigned char devnull[256];
+            while (frag_len) {
+                size_t to_read = frag_len > sizeof(devnull) ? sizeof(devnull) : frag_len;
+                i = ssl->method->ssl_read_bytes(ssl, SSL3_RT_HANDSHAKE, NULL,
+                    devnull, to_read, 0, &readbytes);
+                if (i <= 0)
+                    goto err;
+                frag_len -= readbytes;
+            }
+            return DTLS1_HM_FRAGMENT_RETRY;
+        }
+
         frag = dtls1_hm_fragment_new(frag_len, 0);
         if (frag == NULL)
             goto err;
+
+        s->d1->reassembly_bytes += frag->alloc_bytes;
 
         memcpy(&(frag->msg_header), msg_hdr, sizeof(*msg_hdr));
 
@@ -1240,12 +1265,12 @@ int dtls1_buffer_message(SSL_CONNECTION *s, int is_ccs)
         /* For DTLS1_BAD_VER the header length is non-standard */
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len + ((s->version == DTLS1_BAD_VER) ? 3 : DTLS1_CCS_HEADER_LENGTH)
                 == (unsigned int)s->init_num)) {
-            dtls1_hm_fragment_free(s, frag);
+            dtls1_hm_fragment_free(NULL, frag);
             return 0;
         }
     } else {
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len + DTLS1_HM_HEADER_LENGTH == (unsigned int)s->init_num)) {
-            dtls1_hm_fragment_free(s, frag);
+            dtls1_hm_fragment_free(NULL, frag);
             return 0;
         }
     }
@@ -1270,12 +1295,12 @@ int dtls1_buffer_message(SSL_CONNECTION *s, int is_ccs)
 
     item = pitem_new(seq64be, frag);
     if (item == NULL) {
-        dtls1_hm_fragment_free(s, frag);
+        dtls1_hm_fragment_free(NULL, frag);
         return 0;
     }
 
     if (pqueue_insert(s->d1->sent_messages, item) == NULL) {
-        dtls1_hm_fragment_free(s, frag);
+        dtls1_hm_fragment_free(NULL, frag);
         pitem_free(item);
         return 0;
     }

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -120,6 +120,16 @@ static int dtls_ccs_expected(SSL_CONNECTION *s)
     }
 }
 
+/*
+ * The number of bytes a DTLS reassembly slot for a message of length
+ * |msg_len| will allocate: the message body itself plus, when reassembly
+ * is active, the bitmask used to track which fragments have arrived.
+ */
+static size_t dtls1_reassembly_slot_bytes(size_t msg_len, int reassembly)
+{
+    return msg_len + (reassembly ? RSMBLY_BITMASK_SIZE(msg_len) : 0);
+}
+
 static hm_fragment *dtls1_hm_fragment_new(size_t frag_len, int reassembly)
 {
     hm_fragment *frag = NULL;
@@ -150,14 +160,22 @@ static hm_fragment *dtls1_hm_fragment_new(size_t frag_len, int reassembly)
     }
 
     frag->reassembly = bitmask;
+    frag->alloc_bytes = dtls1_reassembly_slot_bytes(frag_len, reassembly);
 
     return frag;
 }
 
-void dtls1_hm_fragment_free(hm_fragment *frag)
+void dtls1_hm_fragment_free(SSL_CONNECTION *s, hm_fragment *frag)
 {
     if (!frag)
         return;
+
+    if (s != NULL && s->d1 != NULL) {
+        if (!ossl_assert(s->d1->reassembly_bytes >= frag->alloc_bytes))
+            s->d1->reassembly_bytes = 0;
+        else
+            s->d1->reassembly_bytes -= frag->alloc_bytes;
+    }
 
     OPENSSL_free(frag->fragment);
     OPENSSL_free(frag->reassembly);
@@ -503,6 +521,29 @@ static size_t dtls1_max_handshake_message_len(const SSL_CONNECTION *s)
     return max_len;
 }
 
+/*
+ * dtls1_reassembly_budget returns the maximum aggregate bytes that may be
+ * retained in the receive-side reassembly queue (buffered_messages) for
+ * |s|. It is derived per connection from the configured maximum certificate
+ * list size (SSL_CTX_set_max_cert_list) so that the bound scales with that
+ * setting, and is never smaller than the largest single handshake message
+ * the peer may legally send (dtls1_max_handshake_message_len). At the
+ * default certificate list size this is DTLS_MAX_REASSEMBLY_BUDGET_DEFAULT
+ * (~400 KB).
+ */
+static size_t dtls1_reassembly_budget(const SSL_CONNECTION *s)
+{
+    size_t budget;
+
+    if (s->max_cert_list > SIZE_MAX / 4)
+        budget = SIZE_MAX;
+    else
+        budget = s->max_cert_list * 4;
+    if (budget < dtls1_max_handshake_message_len(s))
+        budget = dtls1_max_handshake_message_len(s);
+    return budget;
+}
+
 static int dtls1_preprocess_fragment(SSL_CONNECTION *s,
     struct hm_header_st *msg_hdr)
 {
@@ -586,7 +627,7 @@ static int dtls1_retrieve_buffered_fragment(SSL_CONNECTION *s, size_t *len)
                  * we have an active iterator
                  */
                 pqueue_pop(s->d1->buffered_messages);
-                dtls1_hm_fragment_free(frag);
+                dtls1_hm_fragment_free(s, frag);
                 pitem_free(item);
                 item = NULL;
                 frag = NULL;
@@ -606,7 +647,7 @@ static int dtls1_retrieve_buffered_fragment(SSL_CONNECTION *s, size_t *len)
                          * cookie and one with. Ditch the one without.
                          */
                         pqueue_pop(s->d1->buffered_messages);
-                        dtls1_hm_fragment_free(frag);
+                        dtls1_hm_fragment_free(s, frag);
                         pitem_free(item);
                         item = next;
                         frag = nextfrag;
@@ -637,7 +678,7 @@ static int dtls1_retrieve_buffered_fragment(SSL_CONNECTION *s, size_t *len)
                 frag->msg_header.frag_len);
         }
 
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
         pitem_free(item);
 
         if (ret) {
@@ -688,9 +729,26 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
     item = pqueue_find(s->d1->buffered_messages, seq64be);
 
     if (item == NULL) {
+        size_t new_bytes = dtls1_reassembly_slot_bytes(msg_hdr->msg_len, 1);
+
+        if (new_bytes > dtls1_reassembly_budget(s) - s->d1->reassembly_bytes) {
+            unsigned char devnull[256];
+
+            while (frag_len) {
+                i = ssl->method->ssl_read_bytes(ssl, SSL3_RT_HANDSHAKE, NULL,
+                    devnull,
+                    frag_len > sizeof(devnull) ? sizeof(devnull) : frag_len, 0, &readbytes);
+                if (i <= 0)
+                    goto err;
+                frag_len -= readbytes;
+            }
+            return DTLS1_HM_FRAGMENT_RETRY;
+        }
+
         frag = dtls1_hm_fragment_new(msg_hdr->msg_len, 1);
         if (frag == NULL)
             goto err;
+        s->d1->reassembly_bytes += frag->alloc_bytes;
         memcpy(&(frag->msg_header), msg_hdr, sizeof(*msg_hdr));
         frag->msg_header.frag_len = frag->msg_header.msg_len;
         frag->msg_header.frag_off = 0;
@@ -766,7 +824,7 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
 
 err:
     if (item == NULL)
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
     return -1;
 }
 
@@ -821,9 +879,24 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
         if (frag_len > dtls1_max_handshake_message_len(s))
             goto err;
 
+        if (frag_len > dtls1_reassembly_budget(s) - s->d1->reassembly_bytes) {
+            unsigned char devnull[256];
+
+            while (frag_len) {
+                i = ssl->method->ssl_read_bytes(ssl, SSL3_RT_HANDSHAKE, NULL,
+                    devnull,
+                    frag_len > sizeof(devnull) ? sizeof(devnull) : frag_len, 0, &readbytes);
+                if (i <= 0)
+                    goto err;
+                frag_len -= readbytes;
+            }
+            return DTLS1_HM_FRAGMENT_RETRY;
+        }
+
         frag = dtls1_hm_fragment_new(frag_len, 0);
         if (frag == NULL)
             goto err;
+        s->d1->reassembly_bytes += frag->alloc_bytes;
 
         memcpy(&(frag->msg_header), msg_hdr, sizeof(*msg_hdr));
 
@@ -861,7 +934,7 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
 
 err:
     if (item == NULL)
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
     return 0;
 }
 
@@ -1228,12 +1301,12 @@ int dtls1_buffer_message(SSL_CONNECTION *s, int is_ccs)
         /* For DTLS1_BAD_VER the header length is non-standard */
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len + ((s->version == DTLS1_BAD_VER) ? 3 : DTLS1_CCS_HEADER_LENGTH)
                 == (unsigned int)s->init_num)) {
-            dtls1_hm_fragment_free(frag);
+            dtls1_hm_fragment_free(NULL, frag);
             return 0;
         }
     } else {
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len + DTLS1_HM_HEADER_LENGTH == (unsigned int)s->init_num)) {
-            dtls1_hm_fragment_free(frag);
+            dtls1_hm_fragment_free(NULL, frag);
             return 0;
         }
     }
@@ -1258,12 +1331,12 @@ int dtls1_buffer_message(SSL_CONNECTION *s, int is_ccs)
 
     item = pitem_new(seq64be, frag);
     if (item == NULL) {
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(NULL, frag);
         return 0;
     }
 
     if (pqueue_insert(s->d1->sent_messages, item) == NULL) {
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(NULL, frag);
         pitem_free(item);
         return 0;
     }

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -150,14 +150,22 @@ static hm_fragment *dtls1_hm_fragment_new(size_t frag_len, int reassembly)
     }
 
     frag->reassembly = bitmask;
+    frag->alloc_bytes = frag_len + RSMBLY_BITMASK_SIZE(frag_len);
 
     return frag;
 }
 
-void dtls1_hm_fragment_free(hm_fragment *frag)
+void dtls1_hm_fragment_free(SSL_CONNECTION *s, hm_fragment *frag)
 {
     if (!frag)
         return;
+
+    if (s != NULL && s->d1 != NULL) {
+        if (s->d1->reassembly_bytes >= frag->alloc_bytes)
+            s->d1->reassembly_bytes -= frag->alloc_bytes;
+        else
+            s->d1->reassembly_bytes = 0;
+    }
 
     OPENSSL_free(frag->fragment);
     OPENSSL_free(frag->reassembly);
@@ -586,7 +594,7 @@ static int dtls1_retrieve_buffered_fragment(SSL_CONNECTION *s, size_t *len)
                  * we have an active iterator
                  */
                 pqueue_pop(s->d1->buffered_messages);
-                dtls1_hm_fragment_free(frag);
+                dtls1_hm_fragment_free(s, frag);
                 pitem_free(item);
                 item = NULL;
                 frag = NULL;
@@ -606,7 +614,7 @@ static int dtls1_retrieve_buffered_fragment(SSL_CONNECTION *s, size_t *len)
                          * cookie and one with. Ditch the one without.
                          */
                         pqueue_pop(s->d1->buffered_messages);
-                        dtls1_hm_fragment_free(frag);
+                        dtls1_hm_fragment_free(s, frag);
                         pitem_free(item);
                         item = next;
                         frag = nextfrag;
@@ -637,7 +645,7 @@ static int dtls1_retrieve_buffered_fragment(SSL_CONNECTION *s, size_t *len)
                 frag->msg_header.frag_len);
         }
 
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
         pitem_free(item);
 
         if (ret) {
@@ -688,6 +696,10 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
     item = pqueue_find(s->d1->buffered_messages, seq64be);
 
     if (item == NULL) {
+        size_t new_bytes = msg_hdr->msg_len + RSMBLY_BITMASK_SIZE(msg_hdr->msg_len);
+        if (s->d1->reassembly_bytes + new_bytes > DTLS_MAX_REASSEMBLY_BUDGET)
+            goto err;
+        s->d1->reassembly_bytes += new_bytes;
         frag = dtls1_hm_fragment_new(msg_hdr->msg_len, 1);
         if (frag == NULL)
             goto err;
@@ -766,7 +778,7 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
 
 err:
     if (item == NULL)
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
     return -1;
 }
 
@@ -861,7 +873,7 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
 
 err:
     if (item == NULL)
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
     return 0;
 }
 
@@ -1228,12 +1240,12 @@ int dtls1_buffer_message(SSL_CONNECTION *s, int is_ccs)
         /* For DTLS1_BAD_VER the header length is non-standard */
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len + ((s->version == DTLS1_BAD_VER) ? 3 : DTLS1_CCS_HEADER_LENGTH)
                 == (unsigned int)s->init_num)) {
-            dtls1_hm_fragment_free(frag);
+            dtls1_hm_fragment_free(s, frag);
             return 0;
         }
     } else {
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len + DTLS1_HM_HEADER_LENGTH == (unsigned int)s->init_num)) {
-            dtls1_hm_fragment_free(frag);
+            dtls1_hm_fragment_free(s, frag);
             return 0;
         }
     }
@@ -1258,12 +1270,12 @@ int dtls1_buffer_message(SSL_CONNECTION *s, int is_ccs)
 
     item = pitem_new(seq64be, frag);
     if (item == NULL) {
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
         return 0;
     }
 
     if (pqueue_insert(s->d1->sent_messages, item) == NULL) {
-        dtls1_hm_fragment_free(frag);
+        dtls1_hm_fragment_free(s, frag);
         pitem_free(item);
         return 0;
     }

--- a/test/build.info
+++ b/test/build.info
@@ -109,6 +109,7 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{dtls} -}]
     PROGRAMS{noinst}=dtls_ccs_reorder_test
+    PROGRAMS{noinst}=dtls_reassembly_test
   ENDIF
 
   SOURCE[confdump]=confdump.c
@@ -704,6 +705,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[dtls_ccs_reorder_test]=dtls_ccs_reorder_test.c helpers/ssltestlib.c
     INCLUDE[dtls_ccs_reorder_test]=../include ../apps/include
     DEPEND[dtls_ccs_reorder_test]=../libcrypto ../libssl libtestutil.a
+
+    SOURCE[dtls_reassembly_test]=dtls_reassembly_test.c helpers/ssltestlib.c
+    INCLUDE[dtls_reassembly_test]=.. ../include ../apps/include
+    DEPEND[dtls_reassembly_test]=../libcrypto ../libssl libtestutil.a
   ENDIF
 
   SOURCE[sslcorrupttest]=sslcorrupttest.c helpers/ssltestlib.c

--- a/test/dtls_reassembly_test.c
+++ b/test/dtls_reassembly_test.c
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Tests for the aggregate receive-side DTLS handshake reassembly byte
+ * budget (DTLS_MAX_REASSEMBLY_BUDGET_DEFAULT / dtls1_reassembly_budget).
+ *
+ * Crafted plaintext DTLS handshake records are fed to a server whose
+ * receive BIO is a BIO_s_dgram_mem. Out-of-sequence messages are buffered
+ * by the reassembly queue; the tests check that the per-connection byte
+ * counter (d1->reassembly_bytes) tracks the allocated slots exactly and
+ * that the aggregate budget rejects fragments once it would be exceeded.
+ */
+
+#include <string.h>
+
+#include <openssl/bio.h>
+#include <openssl/dtls1.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/ssl3.h>
+
+#include "internal/nelem.h"
+#include "internal/ssl_unwrap.h"
+#include "helpers/ssltestlib.h"
+#include "testutil.h"
+#include "../ssl/ssl_local.h"
+
+static char *cert = NULL;
+static char *privkey = NULL;
+
+static unsigned int infinite_timer_cb(SSL *s, unsigned int timer_us)
+{
+    (void)s;
+
+    if (timer_us == 0)
+        return 999999999;
+    return timer_us;
+}
+
+/*
+ * Build a plaintext DTLS record carrying a single handshake fragment.
+ * |ver| is the record-layer version, |rec_seq| the record-layer sequence
+ * number, |hstype| the handshake message type, |hs_seq| the handshake
+ * sequence number, |msg_len| the total handshake message length,
+ * |frag_off|/|frag_len| the fragment, and |frag| the fragment body
+ * (|frag_len| bytes; zero-filled if NULL). Returns the record length, or
+ * 0 if it would not fit in |outsz|.
+ */
+static size_t build_hs_record(unsigned char *out, size_t outsz, int ver,
+    unsigned long long rec_seq, unsigned char hstype,
+    unsigned long msg_len, unsigned short hs_seq,
+    unsigned long frag_off, unsigned long frag_len,
+    const unsigned char *frag)
+{
+    unsigned char *p = out;
+    size_t payload = DTLS1_HM_HEADER_LENGTH + frag_len;
+    size_t i;
+
+    if (outsz < DTLS1_RT_HEADER_LENGTH + payload
+        || msg_len > 0xFFFFFFUL || frag_len > 0xFFFFFFUL
+        || frag_off > 0xFFFFFFUL)
+        return 0;
+
+    *p++ = SSL3_RT_HANDSHAKE;
+    *p++ = (unsigned char)(ver >> 8);
+    *p++ = (unsigned char)ver;
+    *p++ = 0; /* epoch 0 */
+    *p++ = 0;
+    for (i = 0; i < 6; i++) /* record-layer sequence number */
+        *p++ = (unsigned char)(rec_seq >> (8 * (5 - i)));
+    *p++ = (unsigned char)(payload >> 8);
+    *p++ = (unsigned char)payload;
+
+    /* handshake message header */
+    *p++ = hstype;
+    *p++ = (unsigned char)(msg_len >> 16);
+    *p++ = (unsigned char)(msg_len >> 8);
+    *p++ = (unsigned char)msg_len;
+    *p++ = (unsigned char)(hs_seq >> 8);
+    *p++ = (unsigned char)hs_seq;
+    *p++ = (unsigned char)(frag_off >> 16);
+    *p++ = (unsigned char)(frag_off >> 8);
+    *p++ = (unsigned char)frag_off;
+    *p++ = (unsigned char)(frag_len >> 16);
+    *p++ = (unsigned char)(frag_len >> 8);
+    *p++ = (unsigned char)frag_len;
+
+    if (frag_len > 0) {
+        if (frag != NULL)
+            memcpy(p, frag, frag_len);
+        else
+            memset(p, 0, frag_len);
+        p += frag_len;
+    }
+
+    return (size_t)(p - out);
+}
+
+/* Create an unconnected DTLS server whose read BIO is a BIO_s_dgram_mem. */
+static int create_server(SSL_CTX **sctxp, SSL **sslp, BIO **rbio, int ver)
+{
+    SSL_CTX *sctx = NULL;
+    SSL *ssl = NULL;
+    BIO *rb = NULL, *wb = NULL;
+
+    if (!TEST_ptr(sctx = SSL_CTX_new(DTLS_server_method()))
+        || !TEST_true(SSL_CTX_set_min_proto_version(sctx, ver))
+        || !TEST_true(SSL_CTX_set_max_proto_version(sctx, ver)))
+        goto err;
+
+    if (ver == DTLS1_VERSION)
+        SSL_CTX_set_security_level(sctx, 0);
+
+    if (!TEST_true(SSL_CTX_use_certificate_file(sctx, cert,
+            SSL_FILETYPE_PEM))
+        || !TEST_true(SSL_CTX_use_PrivateKey_file(sctx, privkey,
+            SSL_FILETYPE_PEM)))
+        goto err;
+
+    if (!TEST_ptr(rb = BIO_new(BIO_s_dgram_mem()))
+        || !TEST_ptr(wb = BIO_new(BIO_s_mem())))
+        goto err;
+
+    if (!TEST_ptr(ssl = SSL_new(sctx)))
+        goto err;
+
+    SSL_set_bio(ssl, rb, wb);
+
+    *sctxp = sctx;
+    *sslp = ssl;
+    *rbio = rb;
+    return 1;
+
+err:
+    BIO_free(rb);
+    BIO_free(wb);
+    SSL_free(ssl);
+    SSL_CTX_free(sctx);
+    return 0;
+}
+
+static size_t reassembly_bytes(SSL *ssl)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(ssl);
+
+    return sc->d1->reassembly_bytes;
+}
+
+/* Drive the server's read state machine; nbio (WANT_READ/WANT_WRITE) is OK. */
+static int drive_server(SSL *ssl)
+{
+    int ret = SSL_accept(ssl);
+
+    if (ret > 0)
+        return 1;
+    if (ret == 0 || SSL_get_error(ssl, ret) == SSL_ERROR_SYSCALL
+        || SSL_get_error(ssl, ret) == SSL_ERROR_SSL)
+        return 0;
+    return 1;
+}
+
+/* Feed one crafted record to the server. */
+static int feed_record(BIO *rbio, const unsigned char *rec, size_t len)
+{
+    return TEST_int_eq(BIO_write(rbio, rec, (int)len), (int)len);
+}
+
+static const int versions[] = {
+#ifndef OPENSSL_NO_DTLS1_2
+    DTLS1_2_VERSION,
+#endif
+#ifndef OPENSSL_NO_DTLS1
+    DTLS1_VERSION,
+#endif
+};
+
+/*
+ * Buffer 3 full-size fragments (fits in the default ~400 KB budget), then
+ * check that a 4th full-size fragment is discarded and that the connection
+ * still accepts a small fragment afterwards. Exercises the partial-fragment
+ * (reassembly) budget path and counter accounting.
+ */
+static int test_reassembly_aggregate(int idx)
+{
+    const size_t msg_len = 100000;
+    const size_t slot = msg_len + ((msg_len + 7) / 8);
+    unsigned char *rec;
+    size_t rec_len;
+    SSL_CTX *sctx = NULL;
+    SSL *ssl = NULL;
+    BIO *rbio = NULL;
+    unsigned long long rseq = 1000;
+    int i, testresult = 0, ver = versions[idx];
+
+    if (!TEST_ptr(rec = OPENSSL_malloc(DTLS1_RT_HEADER_LENGTH
+                      + DTLS1_HM_HEADER_LENGTH + msg_len))
+        || !TEST_true(create_server(&sctx, &ssl, &rbio, ver)))
+        goto end;
+
+    for (i = 0; i < 3; i++) {
+        rec_len = build_hs_record(rec, DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH + msg_len, ver, rseq++,
+            SSL3_MT_CERTIFICATE, msg_len, i + 1, 0, 1, NULL);
+        if (!TEST_size_t_gt(rec_len, 0)
+            || !TEST_true(feed_record(rbio, rec, rec_len)))
+            goto end;
+    }
+    if (!TEST_true(drive_server(ssl))
+        || !TEST_size_t_eq(reassembly_bytes(ssl), 3 * slot))
+        goto end;
+
+    /* 4th full-size fragment would exceed the budget: must be discarded. */
+    rec_len = build_hs_record(rec, DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH + msg_len, ver, rseq++,
+        SSL3_MT_CERTIFICATE, msg_len, 4, 0, 1, NULL);
+    if (!TEST_size_t_gt(rec_len, 0)
+        || !TEST_true(feed_record(rbio, rec, rec_len))
+        || !TEST_true(drive_server(ssl))
+        || !TEST_size_t_eq(reassembly_bytes(ssl), 3 * slot))
+        goto end;
+
+    /* Connection still alive: a small fragment is accepted. */
+    rec_len = build_hs_record(rec, DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH + msg_len, ver, rseq++,
+        SSL3_MT_CERTIFICATE, 1000, 5, 0, 1, NULL);
+    if (!TEST_size_t_gt(rec_len, 0)
+        || !TEST_true(feed_record(rbio, rec, rec_len))
+        || !TEST_true(drive_server(ssl))
+        || !TEST_size_t_eq(reassembly_bytes(ssl),
+            3 * slot + 1000 + ((1000 + 7) / 8)))
+        goto end;
+
+    testresult = 1;
+end:
+    OPENSSL_free(rec);
+    SSL_free(ssl);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
+/*
+ * Complete (non-fragmented) out-of-sequence messages are accounted against
+ * the budget too. They cannot exceed the maximum DTLS record size (~16 KB),
+ * so a second scenario uses a small max_cert_list to make the aggregate
+ * budget bind and prove the complete-message path enforces it.
+ */
+static int test_reassembly_complete_messages(int idx)
+{
+    const size_t msg_len = 10000;
+    unsigned char *rec;
+    size_t rec_len;
+    SSL_CTX *sctx = NULL;
+    SSL *ssl = NULL;
+    BIO *rbio = NULL;
+    unsigned long long rseq = 2000;
+    int i, testresult = 0, ver = versions[idx];
+
+    if (!TEST_ptr(rec = OPENSSL_malloc(DTLS1_RT_HEADER_LENGTH
+                      + DTLS1_HM_HEADER_LENGTH + 20000))
+        || !TEST_true(create_server(&sctx, &ssl, &rbio, ver)))
+        goto end;
+
+    /* complete messages are buffered and counted (window allows 5) */
+    for (i = 0; i < 5; i++) {
+        rec_len = build_hs_record(rec, DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH + 20000, ver, rseq++,
+            SSL3_MT_CERTIFICATE, msg_len, i + 1, 0, msg_len, NULL);
+        if (!TEST_size_t_gt(rec_len, 0)
+            || !TEST_true(feed_record(rbio, rec, rec_len)))
+            goto end;
+    }
+    if (!TEST_true(drive_server(ssl))
+        || !TEST_size_t_eq(reassembly_bytes(ssl), 5 * msg_len))
+        goto end;
+
+    SSL_free(ssl);
+    SSL_CTX_free(sctx);
+    ssl = NULL;
+    sctx = NULL;
+
+    /* with max_cert_list = 20000, budget = 80000: 3 partial 20000-byte
+     * fragments (slot 22500 each) leave 12500 bytes; a complete 15000-byte
+     * message must be discarded */
+    if (!TEST_true(create_server(&sctx, &ssl, &rbio, ver)))
+        goto end;
+    if (!TEST_true(SSL_set_max_cert_list(ssl, 20000)))
+        goto end;
+
+    for (i = 0; i < 3; i++) {
+        rec_len = build_hs_record(rec, DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH + 20000, ver, rseq++,
+            SSL3_MT_CERTIFICATE, 20000, i + 1, 0, 1, NULL);
+        if (!TEST_size_t_gt(rec_len, 0)
+            || !TEST_true(feed_record(rbio, rec, rec_len)))
+            goto end;
+    }
+    rec_len = build_hs_record(rec, DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH + 20000, ver, rseq++,
+        SSL3_MT_CERTIFICATE, 15000, 4, 0, 15000, NULL);
+    if (!TEST_size_t_gt(rec_len, 0)
+        || !TEST_true(feed_record(rbio, rec, rec_len))
+        || !TEST_true(drive_server(ssl))
+        || !TEST_size_t_eq(reassembly_bytes(ssl), 3 * (20000 + ((20000 + 7) / 8))))
+        goto end;
+
+    testresult = 1;
+end:
+    OPENSSL_free(rec);
+    SSL_free(ssl);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
+/*
+ * The 11-slot sequence-number window still bounds the number of buffered
+ * messages: sequence 11 is dropped even though the byte budget is not hit.
+ */
+static int test_reassembly_window(int idx)
+{
+    const size_t msg_len = 1000;
+    const size_t slot = msg_len + ((msg_len + 7) / 8);
+    unsigned char rec[DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH + 1];
+    size_t rec_len;
+    SSL_CTX *sctx = NULL;
+    SSL *ssl = NULL;
+    BIO *rbio = NULL;
+    unsigned long long rseq = 3000;
+    int i, testresult = 0, ver = versions[idx];
+
+    if (!TEST_true(create_server(&sctx, &ssl, &rbio, ver)))
+        goto end;
+
+    for (i = 0; i < 11; i++) {
+        rec_len = build_hs_record(rec, sizeof(rec), ver, rseq++,
+            SSL3_MT_CERTIFICATE, msg_len, i + 1, 0, 1, NULL);
+        if (!TEST_size_t_gt(rec_len, 0)
+            || !TEST_true(feed_record(rbio, rec, rec_len)))
+            goto end;
+    }
+    if (!TEST_true(drive_server(ssl))
+        || !TEST_size_t_eq(reassembly_bytes(ssl), 10 * slot))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(ssl);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
+/*
+ * The budget scales with the configured maximum certificate list size: with
+ * max_cert_list raised to 1 MiB, a single 500 KB message (which would exceed
+ * the ~400 KB default budget) is accepted, because it is legal under the
+ * per-message limit. Under a fixed default-derived constant this message
+ * would be wrongly rejected.
+ */
+static int test_reassembly_scaled_budget(int idx)
+{
+    const size_t msg_len = 500000;
+    const size_t slot = msg_len + ((msg_len + 7) / 8);
+    unsigned char rec[DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH + 1];
+    size_t rec_len;
+    SSL_CTX *sctx = NULL;
+    SSL *ssl = NULL;
+    BIO *rbio = NULL;
+    int testresult = 0, ver = versions[idx];
+
+    if (!TEST_true(create_server(&sctx, &ssl, &rbio, ver)))
+        goto end;
+
+    if (!TEST_true(SSL_set_max_cert_list(ssl, 1024 * 1024)))
+        goto end;
+
+    rec_len = build_hs_record(rec, sizeof(rec), ver, 4000,
+        SSL3_MT_CERTIFICATE, msg_len, 1, 0, 1, NULL);
+    if (!TEST_size_t_gt(rec_len, 0)
+        || !TEST_true(feed_record(rbio, rec, rec_len))
+        || !TEST_true(drive_server(ssl))
+        || !TEST_size_t_eq(reassembly_bytes(ssl), slot))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(ssl);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
+/* A normal DTLS handshake still completes and transfers data. */
+static int test_reassembly_positive_control(int idx)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *sssl = NULL, *cssl = NULL;
+    int max_ver = versions[idx];
+    int testresult = 0, ret;
+    char buf[64];
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), max_ver, max_ver,
+            &sctx, &cctx, cert, privkey)))
+        return 0;
+
+    if (max_ver == DTLS1_VERSION) {
+        SSL_CTX_set_security_level(sctx, 0);
+        SSL_CTX_set_security_level(cctx, 0);
+    }
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, NULL)))
+        goto end;
+
+    DTLS_set_timer_cb(sssl, infinite_timer_cb);
+    DTLS_set_timer_cb(cssl, infinite_timer_cb);
+
+    if (!TEST_int_le(SSL_connect(cssl), 0)
+        || !TEST_int_le(SSL_accept(sssl), 0)
+        || !TEST_int_le(SSL_connect(cssl), 0))
+        goto end;
+
+    ret = SSL_accept(sssl);
+    if (!TEST_int_gt(ret, 0))
+        goto end;
+    ret = SSL_connect(cssl);
+    if (!TEST_int_gt(ret, 0))
+        goto end;
+
+    if (!TEST_int_eq(SSL_write(cssl, "hello", 5), 5)
+        || !TEST_int_eq(SSL_read(sssl, buf, sizeof(buf)), 5)
+        || !TEST_mem_eq(buf, 5, "hello", 5))
+        goto end;
+
+    /* reassembly accounting returned to zero after the handshake */
+    if (!TEST_size_t_eq(reassembly_bytes(sssl), 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(sssl);
+    SSL_free(cssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    if (!TEST_ptr(cert = test_get_argument(0))
+        || !TEST_ptr(privkey = test_get_argument(1)))
+        return 0;
+
+    ADD_ALL_TESTS(test_reassembly_aggregate, OSSL_NELEM(versions));
+    ADD_ALL_TESTS(test_reassembly_complete_messages, OSSL_NELEM(versions));
+    ADD_ALL_TESTS(test_reassembly_window, OSSL_NELEM(versions));
+    ADD_ALL_TESTS(test_reassembly_scaled_budget, OSSL_NELEM(versions));
+    ADD_ALL_TESTS(test_reassembly_positive_control, OSSL_NELEM(versions));
+
+    return 1;
+}

--- a/test/recipes/80-test_dtls_reassembly.t
+++ b/test/recipes/80-test_dtls_reassembly.t
@@ -1,0 +1,21 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+setup("test_dtls_reassembly");
+
+plan skip_all => "No DTLS protocols are supported by this OpenSSL build"
+    if alldisabled(available_protocols("dtls"));
+
+plan tests => 1;
+
+ok(run(test(["dtls_reassembly_test", srctop_file("apps", "server.pem"),
+             srctop_file("apps", "server.pem")])),
+    "running dtls_reassembly_test");


### PR DESCRIPTION
DTLS handshake reassembly was bounded per message but not by aggregate bytes per connection. A connection could retain up to 11 reassembly slots (the current message plus 10 future sequence numbers); at the default certificate list size each full-size slot is 115200 bytes (`msg_len` plus the `ceil(msg_len/8)` reassembly bitmask), so a single connection could hold about 1.3 MB of reassembly state. An unauthenticated peer could open many connections to exhaust memory without completing a handshake.

This adds a per-connection aggregate budget for receive-side reassembly state. The budget is derived from the configured `SSL_CTX_set_max_cert_list()` value (`4x max_cert_list`, about 400 KB at the default) and is never smaller than the largest single handshake message the peer may legally send, so legitimate handshakes are unaffected. Fragments that would exceed the budget are discarded and the record is drained, matching how DTLS already treats out-of-window records; a legitimate peer retransmits within the 11-slot window.

Accounting:
- each slot is charged its actual allocation (`msg_len` plus the bitmask when reassembly is active), recorded in `alloc_bytes`;
- a fragment is charged at peak on first receipt, and the counter is decremented by the same value when the slot is freed;
- both receive paths are covered: partial-fragment reassembly and complete out-of-sequence messages;
- the send-side retransmission buffer is excluded (it only holds data the local stack already sent).

Tests (`test/dtls_reassembly_test.c`, recipe `80-test_dtls_reassembly.t`):
- the aggregate cap across the 11-slot window;
- budget enforcement on both receive paths;
- the sequence-number window still bounding the message count;
- the budget scaling with `SSL_CTX_set_max_cert_list()`;
- a full handshake completing with reassembly accounting back at zero.

The design rationale and intended end-to-end behavior are in the commit message. Fixes #32078.
