### PR TITLE
Add MIPS32 ChaCha20 and Poly1305 assembly

### DIFF
--- a/crypto/chacha/asm/chacha-mips.pl
+++ b/crypto/chacha/asm/chacha-mips.pl
@@ -1,0 +1,573 @@
+#! /usr/bin/env perl
+# Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+#
+# ====================================================================
+# Written by Andy Polyakov, @dot-asm, initially for use with OpenSSL.
+# The module is, however, dual licensed under OpenSSL and CRYPTOGAMS
+# licenses depending on where you obtain it. For further details see
+# https://github.com/dot-asm/cryptogams/.
+# ====================================================================
+# ChaCha20 for MIPS.
+#
+# March 2019.
+#
+# Even though compiler seems to generate optimal rounds loop, same as
+# ROUNDs below, it somehow screws up the outer loop...
+#
+# R1x000	15.5/?		(big-endian)
+# Octeon II	9.2(*)/+65%	(little-endian)
+#
+# (*)	aligned intput and output, result for misaligned is 10.7;
+#
+######################################################################
+# There is a number of MIPS ABI in use, O32 and N32/64 are most
+# widely used. Then there is a new contender: NUBI. It appears that if
+# one picks the latter, it's possible to arrange code in ABI neutral
+# manner. Therefore let's stick to NUBI register layout:
+#
+($zero,$at,$t0,$t1,$t2)=map("\$$_",(0..2,24,25));
+($a0,$a1,$a2,$a3,$a4,$a5,$a6,$a7)=map("\$$_",(4..11));
+($s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7,$s8,$s9,$s10,$s11)=map("\$$_",(12..23));
+($gp,$tp,$sp,$fp,$ra)=map("\$$_",(3,28..31));
+#
+# The return value is placed in $a0. Following coding rules facilitate
+# interoperability:
+#
+# - never ever touch $tp, "thread pointer", former $gp;
+# - copy return value to $t0, former $v0 [or to $a0 if you're adapting
+#   old code];
+# - on O32 populate $a4-$a7 with 'lw $aN,4*N($sp)' if necessary;
+#
+# For reference here is register layout for N32/64 MIPS ABIs:
+#
+# ($zero,$at,$v0,$v1)=map("\$$_",(0..3));
+# ($a0,$a1,$a2,$a3,$a4,$a5,$a6,$a7)=map("\$$_",(4..11));
+# ($t0,$t1,$t2,$t3,$t8,$t9)=map("\$$_",(12..15,24,25));
+# ($s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7)=map("\$$_",(16..23));
+# ($gp,$sp,$fp,$ra)=map("\$$_",(28..31));
+#
+$flavour = shift || "o32"; # supported flavours are o32,n32,64,nubi32,nubi64
+
+if ($flavour =~ /64|n32/i) {
+	$PTR_ADD="daddu";	# incidentally works even on n32
+	$PTR_SUB="dsubu";	# incidentally works even on n32
+	$REG_S="sd";
+	$REG_L="ld";
+	$PTR_SLL="dsll";	# incidentally works even on n32
+	$SZREG=8;
+} else {
+	$PTR_ADD="addu";
+	$PTR_SUB="subu";
+	$REG_S="sw";
+	$REG_L="lw";
+	$PTR_SLL="sll";
+	$SZREG=4;
+}
+
+$FRAMESIZE=64+16*$SZREG;
+$SAVED_REGS_MASK = ($flavour =~ /nubi/i) ? "0xc0fff008" : "0xc0ff0000";
+#
+######################################################################
+
+my @x = map("\$$_",(10..25));
+my @y = map("\$$_",(2,3,7..9,1,31));
+my ($out, $inp, $len, $key, $counter) = ($a0,$a1,$a2,$a3,$a4);
+
+sub ROUND {
+my ($a0,$b0,$c0,$d0)=@_;
+my ($a1,$b1,$c1,$d1)=map(($_&~3)+(($_+1)&3),($a0,$b0,$c0,$d0));
+my ($a2,$b2,$c2,$d2)=map(($_&~3)+(($_+1)&3),($a1,$b1,$c1,$d1));
+my ($a3,$b3,$c3,$d3)=map(($_&~3)+(($_+1)&3),($a2,$b2,$c2,$d2));
+
+$code.=<<___;
+	addu		@x[$a0],@x[$a0],@x[$b0]		# Q0
+	 addu		@x[$a1],@x[$a1],@x[$b1]		# Q1
+	  addu		@x[$a2],@x[$a2],@x[$b2]		# Q2
+	   addu		@x[$a3],@x[$a3],@x[$b3]		# Q3
+	xor		@x[$d0],@x[$d0],@x[$a0]
+	 xor		@x[$d1],@x[$d1],@x[$a1]
+	  xor		@x[$d2],@x[$d2],@x[$a2]
+	   xor		@x[$d3],@x[$d3],@x[$a3]
+#if defined(_MIPS_ARCH_MIPS32R2) || defined(_MIPS_ARCH_MIPS64R2)
+	rotr		@x[$d0],@x[$d0],16
+	 rotr		@x[$d1],@x[$d1],16
+	  rotr		@x[$d2],@x[$d2],16
+	   rotr		@x[$d3],@x[$d3],16
+#else
+	srl		@y[0],@x[$d0],16
+	 srl		@y[1],@x[$d1],16
+	  srl		@y[2],@x[$d2],16
+	   srl		@y[3],@x[$d3],16
+	sll		@x[$d0],@x[$d0],16
+	 sll		@x[$d1],@x[$d1],16
+	  sll		@x[$d2],@x[$d2],16
+	   sll		@x[$d3],@x[$d3],16
+	or		@x[$d0],@x[$d0],@y[0]
+	 or		@x[$d1],@x[$d1],@y[1]
+	  or		@x[$d2],@x[$d2],@y[2]
+	   or		@x[$d3],@x[$d3],@y[3]
+#endif
+
+	addu		@x[$c0],@x[$c0],@x[$d0]
+	 addu		@x[$c1],@x[$c1],@x[$d1]
+	  addu		@x[$c2],@x[$c2],@x[$d2]
+	   addu		@x[$c3],@x[$c3],@x[$d3]
+	xor		@x[$b0],@x[$b0],@x[$c0]
+	 xor		@x[$b1],@x[$b1],@x[$c1]
+	  xor		@x[$b2],@x[$b2],@x[$c2]
+	   xor		@x[$b3],@x[$b3],@x[$c3]
+#if defined(_MIPS_ARCH_MIPS32R2) || defined(_MIPS_ARCH_MIPS64R2)
+	rotr		@x[$b0],@x[$b0],20
+	 rotr		@x[$b1],@x[$b1],20
+	  rotr		@x[$b2],@x[$b2],20
+	   rotr		@x[$b3],@x[$b3],20
+#else
+	srl		@y[0],@x[$b0],20
+	 srl		@y[1],@x[$b1],20
+	  srl		@y[2],@x[$b2],20
+	   srl		@y[3],@x[$b3],20
+	sll		@x[$b0],@x[$b0],12
+	 sll		@x[$b1],@x[$b1],12
+	  sll		@x[$b2],@x[$b2],12
+	   sll		@x[$b3],@x[$b3],12
+	or		@x[$b0],@x[$b0],@y[0]
+	 or		@x[$b1],@x[$b1],@y[1]
+	  or		@x[$b2],@x[$b2],@y[2]
+	   or		@x[$b3],@x[$b3],@y[3]
+#endif
+
+	addu		@x[$a0],@x[$a0],@x[$b0]
+	 addu		@x[$a1],@x[$a1],@x[$b1]
+	  addu		@x[$a2],@x[$a2],@x[$b2]
+	   addu		@x[$a3],@x[$a3],@x[$b3]
+	xor		@x[$d0],@x[$d0],@x[$a0]
+	 xor		@x[$d1],@x[$d1],@x[$a1]
+	  xor		@x[$d2],@x[$d2],@x[$a2]
+	   xor		@x[$d3],@x[$d3],@x[$a3]
+#if defined(_MIPS_ARCH_MIPS32R2) || defined(_MIPS_ARCH_MIPS64R2)
+	rotr		@x[$d0],@x[$d0],24
+	 rotr		@x[$d1],@x[$d1],24
+	  rotr		@x[$d2],@x[$d2],24
+	   rotr		@x[$d3],@x[$d3],24
+#else
+	srl		@y[0],@x[$d0],24
+	 srl		@y[1],@x[$d1],24
+	  srl		@y[2],@x[$d2],24
+	   srl		@y[3],@x[$d3],24
+	sll		@x[$d0],@x[$d0],8
+	 sll		@x[$d1],@x[$d1],8
+	  sll		@x[$d2],@x[$d2],8
+	   sll		@x[$d3],@x[$d3],8
+	or		@x[$d0],@x[$d0],@y[0]
+	 or		@x[$d1],@x[$d1],@y[1]
+	  or		@x[$d2],@x[$d2],@y[2]
+	   or		@x[$d3],@x[$d3],@y[3]
+#endif
+
+	addu		@x[$c0],@x[$c0],@x[$d0]
+	 addu		@x[$c1],@x[$c1],@x[$d1]
+	  addu		@x[$c2],@x[$c2],@x[$d2]
+	   addu		@x[$c3],@x[$c3],@x[$d3]
+	xor		@x[$b0],@x[$b0],@x[$c0]
+	 xor		@x[$b1],@x[$b1],@x[$c1]
+	  xor		@x[$b2],@x[$b2],@x[$c2]
+	   xor		@x[$b3],@x[$b3],@x[$c3]
+#if defined(_MIPS_ARCH_MIPS32R2) || defined(_MIPS_ARCH_MIPS64R2)
+	rotr		@x[$b0],@x[$b0],25
+	 rotr		@x[$b1],@x[$b1],25
+	  rotr		@x[$b2],@x[$b2],25
+	   rotr		@x[$b3],@x[$b3],25
+#else
+	srl		@y[0],@x[$b0],25
+	 srl		@y[1],@x[$b1],25
+	  srl		@y[2],@x[$b2],25
+	   srl		@y[3],@x[$b3],25
+	sll		@x[$b0],@x[$b0],7
+	 sll		@x[$b1],@x[$b1],7
+	  sll		@x[$b2],@x[$b2],7
+	   sll		@x[$b3],@x[$b3],7
+	or		@x[$b0],@x[$b0],@y[0]
+	 or		@x[$b1],@x[$b1],@y[1]
+	  or		@x[$b2],@x[$b2],@y[2]
+	   or		@x[$b3],@x[$b3],@y[3]
+#endif
+___
+}
+
+$code.=<<___;
+# if (defined(__mips_smartmips) || defined(_MIPS_ARCH_MIPS32R3) || \\
+      defined(_MIPS_ARCH_MIPS32R5) || defined(_MIPS_ARCH_MIPS32R6)) \\
+      && !defined(_MIPS_ARCH_MIPS32R2)
+#  define _MIPS_ARCH_MIPS32R2
+# endif
+
+# if (defined(_MIPS_ARCH_MIPS64R3) || defined(_MIPS_ARCH_MIPS64R5) || \\
+      defined(_MIPS_ARCH_MIPS64R6)) \\
+      && !defined(_MIPS_ARCH_MIPS64R2)
+#  define _MIPS_ARCH_MIPS64R2
+# endif
+
+#if defined(__MIPSEB__) && !defined(MIPSEB)
+# define MIPSEB
+#endif
+
+.text
+
+.set	noat
+.set	reorder
+
+.align	5
+.ent	__ChaCha
+__ChaCha:
+	.frame	$sp,0,$ra
+	.mask	0,0
+	.set	reorder
+	lw		@x[0], 4*0($sp)
+	lw		@x[1], 4*1($sp)
+	lw		@x[2], 4*2($sp)
+	lw		@x[3], 4*3($sp)
+	lw		@x[4], 4*4($sp)
+	lw		@x[5], 4*5($sp)
+	lw		@x[6], 4*6($sp)
+	lw		@x[7], 4*7($sp)
+	lw		@x[8], 4*8($sp)
+	lw		@x[9], 4*9($sp)
+	lw		@x[10],4*10($sp)
+	lw		@x[11],4*11($sp)
+	move		@x[12],$fp
+	lw		@x[13],4*13($sp)
+	lw		@x[14],4*14($sp)
+	lw		@x[15],4*15($sp)
+.Lalt_entry:
+#if defined(_MIPS_ARCH_MIPS32R2) || defined(_MIPS_ARCH_MIPS64R2)
+	move		@y[0],@x[0]
+	move		@y[1],@x[1]
+	move		@y[2],@x[2]
+	move		@y[3],@x[3]
+#endif
+.Loop:
+___
+	&ROUND(0, 4, 8, 12);
+	&ROUND(0, 5, 10, 15);
+$code.=<<___;
+	.set		noreorder
+	bnez		$at,.Loop
+	subu		$at,$at,1
+	.set		reorder
+
+#if !defined(_MIPS_ARCH_MIPS32R2) && !defined(_MIPS_ARCH_MIPS64R2)
+	lw		@y[0], 4*0($sp)
+	lw		@y[1], 4*1($sp)
+	lw		@y[2], 4*2($sp)
+	lw		@y[3], 4*3($sp)
+#endif
+	addu		@x[0],@x[0],@y[0]
+	lw		@y[0],4*4($sp)
+	addu		@x[1],@x[1],@y[1]
+	lw		@y[1],4*5($sp)
+	addu		@x[2],@x[2],@y[2]
+	lw		@y[2],4*6($sp)
+	addu		@x[3],@x[3],@y[3]
+	lw		@y[3],4*7($sp)
+	addu		@x[4],@x[4],@y[0]
+	lw		@y[0],4*8($sp)
+	addu		@x[5],@x[5],@y[1]
+	lw		@y[1], 4*9($sp)
+	addu		@x[6],@x[6],@y[2]
+	lw		@y[2],4*10($sp)
+	addu		@x[7],@x[7],@y[3]
+	lw		@y[3],4*11($sp)
+	addu		@x[8],@x[8],@y[0]
+	#lw		@y[0],4*12($sp)
+	addu		@x[9],@x[9],@y[1]
+	lw		@y[1],4*13($sp)
+	addu		@x[10],@x[10],@y[2]
+	lw		@y[2],4*14($sp)
+	addu		@x[11],@x[11],@y[3]
+	lw		@y[3],4*15($sp)
+	addu		@x[12],@x[12],$fp
+	addu		@x[13],@x[13],@y[1]
+	addu		@x[14],@x[14],@y[2]
+	addu		@x[15],@x[15],@y[3]
+	jr		$ra
+.end	__ChaCha
+
+.globl	ChaCha20_ctr32
+.align	5
+.ent	ChaCha20_ctr32
+ChaCha20_ctr32:
+	.frame	$sp,$FRAMESIZE,$ra
+	.mask	$SAVED_REGS_MASK,-$SZREG
+	.set	noreorder
+	$PTR_SUB	$sp,$sp,$FRAMESIZE
+	$REG_S		$ra, ($FRAMESIZE-1*$SZREG)($sp)
+	$REG_S		$fp, ($FRAMESIZE-2*$SZREG)($sp)
+	$REG_S		$s11,($FRAMESIZE-3*$SZREG)($sp)
+	$REG_S		$s10,($FRAMESIZE-4*$SZREG)($sp)
+	$REG_S		$s9, ($FRAMESIZE-5*$SZREG)($sp)
+	$REG_S		$s8, ($FRAMESIZE-6*$SZREG)($sp)
+	$REG_S		$s7, ($FRAMESIZE-7*$SZREG)($sp)
+	$REG_S		$s6, ($FRAMESIZE-8*$SZREG)($sp)
+	$REG_S		$s5, ($FRAMESIZE-9*$SZREG)($sp)
+	$REG_S		$s4, ($FRAMESIZE-10*$SZREG)($sp)
+___
+$code.=<<___ if ($flavour =~ /nubi/i);	# optimize non-nubi prologue
+	$REG_S		$s3, ($FRAMESIZE-11*$SZREG)($sp)
+	$REG_S		$s2, ($FRAMESIZE-12*$SZREG)($sp)
+	$REG_S		$s1, ($FRAMESIZE-13*$SZREG)($sp)
+	$REG_S		$s0, ($FRAMESIZE-14*$SZREG)($sp)
+	$REG_S		$gp, ($FRAMESIZE-15*$SZREG)($sp)
+___
+$code.=<<___ if ($flavour =~ /o32/i);
+	lw		$a4,($FRAMESIZE+4*4)($sp)
+___
+$code.=<<___;
+	.set	reorder
+
+	lui		@x[0],0x6170		# compose sigma
+	lui		@x[1],0x3320
+	lui		@x[2],0x7962
+	lui		@x[3],0x6b20
+	ori		@x[0],@x[0],0x7865
+	ori		@x[1],@x[1],0x646e
+	ori		@x[2],@x[2],0x2d32
+	ori		@x[3],@x[3],0x6574
+
+	lw		@x[4], 4*0($key)
+	lw		@x[5], 4*1($key)
+	lw		@x[6], 4*2($key)
+	lw		@x[7], 4*3($key)
+	lw		@x[8], 4*4($key)
+	lw		@x[9], 4*5($key)
+	lw		@x[10],4*6($key)
+	lw		@x[11],4*7($key)
+
+	lw		@x[12],4*0($counter)
+	lw		@x[13],4*1($counter)
+	lw		@x[14],4*2($counter)
+	lw		@x[15],4*3($counter)
+
+	sw		@x[0], 4*0($sp)
+	sw		@x[1], 4*1($sp)
+	sw		@x[2], 4*2($sp)
+	sw		@x[3], 4*3($sp)
+	sw		@x[4], 4*4($sp)
+	sw		@x[5], 4*5($sp)
+	sw		@x[6], 4*6($sp)
+	sw		@x[7], 4*7($sp)
+	sw		@x[8], 4*8($sp)
+	sw		@x[9], 4*9($sp)
+	sw		@x[10],4*10($sp)
+	sw		@x[11],4*11($sp)
+	move		$fp,@x[12]
+	sw		@x[13],4*13($sp)
+	sw		@x[14],4*14($sp)
+	sw		@x[15],4*15($sp)
+
+	li		$at,9
+	bal		.Lalt_entry
+
+	sltiu		$at,$len,64
+	or		$ra,$inp,$out
+	andi		$ra,$ra,3		# both are aligned?
+	bnez		$at,.Ltail
+
+#ifndef	MIPSEB
+	beqz		$ra,.Loop_aligned
+#endif
+.Loop_misaligned:
+	# On little-endian pre-R6 processor it's possible to reduce
+	# amount of instructions by using lwl+lwr to load input, and
+	# single 'xor' per word. Judging from sheer instruction count
+	# it could give ~15% improvement. But in real life it turned
+	# to be just ~5%, too little to care about...
+
+	lbu		@y[0],0($inp)
+	lbu		@y[1],1($inp)
+	srl		@y[4],@x[0],8
+	lbu		@y[2],2($inp)
+	srl		@y[5],@x[0],16
+	lbu		@y[3],3($inp)
+	srl		@y[6],@x[0],24
+___
+for(my $i=0; $i<15; $i++) {
+my $j=4*$i;
+my $k=4*($i+1);
+$code.=<<___;
+	xor		@x[$i],@x[$i],@y[0]
+	lbu		@y[0],$k+0($inp)
+	xor		@y[4],@y[4],@y[1]
+	lbu		@y[1],$k+1($inp)
+	xor		@y[5],@y[5],@y[2]
+	lbu		@y[2],$k+2($inp)
+	xor		@y[6],@y[6],@y[3]
+	lbu		@y[3],$k+3($inp)
+	sb		@x[$i],$j+0($out)
+	sb		@y[4],$j+1($out)
+	srl		@y[4],@x[$i+1],8
+	sb		@y[5],$j+2($out)
+	srl		@y[5],@x[$i+1],16
+	sb		@y[6],$j+3($out)
+	srl		@y[6],@x[$i+1],24
+___
+}
+$code.=<<___;
+	xor		@x[15],@x[15],@y[0]
+	xor		@y[4],@y[4],@y[1]
+	xor		@y[5],@y[5],@y[2]
+	xor		@y[6],@y[6],@y[3]
+	sb		@x[15],60($out)
+	addu		$fp,$fp,1		# next counter value
+	sb		@y[4],61($out)
+	$PTR_SUB	$len,$len,64
+	sb		@y[5],62($out)
+	$PTR_ADD	$inp,$inp,64
+	sb		@y[6],63($out)
+	$PTR_ADD	$out,$out,64
+	beqz		$len,.Ldone
+
+	sltiu		@y[4],$len,64
+	li		$at,9
+	bal		__ChaCha
+
+	beqz		@y[4],.Loop_misaligned
+
+#ifndef	MIPSEB
+	b		.Ltail
+
+.align	4
+.Loop_aligned:
+	lw		@y[0],0($inp)
+	lw		@y[1],4($inp)
+	lw		@y[2],8($inp)
+	lw		@y[3],12($inp)
+___
+for (my $i=0; $i<12; $i+=4) {
+my $j = 4*$i;
+my $k = 4*($i+4);
+$code.=<<___;
+	xor		@x[$i+0],@x[$i+0],@y[0]
+	lw		@y[0],$k+0($inp)
+	xor		@x[$i+1],@x[$i+1],@y[1]
+	lw		@y[1],$k+4($inp)
+	xor		@x[$i+2],@x[$i+2],@y[2]
+	lw		@y[2],$k+8($inp)
+	xor		@x[$i+3],@x[$i+3],@y[3]
+	lw		@y[3],$k+12($inp)
+	sw		@x[$i+0],$j+0($out)
+	sw		@x[$i+1],$j+4($out)
+	sw		@x[$i+2],$j+8($out)
+	sw		@x[$i+3],$j+12($out)
+___
+}
+$code.=<<___;
+	xor		@x[12],@x[12],@y[0]
+	xor		@x[13],@x[13],@y[1]
+	xor		@x[14],@x[14],@y[2]
+	xor		@x[15],@x[15],@y[3]
+	sw		@x[12],48($out)
+	addu		$fp,$fp,1		# next counter value
+	sw		@x[13],52($out)
+	$PTR_SUB	$len,$len,64
+	sw		@x[14],56($out)
+	$PTR_ADD	$inp,$inp,64
+	sw		@x[15],60($out)
+	$PTR_ADD	$out,$out,64
+	sltiu		@y[4],$len,64
+	beqz		$len,.Ldone
+
+	li		$at,9
+	bal		__ChaCha
+
+	beqz		@y[4],.Loop_aligned
+#endif
+.Ltail:
+	move		$fp,$sp
+	sw		@x[1], 4*1($sp)
+	sw		@x[2], 4*2($sp)
+	sw		@x[3], 4*3($sp)
+	sw		@x[4], 4*4($sp)
+	sw		@x[5], 4*5($sp)
+	sw		@x[6], 4*6($sp)
+	sw		@x[7], 4*7($sp)
+	sw		@x[8], 4*8($sp)
+	sw		@x[9], 4*9($sp)
+	sw		@x[10],4*10($sp)
+	sw		@x[11],4*11($sp)
+	sw		@x[12],4*12($sp)
+	sw		@x[13],4*13($sp)
+	sw		@x[14],4*14($sp)
+	sw		@x[15],4*15($sp)
+
+.Loop_tail:
+	sltiu		$at,$len,4
+	$PTR_ADD	$fp,$fp,4
+	bnez		$at,.Last_word
+
+	lbu		@y[0],0($inp)
+	lbu		@y[1],1($inp)
+	lbu		@y[2],2($inp)
+	$PTR_SUB	$len,$len,4
+	lbu		@y[3],3($inp)
+	$PTR_ADD	$inp,$inp,4
+	xor		@y[0],@y[0],@x[0]
+	srl		@x[0],@x[0],8
+	xor		@y[1],@y[1],@x[0]
+	srl		@x[0],@x[0],8
+	xor		@y[2],@y[2],@x[0]
+	srl		@x[0],@x[0],8
+	xor		@y[3],@y[3],@x[0]
+	lw		@x[0],0($fp)
+	sb		@y[0],0($out)
+	sb		@y[1],1($out)
+	sb		@y[2],2($out)
+	sb		@y[3],3($out)
+	$PTR_ADD	$out,$out,4
+	b		.Loop_tail
+
+	.set	noreorder
+.Last_word:
+	beqz		$len,.Ldone
+	$PTR_SUB	$len,$len,1
+	lbu		@y[0],0($inp)
+	$PTR_ADD	$inp,$inp,1
+	xor		@y[0],@y[0],@x[0]
+	srl		@x[0],@x[0],8
+	sb		@y[0],0($out)
+	b		.Last_word
+	$PTR_ADD	$out,$out,1
+
+.align	4
+.Ldone:
+	$REG_L		$ra, ($FRAMESIZE-1*$SZREG)($sp)
+	$REG_L		$fp, ($FRAMESIZE-2*$SZREG)($sp)
+	$REG_L		$s11,($FRAMESIZE-3*$SZREG)($sp)
+	$REG_L		$s10,($FRAMESIZE-4*$SZREG)($sp)
+	$REG_L		$s9, ($FRAMESIZE-5*$SZREG)($sp)
+	$REG_L		$s8, ($FRAMESIZE-6*$SZREG)($sp)
+	$REG_L		$s7, ($FRAMESIZE-7*$SZREG)($sp)
+	$REG_L		$s6, ($FRAMESIZE-8*$SZREG)($sp)
+	$REG_L		$s5, ($FRAMESIZE-9*$SZREG)($sp)
+	$REG_L		$s4, ($FRAMESIZE-10*$SZREG)($sp)
+___
+$code.=<<___ if ($flavour =~ /nubi/i);
+	$REG_L		$s3, ($FRAMESIZE-11*$SZREG)($sp)
+	$REG_L		$s2, ($FRAMESIZE-12*$SZREG)($sp)
+	$REG_L		$s1, ($FRAMESIZE-13*$SZREG)($sp)
+	$REG_L		$s0, ($FRAMESIZE-14*$SZREG)($sp)
+	$REG_L		$gp, ($FRAMESIZE-15*$SZREG)($sp)
+___
+$code.=<<___;
+	jr		$ra
+	$PTR_ADD	$sp,$sp,$FRAMESIZE
+.end	ChaCha20_ctr32
+___
+
+$output=pop and open STDOUT,">$output";
+print $code;
+close STDOUT;

