### PR TITLE
Fix SSL_poll() multi-reactor cleanup deadlock

### DIFF
--- a/include/internal/quic_reactor.h
+++ b/include/internal/quic_reactor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -139,6 +139,12 @@ struct quic_reactor_st {
 
     /* 1 if a block_until_pred call has put the notifier in the signalled state. */
     unsigned int signalled_notifier : 1;
+
+    /*
+     * Bumped each time the notifier is drained. Lets a phase-2 waiter identify
+     * the signal cycle it participated in (see two-phase leave below).
+     */
+    uint64_t notify_generation;
 };
 
 /* Create an OS notifier? */
@@ -251,11 +257,15 @@ int ossl_quic_reactor_block_until_pred(QUIC_REACTOR *rtor,
  * via the notifier. The reactor mutex must be held while calling these
  * functions.
  *
- * The number of 'active' calls to these functions (i.e., the number of enter
- * calls which have yet to be matched with a subsequent leave call) must *at all
- * times* equal the number of threads blocking on the reactor. In other words, a
- * single thread is not permitted to use these functions "recursively". Failing
- * to adhere to this rule will result in deadlock.
+ * An active registration is an enter call which has not yet been matched by a
+ * subsequent deregister or leave call. A thread may have at most one active
+ * registration for a given reactor; recursive registration will result in
+ * deadlock. A thread which has deregistered may still wait for the notifier in
+ * phase 2, but is no longer counted as an active registration.
+ *
+ * A thread with an active registration on any reactor must not tick a reactor.
+ * A tick can block while notifying other registered threads, which would
+ * prevent the ticking thread from deregistering and can result in deadlock.
  *
  * This means that if a caller has the concept of multiple concurrent blocking
  * calls on the same thread on the same reactor (which may occur in some
@@ -278,6 +288,23 @@ int ossl_quic_reactor_block_until_pred(QUIC_REACTOR *rtor,
  */
 void ossl_quic_reactor_enter_blocking_section(QUIC_REACTOR *rtor);
 void ossl_quic_reactor_leave_blocking_section(QUIC_REACTOR *rtor);
+
+/*
+ * Two-phase leave for callers registered with multiple reactors. First call
+ * deregister_blocking_section() for every reactor; only then call
+ * wait_for_notifier_clear() for each deregistration that returned 1. This
+ * avoids waiting on one reactor while still registered with another.
+ *
+ * deregister_blocking_section() never blocks, requires the reactor mutex, and
+ * stores the signal generation to await in *gen. wait_for_notifier_clear()
+ * acquires the mutex itself and waits only for that generation. Single-reactor
+ * callers may continue to use leave_blocking_section(), whose combined wait is
+ * likewise bounded to the signal generation observed during deregistration.
+ */
+int ossl_quic_reactor_deregister_blocking_section(QUIC_REACTOR *rtor,
+    uint64_t *gen);
+void ossl_quic_reactor_wait_for_notifier_clear(QUIC_REACTOR *rtor,
+    uint64_t gen);
 
 #endif
 

--- a/include/internal/quic_reactor_wait_ctx.h
+++ b/include/internal/quic_reactor_wait_ctx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -56,12 +56,14 @@
  * QUIC_REACTOR_WAIT_CTX before commencing a blocking operation, and then calls
  * ossl_quic_reactor_wait_ctx_enter() whenever encountering a reactor involved
  * in the imminent blocking operation. Later it must ensure it calls
- * ossl_quic_reactor_wait_ctx_leave() the same number of times for each reactor.
- * enter() and leave() may be called multiple times for the same reactor and
- * wait context so long as the number of calls is balanced. The last leave()
- * call for a given thread's wait context *and a given reactor* causes that
- * reactor to do the inter-thread notification housekeeping needed for
- * multithreaded blocking to work correctly.
+ * ossl_quic_reactor_wait_ctx_deregister() the same number of times for
+ * each reactor. enter() and deregister() may be called multiple times for
+ * the same reactor and wait context so long as the number of calls is balanced.
+ * The last deregister() call for a given thread's wait context *and a given
+ * reactor* begins the reactor's inter-thread notification housekeeping
+ * (deregistration, which never blocks); ossl_quic_reactor_wait_ctx_drain()
+ * completes it. Both phases are needed for multithreaded blocking to work
+ * correctly.
  *
  * The gist is that a simple reactor-level counter of active concurrent blocking
  * calls across all threads is not accurate and we need an accurate count of how
@@ -75,7 +77,8 @@
  *   (QUIC_REACTOR *) -> (outstanding call count)
  *
  * When the count for a reactor transitions from 0 to a nonzero value, or vice
- * versa, ossl_quic_reactor_(enter/leave)_blocking_section() is called once.
+ * versa, ossl_quic_reactor_enter_blocking_section() /
+ * ossl_quic_reactor_deregister_blocking_section() is called once.
  *
  * The internal implementation is based on linked lists as we expect the actual
  * number of reactors involved in a given blocking operation to be very small,
@@ -97,18 +100,30 @@ void ossl_quic_reactor_wait_ctx_init(QUIC_REACTOR_WAIT_CTX *ctx);
 int ossl_quic_reactor_wait_ctx_enter(QUIC_REACTOR_WAIT_CTX *ctx,
     QUIC_REACTOR *rtor);
 
-/* Downrefs a given reactor. */
-void ossl_quic_reactor_wait_ctx_leave(QUIC_REACTOR_WAIT_CTX *ctx,
-    QUIC_REACTOR *rtor);
-
 /*
  * Destroys a wait context. Must be called after calling init().
  *
  * Precondition: All prior calls to ossl_quic_reactor_wait_ctx_enter() must have
- * been balanced with corresponding leave() calls before calling this
- * (unchecked).
+ * been balanced with corresponding deregister() calls, and
+ * ossl_quic_reactor_wait_ctx_drain() must have run for any reactor left
+ * signalled, before calling this (unchecked).
  */
 void ossl_quic_reactor_wait_ctx_cleanup(QUIC_REACTOR_WAIT_CTX *ctx);
+
+/*
+ * Two-phase leave support (see quic_reactor.h for the rationale and the
+ * deadlock it avoids). wait_ctx_deregister() is phase 1: it decrements
+ * the per-thread refcount and, on the 1->0 transition, deregisters from the
+ * reactor without blocking, recording whether phase 2 must wait and the
+ * generation to wait for. Caller must hold the reactor mutex.
+ * wait_ctx_drain() is phase 2: for every reactor phase 1 left signalled, it
+ * waits for that signal cycle to clear, acquiring each reactor's mutex
+ * internally.
+ */
+void ossl_quic_reactor_wait_ctx_deregister(QUIC_REACTOR_WAIT_CTX *ctx,
+    QUIC_REACTOR *rtor);
+
+void ossl_quic_reactor_wait_ctx_drain(QUIC_REACTOR_WAIT_CTX *ctx);
 
 #endif
 

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -177,8 +177,14 @@ int ossl_quic_set_diag_title(SSL_CTX *ctx, const char *title);
 int ossl_quic_conn_poll_events(SSL *ssl, uint64_t events, int do_tick,
     uint64_t *revents);
 int ossl_quic_get_notifier_fd(SSL *ssl);
+/*
+ * Blocking-section registration. Multi-reactor callers (e.g. SSL_poll) must
+ * use ossl_quic_deregister_blocking_section() (phase 1, non-blocking) followed
+ * by ossl_quic_reactor_wait_ctx_drain() (phase 2); see quic_reactor.h.
+ */
 void ossl_quic_enter_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx);
-void ossl_quic_leave_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx);
+void ossl_quic_deregister_blocking_section(SSL *ssl,
+    QUIC_REACTOR_WAIT_CTX *wctx);
 QUIC_PORT *ossl_quic_listener_get_port(SSL *s);
 
 #endif

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -177,8 +177,15 @@ int ossl_quic_set_diag_title(SSL_CTX *ctx, const char *title);
 int ossl_quic_conn_poll_events(SSL *ssl, uint64_t events, int do_tick,
     uint64_t *revents);
 int ossl_quic_get_notifier_fd(SSL *ssl);
+/*
+ * Blocking-section enter/leave. Multi-reactor callers (e.g. SSL_poll) must
+ * use ossl_quic_deregister_blocking_section() (phase 1, non-blocking) followed
+ * by ossl_quic_reactor_wait_ctx_drain() (phase 2); see quic_reactor.h.
+ */
 void ossl_quic_enter_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx);
