### PR TITLE
quic: copy buffered stream data out of the received packets

### DIFF
--- a/include/internal/quic_sf_list.h
+++ b/include/internal/quic_sf_list.h
@@ -37,6 +37,20 @@
  */
 #ifndef OPENSSL_NO_QUIC
 
+/*
+ * A stream is too fragmented once its frame list holds this many entries.
+ * Contiguous frames are merged when their data is copied out of the packets,
+ * so a stream received in order keeps a single entry however many frames it
+ * arrived in, and reaching this limit means the data received so far has about
+ * this many gaps in it. Both inserting a frame before the tail and copying the
+ * data out walk the list, so without a limit a peer sending small frames with
+ * a gap between each of them makes reassembly cost quadratic.
+ *
+ * ngtcp2 rejects the same condition, which it calls a heavily fragmented
+ * reorder buffer, once it holds 4000 gaps.
+ */
+#define SFRAME_LIST_MAX_FRAGMENTATION 4000
+
 typedef struct stream_frame_st STREAM_FRAME;
 
 typedef struct sframe_list_st {

--- a/include/internal/quic_sf_list.h
+++ b/include/internal/quic_sf_list.h
@@ -69,6 +69,14 @@
  */
 #define SFRAME_LIST_MIN_MOVE_FILL 4
 
+/*
+ * An unmoved frame pins the buffer it arrived in, typically an MTU sized
+ * packet buffer however small the frame. Past this many pinned frames a move
+ * pass copies even the runs it would otherwise leave behind, so a stream pins
+ * at most about 64 KiB of packet buffers.
+ */
+#define SFRAME_LIST_MAX_PINNED_FRAMES (64 * 1024 / 1500)
+
 typedef struct stream_frame_st STREAM_FRAME;
 
 typedef struct sframe_list_st {
@@ -77,6 +85,8 @@ typedef struct sframe_list_st {
     unsigned int fin;
     /* Number of stream frames in the list. */
     size_t num_frames;
+    /* Number of frames whose data still pins the buffer it arrived in. */
+    size_t num_pinned;
     /* Offset of data not yet dropped */
     uint64_t offset;
     /* Is head locked ? */
@@ -172,12 +182,15 @@ typedef int(sframe_list_write_at_cb)(uint64_t logical_offset,
  * the side storage using the write_at_cb callback, merging frames that become
  * contiguous. Short isolated runs of contiguous frames are left in their
  * packets and moved later once they grow past min_run_len or the data
- * around them fills in.
+ * around them fills in. If move_pinned is nonzero such runs are instead
+ * copied into buffers sized to the run and owned by the list, so that no
+ * frame keeps pinning the buffer it arrived in.
  * Returns 1 if all the calls to the callback return 1.
  * If the callback returns 0, the function stops processing further
  * frames and returns 0.
  */
 int ossl_sframe_list_move_data(SFRAME_LIST *fl, uint64_t min_run_len,
+    int move_pinned,
     sframe_list_write_at_cb *write_at_cb,
     void *cb_arg);
 #endif

--- a/include/internal/quic_sf_list.h
+++ b/include/internal/quic_sf_list.h
@@ -38,18 +38,36 @@
 #ifndef OPENSSL_NO_QUIC
 
 /*
- * A stream is too fragmented once its frame list holds this many entries.
- * Contiguous frames are merged when their data is copied out of the packets,
- * so a stream received in order keeps a single entry however many frames it
- * arrived in, and reaching this limit means the data received so far has about
- * this many gaps in it. Both inserting a frame before the tail and copying the
- * data out walk the list, so without a limit a peer sending small frames with
- * a gap between each of them makes reassembly cost quadratic.
- *
- * ngtcp2 rejects the same condition, which it calls a heavily fragmented
- * reorder buffer, once it holds 4000 gaps.
+ * A stream is too fragmented once the offsets it has received span fewer than
+ * this many bytes per frame list entry. Contiguous frames are merged when their
+ * data is moved out of the packets, so an entry stands for a gap in the data
+ * received, and gaps come from lost packets, which are a packet worth of
+ * offsets apart. The offsets received never span more than the flow control
+ * window, so this limits the entries to a share of that window.
  */
-#define SFRAME_LIST_MAX_FRAGMENTATION 4000
+#define SFRAME_LIST_MIN_AVG_SPAN 1024
+
+/*
+ * Below this many entries a stream is never considered too fragmented, however
+ * few offsets it spans. Frames are merged only when the data is moved out of
+ * the packets, so until that happens the list holds more entries than the data
+ * received has gaps.
+ */
+#define SFRAME_LIST_MIN_FRAGMENTATION 256
+
+/*
+ * An entry is walked both when a frame is inserted before the tail and when the
+ * data is moved out of the packets. That cost does not shrink when the window
+ * is large, so the number of entries is capped as well.
+ */
+#define SFRAME_LIST_MAX_FRAGMENTATION 8192
+
+/*
+ * A short run is only moved when it and the data around it fill at least this
+ * fraction of the space they span, so that a side storage block holds a useful
+ * amount of data whatever spacing the peer picks for its frames.
+ */
+#define SFRAME_LIST_MIN_MOVE_FILL 4
 
 typedef struct stream_frame_st STREAM_FRAME;
 
@@ -150,14 +168,16 @@ typedef int(sframe_list_write_at_cb)(uint64_t logical_offset,
     void *cb_arg);
 
 /*
- * Move the frame data in all the stream frames in the list fl
- * from the packets to the side storage using the write_at_cb
- * callback.
+ * Move the frame data in the stream frames in the list fl from the packets to
+ * the side storage using the write_at_cb callback, merging frames that become
+ * contiguous. Short isolated runs of contiguous frames are left in their
+ * packets and moved later once they grow past min_run_len or the data
+ * around them fills in.
  * Returns 1 if all the calls to the callback return 1.
  * If the callback returns 0, the function stops processing further
  * frames and returns 0.
  */
-int ossl_sframe_list_move_data(SFRAME_LIST *fl,
+int ossl_sframe_list_move_data(SFRAME_LIST *fl, uint64_t min_run_len,
     sframe_list_write_at_cb *write_at_cb,
     void *cb_arg);
 #endif

--- a/include/internal/quic_stream.h
+++ b/include/internal/quic_stream.h
@@ -318,11 +318,8 @@ void ossl_quic_sstream_set_cleanse(QUIC_SSTREAM *qss, int cleanse);
  * controller and statistics module. They can be NULL for unit testing.
  * If they are non-NULL, the `rxfc` is called when receive stream data
  * is read by application. `statm` is queried for current rtt.
- * `rbuf_size` is the initial size of the ring buffer to be used
- * when ossl_quic_rstream_move_to_rbuf() is called.
  */
-QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc,
-    OSSL_STATM *statm, size_t rbuf_size);
+QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc, OSSL_STATM *statm);
 
 /*
  * Frees a QUIC_RSTREAM and any associated storage.
@@ -398,26 +395,6 @@ int ossl_quic_rstream_get_record(QUIC_RSTREAM *qrs,
  * times without calling ossl_quic_rstream_get_record() in between.
  */
 int ossl_quic_rstream_release_record(QUIC_RSTREAM *qrs, size_t read_len);
-
-/*
- * Moves received frame data from decrypted packets to ring buffer.
- * This should be called when there are too many decrypted packets allocated.
- * Returns 1 on success, 0 when it was not possible to release all
- * referenced packets due to an insufficient size of the ring buffer.
- * Exception is the packet from the record returned previously by
- * ossl_quic_rstream_get_record() - that one will be always skipped.
- */
-int ossl_quic_rstream_move_to_rbuf(QUIC_RSTREAM *qrs);
-
-/*
- * Resizes the internal ring buffer to a new `rbuf_size` size.
- * Returns 1 on success, 0 on error.
- * Possible error conditions are an allocation failure, trying to resize
- * the ring buffer when ossl_quic_rstream_get_record() was called and
- * not yet released, or trying to resize the ring buffer to a smaller size
- * than currently occupied.
- */
-int ossl_quic_rstream_resize_rbuf(QUIC_RSTREAM *qrs, size_t rbuf_size);
 
 /*
  * Sets flag to cleanse the buffered data when user reads it.

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -309,7 +309,7 @@ static int ch_init(QUIC_CHANNEL *ch)
     }
 
     for (pn_space = QUIC_PN_SPACE_INITIAL; pn_space < QUIC_PN_SPACE_NUM; ++pn_space) {
-        ch->crypto_recv[pn_space] = ossl_quic_rstream_new(NULL, NULL, 0);
+        ch->crypto_recv[pn_space] = ossl_quic_rstream_new(NULL, NULL);
         if (ch->crypto_recv[pn_space] == NULL)
             goto err;
     }
@@ -3839,7 +3839,7 @@ static int ch_init_new_stream(QUIC_CHANNEL *ch, QUIC_STREAM *qs,
             goto err;
 
     if (can_recv)
-        if ((qs->rstream = ossl_quic_rstream_new(NULL, NULL, 0)) == NULL)
+        if ((qs->rstream = ossl_quic_rstream_new(NULL, NULL)) == NULL)
             goto err;
 
     /* TXFC */

--- a/ssl/quic/quic_rstream.c
+++ b/ssl/quic/quic_rstream.c
@@ -57,6 +57,7 @@ struct quic_rstream_st {
     UINT_RANGE head_range;
     SBUF sbuf;
     size_t frames_at_last_move;
+    size_t pinned_at_last_move;
 };
 
 static void sbuf_init(SBUF *sb)
@@ -206,6 +207,7 @@ int ossl_quic_rstream_queue_data(QUIC_RSTREAM *qrs, OSSL_QRX_PKT *pkt,
     int fin)
 {
     UINT_RANGE range;
+    int move_pinned;
 
     if ((data == NULL && data_len != 0) || (data_len == 0 && fin == 0)) {
         /* empty frame allowed only at the end of the stream */
@@ -221,15 +223,28 @@ int ossl_quic_rstream_queue_data(QUIC_RSTREAM *qrs, OSSL_QRX_PKT *pkt,
 
     if (qrs->frames_at_last_move > qrs->fl.num_frames)
         qrs->frames_at_last_move = qrs->fl.num_frames;
+    if (qrs->pinned_at_last_move > qrs->fl.num_pinned)
+        qrs->pinned_at_last_move = qrs->fl.num_pinned;
+
+    /*
+     * Once too many frames pin the packet they arrived in, they are all
+     * copied out however little they are worth moving. Only a pin count
+     * that grew since the last move triggers this, so frames that cannot
+     * be copied do not make every insert walk the list.
+     */
+    move_pinned = qrs->fl.num_pinned > SFRAME_LIST_MAX_PINNED_FRAMES
+        && qrs->fl.num_pinned > qrs->pinned_at_last_move;
 
     /*
      * Copying is best effort, frames we fail to copy just keep referencing
      * their packet.
      */
-    if (qrs->fl.num_frames >= qrs->frames_at_last_move + RSTREAM_MOVE_THRESHOLD) {
+    if (move_pinned
+        || qrs->fl.num_frames >= qrs->frames_at_last_move + RSTREAM_MOVE_THRESHOLD) {
         (void)ossl_sframe_list_move_data(&qrs->fl, SBUF_MIN_COPY_LEN,
-            write_at_sbuf_cb, &qrs->sbuf);
+            move_pinned, write_at_sbuf_cb, &qrs->sbuf);
         qrs->frames_at_last_move = qrs->fl.num_frames;
+        qrs->pinned_at_last_move = qrs->fl.num_pinned;
     }
 
     return 1;

--- a/ssl/quic/quic_rstream.c
+++ b/ssl/quic/quic_rstream.c
@@ -11,30 +11,163 @@
 #include "internal/time.h"
 #include "internal/quic_stream.h"
 #include "internal/quic_sf_list.h"
-#include "internal/ring_buf.h"
+
+/*
+ * Stream data normally stays in the packet it arrived in, which avoids a copy
+ * but keeps the packet referenced and needs a frame list entry per frame. Once
+ * a stream accumulates enough frames the data is copied to the buffer below
+ * instead, which releases the packets and lets contiguous frames merge.
+ *
+ * The buffer is a list of fixed size chunks ordered by stream offset. Chunks
+ * are aligned to a multiple of SBUF_CHUNK_SIZE and are allocated when first
+ * written to, so the memory used follows the data actually buffered.
+ */
+#define SBUF_CHUNK_SIZE 4096
+
+#define SBUF_BASE(off) ((off) - (off) % SBUF_CHUNK_SIZE)
+
+struct sbuf_chunk_st {
+    struct sbuf_chunk_st *next;
+    /* stream offset of the first byte, always chunk aligned */
+    uint64_t base;
+    unsigned char data[SBUF_CHUNK_SIZE];
+};
+
+typedef struct sbuf_st {
+    /* chunks in ascending base order */
+    struct sbuf_chunk_st *head;
+    /* chunk used last, keeps appending off the list walk */
+    struct sbuf_chunk_st *cursor;
+} SBUF;
+
+/* Number of frames added before the data is copied to the stream buffer. */
+#define RSTREAM_MOVE_THRESHOLD 32
 
 struct quic_rstream_st {
     SFRAME_LIST fl;
     QUIC_RXFC *rxfc;
     OSSL_STATM *statm;
     UINT_RANGE head_range;
-    struct ring_buf rbuf;
+    SBUF sbuf;
+    size_t frames_at_last_move;
 };
 
-QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc,
-    OSSL_STATM *statm, size_t rbuf_size)
+static void sbuf_init(SBUF *sb)
+{
+    sb->head = sb->cursor = NULL;
+}
+
+static void sbuf_destroy(SBUF *sb, int cleanse)
+{
+    struct sbuf_chunk_st *c, *next;
+
+    for (c = sb->head; c != NULL; c = next) {
+        next = c->next;
+        if (cleanse)
+            OPENSSL_cleanse(c->data, sizeof(c->data));
+        OPENSSL_free(c);
+    }
+
+    sb->head = sb->cursor = NULL;
+}
+
+static struct sbuf_chunk_st *sbuf_get_chunk(SBUF *sb, uint64_t base, int create)
+{
+    struct sbuf_chunk_st *prev = NULL, *c, *new_chunk;
+
+    c = (sb->cursor != NULL && sb->cursor->base <= base) ? sb->cursor : sb->head;
+
+    for (; c != NULL && c->base < base; c = c->next)
+        prev = c;
+
+    if (c != NULL && c->base == base) {
+        sb->cursor = c;
+        return c;
+    }
+
+    if (!create)
+        return NULL;
+
+    new_chunk = OPENSSL_zalloc(sizeof(*new_chunk));
+    if (new_chunk == NULL)
+        return NULL;
+
+    new_chunk->base = base;
+    new_chunk->next = c;
+    if (prev != NULL)
+        prev->next = new_chunk;
+    else
+        sb->head = new_chunk;
+
+    sb->cursor = new_chunk;
+    return new_chunk;
+}
+
+static int sbuf_write(SBUF *sb, uint64_t offset, const unsigned char *buf,
+    size_t len)
+{
+    while (len > 0) {
+        struct sbuf_chunk_st *c = sbuf_get_chunk(sb, SBUF_BASE(offset), 1);
+        size_t idx, l;
+
+        if (c == NULL)
+            return 0;
+
+        idx = (size_t)(offset - c->base);
+        l = SBUF_CHUNK_SIZE - idx;
+        if (l > len)
+            l = len;
+
+        memcpy(c->data + idx, buf, l);
+        offset += l;
+        buf += l;
+        len -= l;
+    }
+
+    return 1;
+}
+
+/*
+ * Returns a pointer to the buffered byte at offset, with *max_len set to the
+ * number of bytes contiguous with it. The caller knows how many of those bytes
+ * were actually received.
+ */
+static const unsigned char *sbuf_get_ptr(SBUF *sb, uint64_t offset,
+    size_t *max_len)
+{
+    struct sbuf_chunk_st *c = sbuf_get_chunk(sb, SBUF_BASE(offset), 0);
+    size_t idx;
+
+    if (c == NULL)
+        return NULL;
+
+    idx = (size_t)(offset - c->base);
+    *max_len = SBUF_CHUNK_SIZE - idx;
+    return c->data + idx;
+}
+
+static void sbuf_free_upto(SBUF *sb, uint64_t offset, int cleanse)
+{
+    struct sbuf_chunk_st *c;
+
+    while ((c = sb->head) != NULL && c->base + SBUF_CHUNK_SIZE <= offset) {
+        sb->head = c->next;
+        if (sb->cursor == c)
+            sb->cursor = NULL;
+        if (cleanse)
+            OPENSSL_cleanse(c->data, sizeof(c->data));
+        OPENSSL_free(c);
+    }
+}
+
+QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc, OSSL_STATM *statm)
 {
     QUIC_RSTREAM *ret = OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL)
         return NULL;
 
-    ring_buf_init(&ret->rbuf);
-    if (!ring_buf_resize(&ret->rbuf, rbuf_size, 0)) {
-        OPENSSL_free(ret);
-        return NULL;
-    }
-
+    sbuf_init(&ret->sbuf);
     ossl_sframe_list_init(&ret->fl);
     ret->rxfc = rxfc;
     ret->statm = statm;
@@ -50,8 +183,14 @@ void ossl_quic_rstream_free(QUIC_RSTREAM *qrs)
 
     cleanse = qrs->fl.cleanse;
     ossl_sframe_list_destroy(&qrs->fl);
-    ring_buf_destroy(&qrs->rbuf, cleanse);
+    sbuf_destroy(&qrs->sbuf, cleanse);
     OPENSSL_free(qrs);
+}
+
+static int write_at_sbuf_cb(uint64_t logical_offset, const unsigned char *buf,
+    size_t buf_len, void *cb_arg)
+{
+    return sbuf_write(cb_arg, logical_offset, buf, buf_len);
 }
 
 int ossl_quic_rstream_queue_data(QUIC_RSTREAM *qrs, OSSL_QRX_PKT *pkt,
@@ -70,7 +209,22 @@ int ossl_quic_rstream_queue_data(QUIC_RSTREAM *qrs, OSSL_QRX_PKT *pkt,
     range.start = offset;
     range.end = offset + data_len;
 
-    return ossl_sframe_list_insert(&qrs->fl, &range, pkt, data, fin);
+    if (!ossl_sframe_list_insert(&qrs->fl, &range, pkt, data, fin))
+        return 0;
+
+    if (qrs->frames_at_last_move > qrs->fl.num_frames)
+        qrs->frames_at_last_move = qrs->fl.num_frames;
+
+    /*
+     * Copying is best effort, frames we fail to copy just keep referencing
+     * their packet.
+     */
+    if (qrs->fl.num_frames >= qrs->frames_at_last_move + RSTREAM_MOVE_THRESHOLD) {
+        (void)ossl_sframe_list_move_data(&qrs->fl, write_at_sbuf_cb, &qrs->sbuf);
+        qrs->frames_at_last_move = qrs->fl.num_frames;
+    }
+
+    return 1;
 }
 
 static int read_internal(QUIC_RSTREAM *qrs, unsigned char *buf, size_t size,
@@ -95,35 +249,38 @@ static int read_internal(QUIC_RSTREAM *qrs, unsigned char *buf, size_t size,
             break;
 
         if (data == NULL) {
-            size_t max_len;
+            /* the data was copied to the stream buffer, which is chunked */
+            uint64_t data_off = range.start;
 
-            data = ring_buf_get_ptr(&qrs->rbuf, range.start, &max_len);
-            if (!ossl_assert(data != NULL))
-                return 0;
-            if (max_len < l) {
-                memcpy(buf, data, max_len);
-                size -= max_len;
-                buf += max_len;
-                readbytes_ += max_len;
-                l -= max_len;
-                data = ring_buf_get_ptr(&qrs->rbuf, range.start + max_len,
-                    &max_len);
-                if (!ossl_assert(data != NULL) || !ossl_assert(max_len > l))
+            while (l > 0) {
+                size_t max_len, chunk_len;
+
+                data = sbuf_get_ptr(&qrs->sbuf, data_off, &max_len);
+                if (!ossl_assert(data != NULL))
                     return 0;
+
+                chunk_len = max_len < l ? max_len : l;
+                memcpy(buf, data, chunk_len);
+                size -= chunk_len;
+                buf += chunk_len;
+                readbytes_ += chunk_len;
+                l -= chunk_len;
+                data_off += chunk_len;
             }
+        } else {
+            memcpy(buf, data, l);
+            size -= l;
+            buf += l;
+            readbytes_ += l;
         }
 
-        memcpy(buf, data, l);
-        size -= l;
-        buf += l;
-        readbytes_ += l;
         if (size == 0)
             break;
     }
 
     if (drop && offset != 0) {
         ret = ossl_sframe_list_drop_frames(&qrs->fl, offset);
-        ring_buf_cpop_range(&qrs->rbuf, 0, offset - 1, qrs->fl.cleanse);
+        sbuf_free_upto(&qrs->sbuf, offset, qrs->fl.cleanse);
     }
 
     if (ret) {
@@ -213,8 +370,7 @@ int ossl_quic_rstream_get_record(QUIC_RSTREAM *qrs,
     rec_len_ = (size_t)(qrs->head_range.end - qrs->head_range.start);
 
     if (record_ == NULL && rec_len_ != 0) {
-        record_ = ring_buf_get_ptr(&qrs->rbuf, qrs->head_range.start,
-            &max_len);
+        record_ = sbuf_get_ptr(&qrs->sbuf, qrs->head_range.start, &max_len);
         if (!ossl_assert(record_ != NULL))
             return 0;
         if (max_len < rec_len_) {
@@ -246,8 +402,7 @@ int ossl_quic_rstream_release_record(QUIC_RSTREAM *qrs, size_t read_len)
     if (!ossl_sframe_list_drop_frames(&qrs->fl, offset))
         return 0;
 
-    if (offset > 0)
-        ring_buf_cpop_range(&qrs->rbuf, 0, offset - 1, qrs->fl.cleanse);
+    sbuf_free_upto(&qrs->sbuf, offset, qrs->fl.cleanse);
 
     if (qrs->rxfc != NULL) {
         OSSL_TIME rtt = get_rtt(qrs);
@@ -255,35 +410,6 @@ int ossl_quic_rstream_release_record(QUIC_RSTREAM *qrs, size_t read_len)
         if (!ossl_quic_rxfc_on_retire(qrs->rxfc, offset, rtt))
             return 0;
     }
-
-    return 1;
-}
-
-static int write_at_ring_buf_cb(uint64_t logical_offset,
-    const unsigned char *buf,
-    size_t buf_len,
-    void *cb_arg)
-{
-    struct ring_buf *rbuf = cb_arg;
-
-    return ring_buf_write_at(rbuf, logical_offset, buf, buf_len);
-}
-
-int ossl_quic_rstream_move_to_rbuf(QUIC_RSTREAM *qrs)
-{
-    if (ring_buf_avail(&qrs->rbuf) == 0)
-        return 0;
-    return ossl_sframe_list_move_data(&qrs->fl,
-        write_at_ring_buf_cb, &qrs->rbuf);
-}
-
-int ossl_quic_rstream_resize_rbuf(QUIC_RSTREAM *qrs, size_t rbuf_size)
-{
-    if (ossl_sframe_list_is_head_locked(&qrs->fl))
-        return 0;
-
-    if (!ring_buf_resize(&qrs->rbuf, rbuf_size, qrs->fl.cleanse))
-        return 0;
 
     return 1;
 }

--- a/ssl/quic/quic_rstream.c
+++ b/ssl/quic/quic_rstream.c
@@ -43,6 +43,13 @@ typedef struct sbuf_st {
 /* Number of frames added before the data is copied to the stream buffer. */
 #define RSTREAM_MOVE_THRESHOLD 32
 
+/*
+ * Shorter runs of contiguous data are left in their packets. Copying them would
+ * hold a whole chunk for very little, so this bounds what a chunk can waste at
+ * SBUF_CHUNK_SIZE / SBUF_MIN_COPY_LEN.
+ */
+#define SBUF_MIN_COPY_LEN (SBUF_CHUNK_SIZE / 4)
+
 struct quic_rstream_st {
     SFRAME_LIST fl;
     QUIC_RXFC *rxfc;
@@ -220,7 +227,8 @@ int ossl_quic_rstream_queue_data(QUIC_RSTREAM *qrs, OSSL_QRX_PKT *pkt,
      * their packet.
      */
     if (qrs->fl.num_frames >= qrs->frames_at_last_move + RSTREAM_MOVE_THRESHOLD) {
-        (void)ossl_sframe_list_move_data(&qrs->fl, write_at_sbuf_cb, &qrs->sbuf);
+        (void)ossl_sframe_list_move_data(&qrs->fl, SBUF_MIN_COPY_LEN,
+            write_at_sbuf_cb, &qrs->sbuf);
         qrs->frames_at_last_move = qrs->fl.num_frames;
     }
 

--- a/ssl/quic/quic_sf_list.c
+++ b/ssl/quic/quic_sf_list.c
@@ -16,18 +16,36 @@ struct stream_frame_st {
     UINT_RANGE range;
     OSSL_QRX_PKT *pkt;
     const unsigned char *data;
+    /* Buffer owned by the frame holding its data once copied, or NULL. */
+    unsigned char *own_buf;
 };
+
+/*
+ * Release the storage of a frame whose data was copied elsewhere, whether
+ * that is the buffer the frame arrived in or a buffer the frame owns.
+ */
+static void stream_frame_release_data(SFRAME_LIST *fl, STREAM_FRAME *sf)
+{
+    if (sf->data != NULL && sf->own_buf == NULL)
+        --fl->num_pinned;
+    sf->data = NULL;
+    ossl_qrx_pkt_release(sf->pkt);
+    sf->pkt = NULL;
+    OPENSSL_free(sf->own_buf);
+    sf->own_buf = NULL;
+}
 
 static void stream_frame_free(SFRAME_LIST *fl, STREAM_FRAME *sf)
 {
     if (fl->cleanse && sf->data != NULL)
         OPENSSL_cleanse((unsigned char *)sf->data,
             (size_t)(sf->range.end - sf->range.start));
-    ossl_qrx_pkt_release(sf->pkt);
+    stream_frame_release_data(fl, sf);
     OPENSSL_free(sf);
 }
 
-static STREAM_FRAME *stream_frame_new(UINT_RANGE *range, OSSL_QRX_PKT *pkt,
+static STREAM_FRAME *stream_frame_new(SFRAME_LIST *fl, UINT_RANGE *range,
+    OSSL_QRX_PKT *pkt,
     const unsigned char *data)
 {
     STREAM_FRAME *sf = OPENSSL_zalloc(sizeof(*sf));
@@ -41,6 +59,8 @@ static STREAM_FRAME *stream_frame_new(UINT_RANGE *range, OSSL_QRX_PKT *pkt,
     sf->range = *range;
     sf->pkt = pkt;
     sf->data = data;
+    if (data != NULL)
+        ++fl->num_pinned;
 
     return sf;
 }
@@ -87,7 +107,7 @@ static int append_frame(SFRAME_LIST *fl, UINT_RANGE *range,
     if (sframe_list_too_fragmented(fl, range->end))
         return 0;
 
-    if ((new_frame = stream_frame_new(range, pkt, data)) == NULL)
+    if ((new_frame = stream_frame_new(fl, range, pkt, data)) == NULL)
         return 0;
     new_frame->prev = fl->tail;
     if (fl->tail != NULL)
@@ -116,7 +136,7 @@ int ossl_sframe_list_insert(SFRAME_LIST *fl, UINT_RANGE *range,
 
     /* nothing there yet */
     if (fl->tail == NULL) {
-        fl->tail = fl->head = stream_frame_new(range, pkt, data);
+        fl->tail = fl->head = stream_frame_new(fl, range, pkt, data);
         if (fl->tail == NULL)
             return 0;
 
@@ -150,7 +170,7 @@ int ossl_sframe_list_insert(SFRAME_LIST *fl, UINT_RANGE *range,
      * Now we must create a new frame although in the end we might drop it,
      * because we will be potentially dropping existing overlapping frames.
      */
-    new_frame = stream_frame_new(range, pkt, data);
+    new_frame = stream_frame_new(fl, range, pkt, data);
     if (new_frame == NULL)
         return 0;
 
@@ -331,7 +351,66 @@ static int run_worth_moving(const STREAM_FRAME *last, uint64_t start,
         >= gap_before + run_len + gap_after;
 }
 
+/*
+ * Copy a run of contiguous frames into a single buffer sized to the run and
+ * owned by its first frame, releasing the buffers the frames arrived in.
+ * Runs whose data was partly moved to the side storage already cannot be
+ * brought back into one buffer and are left alone, as are runs pinning
+ * nothing. Returns 0 if the run was left as it is.
+ */
+static int move_run_to_own_buf(SFRAME_LIST *fl, STREAM_FRAME *sf,
+    STREAM_FRAME *last)
+{
+    STREAM_FRAME *cur;
+    unsigned char *buf;
+    uint64_t start = sf->range.start, limit = start;
+    int pinned = 0;
+
+    for (cur = sf;; cur = cur->next) {
+        if (cur->data == NULL && cur->range.end > cur->range.start)
+            return 0;
+        if (cur->data != NULL && cur->own_buf == NULL)
+            pinned = 1;
+        if (cur == last)
+            break;
+    }
+
+    if (!pinned || last->range.end == start)
+        return 0;
+
+    buf = OPENSSL_malloc((size_t)(last->range.end - start));
+    if (buf == NULL)
+        return 0;
+
+    for (cur = sf;; cur = cur->next) {
+        if (cur->data != NULL) {
+            const unsigned char *data = cur->data;
+
+            /* frames in a run may overlap, write only what is new */
+            if (limit > cur->range.start)
+                data += (size_t)(limit - cur->range.start);
+            memcpy(buf + (size_t)(limit - start), data,
+                (size_t)(cur->range.end - limit));
+
+            if (fl->cleanse)
+                OPENSSL_cleanse((unsigned char *)cur->data,
+                    (size_t)(cur->range.end - cur->range.start));
+
+            stream_frame_release_data(fl, cur);
+        }
+
+        limit = cur->range.end;
+        if (cur == last)
+            break;
+    }
+
+    sf->data = buf;
+    sf->own_buf = buf;
+    return 1;
+}
+
 int ossl_sframe_list_move_data(SFRAME_LIST *fl, uint64_t min_run_len,
+    int move_pinned,
     sframe_list_write_at_cb *write_at_cb,
     void *cb_arg)
 {
@@ -354,39 +433,39 @@ int ossl_sframe_list_move_data(SFRAME_LIST *fl, uint64_t min_run_len,
             last = last->next;
 
         if (!run_worth_moving(last, limit, prev_end, min_run_len)) {
-            prev_end = last->range.end;
-            sf = last->next;
-            continue;
-        }
-
-        /* move the data of each frame in the run out of its packet */
-        for (cur = sf;; cur = cur->next) {
-            if (cur->data != NULL) {
-                const unsigned char *data = cur->data;
-                size_t len;
-
-                /* frames in a run may overlap, write only what is new */
-                if (limit > cur->range.start)
-                    data += (size_t)(limit - cur->range.start);
-                len = (size_t)(cur->range.end - limit);
-
-                if (!write_at_cb(limit, data, len, cb_arg))
-                    /* data did not fit */
-                    return 0;
-
-                if (fl->cleanse)
-                    OPENSSL_cleanse((unsigned char *)cur->data,
-                        (size_t)(cur->range.end - cur->range.start));
-
-                /* release the packet */
-                cur->data = NULL;
-                ossl_qrx_pkt_release(cur->pkt);
-                cur->pkt = NULL;
+            if (!move_pinned || !move_run_to_own_buf(fl, sf, last)) {
+                prev_end = last->range.end;
+                sf = last->next;
+                continue;
             }
+        } else {
+            /* move the data of each frame in the run out of its packet */
+            for (cur = sf;; cur = cur->next) {
+                if (cur->data != NULL) {
+                    const unsigned char *data = cur->data;
+                    size_t len;
 
-            limit = cur->range.end;
-            if (cur == last)
-                break;
+                    /* frames in a run may overlap, write only what is new */
+                    if (limit > cur->range.start)
+                        data += (size_t)(limit - cur->range.start);
+                    len = (size_t)(cur->range.end - limit);
+
+                    if (!write_at_cb(limit, data, len, cb_arg))
+                        /* data did not fit */
+                        return 0;
+
+                    if (fl->cleanse)
+                        OPENSSL_cleanse((unsigned char *)cur->data,
+                            (size_t)(cur->range.end - cur->range.start));
+
+                    /* release the packet */
+                    stream_frame_release_data(fl, cur);
+                }
+
+                limit = cur->range.end;
+                if (cur == last)
+                    break;
+            }
         }
 
         /* the moved run is contiguous, merge it into its first frame */

--- a/ssl/quic/quic_sf_list.c
+++ b/ssl/quic/quic_sf_list.c
@@ -60,11 +60,19 @@ void ossl_sframe_list_destroy(SFRAME_LIST *fl)
     }
 }
 
+static int sframe_list_too_fragmented(const SFRAME_LIST *fl)
+{
+    return fl->num_frames >= SFRAME_LIST_MAX_FRAGMENTATION;
+}
+
 static int append_frame(SFRAME_LIST *fl, UINT_RANGE *range,
     OSSL_QRX_PKT *pkt,
     const unsigned char *data)
 {
     STREAM_FRAME *new_frame;
+
+    if (sframe_list_too_fragmented(fl))
+        return 0;
 
     if ((new_frame = stream_frame_new(range, pkt, data)) == NULL)
         return 0;
@@ -150,17 +158,23 @@ int ossl_sframe_list_insert(SFRAME_LIST *fl, UINT_RANGE *range,
         stream_frame_free(fl, drop_frame);
     }
 
-    if (next_frame != NULL) {
-        /* check whether the new_frame is redundant because there is no gap */
-        if (prev_frame != NULL
-            && next_frame->range.start <= prev_frame->range.end) {
-            stream_frame_free(fl, new_frame);
-            goto end;
-        }
-        next_frame->prev = new_frame;
-    } else {
-        fl->tail = new_frame;
+    /* check whether the new_frame is redundant because there is no gap */
+    if (next_frame != NULL && prev_frame != NULL
+        && next_frame->range.start <= prev_frame->range.end) {
+        stream_frame_free(fl, new_frame);
+        goto end;
     }
+
+    /* the frame count only grows past this point */
+    if (sframe_list_too_fragmented(fl)) {
+        stream_frame_free(fl, new_frame);
+        return 0;
+    }
+
+    if (next_frame != NULL)
+        next_frame->prev = new_frame;
+    else
+        fl->tail = new_frame;
 
     new_frame->next = next_frame;
     new_frame->prev = prev_frame;

--- a/ssl/quic/quic_sf_list.c
+++ b/ssl/quic/quic_sf_list.c
@@ -60,9 +60,22 @@ void ossl_sframe_list_destroy(SFRAME_LIST *fl)
     }
 }
 
-static int sframe_list_too_fragmented(const SFRAME_LIST *fl)
+/* end is the end of the range about to be added to the list */
+static int sframe_list_too_fragmented(const SFRAME_LIST *fl, uint64_t end)
 {
-    return fl->num_frames >= SFRAME_LIST_MAX_FRAGMENTATION;
+    uint64_t span;
+
+    if (fl->num_frames >= SFRAME_LIST_MAX_FRAGMENTATION)
+        return 1;
+
+    if (fl->num_frames < SFRAME_LIST_MIN_FRAGMENTATION)
+        return 0;
+
+    if (fl->tail != NULL && fl->tail->range.end > end)
+        end = fl->tail->range.end;
+    span = end - fl->offset;
+
+    return fl->num_frames * (uint64_t)SFRAME_LIST_MIN_AVG_SPAN > span;
 }
 
 static int append_frame(SFRAME_LIST *fl, UINT_RANGE *range,
@@ -71,7 +84,7 @@ static int append_frame(SFRAME_LIST *fl, UINT_RANGE *range,
 {
     STREAM_FRAME *new_frame;
 
-    if (sframe_list_too_fragmented(fl))
+    if (sframe_list_too_fragmented(fl, range->end))
         return 0;
 
     if ((new_frame = stream_frame_new(range, pkt, data)) == NULL)
@@ -145,6 +158,9 @@ int ossl_sframe_list_insert(SFRAME_LIST *fl, UINT_RANGE *range,
         next_frame != NULL && next_frame->range.end <= range->end;) {
         STREAM_FRAME *drop_frame = next_frame;
 
+        /* the reader still holds the data of a locked head */
+        assert(!fl->head_locked || drop_frame != fl->head);
+
         next_frame = next_frame->next;
         if (next_frame != NULL)
             next_frame->prev = drop_frame->prev;
@@ -166,7 +182,7 @@ int ossl_sframe_list_insert(SFRAME_LIST *fl, UINT_RANGE *range,
     }
 
     /* the frame count only grows past this point */
-    if (sframe_list_too_fragmented(fl)) {
+    if (sframe_list_too_fragmented(fl, range->end)) {
         stream_frame_free(fl, new_frame);
         return 0;
     }
@@ -283,12 +299,44 @@ int ossl_sframe_list_is_head_locked(SFRAME_LIST *fl)
     return fl->head_locked;
 }
 
-int ossl_sframe_list_move_data(SFRAME_LIST *fl,
+/*
+ * Whether a run of contiguous frames spanning start to last->range.end is
+ * worth moving to the side storage. A short run surrounded by empty space is
+ * not, as moving it would hold a whole side storage block for very little
+ * data, so it stays in the packets it arrived in and is moved once it grows
+ * or the space around it fills in. Until then its frames keep their data and
+ * packet reference, which is how every frame is read before it is moved, so
+ * the reader is unaffected.
+ */
+static int run_worth_moving(const STREAM_FRAME *last, uint64_t start,
+    uint64_t prev_end, uint64_t min_run_len)
+{
+    uint64_t run_len = last->range.end - start;
+    uint64_t gap_before = start - prev_end;
+    /* space past the last frame is where the rest of the stream goes */
+    uint64_t gap_after = last->next != NULL
+        ? last->next->range.start - last->range.end
+        : 0;
+
+    if (run_len >= min_run_len)
+        return 1;
+
+    /* space farther than min_run_len away could not share a block anyway */
+    if (gap_before > min_run_len)
+        gap_before = min_run_len;
+    if (gap_after > min_run_len)
+        gap_after = min_run_len;
+
+    return run_len * SFRAME_LIST_MIN_MOVE_FILL
+        >= gap_before + run_len + gap_after;
+}
+
+int ossl_sframe_list_move_data(SFRAME_LIST *fl, uint64_t min_run_len,
     sframe_list_write_at_cb *write_at_cb,
     void *cb_arg)
 {
-    STREAM_FRAME *sf = fl->head, *prev_frame = NULL;
-    uint64_t limit = fl->offset;
+    STREAM_FRAME *sf = fl->head;
+    uint64_t prev_end = fl->offset;
 
     if (sf == NULL)
         return 1;
@@ -296,52 +344,67 @@ int ossl_sframe_list_move_data(SFRAME_LIST *fl,
     if (fl->head_locked)
         sf = sf->next;
 
-    for (; sf != NULL; sf = sf->next) {
-        size_t len;
-        const unsigned char *data = sf->data;
+    while (sf != NULL) {
+        STREAM_FRAME *last = sf, *cur, *next_frame;
+        uint64_t limit = sf->range.start > fl->offset ? sf->range.start
+                                                      : fl->offset;
 
-        if (limit < sf->range.start)
-            limit = sf->range.start;
+        /* find the last frame of the run of contiguous frames from sf */
+        while (last->next != NULL && last->next->range.start <= last->range.end)
+            last = last->next;
 
-        if (data != NULL) {
-            if (limit > sf->range.start)
-                data += (size_t)(limit - sf->range.start);
-            len = (size_t)(sf->range.end - limit);
-
-            if (!write_at_cb(limit, data, len, cb_arg))
-                /* data did not fit */
-                return 0;
-
-            if (fl->cleanse)
-                OPENSSL_cleanse((unsigned char *)sf->data,
-                    (size_t)(sf->range.end - sf->range.start));
-
-            /* release the packet */
-            sf->data = NULL;
-            ossl_qrx_pkt_release(sf->pkt);
-            sf->pkt = NULL;
-        }
-
-        limit = sf->range.end;
-
-        /* merge contiguous frames */
-        if (prev_frame != NULL
-            && prev_frame->range.end >= sf->range.start) {
-            prev_frame->range.end = sf->range.end;
-            prev_frame->next = sf->next;
-
-            if (sf->next != NULL)
-                sf->next->prev = prev_frame;
-            else
-                fl->tail = prev_frame;
-
-            --fl->num_frames;
-            stream_frame_free(fl, sf);
-            sf = prev_frame;
+        if (!run_worth_moving(last, limit, prev_end, min_run_len)) {
+            prev_end = last->range.end;
+            sf = last->next;
             continue;
         }
 
-        prev_frame = sf;
+        /* move the data of each frame in the run out of its packet */
+        for (cur = sf;; cur = cur->next) {
+            if (cur->data != NULL) {
+                const unsigned char *data = cur->data;
+                size_t len;
+
+                /* frames in a run may overlap, write only what is new */
+                if (limit > cur->range.start)
+                    data += (size_t)(limit - cur->range.start);
+                len = (size_t)(cur->range.end - limit);
+
+                if (!write_at_cb(limit, data, len, cb_arg))
+                    /* data did not fit */
+                    return 0;
+
+                if (fl->cleanse)
+                    OPENSSL_cleanse((unsigned char *)cur->data,
+                        (size_t)(cur->range.end - cur->range.start));
+
+                /* release the packet */
+                cur->data = NULL;
+                ossl_qrx_pkt_release(cur->pkt);
+                cur->pkt = NULL;
+            }
+
+            limit = cur->range.end;
+            if (cur == last)
+                break;
+        }
+
+        /* the moved run is contiguous, merge it into its first frame */
+        next_frame = last->next;
+        sf->range.end = last->range.end;
+        while (sf->next != next_frame) {
+            cur = sf->next;
+            sf->next = cur->next;
+            --fl->num_frames;
+            stream_frame_free(fl, cur);
+        }
+        if (next_frame != NULL)
+            next_frame->prev = sf;
+        else
+            fl->tail = sf;
+
+        prev_end = sf->range.end;
+        sf = next_frame;
     }
 
     return 1;

--- a/test/quic_stream_test.c
+++ b/test/quic_stream_test.c
@@ -740,6 +740,73 @@ err:
     return ret;
 }
 
+/*
+ * Frames not worth copying to the stream buffer stay in the buffers they
+ * arrived in, but only so many of them; past the limit they are copied into
+ * buffers sized to what they hold. The data must survive being copied that
+ * way, and again once the gaps around it fill in and it merges into runs
+ * that go to the stream buffer after all.
+ */
+static int test_rstream_pinned_limit(int idx)
+{
+    QUIC_RSTREAM *rstream = NULL;
+    unsigned char *data = NULL, *ref = NULL, *read_buf = NULL;
+    const size_t stride = 8;
+    const size_t num_frames = 3 * SFRAME_LIST_MAX_PINNED_FRAMES;
+    const size_t data_size = num_frames * stride;
+    size_t i, readbytes = 0;
+    int fin = 0, ret = 0;
+
+    if (!TEST_ptr(data = OPENSSL_malloc(data_size))
+        || !TEST_ptr(read_buf = OPENSSL_malloc(data_size))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL)))
+        goto err;
+
+    if (idx == 1)
+        ossl_quic_rstream_set_cleanse(rstream, 1);
+
+    for (i = 0; i < data_size; i++)
+        data[i] = (unsigned char)(i & 0xff);
+
+    if (!TEST_ptr(ref = OPENSSL_memdup(data, data_size)))
+        goto err;
+
+    /* single byte frames spaced out so that none is worth moving */
+    for (i = 0; i < num_frames; i++)
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, i * stride,
+                data + i * stride, 1, 0)))
+            goto err;
+
+    /* fill the gaps without covering the frames already buffered */
+    for (i = 0; i < num_frames; i++)
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL,
+                i * stride + 1,
+                data + i * stride + 1, stride - 1,
+                i == num_frames - 1)))
+            goto err;
+
+    if (!TEST_true(ossl_quic_rstream_read(rstream, read_buf, data_size,
+            &readbytes, &fin))
+        || !TEST_true(fin)
+        || !TEST_size_t_eq(readbytes, data_size)
+        || !TEST_mem_eq(read_buf, readbytes, ref, data_size))
+        goto err;
+
+    if (idx == 1)
+        for (i = 0; i < data_size; i++)
+            if (!TEST_uchar_eq(data[i], 0))
+                goto err;
+
+    ret = 1;
+
+err:
+    ossl_quic_rstream_free(rstream);
+    OPENSSL_free(data);
+    OPENSSL_free(ref);
+    OPENSSL_free(read_buf);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_sstream_simple);
@@ -749,5 +816,6 @@ int setup_tests(void)
     ADD_TEST(test_rstream_fragmentation_limit);
     ADD_TEST(test_rstream_fragmentation_ratio);
     ADD_TEST(test_rstream_small_frames);
+    ADD_ALL_TESTS(test_rstream_pinned_limit, 2);
     return 1;
 }

--- a/test/quic_stream_test.c
+++ b/test/quic_stream_test.c
@@ -581,16 +581,20 @@ err:
 }
 
 /*
- * Check that a stream cannot be fragmented without bound, and that the limit only
- * rejects frames which actually grow the list.
+ * Check that a stream cannot be fragmented without bound, and that the limit
+ * only rejects frames which actually grow the list. The frames are spaced out
+ * enough that the data received averages out above the minimum, so it is the
+ * absolute limit that stops this and not the ratio.
  */
 static int test_rstream_fragmentation_limit(void)
 {
     QUIC_RSTREAM *rstream = NULL;
     unsigned char *data = NULL;
     unsigned char *read_buf = NULL;
-    const size_t data_size = 2 * SFRAME_LIST_MAX_FRAGMENTATION + 64;
-    const uint64_t past_tail = 2 * SFRAME_LIST_MAX_FRAGMENTATION;
+    const size_t stride = 2 * SFRAME_LIST_MIN_AVG_SPAN;
+    const size_t data_size = stride * (SFRAME_LIST_MAX_FRAGMENTATION + 16);
+    const uint64_t past_tail = stride * SFRAME_LIST_MAX_FRAGMENTATION;
+    const size_t covered = 10 * stride + 1;
     size_t i, readbytes = 0;
     int fin = 0, ret = 0;
 
@@ -602,10 +606,10 @@ static int test_rstream_fragmentation_limit(void)
     for (i = 0; i < data_size; i++)
         data[i] = (unsigned char)(i & 0xff);
 
-    /* one byte frames separated by one byte gaps can never be merged */
+    /* one byte frames with a gap after each of them can never be merged */
     for (i = 0; i < SFRAME_LIST_MAX_FRAGMENTATION; i++)
-        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 2 * i,
-                data + 2 * i, 1, 0)))
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, i * stride,
+                data + i * stride, 1, 0)))
             goto err;
 
     /* a further frame would exceed the limit and must be refused */
@@ -614,39 +618,33 @@ static int test_rstream_fragmentation_limit(void)
         goto err;
 
     /* a retransmission of a buffered frame does not grow the list */
-    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 10,
-            data + 10, 1, 0)))
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, stride,
+            data + stride, 1, 0)))
         goto err;
 
     /* a frame covering eleven buffered frames shrinks the list by ten */
-    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 0, data, 21, 0)))
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 0, data,
+            covered, 0)))
         goto err;
 
     /* so exactly ten more frames fit, and the eleventh does not */
     for (i = 0; i < 10; i++)
         if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL,