--- a/crypto/chacha/build.info
+++ b/crypto/chacha/build.info
@@ -14,6 +14,8 @@ IF[{- !$disabled{asm} -}]
 
   $CHACHAASM_loongarch64=chacha-loongarch64.S
 
+  $CHACHAASM_mips32=chacha-mips.S
+
   $CHACHAASM_ppc32=chacha_ppc.c chacha-ppc.s
   IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
     $CHACHAASM_ppc32=chacha_ppc.c chacha-ppc.s chachap10-ppc.s
@@ -57,5 +59,6 @@ GENERATE[chacha-s390x.S]=asm/chacha-s390x.pl
 GENERATE[chacha-ia64.S]=asm/chacha-ia64.pl
 GENERATE[chacha-ia64.s]=chacha-ia64.S
 GENERATE[chacha-loongarch64.S]=asm/chacha-loongarch64.pl
+GENERATE[chacha-mips.S]=asm/chacha-mips.pl
 GENERATE[chacha-riscv64-v-zbb.s]=asm/chacha-riscv64-v-zbb.pl
 GENERATE[chacha-riscv64-v-zbb-zvkb.s]=asm/chacha-riscv64-v-zbb.pl zvkb

--- a/crypto/poly1305/asm/poly1305-mips.pl
+++ b/crypto/poly1305/asm/poly1305-mips.pl
@@ -1,29 +1,44 @@
 #! /usr/bin/env perl