-void ossl_quic_leave_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx);
+
+void ossl_quic_deregister_blocking_section(SSL *ssl,
+    QUIC_REACTOR_WAIT_CTX *wctx);
 
 #endif
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5927,7 +5927,8 @@ void ossl_quic_enter_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx)
 }
 
 QUIC_TAKES_LOCK
-void ossl_quic_leave_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx)
+void ossl_quic_deregister_blocking_section(SSL *ssl,
+    QUIC_REACTOR_WAIT_CTX *wctx)
 {
     QCTX ctx;
     QUIC_REACTOR *rtor;
@@ -5937,7 +5938,7 @@ void ossl_quic_leave_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx)
 
     qctx_lock(&ctx);
     rtor = ossl_quic_obj_get0_reactor(ctx.obj);
-    ossl_quic_reactor_wait_ctx_leave(wctx, rtor);
+    ossl_quic_reactor_wait_ctx_deregister(wctx, rtor);
     qctx_unlock(&ctx);
 }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5887,7 +5887,8 @@ void ossl_quic_enter_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx)
 }
 
 QUIC_TAKES_LOCK
-void ossl_quic_leave_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx)
+void ossl_quic_deregister_blocking_section(SSL *ssl,
+    QUIC_REACTOR_WAIT_CTX *wctx)
 {
     QCTX ctx;
     QUIC_REACTOR *rtor;
@@ -5897,7 +5898,7 @@ void ossl_quic_leave_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx)
 
     qctx_lock(&ctx);
     rtor = ossl_quic_obj_get0_reactor(ctx.obj);
-    ossl_quic_reactor_wait_ctx_leave(wctx, rtor);
+    ossl_quic_reactor_wait_ctx_deregister(wctx, rtor);
     qctx_unlock(&ctx);
 }
 

