### PR TITLE
SSL_dup() should copy additional members

### DIFF
--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -100,7 +100,7 @@ SSL_set0_client_CA_list() or similar functions
 
 =item type of client certificate set via L<SSL_set1_client_cert_type(3)>.
 
-=item validation callback set via L<SSL_set_ct_validation_callback(3)>,
+=item certificate transparency validation callback set via L<SSL_set_ct_validation_callback(3)>,
 
 =item OCSP validation set via L<SSL_set_tlsext_status_type(3)>.
 

--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -96,6 +96,14 @@ SSL_set0_client_CA_list() or similar functions
 
 =item any Encrypted Client Hello (ECH) settings (see L<SSL_set1_echstore(3)>).
 
+=item type of server certificate set via L<SSL_set1_server_cert_type(3)>.
+
+=item type of client certificate set via L<SSL_set_client_cert_type(3)>.
+
+=item validation callback set via L<SSL_set_ct_validation_callback(3)>,
+
+=item OCSP validation set via L<SSL_set_tlsext_status_type(3)>.
+
 =back
 
 SSL_dup() is not supported on QUIC SSL objects and returns NULL if called on

--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -98,7 +98,7 @@ SSL_set0_client_CA_list() or similar functions
 
 =item type of server certificate set via L<SSL_set1_server_cert_type(3)>.
 
-=item type of client certificate set via L<SSL_set_client_cert_type(3)>.
+=item type of client certificate set via L<SSL_set1_client_cert_type(3)>.
 
 =item validation callback set via L<SSL_set_ct_validation_callback(3)>,
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5448,6 +5448,7 @@ SSL *SSL_dup(SSL *s)
         goto err;
 
     if (sc->server_cert_type != NULL) {
+        OPENSSL_free(retsc->server_cert_type);
         retsc->server_cert_type = OPENSSL_memdup(sc->server_cert_type,
             sc->server_cert_type_len);
         if (retsc->server_cert_type == NULL)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5447,6 +5447,34 @@ SSL *SSL_dup(SSL *s)
         || !dup_ca_names(&retsc->client_ca_names, sc->client_ca_names))
         goto err;
 