-# Copyright 2016-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
-
 # ====================================================================
-# Written by Andy Polyakov, @dot-asm, initially for use in the OpenSSL
+# Written by Andy Polyakov, @dot-asm, originally for the OpenSSL
 # project. The module is, however, dual licensed under OpenSSL and
 # CRYPTOGAMS licenses depending on where you obtain it. For further
 # details see https://github.com/dot-asm/cryptogams/.
 # ====================================================================
 
-# Poly1305 hash for MIPS64.
+
+# Poly1305 hash for MIPS.
 #
 # May 2016
 #
 # Numbers are cycles per processed byte with poly1305_blocks alone.
 #
 #		IALU/gcc
-# R1x000	5.64/+120%	(big-endian)
-# Octeon II	3.80/+280%	(little-endian)
-
+# R1x000	5.00/+150%	(big-endian)
+# Octeon II	2.50/+70%	(little-endian)
+#
+# March 2019
+#
+# Add 32-bit code path.
+#
+# October 2019
+#
+# Modulo-scheduling reduction allows to omit dependency chain at the
+# end of inner loop and improve performance. Also optimize MIPS32R2
+# code path for MIPS 1004K core. Per René van Dorst's suggestions.
+#
+#		IALU/gcc
+# R1x000	10.0/?		(big-endian)
+# Octeon II	3.65/+140%	(little-endian)
+# MT7621/1004K	4.65/?		(little-endian)
+#
 ######################################################################
 # There is a number of MIPS ABI in use, O32 and N32/64 are most
 # widely used. Then there is a new contender: NUBI. It appears that if
