### PR TITLE
Fix SSL_poll() handling of BIO_POLL_DESCRIPTOR_TYPE_NONE

### DIFF
--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -228,6 +228,9 @@ static int poll_translate(SSL_POLL_ITEM *items,
                 ossl_quic_poll_translate_test_step_cb_arg);
 
         switch (item->desc.type) {
+        case BIO_POLL_DESCRIPTOR_TYPE_NONE:
+            break;
+
         case BIO_POLL_DESCRIPTOR_TYPE_SSL:
             ssl = item->desc.value.ssl;
             if (ssl == NULL)
@@ -383,6 +386,9 @@ static int poll_readout(SSL_POLL_ITEM *items,
         revents = 0;
 
         switch (item->desc.type) {
+        case BIO_POLL_DESCRIPTOR_TYPE_NONE:
+            break;
+
         case BIO_POLL_DESCRIPTOR_TYPE_SSL:
             ssl = item->desc.value.ssl;
             if (ssl == NULL)

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -225,7 +225,7 @@ DEF_FUNC(ssl_poll_check)
 {
     int ok = 0;
     SSL *La, *Lax[4];
-    SSL_POLL_ITEM items[6] = { 0 }, expected_items[6] = { 0 };
+    SSL_POLL_ITEM items[7] = { 0 }, expected_items[7] = { 0 };
     size_t result_count = 0, i;
     const struct timeval z_timeout = { 0 }, *p_timeout = &z_timeout;
     struct timeval timeout = { 0 };
@@ -247,6 +247,11 @@ DEF_FUNC(ssl_poll_check)
     }
 
     items[5].desc = SSL_as_poll_descriptor(SSL_get0_listener(La));
+
+    /* NONE items are ignored and have revents reported as 0. */
+    items[6].desc.type = BIO_POLL_DESCRIPTOR_TYPE_NONE;
+    items[6].events = UINT64_MAX;
+    items[6].revents = UINT64_MAX;
 
     switch (mode) {
     case 0: /* Nothing ready */
@@ -286,12 +291,14 @@ DEF_FUNC(ssl_poll_check)
     /* Zero-timeout call. */
     result_count = SIZE_MAX;
     time_before = ossl_time_now();
+    ERR_clear_error();
     if (!TEST_true(SSL_poll(items, OSSL_NELEM(items), sizeof(SSL_POLL_ITEM),
             p_timeout, 0, &result_count)))
         goto err;
 
     time_after = ossl_time_now();
-    if (!TEST_size_t_eq(result_count, expected_result_count))
+    if (!TEST_size_t_eq(result_count, expected_result_count)
+        || !TEST_ulong_eq(ERR_peek_error(), 0))
         goto err;
 
     for (i = 0; i < OSSL_NELEM(items); ++i)


### PR DESCRIPTION
Fixes #32114 

`SSL_poll` documents that items with descriptor type `BIO_POLL_DESCRIPTOR_TYPE_NONE` are ignored and returned with `revents == 0`.

The readout and blocking-translation paths lacked explicit handling for this descriptor type. Consequently, these items followed the unsupported-descriptor path, causing the call to fail, report `SSL_POLL_EVENT_F`, increment `result_count`, and queue an error.

Treat `BIO_POLL_DESCRIPTOR_TYPE_NONE` as a no-op in both paths, matching the documented behavior and the existing handling of NULL SSL items.

Extend the existing `SSL_poll` RADIX test with a sentinel-filled `NONE` item.
The test covers zero-timeout and blocking calls and verifies that `revents` is cleared, `result_count` is unaffected, and no error is queued.
The test clears the thread-local error queue immediately before `SSL_poll` so the subsequent check detects only errors added by that call, not stale errors from earlier setup.

##### Checklist
- [x] tests are added or updated