### PR TITLE
ci: quote the branch name and read it from env in the feature-branch check

### DIFF
--- a/.github/workflows/check-news-changes.yml
+++ b/.github/workflows/check-news-changes.yml
@@ -72,9 +72,11 @@ jobs:
           fi
       - name: "Check if this is a feature branch merge"
         if: ${{ env.FOUND_NEWS_CHANGES_ADDITION == 'no' && env.SKIP_NEWS_CHECK == 'no' }}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set +e
-          echo ${{ github.head_ref }} | grep -q "feature"
+          echo "$HEAD_REF" | grep -q "feature"
           if [ $? -eq 0 ]; then
             echo "Feature branch found"
             echo "NEED_NEWS_CHANGES=yes" >> $GITHUB_ENV


### PR DESCRIPTION
Hi, and thanks for OpenSSL.

In `.github/workflows/check-news-changes.yml`, the "Check if this is a feature branch merge" step tests the branch name like this:

```yaml
run: |
  set +e
  echo ${{ github.head_ref }} | grep -q "feature"
```

Actions expands `${{ ... }}` into the script text before bash runs, so the branch name arrives as part of the command rather than as an argument to `echo`, and it is unquoted. The workflow is `on: pull_request`, so on a fork PR that name is chosen by whoever opened it, and git allows `$`, `(`, `)`, backticks and spaces in branch names.

Two consequences: a name containing `$(...)` would be executed rather than echoed, and a name containing spaces would reach `echo` as several arguments — which also makes the `grep -q "feature"` test less predictable than it looks.

I should be clear about scope rather than overstate it. This is a `pull_request` trigger, not `pull_request_target`, so a fork PR carries a read-only `GITHUB_TOKEN` and no repository secrets, and the job only sets `NEED_NEWS_CHANGES` in `$GITHUB_ENV`. I am raising it as hardening on a small surface, not as a live exploit path.

The change binds the ref to an environment variable and quotes it at the point of use:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
run: |
  set +e
  echo "$HEAD_REF" | grep -q "feature"
```

The `set +e`, the `$?` check and the `NEED_NEWS_CHANGES=yes` write below are untouched, so branches matching `feature` are detected exactly as before. Two lines added, one changed.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its trigger myself.
