### PR TITLE
Fix AArch64 Poly1305 SVE2 symbol visibility

### DIFF
--- a/crypto/poly1305/asm/poly1305-armv9-sve2.pl
+++ b/crypto/poly1305/asm/poly1305-armv9-sve2.pl
@@ -304,6 +304,7 @@ poly1305_lazy_reduce_sve2:
 //  a VLA risc-v implementation in https://github.com/dot-asm/cryptogams.
 //
 .globl	poly1305_blocks_sve2
+.hidden	poly1305_blocks_sve2
 .type	poly1305_blocks_sve2,%function
 .align	5
 poly1305_blocks_sve2:


### PR DESCRIPTION
poly1305-armv8.pl materializes the address of `poly1305_blocks_sve2` using a direct ADRP/ADD sequence. Because the symbol has default visibility, ELF linkers can treat it as preemptible and reject the `R_AARCH64_ADR_PREL_PG_HI21` relocation when building a shared library.

Mark `poly1305_blocks_sve2` hidden so it is bound locally. The assembly translator emits `.hidden` for ELF, `.private_extern` for Mach-O, and omits the directive for Windows.

Validation performed:

- Linked the generated AArch64 objects into shared libraries with LLD 18 and GNU ld 2.42.
- Confirmed that `poly1305_blocks_sve2` is `GLOBAL HIDDEN` and absent from the dynamic symbol table.
- Compiled the generated assembly for arm64 Apple Darwin and AArch64 Windows targets.
- Ran `make test TESTS=test_internal_poly1305`.

Fixes #31670
