### PR TITLE
quic: Limit the number of buffered stream frames

### DIFF
--- a/include/internal/quic_sf_list.h
+++ b/include/internal/quic_sf_list.h
@@ -37,6 +37,16 @@
  */
 #ifndef OPENSSL_NO_QUIC
 
+/*
+ * Insertion scans the list linearly, so an unbounded list lets a peer sending
+ * many small frames out of order make reassembly cost quadratic. The list is
+ * limited to one frame per SFRAME_LIST_MIN_AVG_FRAME_LEN bytes the peer is
+ * able to buffer, clamped to the range below.
+ */
+#define SFRAME_LIST_MIN_AVG_FRAME_LEN 64
+#define SFRAME_LIST_MIN_MAX_FRAMES 1024
+#define SFRAME_LIST_MAX_MAX_FRAMES 16384
+
 typedef struct stream_frame_st STREAM_FRAME;
 
 typedef struct sframe_list_st {
@@ -45,6 +55,8 @@ typedef struct sframe_list_st {
     unsigned int fin;
     /* Number of stream frames in the list. */
     size_t num_frames;
+    /* Maximum number of stream frames allowed in the list. */
+    size_t max_frames;
     /* Offset of data not yet dropped */
     uint64_t offset;
     /* Is head locked ? */
@@ -63,6 +75,12 @@ void ossl_sframe_list_init(SFRAME_LIST *fl);
  * still present inside it.
  */
 void ossl_sframe_list_destroy(SFRAME_LIST *fl);
+
+/*
+ * Derives the maximum number of buffered frames from window, which is the
+ * largest amount of data the peer can ever have in flight for the stream.
+ */
+void ossl_sframe_list_set_rx_window(SFRAME_LIST *fl, uint64_t window);
 
 /*
  * Insert a stream frame data into the list.

--- a/include/internal/quic_stream.h
+++ b/include/internal/quic_stream.h
@@ -423,6 +423,12 @@ int ossl_quic_rstream_resize_rbuf(QUIC_RSTREAM *qrs, size_t rbuf_size);
  * Sets flag to cleanse the buffered data when user reads it.
  */
 void ossl_quic_rstream_set_cleanse(QUIC_RSTREAM *qrs, int cleanse);
+
+/*
+ * Sets the largest amount of data the peer can ever have in flight for the
+ * stream, which bounds the number of frames buffered for reassembly.
+ */
+void ossl_quic_rstream_set_rx_window(QUIC_RSTREAM *qrs, uint64_t window);
 #endif
 
 #endif

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -312,6 +312,9 @@ static int ch_init(QUIC_CHANNEL *ch)
         ch->crypto_recv[pn_space] = ossl_quic_rstream_new(NULL, NULL, 0);
         if (ch->crypto_recv[pn_space] == NULL)
             goto err;
+
+        ossl_quic_rstream_set_rx_window(ch->crypto_recv[pn_space],
+            INIT_CRYPTO_RECV_BUF_LEN);
     }
 
     /* Plug in the TLS handshake layer. */
@@ -3829,7 +3832,7 @@ SSL *ossl_quic_channel_get0_ssl(QUIC_CHANNEL *ch)
 static int ch_init_new_stream(QUIC_CHANNEL *ch, QUIC_STREAM *qs,
     int can_send, int can_recv)
 {
-    uint64_t rxfc_wnd;
+    uint64_t rxfc_wnd, max_rxfc_wnd;
     int server_init = ossl_quic_stream_is_server_init(qs);
     int local_init = (ch->is_server == server_init);
     int is_uni = !ossl_quic_stream_is_bidi(qs);
@@ -3876,11 +3879,15 @@ static int ch_init_new_stream(QUIC_CHANNEL *ch, QUIC_STREAM *qs,
     else
         rxfc_wnd = ch->tx_init_max_stream_data_bidi_remote;
 
+    max_rxfc_wnd = DEFAULT_STREAM_RXFC_MAX_WND_MUL * rxfc_wnd;
+
     if (!ossl_quic_rxfc_init(&qs->rxfc, &ch->conn_rxfc,
-            rxfc_wnd,
-            DEFAULT_STREAM_RXFC_MAX_WND_MUL * rxfc_wnd,
+            rxfc_wnd, max_rxfc_wnd,
             get_time, ch))
         goto err;
+
+    if (can_recv)
+        ossl_quic_rstream_set_rx_window(qs->rstream, max_rxfc_wnd);
 
     return 1;
 

--- a/ssl/quic/quic_rstream.c
+++ b/ssl/quic/quic_rstream.c
@@ -292,3 +292,8 @@ void ossl_quic_rstream_set_cleanse(QUIC_RSTREAM *qrs, int cleanse)
 {
     qrs->fl.cleanse = cleanse;
 }
+
+void ossl_quic_rstream_set_rx_window(QUIC_RSTREAM *qrs, uint64_t window)
+{
+    ossl_sframe_list_set_rx_window(&qrs->fl, window);
+}

--- a/ssl/quic/quic_sf_list.c
+++ b/ssl/quic/quic_sf_list.c
@@ -48,6 +48,19 @@ static STREAM_FRAME *stream_frame_new(UINT_RANGE *range, OSSL_QRX_PKT *pkt,
 void ossl_sframe_list_init(SFRAME_LIST *fl)
 {
     memset(fl, 0, sizeof(*fl));
+    fl->max_frames = SFRAME_LIST_MAX_MAX_FRAMES;
+}
+
+void ossl_sframe_list_set_rx_window(SFRAME_LIST *fl, uint64_t window)
+{
+    uint64_t max_frames = window / SFRAME_LIST_MIN_AVG_FRAME_LEN;
+
+    if (max_frames < SFRAME_LIST_MIN_MAX_FRAMES)
+        max_frames = SFRAME_LIST_MIN_MAX_FRAMES;
+    else if (max_frames > SFRAME_LIST_MAX_MAX_FRAMES)
+        max_frames = SFRAME_LIST_MAX_MAX_FRAMES;
+
+    fl->max_frames = (size_t)max_frames;
 }
 
 void ossl_sframe_list_destroy(SFRAME_LIST *fl)
@@ -65,6 +78,9 @@ static int append_frame(SFRAME_LIST *fl, UINT_RANGE *range,
     const unsigned char *data)
 {
     STREAM_FRAME *new_frame;
+
+    if (fl->num_frames >= fl->max_frames)
+        return 0;
 
     if ((new_frame = stream_frame_new(range, pkt, data)) == NULL)
         return 0;
@@ -150,17 +166,23 @@ int ossl_sframe_list_insert(SFRAME_LIST *fl, UINT_RANGE *range,
         stream_frame_free(fl, drop_frame);
     }
 
-    if (next_frame != NULL) {
-        /* check whether the new_frame is redundant because there is no gap */
-        if (prev_frame != NULL
-            && next_frame->range.start <= prev_frame->range.end) {
-            stream_frame_free(fl, new_frame);
-            goto end;
-        }
-        next_frame->prev = new_frame;
-    } else {
-        fl->tail = new_frame;
+    /* check whether the new_frame is redundant because there is no gap */
+    if (next_frame != NULL && prev_frame != NULL
+        && next_frame->range.start <= prev_frame->range.end) {
+        stream_frame_free(fl, new_frame);
+        goto end;
     }
+
+    /* the frame count only grows past this point */
+    if (fl->num_frames >= fl->max_frames) {
+        stream_frame_free(fl, new_frame);
+        return 0;
+    }
+
+    if (next_frame != NULL)
+        next_frame->prev = new_frame;
+    else
+        fl->tail = new_frame;
 
     new_frame->next = next_frame;
     new_frame->prev = prev_frame;

--- a/test/quic_stream_test.c
+++ b/test/quic_stream_test.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 #include "internal/packet.h"
+#include "internal/quic_sf_list.h"
 #include "internal/quic_stream.h"
 #include "testutil.h"
 
@@ -595,11 +596,107 @@ err:
     return ret;
 }
 
+/*
+ * The frame limit is derived from the flow control window, clamped to
+ * [SFRAME_LIST_MIN_MAX_FRAMES, SFRAME_LIST_MAX_MAX_FRAMES].
+ */
+static const struct {
+    uint64_t window;
+    size_t max_frames;
+} frame_limit_tests[] = {
+    { 256 * 1024, 4096 }, /* derived from the window */
+    { 1024, SFRAME_LIST_MIN_MAX_FRAMES }, /* raised to the minimum */
+    { 64 * 1024 * 1024, SFRAME_LIST_MAX_MAX_FRAMES }, /* capped at the maximum */
+};
+
+/*
+ * Check that the number of buffered stream frames is capped, and that the cap
+ * only rejects frames which actually grow the list.
+ */
+static int test_rstream_frame_limit(int idx)
+{
+    QUIC_RSTREAM *rstream = NULL;
+    unsigned char *data = NULL;
+    unsigned char *read_buf = NULL;
+    const size_t max_frames = frame_limit_tests[idx].max_frames;
+    const size_t data_size = 2 * max_frames + 64;
+    const uint64_t past_tail = 2 * max_frames;
+    size_t i, readbytes = 0;
+    int fin = 0, ret = 0;
+
+    if (!TEST_ptr(data = OPENSSL_malloc(data_size))
+        || !TEST_ptr(read_buf = OPENSSL_malloc(data_size))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+        goto err;
+
+    ossl_quic_rstream_set_rx_window(rstream, frame_limit_tests[idx].window);
+
+    for (i = 0; i < data_size; i++)
+        data[i] = (unsigned char)(i & 0xff);
+
+    /* fill the list to the cap with one byte frames separated by one byte gaps */
+    for (i = 0; i < max_frames; i++)
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 2 * i,
+                data + 2 * i, 1, 0)))
+            goto err;
+
+    /* a further frame would exceed the cap and must be refused */
+    if (!TEST_false(ossl_quic_rstream_queue_data(rstream, NULL, past_tail,
+            data + past_tail, 1, 0)))
+        goto err;
+
+    /* a retransmission of a buffered frame does not grow the list */
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 10,
+            data + 10, 1, 0)))
+        goto err;
+
+    /* a frame covering eleven buffered frames shrinks the list by ten */
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 0, data, 21, 0)))
+        goto err;
+
+    /* so exactly ten more frames fit, and the eleventh does not */
+    for (i = 0; i < 10; i++)
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL,
+                past_tail + 2 * i,
+                data + past_tail + 2 * i, 1, 0)))
+            goto err;
+
+    if (!TEST_false(ossl_quic_rstream_queue_data(rstream, NULL,
+            past_tail + 20,
+            data + past_tail + 20, 1, 0)))
+        goto err;
+
+    /* the buffered data is unaffected by all of the above */
+    if (!TEST_true(ossl_quic_rstream_read(rstream, read_buf, data_size,
+            &readbytes, &fin))
+        || !TEST_false(fin)
+        || !TEST_size_t_eq(readbytes, 21)
+        || !TEST_mem_eq(read_buf, readbytes, data, 21))
+        goto err;
+
+    /* reading released one frame, so one more frame fits again */
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, past_tail + 20,
+            data + past_tail + 20, 1, 0))
+        || !TEST_false(ossl_quic_rstream_queue_data(rstream, NULL,
+            past_tail + 22,
+            data + past_tail + 22, 1, 0)))
+        goto err;
+
+    ret = 1;
+
+err:
+    ossl_quic_rstream_free(rstream);
+    OPENSSL_free(data);
+    OPENSSL_free(read_buf);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_sstream_simple);
     ADD_ALL_TESTS(test_sstream_bulk, 100);
     ADD_ALL_TESTS(test_rstream_simple, 4);
     ADD_ALL_TESTS(test_rstream_random, 100);
+    ADD_ALL_TESTS(test_rstream_frame_limit, OSSL_NELEM(frame_limit_tests));
     return 1;
 }


### PR DESCRIPTION
This introduce window size driven limit on the number of frames buffered for one stream. Exceeding the limit makes the insert fail, which the depacketizer already turns into a connection error. The check only rejects frames which actually grow the list, so retransmissions of buffered frames and frames covering several existing frames stay accepted.

Frames are never merged, so even a gapless stream needs one list entry per frame received until the application reads it. The limit is derived from the largest window the peer can ever be granted for the stream, allowing one frame per `SFRAME_LIST_MIN_AVG_FRAME_LEN` bytes and clamped to a fixed range.