@@ -52,26 +67,48 @@
 # ($s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7)=map("\$$_",(16..23));
 # ($gp,$sp,$fp,$ra)=map("\$$_",(28..31));
 #
-# <https://github.com/dot-asm>
+# <appro@openssl.org>
 #
 ######################################################################
 
-# $output is the last argument if it looks like a file (it has an extension)
-# $flavour is the first argument if it doesn't look like a file
-$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
-# supported flavours are o32,n32,64,nubi32,nubi64, default is o32
-$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : "o32";
-
-die "MIPS64 only" unless ($flavour =~ /64|n32/i);
+$flavour = shift || "64"; # supported flavours are o32,n32,64,nubi32,nubi64
 
 $v0 = ($flavour =~ /nubi/i) ? $a0 : $t0;
-$SAVED_REGS_MASK = ($flavour =~ /nubi/i) ? "0x0003f000" : "0x00030000";
 
-($ctx,$inp,$len,$padbit) = ($a0,$a1,$a2,$a3);
-($in0,$in1,$tmp0,$tmp1,$tmp2,$tmp3,$tmp4) = ($a4,$a5,$a6,$a7,$at,$t0,$t1);
+if ($flavour =~ /64|n32/i) {{{
+######################################################################
+# 64-bit code path
+#
+
+my ($ctx,$inp,$len,$padbit) = ($a0,$a1,$a2,$a3);
+my ($in0,$in1,$tmp0,$tmp1,$tmp2,$tmp3,$tmp4) = ($a4,$a5,$a6,$a7,$at,$t0,$t1);
 
 $code.=<<___;
-#include "arch/mips_arch.h"
+#if (defined(_MIPS_ARCH_MIPS64R3) || defined(_MIPS_ARCH_MIPS64R5) || \\
+     defined(_MIPS_ARCH_MIPS64R6)) \\
+     && !defined(_MIPS_ARCH_MIPS64R2)
+# define _MIPS_ARCH_MIPS64R2
+#endif
+
+#if defined(_MIPS_ARCH_MIPS64R6)
+# define dmultu(rs,rt)
+# define mflo(rd,rs,rt)	dmulu	rd,rs,rt
+# define mfhi(rd,rs,rt)	dmuhu	rd,rs,rt
+#else
+# define dmultu(rs,rt)		dmultu	rs,rt
+# define mflo(rd,rs,rt)	mflo	rd
+# define mfhi(rd,rs,rt)	mfhi	rd
+#endif
+
+#ifdef	__KERNEL__
+# define poly1305_init   poly1305_init_mips
+# define poly1305_blocks poly1305_blocks_mips
+# define poly1305_emit   poly1305_emit_mips
+#endif
+
+#if defined(__MIPSEB__) && !defined(MIPSEB)
+# define MIPSEB
+#endif
 
 #ifdef MIPSEB
 # define MSB 0
@@ -99,8 +136,29 @@ poly1305_init:
 	beqz	$inp,.Lno_key
 
 #if defined(_MIPS_ARCH_MIPS64R6)
+	andi	$tmp0,$inp,7		# $inp % 8
+	dsubu	$inp,$inp,$tmp0		# align $inp
+	sll	$tmp0,$tmp0,3		# byte to bit offset
 	ld	$in0,0($inp)
 	ld	$in1,8($inp)
+	beqz	$tmp0,.Laligned_key
+	ld	$tmp2,16($inp)
+
+	subu	$tmp1,$zero,$tmp0
+# ifdef	MIPSEB
+	dsllv	$in0,$in0,$tmp0
+	dsrlv	$tmp3,$in1,$tmp1
+	dsllv	$in1,$in1,$tmp0
+	dsrlv	$tmp2,$tmp2,$tmp1
+# else
+	dsrlv	$in0,$in0,$tmp0
+	dsllv	$tmp3,$in1,$tmp1
+	dsrlv	$in1,$in1,$tmp0
+	dsllv	$tmp2,$tmp2,$tmp1
+# endif
+	or	$in0,$in0,$tmp3
+	or	$in1,$in1,$tmp2
+.Laligned_key:
 #else
 	ldl	$in0,0+MSB($inp)
 	ldl	$in1,8+MSB($inp)
@@ -150,13 +208,13 @@ poly1305_init:
 # endif
 #endif
 	li	$tmp0,1
-	dsll	$tmp0,32
-	daddiu	$tmp0,-63
-	dsll	$tmp0,28
-	daddiu	$tmp0,-1		# 0ffffffc0fffffff
+	dsll	$tmp0,32		# 0x0000000100000000
+	daddiu	$tmp0,-63		# 0x00000000ffffffc1
+	dsll	$tmp0,28		# 0x0ffffffc10000000
+	daddiu	$tmp0,-1		# 0x0ffffffc0fffffff
 
 	and	$in0,$tmp0
-	daddiu	$tmp0,-3		# 0ffffffc0ffffffc
+	daddiu	$tmp0,-3		# 0x0ffffffc0ffffffc
 	and	$in1,$tmp0
 
 	sd	$in0,24($ctx)
@@ -171,8 +229,11 @@ poly1305_init:
 .end	poly1305_init
 ___
 {
-my ($h0,$h1,$h2,$r0,$r1,$s1,$d0,$d1,$d2) =
+my $SAVED_REGS_MASK = ($flavour =~ /nubi/i) ? "0x0003f000" : "0x00030000";
+
+my ($h0,$h1,$h2,$r0,$r1,$rs1,$d0,$d1,$d2) =
    ($s0,$s1,$s2,$s3,$s4,$s5,$in0,$in1,$t2);
+my ($shr,$shl) = ($s6,$s7);		# used on R6
 
 $code.=<<___;
 .align	5
@@ -190,10 +251,18 @@ poly1305_blocks:
 .align	5
 .ent	poly1305_blocks_internal
 poly1305_blocks_internal:
+	.set	noreorder
+#if defined(_MIPS_ARCH_MIPS64R6)
+	.frame	$sp,8*8,$ra
+	.mask	$SAVED_REGS_MASK|0x000c0000,-8
+	dsubu	$sp,8*8
+	sd	$s7,56($sp)
+	sd	$s6,48($sp)
+#else
 	.frame	$sp,6*8,$ra
 	.mask	$SAVED_REGS_MASK,-8
-	.set	noreorder
 	dsubu	$sp,6*8
+#endif
 	sd	$s5,40($sp)
 	sd	$s4,32($sp)
 ___
@@ -206,25 +275,53 @@ ___
 $code.=<<___;
 	.set	reorder
 
+#if defined(_MIPS_ARCH_MIPS64R6)
+	andi	$shr,$inp,7
+	dsubu	$inp,$inp,$shr		# align $inp
+	sll	$shr,$shr,3		# byte to bit offset
+	subu	$shl,$zero,$shr
+#endif
+
 	ld	$h0,0($ctx)		# load hash value
 	ld	$h1,8($ctx)
 	ld	$h2,16($ctx)
 
 	ld	$r0,24($ctx)		# load key
 	ld	$r1,32($ctx)
-	ld	$s1,40($ctx)
+	ld	$rs1,40($ctx)
 
+	dsll	$len,4
+	daddu	$len,$inp		# end of buffer
+	b	.Loop
+
+.align	4
 .Loop:
 #if defined(_MIPS_ARCH_MIPS64R6)
 	ld	$in0,0($inp)		# load input
 	ld	$in1,8($inp)
+	beqz	$shr,.Laligned_inp
+
+	ld	$tmp2,16($inp)
+# ifdef	MIPSEB
+	dsllv	$in0,$in0,$shr
+	dsrlv	$tmp3,$in1,$shl
+	dsllv	$in1,$in1,$shr
+	dsrlv	$tmp2,$tmp2,$shl
+# else
+	dsrlv	$in0,$in0,$shr
+	dsllv	$tmp3,$in1,$shl
+	dsrlv	$in1,$in1,$shr
+	dsllv	$tmp2,$tmp2,$shl
+# endif
+	or	$in0,$in0,$tmp3
+	or	$in1,$in1,$tmp2
+.Laligned_inp:
 #else
 	ldl	$in0,0+MSB($inp)	# load input
 	ldl	$in1,8+MSB($inp)
 	ldr	$in0,0+LSB($inp)
 	ldr	$in1,8+LSB($inp)
 #endif
-	daddiu	$len,-1
 	daddiu	$inp,16
 #ifdef	MIPSEB
 # if defined(_MIPS_ARCH_MIPS64R2)
@@ -268,72 +365,73 @@ $code.=<<___;
 	 or	$in1,$tmp3
 # endif
 #endif
-	daddu	$h0,$in0		# accumulate input
-	daddu	$h1,$in1
-	sltu	$tmp0,$h0,$in0
-	sltu	$tmp1,$h1,$in1
-	daddu	$h1,$tmp0
+	dsrl	$tmp1,$h2,2		# modulo-scheduled reduction
+	andi	$h2,$h2,3
+	dsll	$tmp0,$tmp1,2
 
-	dmultu	($r0,$h0)		# h0*r0
-	 daddu	$h2,$padbit
-	 sltu	$tmp0,$h1,$tmp0
-	mflo	($d0,$r0,$h0)
-	mfhi	($d1,$r0,$h0)
-
-	dmultu	($s1,$h1)		# h1*5*r1
-	 daddu	$tmp0,$tmp1
-	 daddu	$h2,$tmp0
-	mflo	($tmp0,$s1,$h1)
-	mfhi	($tmp1,$s1,$h1)
-
-	dmultu	($r1,$h0)		# h0*r1
-	 daddu	$d0,$tmp0
-	 daddu	$d1,$tmp1
-	mflo	($tmp2,$r1,$h0)
-	mfhi	($d2,$r1,$h0)
-	 sltu	$tmp0,$d0,$tmp0
-	 daddu	$d1,$tmp0
-
-	dmultu	($r0,$h1)		# h1*r0
-	 daddu	$d1,$tmp2
-	 sltu	$tmp2,$d1,$tmp2
-	mflo	($tmp0,$r0,$h1)
-	mfhi	($tmp1,$r0,$h1)
-	 daddu	$d2,$tmp2
-
-	dmultu	($s1,$h2)		# h2*5*r1
-	 daddu	$d1,$tmp0
-	 daddu	$d2,$tmp1
-	mflo	($tmp2,$s1,$h2)
-
-	dmultu	($r0,$h2)		# h2*r0
-	 sltu	$tmp0,$d1,$tmp0
-	 daddu	$d2,$tmp0
-	mflo	($tmp3,$r0,$h2)
-
-	daddu	$d1,$tmp2
-	daddu	$d2,$tmp3
-	sltu	$tmp2,$d1,$tmp2
-	daddu	$d2,$tmp2
-
-	li	$tmp0,-4		# final reduction
-	and	$tmp0,$d2
-	dsrl	$tmp1,$d2,2
-	andi	$h2,$d2,3
+	daddu	$d0,$h0,$in0		# accumulate input
+	 daddu	$tmp1,$tmp0
+	sltu	$tmp0,$d0,$h0
+	daddu	$d0,$d0,$tmp1		# ... and residue
+	sltu	$tmp1,$d0,$tmp1
+	daddu	$d1,$h1,$in1
 	daddu	$tmp0,$tmp1
-	daddu	$h0,$d0,$tmp0
-	sltu	$tmp0,$h0,$tmp0
-	daddu	$h1,$d1,$tmp0
-	sltu	$tmp0,$h1,$tmp0
-	daddu	$h2,$h2,$tmp0
+	sltu	$tmp1,$d1,$h1
+	daddu	$d1,$tmp0
 
-	bnez	$len,.Loop
+	dmultu	($r0,$d0)		# h0*r0
+	 daddu	$d2,$h2,$padbit
+	 sltu	$tmp0,$d1,$tmp0
+	mflo	($h0,$r0,$d0)
+	mfhi	($h1,$r0,$d0)
+
+	dmultu	($rs1,$d1)		# h1*5*r1
+	 daddu	$d2,$tmp1
+	 daddu	$d2,$tmp0
+	mflo	($tmp0,$rs1,$d1)
+	mfhi	($tmp1,$rs1,$d1)
+
+	dmultu	($r1,$d0)		# h0*r1
+	mflo	($tmp2,$r1,$d0)
+	mfhi	($h2,$r1,$d0)
+	 daddu	$h0,$tmp0
+	 daddu	$h1,$tmp1
+	 sltu	$tmp0,$h0,$tmp0
+
+	dmultu	($r0,$d1)		# h1*r0
+	 daddu	$h1,$tmp0
+	 daddu	$h1,$tmp2
+	mflo	($tmp0,$r0,$d1)
+	mfhi	($tmp1,$r0,$d1)
+
+	dmultu	($rs1,$d2)		# h2*5*r1
+	 sltu	$tmp2,$h1,$tmp2
+	 daddu	$h2,$tmp2
+	mflo	($tmp2,$rs1,$d2)
+
+	dmultu	($r0,$d2)		# h2*r0
+	 daddu	$h1,$tmp0
+	 daddu	$h2,$tmp1
+	mflo	($tmp3,$r0,$d2)
+	 sltu	$tmp0,$h1,$tmp0
+	 daddu	$h2,$tmp0
+
+	daddu	$h1,$tmp2
+	sltu	$tmp2,$h1,$tmp2
+	daddu	$h2,$tmp2
+	daddu	$h2,$tmp3
+
+	bne	$inp,$len,.Loop
 
 	sd	$h0,0($ctx)		# store hash value
 	sd	$h1,8($ctx)
 	sd	$h2,16($ctx)
 
 	.set	noreorder
+#if defined(_MIPS_ARCH_MIPS64R6)
+	ld	$s7,56($sp)
+	ld	$s6,48($sp)
+#endif
 	ld	$s5,40($sp)		# epilogue
 	ld	$s4,32($sp)
 ___
@@ -345,7 +443,11 @@ $code.=<<___ if ($flavour =~ /nubi/i);	# optimize non-nubi epilogue
 ___
 $code.=<<___;
 	jr	$ra
+#if defined(_MIPS_ARCH_MIPS64R6)
+	daddu	$sp,8*8
+#else
 	daddu	$sp,6*8
+#endif
 .end	poly1305_blocks_internal
 ___
 }
@@ -360,26 +462,36 @@ poly1305_emit:
 	.frame	$sp,0,$ra
 	.set	reorder
 
+	ld	$tmp2,16($ctx)
 	ld	$tmp0,0($ctx)
 	ld	$tmp1,8($ctx)
-	ld	$tmp2,16($ctx)
 
-	daddiu	$in0,$tmp0,5		# compare to modulus
-	sltiu	$tmp3,$in0,5
-	daddu	$in1,$tmp1,$tmp3
-	sltu	$tmp3,$in1,$tmp3
-	daddu	$tmp2,$tmp2,$tmp3
+	li	$in0,-4			# final reduction
+	dsrl	$in1,$tmp2,2
+	and	$in0,$tmp2
+	andi	$tmp2,$tmp2,3
+	daddu	$in0,$in1
+
+	daddu	$tmp0,$tmp0,$in0
+	sltu	$in1,$tmp0,$in0
+	 daddiu	$in0,$tmp0,5		# compare to modulus
+	daddu	$tmp1,$tmp1,$in1
+	 sltiu	$tmp3,$in0,5
+	sltu	$tmp4,$tmp1,$in1
+	 daddu	$in1,$tmp1,$tmp3
+	daddu	$tmp2,$tmp2,$tmp4
+	 sltu	$tmp3,$in1,$tmp3
+	 daddu	$tmp2,$tmp2,$tmp3
 
 	dsrl	$tmp2,2			# see if it carried/borrowed
 	dsubu	$tmp2,$zero,$tmp2
-	nor	$tmp3,$zero,$tmp2
 
+	xor	$in0,$tmp0
+	xor	$in1,$tmp1
 	and	$in0,$tmp2
-	and	$tmp0,$tmp3
 	and	$in1,$tmp2
-	and	$tmp1,$tmp3
-	or	$in0,$tmp0
-	or	$in1,$tmp1
+	xor	$in0,$tmp0
+	xor	$in1,$tmp1
 
 	lwu	$tmp0,0($nonce)		# load nonce
 	lwu	$tmp1,4($nonce)
@@ -430,12 +542,740 @@ poly1305_emit:
 	jr	$ra
 .end	poly1305_emit
 .rdata
-.asciiz	"Poly1305 for MIPS64, CRYPTOGAMS by <https://github.com/dot-asm>"
+.asciiz	"Poly1305 for MIPS64, CRYPTOGAMS by \@dot-asm"
 .align	2
 ___
 }
+}}} else {{{
+######################################################################
+# 32-bit code path
+#
 
-$output and open STDOUT,">$output";
+my ($ctx,$inp,$len,$padbit) = ($a0,$a1,$a2,$a3);
+my ($in0,$in1,$in2,$in3,$tmp0,$tmp1,$tmp2,$tmp3) =
+   ($a4,$a5,$a6,$a7,$at,$t0,$t1,$t2);
+
+$code.=<<___;
+#if (defined(_MIPS_ARCH_MIPS32R3) || defined(_MIPS_ARCH_MIPS32R5) || \\
+     defined(_MIPS_ARCH_MIPS32R6)) \\
+     && !defined(_MIPS_ARCH_MIPS32R2)
+# define _MIPS_ARCH_MIPS32R2
+#endif
+
+#if defined(_MIPS_ARCH_MIPS32R6)
+# define multu(rs,rt)
+# define mflo(rd,rs,rt)	mulu	rd,rs,rt
+# define mfhi(rd,rs,rt)	muhu	rd,rs,rt
+#else
+# define multu(rs,rt)	multu	rs,rt
+# define mflo(rd,rs,rt)	mflo	rd
+# define mfhi(rd,rs,rt)	mfhi	rd
+#endif
+
+#ifdef	__KERNEL__
+# define poly1305_init   poly1305_init_mips
+# define poly1305_blocks poly1305_blocks_mips
+# define poly1305_emit   poly1305_emit_mips
+#endif
+
+#if defined(__MIPSEB__) && !defined(MIPSEB)
+# define MIPSEB
+#endif
+
+#ifdef MIPSEB
+# define MSB 0
+# define LSB 3
+#else
+# define MSB 3
+# define LSB 0
+#endif
+
+.text
+.set	noat
+.set	noreorder
+
+.align	5
+.globl	poly1305_init
+.ent	poly1305_init
+poly1305_init:
+	.frame	$sp,0,$ra
+	.set	reorder
+
+	sw	$zero,0($ctx)
+	sw	$zero,4($ctx)
+	sw	$zero,8($ctx)
+	sw	$zero,12($ctx)
+	sw	$zero,16($ctx)
+
+	beqz	$inp,.Lno_key
+
+#if defined(_MIPS_ARCH_MIPS32R6)
+	andi	$tmp0,$inp,3		# $inp % 4
+	subu	$inp,$inp,$tmp0		# align $inp
+	sll	$tmp0,$tmp0,3		# byte to bit offset
+	lw	$in0,0($inp)
+	lw	$in1,4($inp)
+	lw	$in2,8($inp)
+	lw	$in3,12($inp)
+	beqz	$tmp0,.Laligned_key
+
+	lw	$tmp2,16($inp)
+	subu	$tmp1,$zero,$tmp0
+# ifdef	MIPSEB
+	sllv	$in0,$in0,$tmp0
+	srlv	$tmp3,$in1,$tmp1
+	sllv	$in1,$in1,$tmp0
+	or	$in0,$in0,$tmp3
+	srlv	$tmp3,$in2,$tmp1
+	sllv	$in2,$in2,$tmp0
+	or	$in1,$in1,$tmp3
+	srlv	$tmp3,$in3,$tmp1
+	sllv	$in3,$in3,$tmp0
+	or	$in2,$in2,$tmp3
+	srlv	$tmp2,$tmp2,$tmp1
+	or	$in3,$in3,$tmp2
+# else
+	srlv	$in0,$in0,$tmp0
+	sllv	$tmp3,$in1,$tmp1
+	srlv	$in1,$in1,$tmp0
+	or	$in0,$in0,$tmp3
+	sllv	$tmp3,$in2,$tmp1
+	srlv	$in2,$in2,$tmp0
+	or	$in1,$in1,$tmp3
+	sllv	$tmp3,$in3,$tmp1
+	srlv	$in3,$in3,$tmp0
+	or	$in2,$in2,$tmp3
+	sllv	$tmp2,$tmp2,$tmp1
+	or	$in3,$in3,$tmp2
+# endif
+.Laligned_key:
+#else
+	lwl	$in0,0+MSB($inp)
+	lwl	$in1,4+MSB($inp)
+	lwl	$in2,8+MSB($inp)
+	lwl	$in3,12+MSB($inp)
+	lwr	$in0,0+LSB($inp)
+	lwr	$in1,4+LSB($inp)
+	lwr	$in2,8+LSB($inp)
+	lwr	$in3,12+LSB($inp)
+#endif
+#ifdef	MIPSEB
+# if defined(_MIPS_ARCH_MIPS32R2)
+	wsbh	$in0,$in0		# byte swap
+	wsbh	$in1,$in1
+	wsbh	$in2,$in2
+	wsbh	$in3,$in3
+	rotr	$in0,$in0,16
+	rotr	$in1,$in1,16
+	rotr	$in2,$in2,16
+	rotr	$in3,$in3,16
+# else
+	srl	$tmp0,$in0,24		# byte swap
+	srl	$tmp1,$in0,8
+	andi	$tmp2,$in0,0xFF00
+	sll	$in0,$in0,24
+	andi	$tmp1,0xFF00
+	sll	$tmp2,$tmp2,8
+	or	$in0,$tmp0
+	 srl	$tmp0,$in1,24
+	or	$tmp1,$tmp2
+	 srl	$tmp2,$in1,8
+	or	$in0,$tmp1
+	 andi	$tmp1,$in1,0xFF00
+	 sll	$in1,$in1,24
+	 andi	$tmp2,0xFF00
+	 sll	$tmp1,$tmp1,8
+	 or	$in1,$tmp0
+	srl	$tmp0,$in2,24
+	 or	$tmp2,$tmp1
+	srl	$tmp1,$in2,8
+	 or	$in1,$tmp2
+	andi	$tmp2,$in2,0xFF00
+	sll	$in2,$in2,24
+	andi	$tmp1,0xFF00
+	sll	$tmp2,$tmp2,8
+	or	$in2,$tmp0
+	 srl	$tmp0,$in3,24
+	or	$tmp1,$tmp2
+	 srl	$tmp2,$in3,8
+	or	$in2,$tmp1
+	 andi	$tmp1,$in3,0xFF00
+	 sll	$in3,$in3,24
+	 andi	$tmp2,0xFF00
+	 sll	$tmp1,$tmp1,8
+	 or	$in3,$tmp0
+	 or	$tmp2,$tmp1
+	 or	$in3,$tmp2
+# endif
+#endif
+	lui	$tmp0,0x0fff
+	ori	$tmp0,0xffff		# 0x0fffffff
+	and	$in0,$in0,$tmp0
+	subu	$tmp0,3			# 0x0ffffffc
+	and	$in1,$in1,$tmp0
+	and	$in2,$in2,$tmp0
+	and	$in3,$in3,$tmp0
+
+	sw	$in0,20($ctx)
+	sw	$in1,24($ctx)
+	sw	$in2,28($ctx)
+	sw	$in3,32($ctx)
+
+	srl	$tmp1,$in1,2
+	srl	$tmp2,$in2,2
+	srl	$tmp3,$in3,2
+	addu	$in1,$in1,$tmp1		# s1 = r1 + (r1 >> 2)
+	addu	$in2,$in2,$tmp2
+	addu	$in3,$in3,$tmp3
+	sw	$in1,36($ctx)
+	sw	$in2,40($ctx)
+	sw	$in3,44($ctx)
+.Lno_key:
+	li	$v0,0
+	jr	$ra
+.end	poly1305_init
+___
+{
+my $SAVED_REGS_MASK = ($flavour =~ /nubi/i) ? "0x00fff000" : "0x00ff0000";
+
+my ($h0,$h1,$h2,$h3,$h4, $r0,$r1,$r2,$r3, $rs1,$rs2,$rs3) =
+   ($s0,$s1,$s2,$s3,$s4, $s5,$s6,$s7,$s8, $s9,$s10,$s11);
+my ($d0,$d1,$d2,$d3) =
+   ($a4,$a5,$a6,$a7);
+my $shr = $t2;		# used on R6
+my $one = $t2;		# used on R2
+
+$code.=<<___;
+.globl	poly1305_blocks
+.align	5
+.ent	poly1305_blocks
+poly1305_blocks:
+	.frame	$sp,12*4,$ra
+	.mask	$SAVED_REGS_MASK,-4
+	.set	noreorder
+	subu	$sp, $sp,4*12
+	sw	$s11,4*11($sp)
+	sw	$s10,4*10($sp)
+	sw	$s9, 4*9($sp)
+	sw	$s8, 4*8($sp)
+	sw	$s7, 4*7($sp)
+	sw	$s6, 4*6($sp)
+	sw	$s5, 4*5($sp)
+	sw	$s4, 4*4($sp)
+___
+$code.=<<___ if ($flavour =~ /nubi/i);	# optimize non-nubi prologue
+	sw	$s3, 4*3($sp)
+	sw	$s2, 4*2($sp)
+	sw	$s1, 4*1($sp)
+	sw	$s0, 4*0($sp)
+___
+$code.=<<___;
+	.set	reorder
+
+	srl	$len,4			# number of complete blocks
+	li	$one,1
+	beqz	$len,.Labort
+
+#if defined(_MIPS_ARCH_MIPS32R6)
+	andi	$shr,$inp,3
+	subu	$inp,$inp,$shr		# align $inp
+	sll	$shr,$shr,3		# byte to bit offset
+#endif
+
+	lw	$h0,0($ctx)		# load hash value
+	lw	$h1,4($ctx)
+	lw	$h2,8($ctx)
+	lw	$h3,12($ctx)
+	lw	$h4,16($ctx)
+
+	lw	$r0,20($ctx)		# load key
+	lw	$r1,24($ctx)
+	lw	$r2,28($ctx)
+	lw	$r3,32($ctx)
+	lw	$rs1,36($ctx)
+	lw	$rs2,40($ctx)
+	lw	$rs3,44($ctx)
+
+	sll	$len,4
+	addu	$len,$len,$inp		# end of buffer
+	b	.Loop
+
+.align	4
+.Loop:
+#if defined(_MIPS_ARCH_MIPS32R6)
+	lw	$d0,0($inp)		# load input
+	lw	$d1,4($inp)
+	lw	$d2,8($inp)
+	lw	$d3,12($inp)
+	beqz	$shr,.Laligned_inp
+
+	lw	$t0,16($inp)
+	subu	$t1,$zero,$shr
+# ifdef	MIPSEB
+	sllv	$d0,$d0,$shr
+	srlv	$at,$d1,$t1
+	sllv	$d1,$d1,$shr
+	or	$d0,$d0,$at
+	srlv	$at,$d2,$t1
+	sllv	$d2,$d2,$shr
+	or	$d1,$d1,$at
+	srlv	$at,$d3,$t1
+	sllv	$d3,$d3,$shr
+	or	$d2,$d2,$at
+	srlv	$t0,$t0,$t1
+	or	$d3,$d3,$t0
+# else
+	srlv	$d0,$d0,$shr
+	sllv	$at,$d1,$t1
+	srlv	$d1,$d1,$shr
+	or	$d0,$d0,$at
+	sllv	$at,$d2,$t1
+	srlv	$d2,$d2,$shr
+	or	$d1,$d1,$at
+	sllv	$at,$d3,$t1
+	srlv	$d3,$d3,$shr
+	or	$d2,$d2,$at
+	sllv	$t0,$t0,$t1
+	or	$d3,$d3,$t0
+# endif
+.Laligned_inp:
+#else
+	lwl	$d0,0+MSB($inp)		# load input
+	lwl	$d1,4+MSB($inp)
+	lwl	$d2,8+MSB($inp)
+	lwl	$d3,12+MSB($inp)
+	lwr	$d0,0+LSB($inp)
+	lwr	$d1,4+LSB($inp)
+	lwr	$d2,8+LSB($inp)
+	lwr	$d3,12+LSB($inp)
+#endif
+#ifdef	MIPSEB
+# if defined(_MIPS_ARCH_MIPS32R2)
+	wsbh	$d0,$d0			# byte swap
+	wsbh	$d1,$d1
+	wsbh	$d2,$d2
+	wsbh	$d3,$d3
+	rotr	$d0,$d0,16
+	rotr	$d1,$d1,16
+	rotr	$d2,$d2,16
+	rotr	$d3,$d3,16
+# else
+	srl	$at,$d0,24		# byte swap
+	srl	$t0,$d0,8
+	andi	$t1,$d0,0xFF00
+	sll	$d0,$d0,24
+	andi	$t0,0xFF00
+	sll	$t1,$t1,8
+	or	$d0,$at
+	 srl	$at,$d1,24
+	or	$t0,$t1
+	 srl	$t1,$d1,8
+	or	$d0,$t0
+	 andi	$t0,$d1,0xFF00
+	 sll	$d1,$d1,24
+	 andi	$t1,0xFF00
+	 sll	$t0,$t0,8
+	 or	$d1,$at
+	srl	$at,$d2,24
+	 or	$t1,$t0
+	srl	$t0,$d2,8
+	 or	$d1,$t1
+	andi	$t1,$d2,0xFF00
+	sll	$d2,$d2,24
+	andi	$t0,0xFF00
+	sll	$t1,$t1,8
+	or	$d2,$at
+	 srl	$at,$d3,24
+	or	$t0,$t1
+	 srl	$t1,$d3,8
+	or	$d2,$t0
+	 andi	$t0,$d3,0xFF00
+	 sll	$d3,$d3,24
+	 andi	$t1,0xFF00
+	 sll	$t0,$t0,8
+	 or	$d3,$at
+	 or	$t1,$t0
+	 or	$d3,$t1
+# endif
+#endif
+	srl	$t0,$h4,2		# modulo-scheduled reduction
+	andi	$h4,$h4,3
+	sll	$at,$t0,2
+
+	addu	$d0,$d0,$h0		# accumulate input
+	 addu	$t0,$t0,$at
+	sltu	$h0,$d0,$h0
+	addu	$d0,$d0,$t0		# ... and residue
+	sltu	$at,$d0,$t0
+
+	addu	$d1,$d1,$h1
+	 addu	$h0,$h0,$at		# carry
+	sltu	$h1,$d1,$h1
+	addu	$d1,$d1,$h0
+	sltu	$h0,$d1,$h0
+
+	addu	$d2,$d2,$h2
+	 addu	$h1,$h1,$h0		# carry
+	sltu	$h2,$d2,$h2
+	addu	$d2,$d2,$h1
+	sltu	$h1,$d2,$h1
+
+	addu	$d3,$d3,$h3
+	 addu	$h2,$h2,$h1		# carry
+	sltu	$h3,$d3,$h3
+	addu	$d3,$d3,$h2
+
+#if defined(_MIPS_ARCH_MIPS32R2) && !defined(_MIPS_ARCH_MIPS32R6)
+	multu	$r0,$d0			# d0*r0
+	 sltu	$h2,$d3,$h2
+	maddu	$rs3,$d1		# d1*s3
+	 addu	$h3,$h3,$h2		# carry
+	maddu	$rs2,$d2		# d2*s2
+	 addu	$h4,$h4,$padbit
+	maddu	$rs1,$d3		# d3*s1
+	 addu	$h4,$h4,$h3
+	mfhi	$at
+	mflo	$h0
+
+	multu	$r1,$d0			# d0*r1
+	maddu	$r0,$d1			# d1*r0
+	maddu	$rs3,$d2		# d2*s3
+	maddu	$rs2,$d3		# d3*s2
+	maddu	$rs1,$h4		# h4*s1
+	maddu	$at,$one		# hi*1
+	mfhi	$at
+	mflo	$h1
+
+	multu	$r2,$d0			# d0*r2
+	maddu	$r1,$d1			# d1*r1
+	maddu	$r0,$d2			# d2*r0
+	maddu	$rs3,$d3		# d3*s3
+	maddu	$rs2,$h4		# h4*s2
+	maddu	$at,$one		# hi*1
+	mfhi	$at
+	mflo	$h2
+
+	mul	$t0,$r0,$h4		# h4*r0
+
+	multu	$r3,$d0			# d0*r3
+	maddu	$r2,$d1			# d1*r2
+	maddu	$r1,$d2			# d2*r1
+	maddu	$r0,$d3			# d3*r0
+	maddu	$rs3,$h4		# h4*s3
+	maddu	$at,$one		# hi*1
+	mfhi	$at
+	mflo	$h3
+
+	 addiu	$inp,$inp,16
+
+	addu	$h4,$t0,$at
+#else
+	multu	($r0,$d0)		# d0*r0
+	mflo	($h0,$r0,$d0)
+	mfhi	($h1,$r0,$d0)
+
+	 sltu	$h2,$d3,$h2
+	 addu	$h3,$h3,$h2		# carry
+
+	multu	($rs3,$d1)		# d1*s3
+	mflo	($at,$rs3,$d1)
+	mfhi	($t0,$rs3,$d1)
+
+	 addu	$h4,$h4,$padbit
+	 addiu	$inp,$inp,16
+	 addu	$h4,$h4,$h3
+
+	multu	($rs2,$d2)		# d2*s2
+	mflo	($a3,$rs2,$d2)
+	mfhi	($t1,$rs2,$d2)
+	 addu	$h0,$h0,$at
+	 addu	$h1,$h1,$t0
+	multu	($rs1,$d3)		# d3*s1
+	 sltu	$at,$h0,$at
+	 addu	$h1,$h1,$at
+
+	mflo	($at,$rs1,$d3)
+	mfhi	($t0,$rs1,$d3)
+	 addu	$h0,$h0,$a3
+	 addu	$h1,$h1,$t1
+	multu	($r1,$d0)		# d0*r1
+	 sltu	$a3,$h0,$a3
+	 addu	$h1,$h1,$a3
+
+
+	mflo	($a3,$r1,$d0)
+	mfhi	($h2,$r1,$d0)
+	 addu	$h0,$h0,$at
+	 addu	$h1,$h1,$t0
+	multu	($r0,$d1)		# d1*r0
+	 sltu	$at,$h0,$at
+	 addu	$h1,$h1,$at
+
+	mflo	($at,$r0,$d1)
+	mfhi	($t0,$r0,$d1)
+	 addu	$h1,$h1,$a3
+	 sltu	$a3,$h1,$a3
+	multu	($rs3,$d2)		# d2*s3
+	 addu	$h2,$h2,$a3
+
+	mflo	($a3,$rs3,$d2)
+	mfhi	($t1,$rs3,$d2)
+	 addu	$h1,$h1,$at
+	 addu	$h2,$h2,$t0
+	multu	($rs2,$d3)		# d3*s2
+	 sltu	$at,$h1,$at
+	 addu	$h2,$h2,$at
+
+	mflo	($at,$rs2,$d3)
+	mfhi	($t0,$rs2,$d3)
+	 addu	$h1,$h1,$a3
+	 addu	$h2,$h2,$t1
+	multu	($rs1,$h4)		# h4*s1
+	 sltu	$a3,$h1,$a3
+	 addu	$h2,$h2,$a3
+
+	mflo	($a3,$rs1,$h4)
+	 addu	$h1,$h1,$at
+	 addu	$h2,$h2,$t0
+	multu	($r2,$d0)		# d0*r2
+	 sltu	$at,$h1,$at
+	 addu	$h2,$h2,$at
+
+
+	mflo	($at,$r2,$d0)
+	mfhi	($h3,$r2,$d0)
+	 addu	$h1,$h1,$a3
+	 sltu	$a3,$h1,$a3
+	multu	($r1,$d1)		# d1*r1
+	 addu	$h2,$h2,$a3
+
+	mflo	($a3,$r1,$d1)
+	mfhi	($t1,$r1,$d1)
+	 addu	$h2,$h2,$at
+	 sltu	$at,$h2,$at
+	multu	($r0,$d2)		# d2*r0
+	 addu	$h3,$h3,$at
+
+	mflo	($at,$r0,$d2)
+	mfhi	($t0,$r0,$d2)
+	 addu	$h2,$h2,$a3
+	 addu	$h3,$h3,$t1
+	multu	($rs3,$d3)		# d3*s3
+	 sltu	$a3,$h2,$a3
+	 addu	$h3,$h3,$a3
+
+	mflo	($a3,$rs3,$d3)
+	mfhi	($t1,$rs3,$d3)
+	 addu	$h2,$h2,$at
+	 addu	$h3,$h3,$t0
+	multu	($rs2,$h4)		# h4*s2
+	 sltu	$at,$h2,$at
+	 addu	$h3,$h3,$at
+
+	mflo	($at,$rs2,$h4)
+	 addu	$h2,$h2,$a3
+	 addu	$h3,$h3,$t1
+	multu	($r3,$d0)		# d0*r3
+	 sltu	$a3,$h2,$a3
+	 addu	$h3,$h3,$a3
+
+
+	mflo	($a3,$r3,$d0)
+	mfhi	($t1,$r3,$d0)
+	 addu	$h2,$h2,$at
+	 sltu	$at,$h2,$at
+	multu	($r2,$d1)		# d1*r2
+	 addu	$h3,$h3,$at
+
+	mflo	($at,$r2,$d1)
+	mfhi	($t0,$r2,$d1)
+	 addu	$h3,$h3,$a3
+	 sltu	$a3,$h3,$a3
+	multu	($r0,$d3)		# d3*r0
+	 addu	$t1,$t1,$a3
+
+	mflo	($a3,$r0,$d3)
+	mfhi	($d3,$r0,$d3)
+	 addu	$h3,$h3,$at
+	 addu	$t1,$t1,$t0
+	multu	($r1,$d2)		# d2*r1
+	 sltu	$at,$h3,$at
+	 addu	$t1,$t1,$at
+
+	mflo	($at,$r1,$d2)
+	mfhi	($t0,$r1,$d2)
+	 addu	$h3,$h3,$a3
+	 addu	$t1,$t1,$d3
+	multu	($rs3,$h4)		# h4*s3
+	 sltu	$a3,$h3,$a3
+	 addu	$t1,$t1,$a3
+
+	mflo	($a3,$rs3,$h4)
+	 addu	$h3,$h3,$at
+	 addu	$t1,$t1,$t0
+	multu	($r0,$h4)		# h4*r0
+	 sltu	$at,$h3,$at
+	 addu	$t1,$t1,$at
+
+
+	mflo	($h4,$r0,$h4)
+	 addu	$h3,$h3,$a3
+	 sltu	$a3,$h3,$a3
+	 addu	$t1,$t1,$a3
+	addu	$h4,$h4,$t1
+
+	li	$padbit,1		# if we loop, padbit is 1
+#endif
+	bne	$inp,$len,.Loop
+
+	sw	$h0,0($ctx)		# store hash value
+	sw	$h1,4($ctx)
+	sw	$h2,8($ctx)
+	sw	$h3,12($ctx)
+	sw	$h4,16($ctx)
+
+	.set	noreorder
+.Labort:
+	lw	$s11,4*11($sp)
+	lw	$s10,4*10($sp)
+	lw	$s9, 4*9($sp)
+	lw	$s8, 4*8($sp)
+	lw	$s7, 4*7($sp)
+	lw	$s6, 4*6($sp)
+	lw	$s5, 4*5($sp)
+	lw	$s4, 4*4($sp)
+___
+$code.=<<___ if ($flavour =~ /nubi/i);	# optimize non-nubi prologue
+	lw	$s3, 4*3($sp)
+	lw	$s2, 4*2($sp)
+	lw	$s1, 4*1($sp)
+	lw	$s0, 4*0($sp)
+___
+$code.=<<___;
+	jr	$ra
+	addu	$sp,$sp,4*12
+.end	poly1305_blocks
+___
+}
+{
+my ($ctx,$mac,$nonce,$tmp4) = ($a0,$a1,$a2,$a3);
+
+$code.=<<___;
+.align	5
+.globl	poly1305_emit
+.ent	poly1305_emit
+poly1305_emit:
+	.frame	$sp,0,$ra
+	.set	reorder
+
+	lw	$tmp4,16($ctx)
+	lw	$tmp0,0($ctx)
+	lw	$tmp1,4($ctx)
+	lw	$tmp2,8($ctx)
+	lw	$tmp3,12($ctx)
+
+	li	$in0,-4			# final reduction
+	srl	$ctx,$tmp4,2
+	and	$in0,$in0,$tmp4
+	andi	$tmp4,$tmp4,3
+	addu	$ctx,$ctx,$in0
+
+	addu	$tmp0,$tmp0,$ctx
+	sltu	$ctx,$tmp0,$ctx
+	 addiu	$in0,$tmp0,5		# compare to modulus
+	addu	$tmp1,$tmp1,$ctx
+	 sltiu	$in1,$in0,5
+	sltu	$ctx,$tmp1,$ctx
+	 addu	$in1,$in1,$tmp1
+	addu	$tmp2,$tmp2,$ctx
+	 sltu	$in2,$in1,$tmp1
+	sltu	$ctx,$tmp2,$ctx
+	 addu	$in2,$in2,$tmp2
+	addu	$tmp3,$tmp3,$ctx
+	 sltu	$in3,$in2,$tmp2
+	sltu	$ctx,$tmp3,$ctx
+	 addu	$in3,$in3,$tmp3
+	addu	$tmp4,$tmp4,$ctx
+	 sltu	$ctx,$in3,$tmp3
+	 addu	$ctx,$tmp4
+
+	srl	$ctx,2			# see if it carried/borrowed
+	subu	$ctx,$zero,$ctx
+
+	xor	$in0,$tmp0
+	xor	$in1,$tmp1
+	xor	$in2,$tmp2
+	xor	$in3,$tmp3
+	and	$in0,$ctx
+	and	$in1,$ctx
+	and	$in2,$ctx
+	and	$in3,$ctx
+	xor	$in0,$tmp0
+	xor	$in1,$tmp1
+	xor	$in2,$tmp2
+	xor	$in3,$tmp3
+
+	lw	$tmp0,0($nonce)		# load nonce
+	lw	$tmp1,4($nonce)
+	lw	$tmp2,8($nonce)
+	lw	$tmp3,12($nonce)
+
+	addu	$in0,$tmp0		# accumulate nonce
+	sltu	$ctx,$in0,$tmp0
+
+	addu	$in1,$tmp1
+	sltu	$tmp1,$in1,$tmp1
+	addu	$in1,$ctx
+	sltu	$ctx,$in1,$ctx
+	addu	$ctx,$tmp1
+
+	addu	$in2,$tmp2
+	sltu	$tmp2,$in2,$tmp2
+	addu	$in2,$ctx
+	sltu	$ctx,$in2,$ctx
+	addu	$ctx,$tmp2
+
+	addu	$in3,$tmp3
+	addu	$in3,$ctx
+
+	srl	$tmp0,$in0,8		# write mac value
+	srl	$tmp1,$in0,16
+	srl	$tmp2,$in0,24
+	sb	$in0, 0($mac)
+	sb	$tmp0,1($mac)
+	srl	$tmp0,$in1,8
+	sb	$tmp1,2($mac)
+	srl	$tmp1,$in1,16
+	sb	$tmp2,3($mac)
+	srl	$tmp2,$in1,24
+	sb	$in1, 4($mac)
+	sb	$tmp0,5($mac)
+	srl	$tmp0,$in2,8
+	sb	$tmp1,6($mac)
+	srl	$tmp1,$in2,16
+	sb	$tmp2,7($mac)
+	srl	$tmp2,$in2,24
+	sb	$in2, 8($mac)
+	sb	$tmp0,9($mac)
+	srl	$tmp0,$in3,8
+	sb	$tmp1,10($mac)
+	srl	$tmp1,$in3,16
+	sb	$tmp2,11($mac)
+	srl	$tmp2,$in3,24
+	sb	$in3, 12($mac)
+	sb	$tmp0,13($mac)
+	sb	$tmp1,14($mac)
+	sb	$tmp2,15($mac)
+
+	jr	$ra
+.end	poly1305_emit
+.rdata
+.asciiz	"Poly1305 for MIPS32, CRYPTOGAMS by \@dot-asm"
+.align	2
+___
+}
+}}}
+
+$output=pop and open STDOUT,">$output";
 print $code;