-                past_tail + 2 * i,
-                data + past_tail + 2 * i, 1, 0)))
+                past_tail + i * stride,
+                data + past_tail + i * stride, 1, 0)))
             goto err;
 
-    if (!TEST_false(ossl_quic_rstream_queue_data(rstream, NULL, past_tail + 20,
-            data + past_tail + 20, 1, 0)))
+    if (!TEST_false(ossl_quic_rstream_queue_data(rstream, NULL,
+            past_tail + 10 * stride,
+            data + past_tail + 10 * stride, 1, 0)))
         goto err;
 
     /* the buffered data is unaffected by all of the above */
     if (!TEST_true(ossl_quic_rstream_read(rstream, read_buf, data_size,
             &readbytes, &fin))
         || !TEST_false(fin)
-        || !TEST_size_t_eq(readbytes, 21)
-        || !TEST_mem_eq(read_buf, readbytes, data, 21))
-        goto err;
-
-    /* reading released one frame, so one more frame fits again */
-    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, past_tail + 20,
-            data + past_tail + 20, 1, 0))
-        || !TEST_false(ossl_quic_rstream_queue_data(rstream, NULL,
-            past_tail + 22,
-            data + past_tail + 22, 1, 0)))
+        || !TEST_size_t_eq(readbytes, covered)
+        || !TEST_mem_eq(read_buf, readbytes, data, covered))
         goto err;
 
     ret = 1;
