### PR TITLE
Add a comment justifying non-constant-time memcmp

### DIFF
--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -500,6 +500,11 @@ int ossl_ml_dsa_generate_key(ML_DSA_KEY *out)
     if (sk == NULL) {
         ret = keygen_internal(out);
     } else {
+        /*
+         * A constant-time comparison is unnecessary here since this check
+         * is only performed during key generation and is not exposed to
+         * timing attacks.
+         */
         if ((ret = keygen_internal(out)) != 0
             && memcmp(out->priv_encoding, sk, out->params->sk_len) != 0) {
             ret = 0;


### PR DESCRIPTION
This non-constant-time memcmp was reported twice already, so it's worth adding a comment.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