+    if (sc->server_cert_type != NULL) {
+        retsc->server_cert_type = OPENSSL_memdup(sc->server_cert_type,
+            sc->server_cert_type_len);
+        if (retsc->server_cert_type == NULL)
+            goto err;
+        retsc->server_cert_type_len = sc->server_cert_type_len;
+    }
+
+    if (sc->client_cert_type != NULL) {
+        retsc->client_cert_type = OPENSSL_memdup(sc->client_cert_type,
+            sc->client_cert_type_len);
+        if (retsc->client_cert_type == NULL)
+            goto err;
+        retsc->client_cert_type_len = sc->client_cert_type_len;
+    }
+
+#ifndef OPENSSL_NO_CT
+    retsc->ct_validation_callback = sc->ct_validation_callback;
+    /*
+     * application that uses SSL_dup() must understand the `callback` must
+     * not free arg. The arg becomes shared between all SSL connection objects
+     * entangled by SSL_dup().
+     */
+    retsc->ct_validation_callback_arg = sc->ct_validation_callback_arg;
+#endif
+
+    retsc->ext.status_type = sc->ext.status_type;
+
     return ret;
 
 err:

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5457,6 +5457,7 @@ SSL *SSL_dup(SSL *s)
     }
 
     if (sc->client_cert_type != NULL) {
+        OPENSSL_free(retsc->client_cert_type);
         retsc->client_cert_type = OPENSSL_memdup(sc->client_cert_type,
             sc->client_cert_type_len);
         if (retsc->client_cert_type == NULL)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5465,11 +5465,6 @@ SSL *SSL_dup(SSL *s)
 
 #ifndef OPENSSL_NO_CT
     retsc->ct_validation_callback = sc->ct_validation_callback;
-    /*
-     * application that uses SSL_dup() must understand the `callback` must
-     * not free arg. The arg becomes shared between all SSL connection objects
-     * entangled by SSL_dup().
-     */
     retsc->ct_validation_callback_arg = sc->ct_validation_callback_arg;
 #endif
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -11624,10 +11624,6 @@ static int test_ssl_dup(void)
     unsigned char *ctype;
     size_t ctype_len;
 
-    /*
-     * need leaf_chain so we can test how SSL_dup() deals with OCSP
-     * extensions.
-     */
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
             TLS_client_method(),
             0,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -11600,13 +11600,34 @@ end:
 #endif
 
 #ifndef OPENSSL_NO_TLS1_2
+
+#define CERT_TYPE_C "\x0" /* TLSEXT_cert_type_x509 */
+#define CERT_TYPE_S "\x2" /* TLSEXT_cert_type_rpk */
+
+#ifndef OPENSSL_NO_CT
+#define CB_ARG "callback arg"
+
+/* ARGSUSED */
+static int validation_cbk(const CT_POLICY_EVAL_CTX *ctx,
+    const STACK_OF(SCT) *scts, void *arg)
+{
+    return 1;
+}
+#endif
+
 static int test_ssl_dup(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL, *client2ssl = NULL;
     int testresult = 0;
     BIO *rbio = NULL, *wbio = NULL;
+    unsigned char *ctype;
+    size_t ctype_len;
 
+    /*
+     * need leaf_chain so we can test how SSL_dup() deals with OCSP
+     * extensions.
+     */
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
             TLS_client_method(),
             0,
@@ -11621,6 +11642,27 @@ static int test_ssl_dup(void)
     if (!TEST_true(SSL_set_min_proto_version(clientssl, TLS1_2_VERSION))
         || !TEST_true(SSL_set_max_proto_version(clientssl, TLS1_2_VERSION)))
         goto end;
+
+    if (!TEST_true(
+            SSL_set1_client_cert_type(clientssl,
+                (const unsigned char *)CERT_TYPE_C, sizeof(CERT_TYPE_C) - 1)))
+        goto end;
+
+    if (!TEST_true(
+            SSL_set1_server_cert_type(clientssl,
+                (const unsigned char *)CERT_TYPE_S, sizeof(CERT_TYPE_S) - 1)))
+        goto end;
+
+#ifndef OPENSSL_NO_CT
+    if (!TEST_true(SSL_set_ct_validation_callback(clientssl, validation_cbk, CB_ARG)))
+        goto end;
+#endif
+
+#ifndef OPENSSL_NO_OCSP
+    if (!TEST_true(
+            SSL_set_tlsext_status_type(clientssl, TLSEXT_STATUSTYPE_ocsp)))
+        goto end;
+#endif
 
     client2ssl = SSL_dup(clientssl);
     rbio = SSL_get_rbio(clientssl);
@@ -11648,6 +11690,28 @@ static int test_ssl_dup(void)
 
     if (!TEST_true(create_ssl_connection(serverssl, client2ssl, SSL_ERROR_NONE)))
         goto end;
+
+    if (!TEST_true(SSL_get0_client_cert_type(client2ssl, &ctype, &ctype_len)))
+        goto end;
+
+    if (!TEST_mem_eq(ctype, ctype_len, CERT_TYPE_C, sizeof(CERT_TYPE_C) - 1))
+        goto end;
+
+    if (!TEST_true(SSL_get0_server_cert_type(client2ssl, &ctype, &ctype_len)))
+        goto end;
+
+    if (!TEST_mem_eq(ctype, ctype_len, CERT_TYPE_S, sizeof(CERT_TYPE_S) - 1))
+        goto end;
+
+#ifndef OPENSSL_NO_CT
+    if (!TEST_true(SSL_ct_is_enabled(client2ssl)))
+        goto end;
+#endif
+
+#ifndef OPENSSL_NO_OCSP
+    if (!TEST_long_eq(SSL_get_tlsext_status_type(client2ssl), TLSEXT_STATUSTYPE_ocsp))
+        goto end;
+#endif
 
     SSL_free(clientssl);
     clientssl = SSL_dup(client2ssl);


### PR DESCRIPTION
currently those members are missing to be copied in SSL_dup(3ossl)
   - server_cert_type
   - client_cert_type
   - ct_validation_callback
   - retsc->ext.status_type (typically needed for OCSP)

All those missing members are usually set before handshake starts, so SSL_dup() needs to copy them so behavior of duplicated SSL object is consistent with its original.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