@@ -655,6 +653,44 @@ err:
     ossl_quic_rstream_free(rstream);
     OPENSSL_free(data);
     OPENSSL_free(read_buf);
+    return ret;
+}
+
+/*
+ * A peer sending tiny frames with a gap after each of them is refused long
+ * before the absolute limit, because the data it has sent does not average out
+ * at a sensible size.
+ */
+static int test_rstream_fragmentation_ratio(void)
+{
+    QUIC_RSTREAM *rstream = NULL;
+    unsigned char *data = NULL;
+    const size_t stride = 2;
+    const size_t data_size = stride * (SFRAME_LIST_MIN_FRAGMENTATION + 8);
+    size_t i;
+    int ret = 0;
+
+    if (!TEST_ptr(data = OPENSSL_malloc(data_size))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL)))
+        goto err;
+
+    memset(data, 'x', data_size);
+
+    for (i = 0; i < SFRAME_LIST_MIN_FRAGMENTATION; i++)
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, i * stride,
+                data + i * stride, 1, 0)))
+            goto err;
+
+    if (!TEST_false(ossl_quic_rstream_queue_data(rstream, NULL,
+            SFRAME_LIST_MIN_FRAGMENTATION * stride,
+            data + SFRAME_LIST_MIN_FRAGMENTATION * stride, 1, 0)))
+        goto err;
+
+    ret = 1;
+
+err:
+    ossl_quic_rstream_free(rstream);
+    OPENSSL_free(data);
     return ret;
 }
 