--- a/ssl/quic/quic_reactor.c
+++ b/ssl/quic/quic_reactor.c
@@ -44,6 +44,7 @@ int ossl_quic_reactor_init(QUIC_REACTOR *rtor,
     rtor->mutex = mutex;
 
     rtor->cur_blocking_waiters = 0;
+    rtor->notify_generation = 0;
 
     if ((flags & QUIC_REACTOR_FLAG_USE_NOTIFIER) != 0) {
         if (!ossl_rio_notifier_init(&rtor->notifier))
@@ -608,25 +609,56 @@ void ossl_quic_reactor_enter_blocking_section(QUIC_REACTOR *rtor)
     ++rtor->cur_blocking_waiters;
 }
 
-void ossl_quic_reactor_leave_blocking_section(QUIC_REACTOR *rtor)
+int ossl_quic_reactor_deregister_blocking_section(QUIC_REACTOR *rtor,
+    uint64_t *gen)
 {
     assert(rtor->cur_blocking_waiters > 0);
     --rtor->cur_blocking_waiters;
 
-    if (rtor->have_notifier && rtor->signalled_notifier) {
-        if (rtor->cur_blocking_waiters == 0) {
-            ossl_rio_notifier_unsignal(&rtor->notifier);
-            rtor->signalled_notifier = 0;
-
-            /*
-             * Release the other threads which have woken up (and possibly
-             * rtor_notify_other_threads as well).
-             */
-            ossl_crypto_condvar_broadcast(rtor->notifier_cv);
-        } else {
-            /* We are not the last waiter out - so wait for that one. */
-            while (rtor->signalled_notifier)
-                ossl_crypto_condvar_wait(rtor->notifier_cv, rtor->mutex);
-        }
+    /* The last waiter drains the notifier and advances its signal generation. */
+    if (rtor->have_notifier && rtor->signalled_notifier
+        && rtor->cur_blocking_waiters == 0) {
+        ossl_rio_notifier_unsignal(&rtor->notifier);
+        rtor->signalled_notifier = 0;
+        ++rtor->notify_generation;
+        ossl_crypto_condvar_broadcast(rtor->notifier_cv);
     }
+
+    /* Remaining waiters require phase 2 for the current signal generation. */
+    if (rtor->have_notifier && rtor->signalled_notifier) {
+        *gen = rtor->notify_generation;
+        return 1;
+    }
+
+    return 0;
+}
+
+/*
+ * Wait only for the signal cycle observed during deregistration.
+ * Precondition: reactor mutex held.
+ */
+static void rtor_wait_for_notifier_clear_locked(QUIC_REACTOR *rtor,
+    uint64_t gen)
+{
+    if (rtor->have_notifier)
+        while (rtor->signalled_notifier
+            && rtor->notify_generation == gen)
+            ossl_crypto_condvar_wait(rtor->notifier_cv, rtor->mutex);
+}
+
+void ossl_quic_reactor_wait_for_notifier_clear(QUIC_REACTOR *rtor,
+    uint64_t gen)
+{
+    ossl_crypto_mutex_lock(rtor->mutex);
+    rtor_wait_for_notifier_clear_locked(rtor, gen);
+    ossl_crypto_mutex_unlock(rtor->mutex);
+}
+
+void ossl_quic_reactor_leave_blocking_section(QUIC_REACTOR *rtor)
+{
+    uint64_t gen;
+
+    /* Caller holds the reactor mutex across both phases. */
+    if (ossl_quic_reactor_deregister_blocking_section(rtor, &gen))
+        rtor_wait_for_notifier_clear_locked(rtor, gen);
 }

--- a/ssl/quic/quic_reactor_wait_ctx.c
+++ b/ssl/quic/quic_reactor_wait_ctx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,6 +15,9 @@ struct quic_reactor_wait_slot_st {
     OSSL_LIST_MEMBER(quic_reactor_wait_slot, QUIC_REACTOR_WAIT_SLOT);
     QUIC_REACTOR *rtor; /* primary key */
     size_t blocking_count; /* datum */
+    /* Generation captured at the 1->0 deregistration, for the phase-2 wait. */
+    uint64_t notify_generation;
+    unsigned int need_notify_wait : 1; /* set when phase 2 must wait */
 };
 
 DEFINE_LIST_OF_IMPL(quic_reactor_wait_slot, QUIC_REACTOR_WAIT_SLOT);
@@ -30,14 +33,22 @@ static void slot_activate(QUIC_REACTOR_WAIT_SLOT *slot)
         ossl_quic_reactor_enter_blocking_section(slot->rtor);
 }
 
-static void slot_deactivate(QUIC_REACTOR_WAIT_SLOT *slot)
+/*
+ * Phase-1 deregistration: on the 1->0 transition, deregister from the reactor
+ * without blocking and capture whether phase 2 must wait (and the generation).
+ * Caller must hold the reactor mutex.
+ */
+static void slot_deactivate_deregister(QUIC_REACTOR_WAIT_SLOT *slot)
 {
     assert(slot->blocking_count > 0);
 
     if (--slot->blocking_count > 0)
         return;
 
-    ossl_quic_reactor_leave_blocking_section(slot->rtor);
+    slot->need_notify_wait
+        = ossl_quic_reactor_deregister_blocking_section(slot->rtor,
+              &slot->notify_generation)
+        != 0;
 }
 
 int ossl_quic_reactor_wait_ctx_enter(QUIC_REACTOR_WAIT_CTX *ctx,
@@ -61,7 +72,7 @@ int ossl_quic_reactor_wait_ctx_enter(QUIC_REACTOR_WAIT_CTX *ctx,
     return 1;
 }
 
-void ossl_quic_reactor_wait_ctx_leave(QUIC_REACTOR_WAIT_CTX *ctx,
+void ossl_quic_reactor_wait_ctx_deregister(QUIC_REACTOR_WAIT_CTX *ctx,
     QUIC_REACTOR *rtor)
 {
     QUIC_REACTOR_WAIT_SLOT *slot;
@@ -71,7 +82,31 @@ void ossl_quic_reactor_wait_ctx_leave(QUIC_REACTOR_WAIT_CTX *ctx,
         break;
 
     assert(slot != NULL);
-    slot_deactivate(slot);
+    slot_deactivate_deregister(slot);
+}
+
+/*
+ * Phase 2: wait for every notifier phase 1 left signalled to clear. Because
+ * phase 1 has already decremented every slot's refcount to zero, the calling
+ * thread holds no waiter registration here and cannot be part of a
+ * cross-reactor deadlock. Each reactor's mutex is acquired internally.
+ */
+void ossl_quic_reactor_wait_ctx_drain(QUIC_REACTOR_WAIT_CTX *ctx)
+{
+    QUIC_REACTOR_WAIT_SLOT *slot;
+
+    OSSL_LIST_FOREACH(slot, quic_reactor_wait_slot, &ctx->slots)
+    {
+        /* Invariant: phase 1 must have deregistered every slot by now. */
+        assert(slot->blocking_count == 0);
+
+        if (!slot->need_notify_wait)
+            continue;
+
+        ossl_quic_reactor_wait_for_notifier_clear(slot->rtor,
+            slot->notify_generation);
+        slot->need_notify_wait = 0;
+    }
 }
 
 void ossl_quic_reactor_wait_ctx_cleanup(QUIC_REACTOR_WAIT_CTX *ctx)
@@ -81,6 +116,7 @@ void ossl_quic_reactor_wait_ctx_cleanup(QUIC_REACTOR_WAIT_CTX *ctx)
     OSSL_LIST_FOREACH_DELSAFE(slot, nslot, quic_reactor_wait_slot, &ctx->slots)
     {
         assert(slot->blocking_count == 0);
+        assert(!slot->need_notify_wait);
         OPENSSL_free(slot);
     }
 }

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -142,15 +142,16 @@ static int poll_translate_ssl_quic(SSL *ssl,
          * it is possible the object became ready after our initial
          * poll_readout() call (before we determined that nothing was ready and
          * we needed to block). We now need to do another readout, in which case
-         * blocking is to be aborted.
+         * blocking is to be aborted. do_tick is 0 because ticking here would
+         * block on the notifier condvar while still registered.
          */
         if (!ossl_quic_conn_poll_events(ssl, events, /*do_tick = */ 0, &revents)) {
-            ossl_quic_leave_blocking_section(ssl, wctx);
+            ossl_quic_deregister_blocking_section(ssl, wctx);
             return 0;
         }
 
         if (revents != 0) {
-            ossl_quic_leave_blocking_section(ssl, wctx);
+            ossl_quic_deregister_blocking_section(ssl, wctx);
             *abort_blocking = 1;
             return 1;
         }
@@ -159,11 +160,11 @@ static int poll_translate_ssl_quic(SSL *ssl,
     return 1;
 }
 
-static void postpoll_translation_cleanup_ssl_quic(SSL *ssl,
+static void postpoll_translation_deregister_ssl_quic(SSL *ssl,
     QUIC_REACTOR_WAIT_CTX *wctx)
 {
     if (ossl_quic_get_notifier_fd(ssl) != -1)
-        ossl_quic_leave_blocking_section(ssl, wctx);
+        ossl_quic_deregister_blocking_section(ssl, wctx);
 }
 
 static void postpoll_translation_cleanup(SSL_POLL_ITEM *items,
@@ -175,6 +176,11 @@ static void postpoll_translation_cleanup(SSL_POLL_ITEM *items,
     SSL *ssl;
     size_t i;
 
+    /*
+     * Two-phase cleanup: deregister from all reactors first without blocking,
+     * then wait for still-signalled notifiers. See quic_reactor.h for why this
+     * avoids the cross-reactor leave-ordering deadlock.
+     */
     for (i = 0; i < num_items; ++i) {
         item = &ITEM_N(items, stride, i);
 
@@ -189,7 +195,7 @@ static void postpoll_translation_cleanup(SSL_POLL_ITEM *items,
             case SSL_TYPE_QUIC_LISTENER:
             case SSL_TYPE_QUIC_CONNECTION:
             case SSL_TYPE_QUIC_XSO:
-                postpoll_translation_cleanup_ssl_quic(ssl, wctx);
+                postpoll_translation_deregister_ssl_quic(ssl, wctx);
                 break;
 #endif
             default:
@@ -200,6 +206,12 @@ static void postpoll_translation_cleanup(SSL_POLL_ITEM *items,
             break;
         }
     }
+
+    /*
+     * Phase 2 also prevents the retry loop from re-registering before the
+     * signal cycle observed by this blocking attempt has been drained.
+     */
+    ossl_quic_reactor_wait_ctx_drain(wctx);
 }
 
 static int poll_translate(SSL_POLL_ITEM *items,
@@ -283,9 +295,11 @@ static int poll_translate(SSL_POLL_ITEM *items,
 
 out:
     /*
-     * On abort_blocking, the item which triggered the abort has already
-     * balanced its own enter/leave of the blocking section (see
-     * poll_translate_ssl_quic()); only items 0..i-1 still need cleanup here.
+     * poll_translate_ssl_quic() either leaves the triggering item unregistered
+     * or deregisters it before returning. SSL_get_event_timeout() failures
+     * increment i so the registered triggering item is included in the cleanup
+     * prefix. Phase 2 drains every reactor recorded in wctx, including one
+     * already deregistered by the triggering item.
      */
     if (!ok || *abort_blocking)
         postpoll_translation_cleanup(items, i, stride, wctx);

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,6 +9,9 @@
 
 #include "internal/quic_stream_map.h"
 #include "internal/quic_reactor.h"
+#include "internal/quic_channel.h"
+#include "internal/quic_ssl.h"
+#include "internal/time.h"
 #include "../../ssl/rio/poll_builder.h"
 
 #if defined(_AIX)
@@ -584,6 +587,282 @@ DEF_SCRIPT(poll_abort_blocking,
     OP_SELECT_SSL(2, Cb0);
     OP_SELECT_SSL(3, Lb0);
     OP_FUNC(check_poll_abort_blocking);
+}
+
+/*
+ * Test: poll_multi_reactor_cleanup
+ * --------------------------------
+ *
+ * Exercise SSL_poll() cleanup when two workers register the same two
+ * notifier-enabled reactors in opposite orders. Both notifiers are armed
+ * while each reactor has two blocking waiters. Cleanup must allow both
+ * workers to finish and leave both reactors with no waiters or signals.
+ *
+ * Each worker's third poll item is a NULL sentinel. Its translation hook
+ * blocks after the first two items have registered both reactors but before
+ * cleanup can begin. Once both workers reach this barrier, the coordinator
+ * arms the notifiers and releases them, making the ordering deterministic.
+ */
+
+#if defined(OPENSSL_THREADS)
+struct poll_multi_reactor_ctx {
+    CRYPTO_MUTEX *mu;
+    CRYPTO_CONDVAR *cv;
+    int arrived;
+    int release;
+    int done;
+    int rc[2];
+    size_t result_count[2];
+};
+
+struct poll_cleanup_thread_ctx {
+    SSL *ssl0, *ssl1;
+    size_t idx;
+    struct poll_multi_reactor_ctx *ctx;
+};
+
+/*
+ * Arm the notifier exactly as rtor_notify_other_threads() does, but without
+ * its condvar wait, so both reactors can be put into the required state
+ * deterministically before the workers are released.
+ */
+static void poll_cleanup_signal_notifier(QUIC_REACTOR *rtor)
+{
+    ossl_crypto_mutex_lock(rtor->mutex);
+    if (rtor->have_notifier && !rtor->signalled_notifier
+        && rtor->cur_blocking_waiters > 0) {
+        ossl_rio_notifier_signal(&rtor->notifier);
+        rtor->signalled_notifier = 1;
+    }
+    ossl_crypto_mutex_unlock(rtor->mutex);
+}
+
+static void poll_cleanup_test_step_cb(size_t idx, void *arg)
+{
+    struct poll_multi_reactor_ctx *ctx = arg;
+
+    /* Both reactors are registered when the NULL sentinel is reached. */
+    if (idx != 2)
+        return;
+
+    ossl_crypto_mutex_lock(ctx->mu);
+    if (!ctx->release) {
+        ++ctx->arrived;
+        ossl_crypto_condvar_broadcast(ctx->cv);
+        while (!ctx->release)
+            ossl_crypto_condvar_wait(ctx->cv, ctx->mu);
+    }
+    ossl_crypto_mutex_unlock(ctx->mu);
+}
+
+static CRYPTO_THREAD_RETVAL poll_cleanup_thread(void *arg)
+{
+    struct poll_cleanup_thread_ctx *d = arg;
+    struct poll_multi_reactor_ctx *ctx = d->ctx;
+    SSL_POLL_ITEM items[3] = { 0 };
+    const struct timeval timeout = { 1, 0 };
+    size_t result_count = 0;
+    int rc;
+
+    items[0].desc = SSL_as_poll_descriptor(d->ssl0);
+    items[0].events = SSL_POLL_EVENT_R;
+    items[1].desc = SSL_as_poll_descriptor(d->ssl1);
+    items[1].events = SSL_POLL_EVENT_R;
+    items[2].desc = SSL_as_poll_descriptor(NULL);
+
+    rc = SSL_poll(items, OSSL_NELEM(items), sizeof(SSL_POLL_ITEM),
+        &timeout, 0, &result_count);
+
+    ossl_crypto_mutex_lock(ctx->mu);
+    ctx->rc[d->idx] = rc;
+    ctx->result_count[d->idx] = result_count;
+    ++ctx->done;
+    ossl_crypto_condvar_broadcast(ctx->cv);
+    ossl_crypto_mutex_unlock(ctx->mu);
+    return 0;
+}
+#endif
+
+DEF_FUNC(check_poll_multi_reactor_cleanup)
+{
+    int ok = 0;
+#if !defined(OPENSSL_THREADS)
+    TEST_skip("threading not supported, skipping");
+    F_SKIP_REST();
+err:
+    return ok;
+#else
+    SSL *stream_a0, *stream_a1, *stream_b0, *stream_b1, *conn;
+    QUIC_CHANNEL *ch;
+    QUIC_REACTOR *rtor[2];
+    CRYPTO_THREAD *thread[2] = { NULL, NULL };
+    OSSL_TIME deadline;
+    size_t i;
+    int state_ok;
+    struct poll_multi_reactor_ctx ctx = { 0 };
+    struct poll_cleanup_thread_ctx worker[2] = { 0 };
+
+    REQUIRE_SSL_4(stream_a0, stream_a1, stream_b0, stream_b1);
+
+    for (i = 0; i < 2; ++i)
+        if (!TEST_ptr(conn = SSL_get0_connection(i == 0 ? stream_a0
+                                                        : stream_b0))
+            || !TEST_ptr(ch = ossl_quic_conn_get_channel(conn))
+            || !TEST_ptr(rtor[i] = ossl_quic_channel_get_reactor(ch)))
+            return 0;
+
+    if (rtor[0] == rtor[1]
+        || !rtor[0]->have_notifier
+        || !rtor[1]->have_notifier) {
+        TEST_skip("test requires two distinct notifier-enabled reactors");
+        F_SKIP_REST();
+    }
+
+    if ((ctx.mu = ossl_crypto_mutex_new()) == NULL
+        || (ctx.cv = ossl_crypto_condvar_new()) == NULL)
+        goto err;
+
+    worker[0].ssl0 = stream_a0;
+    worker[0].ssl1 = stream_b0;
+    worker[1].ssl0 = stream_b1;
+    worker[1].ssl1 = stream_a1;
+    for (i = 0; i < 2; ++i) {
+        worker[i].idx = i;
+        worker[i].ctx = &ctx;
+    }
+
+    ossl_quic_poll_translate_test_step_cb_arg = &ctx;
+    ossl_quic_poll_translate_test_step_cb = poll_cleanup_test_step_cb;
+
+    for (i = 0; i < 2; ++i)
+        if ((thread[i] = ossl_crypto_thread_native_start(poll_cleanup_thread,
+                 &worker[i], 1))
+            == NULL)
+            goto err_release;
+
+    /* Wait until both workers have registered both reactors. */
+    deadline = ossl_time_add(ossl_time_now(), ossl_seconds2time(10));
+    ossl_crypto_mutex_lock(ctx.mu);
+    while (ctx.arrived < 2
+        && ossl_time_compare(ossl_time_now(), deadline) < 0)
+        ossl_crypto_condvar_wait_timeout(ctx.cv, ctx.mu, deadline);
+    if (ctx.arrived < 2) {
+        TEST_error("coordinator timed out waiting for workers to register "
+                   "(arrived=%d/2, done=%d); SSL_poll() registration "
+                   "never reached",
+            ctx.arrived, ctx.done);
+        ossl_crypto_mutex_unlock(ctx.mu);
+        goto err_release;
+    }
+    ossl_crypto_mutex_unlock(ctx.mu);
+
+    /* The barrier keeps the waiter counts stable until release. */
+    state_ok = 1;
+    for (i = 0; i < 2; ++i) {
+        ossl_crypto_mutex_lock(rtor[i]->mutex);
+        if (!TEST_size_t_eq(rtor[i]->cur_blocking_waiters, 2))
+            state_ok = 0;
+        ossl_crypto_mutex_unlock(rtor[i]->mutex);
+    }
+    if (!state_ok)
+        goto err_release;
+
+    for (i = 0; i < 2; ++i)
+        poll_cleanup_signal_notifier(rtor[i]);
+
+    ossl_crypto_mutex_lock(ctx.mu);
+    ctx.release = 1;
+    ossl_crypto_condvar_broadcast(ctx.cv);
+    ossl_crypto_mutex_unlock(ctx.mu);
+
+    /* Do not let a cleanup regression hang the test process. */
+    deadline = ossl_time_add(ossl_time_now(), ossl_seconds2time(10));
+    ossl_crypto_mutex_lock(ctx.mu);
+    while (ctx.done < 2
+        && ossl_time_compare(ossl_time_now(), deadline) < 0)
+        ossl_crypto_condvar_wait_timeout(ctx.cv, ctx.mu, deadline);
+    if (ctx.done < 2) {
+        TEST_error("SSL_poll multi-reactor cleanup stuck (finished %d/2)",
+            ctx.done);
+        ossl_crypto_mutex_unlock(ctx.mu);
+        goto err_wedge;
+    }
+
+    state_ok = 1;
+    for (i = 0; i < 2; ++i)
+        if (!TEST_int_eq(ctx.rc[i], 1)
+            || !TEST_size_t_eq(ctx.result_count[i], 0))
+            state_ok = 0;
+    ossl_crypto_mutex_unlock(ctx.mu);
+    if (!state_ok)
+        goto err_join;
+
+    state_ok = 1;
+    for (i = 0; i < 2; ++i) {
+        ossl_crypto_mutex_lock(rtor[i]->mutex);
+        if (!TEST_size_t_eq(rtor[i]->cur_blocking_waiters, 0))
+            state_ok = 0;
+        if (!TEST_int_eq(rtor[i]->signalled_notifier, 0))
+            state_ok = 0;
+        ossl_crypto_mutex_unlock(rtor[i]->mutex);
+    }
+    if (!state_ok)
+        goto err_join;
+
+    ok = 1;
+
+err_join:
+    for (i = 0; i < 2; ++i) {
+        if (thread[i] == NULL)
+            continue;
+        ossl_crypto_thread_native_join(thread[i], NULL);
+        ossl_crypto_thread_native_clean(thread[i]);
+    }
+    goto err;
+
+err_release:
+    /* Release any worker stopped at the registration barrier. */
+    ossl_crypto_mutex_lock(ctx.mu);
+    ctx.release = 1;
+    ossl_crypto_condvar_broadcast(ctx.cv);
+    ossl_crypto_mutex_unlock(ctx.mu);
+    goto err_join;
+
+err_wedge:
+    /* Normal cleanup would re-enter reactors held by the wedged workers. */
+    OPENSSL_die("SSL_poll cleanup workers are wedged", __FILE__, __LINE__);
+
+err:
+    ossl_quic_poll_translate_test_step_cb = NULL;
+    ossl_quic_poll_translate_test_step_cb_arg = NULL;
+    ossl_crypto_condvar_free(&ctx.cv);
+    ossl_crypto_mutex_free(&ctx.mu);
+    return ok;
+#endif
+}
+
+DEF_SCRIPT(poll_multi_reactor_cleanup,
+    "verify SSL_poll() multi-reactor two-phase cleanup does not deadlock")
+{
+    OP_SIMPLE_PAIR_CONN_ND();
+
+    OP_NEW_STREAM(C, C0, 0);
+    OP_NEW_STREAM(C, C1, 0);
+
+    /* A second, independent client connection (its own reactor). */
+    OP_NEW_SSL_C(Cb);
+    OP_SET_PEER_ADDR_FROM(Cb, L);
+    OP_CONNECT_WAIT(Cb);
+    OP_SET_DEFAULT_STREAM_MODE(Cb, SSL_DEFAULT_STREAM_MODE_NONE);
+
+    OP_NEW_STREAM(Cb, Cb0, 0);
+    OP_NEW_STREAM(Cb, Cb1, 0);
+
+    OP_SELECT_SSL(0, C0);
+    OP_SELECT_SSL(1, C1);
+    OP_SELECT_SSL(2, Cb0);
+    OP_SELECT_SSL(3, Cb1);
+    OP_FUNC(check_poll_multi_reactor_cleanup);
 }
 
 DEF_FUNC(check_writeable)
@@ -3065,6 +3344,7 @@ static SCRIPT_INFO *const scripts[] = {
     USE(simple_thread),
     USE(ssl_poll),
     USE(poll_abort_blocking),
+    USE(poll_multi_reactor_cleanup),
     USE(check_cwm),
     USE(check_pc_flood),
     USE(check_ctx_cbks),

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -9,6 +9,9 @@
 
 #include "internal/quic_stream_map.h"
 #include "internal/quic_reactor.h"
+#include "internal/quic_channel.h"
+#include "internal/quic_ssl.h"
+#include "internal/time.h"
 #include "../../ssl/rio/poll_builder.h"
 
 #if defined(_AIX)
@@ -555,6 +558,282 @@ DEF_SCRIPT(poll_abort_blocking,
     OP_SELECT_SSL(2, Cb0);
     OP_SELECT_SSL(3, Lb0);
     OP_FUNC(check_poll_abort_blocking);
+}
+
+/*
+ * Test: poll_multi_reactor_cleanup
+ * --------------------------------
+ *
+ * Exercise SSL_poll() cleanup when two workers register the same two
+ * notifier-enabled reactors in opposite orders. Both notifiers are armed
+ * while each reactor has two blocking waiters. Cleanup must allow both
+ * workers to finish and leave both reactors with no waiters or signals.
+ *
+ * Each worker's third poll item is a NULL sentinel. Its translation hook
+ * blocks after the first two items have registered both reactors but before
+ * cleanup can begin. Once both workers reach this barrier, the coordinator
+ * arms the notifiers and releases them, making the ordering deterministic.
+ */
+
+#if defined(OPENSSL_THREADS)
+struct poll_multi_reactor_ctx {
+    CRYPTO_MUTEX *mu;
+    CRYPTO_CONDVAR *cv;
+    int arrived;
+    int release;
+    int done;
+    int rc[2];
+    size_t result_count[2];
+};
+
+struct poll_cleanup_thread_ctx {
+    SSL *ssl0, *ssl1;
+    size_t idx;
+    struct poll_multi_reactor_ctx *ctx;
+};
+
+/*
+ * Arm the notifier exactly as rtor_notify_other_threads() does, but without
+ * its condvar wait, so both reactors can be put into the required state
+ * deterministically before the workers are released.
+ */
+static void poll_cleanup_signal_notifier(QUIC_REACTOR *rtor)
+{
+    ossl_crypto_mutex_lock(rtor->mutex);
+    if (rtor->have_notifier && !rtor->signalled_notifier
+        && rtor->cur_blocking_waiters > 0) {
+        ossl_rio_notifier_signal(&rtor->notifier);
+        rtor->signalled_notifier = 1;
+    }
+    ossl_crypto_mutex_unlock(rtor->mutex);
+}
+
+static void poll_cleanup_test_step_cb(size_t idx, void *arg)
+{
+    struct poll_multi_reactor_ctx *ctx = arg;
+
+    /* Both reactors are registered when the NULL sentinel is reached. */
+    if (idx != 2)
+        return;
+
+    ossl_crypto_mutex_lock(ctx->mu);
+    if (!ctx->release) {
+        ++ctx->arrived;
+        ossl_crypto_condvar_broadcast(ctx->cv);
+        while (!ctx->release)
+            ossl_crypto_condvar_wait(ctx->cv, ctx->mu);
+    }
+    ossl_crypto_mutex_unlock(ctx->mu);
+}
+
+static CRYPTO_THREAD_RETVAL poll_cleanup_thread(void *arg)
+{
+    struct poll_cleanup_thread_ctx *d = arg;
+    struct poll_multi_reactor_ctx *ctx = d->ctx;
+    SSL_POLL_ITEM items[3] = { 0 };
+    const struct timeval timeout = { 1, 0 };
+    size_t result_count = 0;
+    int rc;
+
+    items[0].desc = SSL_as_poll_descriptor(d->ssl0);
+    items[0].events = SSL_POLL_EVENT_R;
+    items[1].desc = SSL_as_poll_descriptor(d->ssl1);
+    items[1].events = SSL_POLL_EVENT_R;
+    items[2].desc = SSL_as_poll_descriptor(NULL);
+
+    rc = SSL_poll(items, OSSL_NELEM(items), sizeof(SSL_POLL_ITEM),
+        &timeout, 0, &result_count);
+
+    ossl_crypto_mutex_lock(ctx->mu);
+    ctx->rc[d->idx] = rc;
+    ctx->result_count[d->idx] = result_count;
+    ++ctx->done;
+    ossl_crypto_condvar_broadcast(ctx->cv);
+    ossl_crypto_mutex_unlock(ctx->mu);
+    return 0;
+}
+#endif
+
+DEF_FUNC(check_poll_multi_reactor_cleanup)
+{
+    int ok = 0;
+#if !defined(OPENSSL_THREADS)
+    TEST_skip("threading not supported, skipping");
+    F_SKIP_REST();
+err:
+    return ok;
+#else
+    SSL *stream_a0, *stream_a1, *stream_b0, *stream_b1, *conn;
+    QUIC_CHANNEL *ch;
+    QUIC_REACTOR *rtor[2];
+    CRYPTO_THREAD *thread[2] = { NULL, NULL };
+    OSSL_TIME deadline;
+    size_t i;
+    int state_ok;
+    struct poll_multi_reactor_ctx ctx = { 0 };
+    struct poll_cleanup_thread_ctx worker[2] = { 0 };
+
+    REQUIRE_SSL_4(stream_a0, stream_a1, stream_b0, stream_b1);
+
+    for (i = 0; i < 2; ++i)
+        if (!TEST_ptr(conn = SSL_get0_connection(i == 0 ? stream_a0
+                                                        : stream_b0))
+            || !TEST_ptr(ch = ossl_quic_conn_get_channel(conn))
+            || !TEST_ptr(rtor[i] = ossl_quic_channel_get_reactor(ch)))
+            return 0;
+
+    if (rtor[0] == rtor[1]
+        || !rtor[0]->have_notifier
+        || !rtor[1]->have_notifier) {
+        TEST_skip("test requires two distinct notifier-enabled reactors");
+        F_SKIP_REST();
+    }
+
+    if ((ctx.mu = ossl_crypto_mutex_new()) == NULL
+        || (ctx.cv = ossl_crypto_condvar_new()) == NULL)
+        goto err;
+
+    worker[0].ssl0 = stream_a0;
+    worker[0].ssl1 = stream_b0;
+    worker[1].ssl0 = stream_b1;
+    worker[1].ssl1 = stream_a1;
+    for (i = 0; i < 2; ++i) {
+        worker[i].idx = i;
+        worker[i].ctx = &ctx;
+    }
+
+    ossl_quic_poll_translate_test_step_cb_arg = &ctx;
+    ossl_quic_poll_translate_test_step_cb = poll_cleanup_test_step_cb;
+
+    for (i = 0; i < 2; ++i)
+        if ((thread[i] = ossl_crypto_thread_native_start(poll_cleanup_thread,
+                 &worker[i], 1))
+            == NULL)
+            goto err_release;
+
+    /* Wait until both workers have registered both reactors. */
+    deadline = ossl_time_add(ossl_time_now(), ossl_seconds2time(10));
+    ossl_crypto_mutex_lock(ctx.mu);
+    while (ctx.arrived < 2
+        && ossl_time_compare(ossl_time_now(), deadline) < 0)
+        ossl_crypto_condvar_wait_timeout(ctx.cv, ctx.mu, deadline);
+    if (ctx.arrived < 2) {
+        TEST_error("coordinator timed out waiting for workers to register "
+                   "(arrived=%d/2, done=%d); SSL_poll() registration "
+                   "never reached",
+            ctx.arrived, ctx.done);
+        ossl_crypto_mutex_unlock(ctx.mu);
+        goto err_release;
+    }
+    ossl_crypto_mutex_unlock(ctx.mu);
+
+    /* The barrier keeps the waiter counts stable until release. */
+    state_ok = 1;
+    for (i = 0; i < 2; ++i) {
+        ossl_crypto_mutex_lock(rtor[i]->mutex);
+        if (!TEST_size_t_eq(rtor[i]->cur_blocking_waiters, 2))
+            state_ok = 0;
+        ossl_crypto_mutex_unlock(rtor[i]->mutex);
+    }
+    if (!state_ok)
+        goto err_release;
+
+    for (i = 0; i < 2; ++i)
+        poll_cleanup_signal_notifier(rtor[i]);
+
+    ossl_crypto_mutex_lock(ctx.mu);
+    ctx.release = 1;
+    ossl_crypto_condvar_broadcast(ctx.cv);
+    ossl_crypto_mutex_unlock(ctx.mu);
+
+    /* Do not let a cleanup regression hang the test process. */
+    deadline = ossl_time_add(ossl_time_now(), ossl_seconds2time(10));
+    ossl_crypto_mutex_lock(ctx.mu);
+    while (ctx.done < 2
+        && ossl_time_compare(ossl_time_now(), deadline) < 0)
+        ossl_crypto_condvar_wait_timeout(ctx.cv, ctx.mu, deadline);
+    if (ctx.done < 2) {
+        TEST_error("SSL_poll multi-reactor cleanup stuck (finished %d/2)",
+            ctx.done);
+        ossl_crypto_mutex_unlock(ctx.mu);
+        goto err_wedge;
+    }
+
+    state_ok = 1;
+    for (i = 0; i < 2; ++i)
+        if (!TEST_int_eq(ctx.rc[i], 1)
+            || !TEST_size_t_eq(ctx.result_count[i], 0))
+            state_ok = 0;
+    ossl_crypto_mutex_unlock(ctx.mu);
+    if (!state_ok)
+        goto err_join;
+
+    state_ok = 1;
+    for (i = 0; i < 2; ++i) {
+        ossl_crypto_mutex_lock(rtor[i]->mutex);
+        if (!TEST_size_t_eq(rtor[i]->cur_blocking_waiters, 0))
+            state_ok = 0;
+        if (!TEST_int_eq(rtor[i]->signalled_notifier, 0))
+            state_ok = 0;
+        ossl_crypto_mutex_unlock(rtor[i]->mutex);
+    }
+    if (!state_ok)
+        goto err_join;
+
+    ok = 1;
+
+err_join:
+    for (i = 0; i < 2; ++i) {
+        if (thread[i] == NULL)
+            continue;
+        ossl_crypto_thread_native_join(thread[i], NULL);
+        ossl_crypto_thread_native_clean(thread[i]);
+    }
+    goto err;
+
+err_release:
+    /* Release any worker stopped at the registration barrier. */
+    ossl_crypto_mutex_lock(ctx.mu);
+    ctx.release = 1;
+    ossl_crypto_condvar_broadcast(ctx.cv);
+    ossl_crypto_mutex_unlock(ctx.mu);
+    goto err_join;
+
+err_wedge:
+    /* Normal cleanup would re-enter reactors held by the wedged workers. */
+    OPENSSL_die("SSL_poll cleanup workers are wedged", __FILE__, __LINE__);
+
+err:
+    ossl_quic_poll_translate_test_step_cb = NULL;
+    ossl_quic_poll_translate_test_step_cb_arg = NULL;
+    ossl_crypto_condvar_free(&ctx.cv);
+    ossl_crypto_mutex_free(&ctx.mu);
+    return ok;
+#endif
+}
+
+DEF_SCRIPT(poll_multi_reactor_cleanup,
+    "verify SSL_poll() multi-reactor two-phase cleanup does not deadlock")
+{
+    OP_SIMPLE_PAIR_CONN_ND();
+
+    OP_NEW_STREAM(C, C0, 0);
+    OP_NEW_STREAM(C, C1, 0);
+
+    /* A second, independent client connection (its own reactor). */
+    OP_NEW_SSL_C(Cb);
+    OP_SET_PEER_ADDR_FROM(Cb, L);
+    OP_CONNECT_WAIT(Cb);
+    OP_SET_DEFAULT_STREAM_MODE(Cb, SSL_DEFAULT_STREAM_MODE_NONE);
+
+    OP_NEW_STREAM(Cb, Cb0, 0);
+    OP_NEW_STREAM(Cb, Cb1, 0);
+
+    OP_SELECT_SSL(0, C0);
+    OP_SELECT_SSL(1, C1);
+    OP_SELECT_SSL(2, Cb0);
+    OP_SELECT_SSL(3, Cb1);
+    OP_FUNC(check_poll_multi_reactor_cleanup);
 }
 
 DEF_FUNC(check_writeable)
@@ -2311,6 +2590,7 @@ static SCRIPT_INFO *const scripts[] = {
     USE(simple_thread),
     USE(ssl_poll),
     USE(poll_abort_blocking),
+    USE(poll_multi_reactor_cleanup),
     USE(check_cwm),
     USE(check_pc_flood),
     USE(check_ctx_cbks),


### PR DESCRIPTION
Fixes #32130.

Multi-reactor leave is split into two phases:

* `ossl_quic_reactor_deregister_blocking_section` deregisters every reactor without blocking and records any active signal cycle.
* `ossl_quic_reactor_wait_for_notifier_clear` waits for those cycles only after all registrations have been removed.

No thread therefore waits on one reactor while still counted as a waiter on another, so the last waiter can always clear each notifier.
`notify_generation` limits each wait to the signal cycle seen during deregistration, and phase 2 prevents immediate re-registration.

Single-reactor callers retain the combined leave operation with the same generation bound, and the translation abort path uses the two-phase cleanup.
The existing `do_tick = 0` translation path is documented because ticking while registrations are held can block during notification.

## Testing

The new `poll_multi_reactor_cleanup` test creates two client connections on separate implicit domains and two distinct streams on each. Two workers call the real `SSL_poll` in opposite reactor orders without using any `SSL *` concurrently. A coordinator deterministically arms both notifiers under their reactor mutexes. The old item-ordered cleanup wedges both workers. The two-phase cleanup lets both return and leaves both reactors clean.

Directly signalling the notifiers lets the test reproduce deterministically a state that can also arise during normal operation.
A watchdog prevents CI from hanging on regression.

## Backport

The affected portions of quic_reactor.c and poll_immediate.c are identical across openssl-3.5, openssl-3.6, and openssl-4.0, so the fix should apply cleanly to all three branches.

##### Checklist

- [x] tests are added or updated