-close STDOUT or die "error closing STDOUT: $!";
-
+close STDOUT;

--- a/crypto/poly1305/build.info
+++ b/crypto/poly1305/build.info
@@ -9,6 +9,7 @@ IF[{- !$disabled{asm} -}]
 
   $POLY1305ASM_sparcv9=poly1305-sparcv9.S
 
+  $POLY1305ASM_mips32=poly1305-mips.S
   $POLY1305ASM_mips64=poly1305-mips.S
 
   $POLY1305ASM_s390x=poly1305-s390x.S


### PR DESCRIPTION
## Summary

Add MIPS32/O32 assembly implementations of ChaCha20 and Poly1305 and select them for `linux-mips32` builds.

The implementations are the OpenSSL-compatible CRYPTOGAMS modules written by Andy Polyakov:

- ChaCha20: CRYPTOGAMS commit `0c24982287ad4ddfeb1dba84698c6c00615d56b3`;
- Poly1305: CRYPTOGAMS commit `bac01af1d4549aa98d130215c8e8d74ba74a8542`.

The ChaCha20 generator is adapted to open the output filename passed by the current OpenSSL build system. The Poly1305 update retains the existing MIPS64 path and adds the CRYPTOGAMS MIPS32 path.

The changes are split into two commits so that the implementations can be reviewed and measured independently.

