### PR TITLE
CI: work around Podman/crun mismatch in linux-x86 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,10 @@ jobs:
         persist-credentials: false
     - name: run container
       run: |
-        CONTAINER_ID=$(podman run -d -v $(pwd):/mnt -w /mnt --platform=linux/i386 docker.io/i386/debian:13 sleep infinity)
+        # Work around actions/runner-images#14473, where Podman's built-in
+        # runtime search can prefer a stale crun over the PATH-selected one.
+        OCI_RUNTIME=$(command -v crun)
+        CONTAINER_ID=$(podman --runtime "$OCI_RUNTIME" run -d -v $(pwd):/mnt -w /mnt --platform=linux/i386 docker.io/i386/debian:13 sleep infinity)
         echo "CONTAINER_ID=$CONTAINER_ID" >> "$GITHUB_ENV"
     - name: install dependencies
       run:

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -223,7 +223,10 @@ jobs:
         persist-credentials: false
     - name: run container
       run: |
-        CONTAINER_ID=$(podman run -d -v $(pwd):/mnt -w /mnt --platform=linux/i386 docker.io/i386/debian:13 sleep infinity)
+        # Work around actions/runner-images#14473, where Podman's built-in
+        # runtime search can prefer a stale crun over the PATH-selected one.
+        OCI_RUNTIME=$(command -v crun)
+        CONTAINER_ID=$(podman --runtime "$OCI_RUNTIME" run -d -v $(pwd):/mnt -w /mnt --platform=linux/i386 docker.io/i386/debian:13 sleep infinity)
         echo "CONTAINER_ID=$CONTAINER_ID" >> "$GITHUB_ENV"
     - name: install dependencies
       run:


### PR DESCRIPTION
The GitHub-hosted Ubuntu runner image `20260726.254.1` upgraded Podman to 5.8.4 and ships a compatible crun in `/usr/local/bin`. However, Podman's built-in runtime search selects the stale `/usr/bin/crun` first.

The older runtime rejects the OCI configuration generated by the new Podman, causing every `linux-x86` job to fail before OpenSSL is configured or built:

```text
Error: OCI runtime error: crun: unknown version specified
```

Resolve crun through PATH and pass its absolute path explicitly to Podman. This selects /usr/local/bin/crun on the affected image while remaining compatible with previous runner images.

Apply the workaround to the duplicated linux-x86 jobs in both the regular CI and OS Zoo workflows.

The runner-image regression is tracked at:
https://github.com/actions/runner-images/issues/14473

Validation:

- Both modified workflow files parse successfully as YAML.
- git diff --check passes.