@@ -711,6 +747,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_rstream_simple, 2);
     ADD_ALL_TESTS(test_rstream_random, 100);
     ADD_TEST(test_rstream_fragmentation_limit);
+    ADD_TEST(test_rstream_fragmentation_ratio);
     ADD_TEST(test_rstream_small_frames);
     return 1;
 }

--- a/test/quic_stream_test.c
+++ b/test/quic_stream_test.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 #include "internal/packet.h"
+#include "internal/quic_sf_list.h"
 #include "internal/quic_stream.h"
 #include "testutil.h"
 
@@ -580,6 +581,84 @@ err:
 }
 
 /*
+ * Check that a stream cannot be fragmented without bound, and that the limit only
+ * rejects frames which actually grow the list.
+ */
+static int test_rstream_fragmentation_limit(void)
+{
+    QUIC_RSTREAM *rstream = NULL;
+    unsigned char *data = NULL;
+    unsigned char *read_buf = NULL;
+    const size_t data_size = 2 * SFRAME_LIST_MAX_FRAGMENTATION + 64;
+    const uint64_t past_tail = 2 * SFRAME_LIST_MAX_FRAGMENTATION;
+    size_t i, readbytes = 0;
+    int fin = 0, ret = 0;
+
+    if (!TEST_ptr(data = OPENSSL_malloc(data_size))
+        || !TEST_ptr(read_buf = OPENSSL_malloc(data_size))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL)))
+        goto err;
+
+    for (i = 0; i < data_size; i++)
+        data[i] = (unsigned char)(i & 0xff);
+
+    /* one byte frames separated by one byte gaps can never be merged */
+    for (i = 0; i < SFRAME_LIST_MAX_FRAGMENTATION; i++)
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 2 * i,
+                data + 2 * i, 1, 0)))
+            goto err;
+
+    /* a further frame would exceed the limit and must be refused */
+    if (!TEST_false(ossl_quic_rstream_queue_data(rstream, NULL, past_tail,
+            data + past_tail, 1, 0)))
+        goto err;
+
+    /* a retransmission of a buffered frame does not grow the list */
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 10,
+            data + 10, 1, 0)))
+        goto err;
+
+    /* a frame covering eleven buffered frames shrinks the list by ten */
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 0, data, 21, 0)))
+        goto err;
+
+    /* so exactly ten more frames fit, and the eleventh does not */
+    for (i = 0; i < 10; i++)
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL,
+                past_tail + 2 * i,
+                data + past_tail + 2 * i, 1, 0)))
+            goto err;
+
+    if (!TEST_false(ossl_quic_rstream_queue_data(rstream, NULL, past_tail + 20,
+            data + past_tail + 20, 1, 0)))
+        goto err;
+
+    /* the buffered data is unaffected by all of the above */
+    if (!TEST_true(ossl_quic_rstream_read(rstream, read_buf, data_size,
+            &readbytes, &fin))
+        || !TEST_false(fin)
+        || !TEST_size_t_eq(readbytes, 21)
+        || !TEST_mem_eq(read_buf, readbytes, data, 21))
+        goto err;
+
+    /* reading released one frame, so one more frame fits again */
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, past_tail + 20,
+            data + past_tail + 20, 1, 0))
+        || !TEST_false(ossl_quic_rstream_queue_data(rstream, NULL,
+            past_tail + 22,
+            data + past_tail + 22, 1, 0)))
+        goto err;
+
+    ret = 1;
+
+err:
+    ossl_quic_rstream_free(rstream);
+    OPENSSL_free(data);
+    OPENSSL_free(read_buf);
+    return ret;
+}
+
+/*
  * Small in-order frames are merged once their data is copied to the stream
  * buffer, so the frame limit does not apply to them however many arrive. The
  * data spans many buffer chunks, which the read path has to walk.
@@ -631,6 +710,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_sstream_bulk, 100);
     ADD_ALL_TESTS(test_rstream_simple, 2);
     ADD_ALL_TESTS(test_rstream_random, 100);
+    ADD_TEST(test_rstream_fragmentation_limit);
     ADD_TEST(test_rstream_small_frames);
     return 1;
 }

--- a/test/quic_stream_test.c
+++ b/test/quic_stream_test.c
@@ -379,14 +379,13 @@ static int test_rstream_simple(int idx)
     unsigned char buf[sizeof(simple_data)];
     size_t readbytes = 0, avail = 0;
     int fin = 0;
-    int use_rbuf = idx > 1;
     int use_sc = idx % 2;
     int (*read_fn)(QUIC_RSTREAM *, unsigned char *, size_t, size_t *,
         int *)
         = use_sc ? test_single_copy_read
                  : ossl_quic_rstream_read;
 
-    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL)))
         goto err;
 
     if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 5,
@@ -410,11 +409,6 @@ static int test_rstream_simple(int idx)
         || !TEST_false(fin)
         || !TEST_size_t_eq(readbytes, 1)
         || !TEST_mem_eq(buf, 1, simple_data, 1)
-        || (use_rbuf && !TEST_false(ossl_quic_rstream_move_to_rbuf(rstream)))
-        || (use_rbuf
-            && !TEST_true(ossl_quic_rstream_resize_rbuf(rstream,
-                sizeof(simple_data))))
-        || (use_rbuf && !TEST_true(ossl_quic_rstream_move_to_rbuf(rstream)))
         || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL,
             0, simple_data,
             10, 0))
@@ -446,10 +440,6 @@ static int test_rstream_simple(int idx)
             sizeof(simple_data),
             NULL,
             0, 1))
-        || (use_rbuf
-            && !TEST_true(ossl_quic_rstream_resize_rbuf(rstream,
-                2 * sizeof(simple_data))))
-        || (use_rbuf && !TEST_true(ossl_quic_rstream_move_to_rbuf(rstream)))
         || !TEST_true(read_fn(rstream, buf + 14, 5, &readbytes, &fin))
         || !TEST_false(fin)
         || !TEST_size_t_eq(readbytes, 5)
@@ -459,7 +449,6 @@ static int test_rstream_simple(int idx)
         || !TEST_true(fin)
         || !TEST_size_t_eq(readbytes, sizeof(buf) - 14 - 5)
         || !TEST_mem_eq(buf, sizeof(buf), simple_data, sizeof(simple_data))
-        || (use_rbuf && !TEST_true(ossl_quic_rstream_move_to_rbuf(rstream)))
         || !TEST_true(read_fn(rstream, buf, sizeof(buf), &readbytes, &fin))
         || !TEST_true(fin)
         || !TEST_size_t_eq(readbytes, 0))
@@ -485,7 +474,7 @@ static int test_rstream_random(int idx)
 
     if (!TEST_ptr(bulk_data = OPENSSL_malloc(data_size))
         || !TEST_ptr(read_buf = OPENSSL_malloc(data_size))
-        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL)))
         goto err;
 
     if (idx % 3 == 0)
@@ -550,11 +539,6 @@ static int test_rstream_random(int idx)
             goto err;
         read_off += readbytes;
         queued_min = read_off;
-        if (test_random() % 50 == 0)
-            if (!TEST_true(ossl_quic_rstream_resize_rbuf(rstream,
-                    queued_max - read_off + 1))
-                || !TEST_true(ossl_quic_rstream_move_to_rbuf(rstream)))
-                goto err;
         if (!fin_set && queued_max >= data_size - test_random() % 200) {
             fin_set = 1;
             /* Queue empty fin frame */