## MT7620A results

OpenSSL 3.5.7 was built in four otherwise identical `linux-mips32` configurations with GCC 14.4.0, musl, `-mips32r2 -Os`. Values are medians of five alternating packet-style EVP ChaCha20-Poly1305 runs on a 580 MHz MIPS 24KEc. Each packet resets the nonce, processes 16 bytes of AAD, encrypts, finalizes, and obtains the tag.

| Bytes | Stock MB/s | ChaCha asm | Poly1305 asm | Both asm |
|---:|---:|---:|---:|---:|
| 64 | 4.365 | 5.550 | 4.536 | 5.797 |
| 1500 | 13.152 | 19.427 | 14.493 | 22.429 |
| 16384 | 14.023 | 21.370 | 15.642 | 25.155 |

At 1500 bytes the combined implementation is 70.5% faster. Processing a fixed 100,000 packets reduced user CPU time from 11.39 to 6.68 seconds (41.4%). These are crypto-library measurements, not end-to-end VPN results.

## Validation

- RFC 8439 ChaCha20-Poly1305 AEAD known-answer test;
- encrypt/decrypt round trips at 0, 1, 15, 16, 17, 63, 64, 65, 255, 1500, and 16384 bytes with buffer offsets 0 through 3;
- identical outputs for stock, each individual implementation, and both;
- runtime tests under `qemu-mipsel` and on a physical MT7620A;
- current OpenSSL `master` cross-build and the same runtime checks;
- Clang assembly checks for big-endian MIPS32r2 and both big- and little-endian MIPS64r2.

Only little-endian MIPS32 was runtime-tested.
