### PR TITLE
Fix FIPS to require a derivation function

### DIFF
--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -599,6 +599,18 @@ static int drbg_ctr_init(PROV_DRBG *drbg)
     drbg->strength = (unsigned int)(keylen * 8);
     drbg->seedlen = keylen + 16;
 
+#ifdef FIPS_MODULE
+    /*
+     * FIPS requires that we use a derivation function since our
+     * entropy source is outside the fips boundary
+     */
+    if (ctr->use_df == 0) {
+        ERR_raise_data(ERR_LIB_PROV, PROV_R_DERIVATION_FUNCTION_INIT_FAILED,
+            "FIPS requires the use of a derivation function\n");
+        goto err;
+    }
+#endif
+
     if (ctr->use_df) {
         /* df initialisation */
         static const unsigned char df_key[32] = {

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -606,7 +606,7 @@ static int drbg_ctr_init(PROV_DRBG *drbg)
      */
     if (ctr->use_df == 0) {
         ERR_raise_data(ERR_LIB_PROV, PROV_R_DERIVATION_FUNCTION_INIT_FAILED,
-            "FIPS requires the use of a derivation function\n");
+            "FIPS requires the use of a derivation function");
         goto err;
     }
 #endif

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -5430,6 +5430,7 @@ static int parse(EVP_TEST *t)
     KEY_LIST *key, **klist;
     EVP_PKEY *pkey;
     PAIR *pp;
+    const char *alg_name = NULL;
     int i, j, skipped = 0;
 
     fips_indicator_callback_unapproved_count = 0;
@@ -5572,6 +5573,7 @@ start:
     /* Find the test, based on first keyword. */
     if (!TEST_ptr(t->meth = find_test(pp->key)))
         return 0;
+    alg_name = pp->value;
     if (!t->meth->init(t, pp->value)) {
         TEST_error("unknown %s: %s\n", pp->key, pp->value);
         return 0;
@@ -5656,6 +5658,16 @@ start:
             }
             if (t->skip)
                 return 0;
+        }
+    }
+    if (t->meth->parse == rand_test_parse) {
+        if (OSSL_PROVIDER_available(libctx, "fips")
+            && !strcmp(alg_name, "CTR-DRBG")) {
+            if (((RAND_DATA *)t->data)->use_df == 0) {
+                TEST_info("Skipping %s:%d as fips requires a derivation function\n", t->s.test_file, t->s.curr);
+                t->skip = 1;
+                return 0;
+            }
         }
     }
 


### PR DESCRIPTION
FIPS-140-3 requires that if a CTR-DRBG is allocated from the fips provider that either:

a) The entropy source must be NIST validated and exist within the FIPS boundary

or

b) The CTR-DRBG must use a derivation function with an entropy source outside the FIPS boundary

Given that we have no approved noise source inside the FIPS boundary, we need to enforce the fact that FIPS allocated CTR-DRBGS only allocate instances in which a derivation function is requested (i.e. the USE_DF parameter is asserted and set to one)

Follow path b, and ensure that FIPS CTR-DRBG allocations assert the use of USE_DF or fail if an allocation does not

Also fix up the evp tests to skip the 144 tests which allocate a DRBG without a derivation function when testing the fips provider



##### Checklist
- [x] tests are added or updated