@@ -595,11 +579,58 @@ err:
     return ret;
 }
 
+/*
+ * Small in-order frames are merged once their data is copied to the stream
+ * buffer, so the frame limit does not apply to them however many arrive. The
+ * data spans many buffer chunks, which the read path has to walk.
+ */
+static int test_rstream_small_frames(void)
+{
+    QUIC_RSTREAM *rstream = NULL;
+    unsigned char *data = NULL;
+    unsigned char *read_buf = NULL;
+    const size_t frame_len = 4;
+    const size_t num_frames = 65536;
+    const size_t data_size = num_frames * frame_len;
+    size_t i, readbytes = 0;
+    int fin = 0, ret = 0;
+
+    if (!TEST_ptr(data = OPENSSL_malloc(data_size))
+        || !TEST_ptr(read_buf = OPENSSL_malloc(data_size))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL)))
+        goto err;
+
+    for (i = 0; i < data_size; i++)
+        data[i] = (unsigned char)(i & 0xff);
+
+    for (i = 0; i < num_frames; i++)
+        if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL,
+                i * frame_len, data + i * frame_len,
+                frame_len, 0)))
+            goto err;
+
+    if (!TEST_true(ossl_quic_rstream_read(rstream, read_buf, data_size,
+            &readbytes, &fin))
+        || !TEST_false(fin)
+        || !TEST_size_t_eq(readbytes, data_size)
+        || !TEST_mem_eq(read_buf, readbytes, data, data_size))
+        goto err;
+
+    ret = 1;
+
+err:
+    ossl_quic_rstream_free(rstream);
+    OPENSSL_free(data);
+    OPENSSL_free(read_buf);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_sstream_simple);
     ADD_ALL_TESTS(test_sstream_bulk, 100);
