### PR TITLE
doc: update X509_STORE_CTX_get_error.pod to match x509_txt.c

### DIFF
--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -161,7 +161,7 @@ The signature of the certificate is invalid.
 
 The signature of the CRL is invalid.
 
-=item B<X509_V_ERR_CERT_NOT_YET_VALID: certificate is not yet valid>
+=item B<X509_V_ERR_CERT_NOT_YET_VALID: certificate is not yet valid or the system clock is incorrect>
 
 The certificate is not yet valid: the C<notBefore> date is after the
 current time.


### PR DESCRIPTION
Clarified the error message for X509_V_ERR_CERT_NOT_YET_VALID to match x509_txt.c.

X509_STORE_CTX_get_error.pod had the old version of X509_V_ERR_CERT_NOT_YET_VALID error output: "certificate is not yet valid". Updated to: "certificate is not yet valid or the system clock is incorrect"

##### Checklist
- [x] documentation is added or updated

Fixes: #30915 

CLA: trivial
