### PR TITLE
Fix duplicate fd event merging in poll() RIO backend

### DIFF
--- a/ssl/rio/poll_builder.c
+++ b/ssl/rio/poll_builder.c
@@ -120,8 +120,10 @@ int ossl_rio_poll_builder_add_fd(RIO_POLL_BUILDER *rpb, int fd,
 
     assert((rpb->pfd_heap != NULL && rpb->pfd_heap == pfds) || (rpb->pfd_heap == NULL && rpb->pfds == pfds));
     assert(i <= rpb->pfd_num && rpb->pfd_num <= rpb->pfd_alloc);
+    /* Check the index first because an appended entry is uninitialised. */
+    if (i == rpb->pfd_num || pfds[i].fd == -1)
+        pfds[i].events = 0;
     pfds[i].fd = fd;
-    pfds[i].events = 0;
 
     if (want_read)
         pfds[i].events |= POLLIN;

--- a/test/build.info
+++ b/test/build.info
@@ -91,7 +91,8 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{quic} -}]
     PROGRAMS{noinst}=priority_queue_test quicfaultstest quicapitest \
-                     quic_newcid_test quic_srt_gen_test rio_notifier_test
+                     quic_newcid_test quic_srt_gen_test rio_notifier_test \
+                     rio_poll_builder_test
   ENDIF
 
   IF[{- !$disabled{quic} && !$disabled{qlog} -}]
@@ -400,6 +401,10 @@ IF[{- !$disabled{tests} -}]
       SOURCE[rio_notifier_test]=rio_notifier_test.c
       INCLUDE[rio_notifier_test]=.. ../include ../apps/include
       DEPEND[rio_notifier_test]=../libcrypto.a ../libssl.a libtestutil.a
+
+      SOURCE[rio_poll_builder_test]=rio_poll_builder_test.c
+      INCLUDE[rio_poll_builder_test]=.. ../include ../apps/include
+      DEPEND[rio_poll_builder_test]=../libcrypto.a ../libssl.a libtestutil.a
 
       SOURCE[quic_wire_test]=quic_wire_test.c
       INCLUDE[quic_wire_test]=../include ../apps/include

--- a/test/recipes/70-test_rio_poll_builder.t
+++ b/test/recipes/70-test_rio_poll_builder.t
@@ -1,0 +1,19 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_rio_poll_builder");
+
+plan skip_all => "RIO poll builder tests require QUIC"
+    if disabled("quic");
+
+plan tests => 1;
+
+ok(run(test(["rio_poll_builder_test"])));

--- a/test/rio_poll_builder_test.c
+++ b/test/rio_poll_builder_test.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "../ssl/rio/poll_builder.h"
+#include "testutil.h"
+
+static int test_duplicate_fd(void)
+{
+#if RIO_POLL_METHOD == RIO_POLL_METHOD_POLL
+    RIO_POLL_BUILDER rpb;
+    struct pollfd *pfds;
+    int ret = 0;
+
+    if (!TEST_true(ossl_rio_poll_builder_init(&rpb)))
+        return 0;
+
+    if (!TEST_true(ossl_rio_poll_builder_add_fd(&rpb, 0, 1, 0))
+        || !TEST_true(ossl_rio_poll_builder_add_fd(&rpb, 0, 0, 1)))
+        goto out;
+
+    pfds = rpb.pfd_heap != NULL ? rpb.pfd_heap : rpb.pfds;
+    if (!TEST_size_t_eq(rpb.pfd_num, 1)
+        || !TEST_int_eq(pfds[0].events, POLLIN | POLLOUT))
+        goto out;
+
+    ret = 1;
+out:
+    ossl_rio_poll_builder_cleanup(&rpb);
+    return ret;
+#else
+    return TEST_skip("poll() backend is not in use");
+#endif
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_duplicate_fd);
+    return 1;
+}


### PR DESCRIPTION
Fixes #32116

`ossl_rio_poll_builder_add_fd` documents duplicate registrations as the logical OR of their requested directions. The `poll` backend instead reset an existing entry, making duplicates last-writer-wins, while the `select` backend already merges them.

The current QUIC path usually hides this because objects in one domain share network desires and a single port. It is reachable when independent domains expose the same fd with different masks; a dropped direction can then leave `poll` waiting for another event, timer, or deadline. Planned raw-fd support would also make direction combinations caller-controlled.

This change clears the mask only for new or reusable entries and preserves it for an existing fd before ORing in `POLLIN` and `POLLOUT`.

A poll-backend unit test verifies that read and write registrations for the same fd produce one `pollfd` with both bits set. Before the fix, it fails with mask `4` (`POLLOUT`) instead of `5` (`POLLIN | POLLOUT`).

Validation performed:

- `make test TESTS=test_rio_poll_builder` (PASS)
- `make test TESTS='test_rio_notifier test_quic_radix'` (PASS)

The affected code is identical on the `openssl-3.5`, `openssl-3.6`, and `openssl-4.0` branches, so the fix is also applicable there if backports is desired.

##### Checklist
- [x] tests are added or updated