-    ADD_ALL_TESTS(test_rstream_simple, 4);
+    ADD_ALL_TESTS(test_rstream_simple, 2);
     ADD_ALL_TESTS(test_rstream_random, 100);
+    ADD_TEST(test_rstream_small_frames);
     return 1;
 }

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -1507,8 +1507,7 @@ static int run_script(int script_idx, const struct script_op *script)
                     1 * 1024 * 1024,
                     16 * 1024 * 1024,
                     fake_now, NULL))
-                || !TEST_ptr(s->rstream = ossl_quic_rstream_new(&s->rxfc,
-                                 NULL, 1024))) {
+                || !TEST_ptr(s->rstream = ossl_quic_rstream_new(&s->rxfc, NULL))) {
                 ossl_quic_sstream_free(s->sstream);
                 ossl_quic_stream_map_release(h.args.qsm, s);
                 goto err;


### PR DESCRIPTION
Receiving a stream is quadratic in the number of frames the peer sends. Inserting a frame that is not a simple append at the tail scans the frame list from the head, and the list is bounded only by the stream flow control window, with gaps counting towards it. Sending one byte frames at even offsets and then filling the odd ones takes 35 seconds of CPU for 262144 frames, which is about half of what the default 512 KiB window permits. Frames are also never merged, so even a gapless stream keeps one list entry per frame received until the application reads it, and each entry pins the packet it arrived in.

Looking at how other implementations avoid this, both nginx and ngtcp2 copy received stream data into fixed size chunks (4 KiB and 8 KiB respectively) rather than keeping references to the packets. That is what decouples their bookkeeping from the number of frames received and ties it to the bytes actually buffered instead. It turned out we already have most of the machinery for this: `ossl_sframe_list_move_data()` copies the data out and merges frames that have become contiguous, but it has never been called, because the ring buffer it writes into is always created with size 0. So this replaces that ring buffer with a list of chunks allocated on demand and calls the copy once a stream accumulates enough frames. A stream received in order then collapses to a single list entry however many frames it arrived in, and the packets are released.

Copying alone is not enough, because frames separated by gaps still cannot be merged, and with the copy pass in place the quadratic simply moves from the insert scan into the copy walk. So there is still a limit on how many entries the list may hold, set to 4000 to match ngtcp2, which rejects the same condition once its reorder buffer holds 4000 gaps and raised that from 1000 to cope with high loss and large flow control windows.

This overlaps with #32126, which limits the number of buffered frames without changing anything else. That one is deliberately minimal and derives its limit from the flow control window, because without merging the limit has to tolerate  a peer sending many small frames in order. Here the merging does that work, so the limit can be a plain constant and only ever triggers on genuinely fragmented streams. If this is acceptable then #32126 is not needed, otherwise #32126 stands on its own as the smaller change.