### PR TITLE
docs: document thread cancellation safety limitations

### DIFF
--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -224,6 +224,9 @@ with those threads. The application should either call OPENSSL_thread_stop() on
 each thread prior to the dlclose() call, or alternatively the original dlopen()
 call should use the RTLD_NODELETE flag (where available on the platform).
 
+Thread cleanup does not unwind an OpenSSL function interrupted by cancellation
+or thread exit; see L<openssl-threads(7)>.
+
 =head1 RETURN VALUES
 
 The functions OPENSSL_init_crypto, and
@@ -231,7 +234,7 @@ OPENSSL_INIT_set_config_appname() return 1 on success or 0 on error.
 
 =head1 SEE ALSO
 
-L<OPENSSL_init_ssl(3)>
+L<OPENSSL_init_ssl(3)>, L<openssl-threads(7)>
 
 =head1 HISTORY
 

--- a/doc/man3/SSL_poll.pod
+++ b/doc/man3/SSL_poll.pod
@@ -337,6 +337,20 @@ stream SSL objects, are supported.
 
 This limitation may be revised in a future release of OpenSSL.
 
+=head1 THREAD CANCELLATION
+
+A finite I<timeout> limits ordinary waiting by SSL_poll(), but does not make the
+call safe against thread cancellation; see L<openssl-threads(7)>.
+
+Cancellation can prevent SSL_poll() from removing internal wait state. Because
+an I<items> array can span multiple QUIC domains, one interrupted call can leave
+stale state in several domains and cause later calls on those domains, including
+SSL_poll() with a finite timeout, to block indefinitely.
+
+For cooperative cancellation, use a finite timeout and check a cancellation
+condition between calls; see L<openssl-quic-concurrency(7)/THREAD CANCELLATION>
+for the nonblocking alternative.
+
 =head1 RETURN VALUES
 
 SSL_poll() returns 1 on success and 0 on failure.
@@ -406,7 +420,9 @@ I<result_count>.
 =head1 SEE ALSO
 
 L<BIO_get_rpoll_descriptor(3)>, L<BIO_get_wpoll_descriptor(3)>,
-L<SSL_get_rpoll_descriptor(3)>, L<SSL_get_wpoll_descriptor(3)>
+L<SSL_get_rpoll_descriptor(3)>, L<SSL_get_wpoll_descriptor(3)>,
+L<openssl-threads(7)>, L<openssl-quic(7)>,
+L<openssl-quic-concurrency(7)>
 
 =head1 HISTORY
 
@@ -421,7 +437,7 @@ event types were not present.
 
 =head1 COPYRIGHT
 
-Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/openssl-quic-concurrency.pod
+++ b/doc/man7/openssl-quic-concurrency.pod
@@ -150,6 +150,29 @@ default concurrency model if the application does not explicitly specify a
 concurrency model or disable it. This is known as Legacy Blocking Compatibility
 Mode, and its usage is not recommended for multi-threaded applications.
 
+=head1 THREAD CANCELLATION
+
+The restrictions in L<openssl-threads(7)/THREAD CANCELLATION> also apply to
+OpenSSL QUIC APIs, including calls used in nonblocking mode.
+
+CCM and TACM use domain-wide synchronisation during API processing. Event
+processing may perform network I/O while it is held, which can be a POSIX
+cancellation point. Interruption can leave later use or teardown of the domain
+unsafe.
+
+TACM and CCM with B<SSL_DOMAIN_FLAG_BLOCKING> also maintain internal wait state
+for blocking calls. If interruption prevents cleanup of this state, later calls
+on the affected domain can block indefinitely. L<SSL_poll(3)> can maintain such
+state in multiple domains in one call.
+
+Because most blocking QUIC functions do not provide a per-call timeout,
+applications requiring prompt cooperative cancellation should use nonblocking
+mode and an application-driven event loop as described in
+L<openssl-quic(7)/APPLICATION-DRIVEN EVENT LOOPS>, waiting for the application
+cancellation event alongside QUIC events. Alternatively, an application can
+call L<SSL_poll(3)> with a finite timeout and check a cancellation condition
+between calls.
+
 =head1 RECOMMENDED USAGE
 
 New applications are advised to choose a concurrency model as follows:
@@ -323,13 +346,15 @@ blocking mode can be changed explicitly using L<SSL_set_blocking_mode(3)>.
 
 =head1 SEE ALSO
 
-L<openssl-quic(7)>, L<SSL_handle_events(3)>, L<SSL_get_event_timeout(3)>,
+L<openssl-quic(7)>, L<openssl-threads(7)>, L<SSL_handle_events(3)>,
+L<SSL_get_event_timeout(3)>, L<SSL_get_rpoll_descriptor(3)>,
+L<SSL_get_wpoll_descriptor(3)>, L<SSL_poll(3)>,
 L<OSSL_QUIC_client_thread_method(3)>, L<SSL_CTX_set_domain_flags(3)>,
 L<SSL_new_domain(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/openssl-threads.pod
+++ b/doc/man7/openssl-threads.pod
@@ -92,9 +92,35 @@ are using the same B<SSL> object concurrently.
 Each thread handling TLS connections in parallel should create its own
 B<SSL> object from the shared B<SSL_CTX>.
 
+=head1 THREAD CANCELLATION
+
+Thread safety does not imply cancellation safety.
+Unless a specific function documents otherwise, OpenSSL does not guarantee
+that an in-progress call can be abandoned safely by thread cancellation or
+forced termination. An interruption can leave locks held, resources unreleased,
+or shared state inconsistent, making later use or cleanup unsafe.
+
+Deferred cancellation can take effect at a cancellation point reached directly
+or through a callback, BIO, provider, or other pluggable implementation.
+Automatic thread-local cleanup and L<OPENSSL_thread_stop(3)>, when they run, do
+not unwind the interrupted call.
+
+Applications should act on cancellation only between OpenSSL calls. On POSIX
+systems, applications using pthread cancellation should disable cancellation
+with B<pthread_setcancelstate>() before entering OpenSSL and restore it only
+after OpenSSL returns at a point safe for cancellation. Callbacks invoked by
+OpenSSL must not re-enable it. Disabling cancellation does not make a blocking
+call return on a cancellation request; applications requiring prompt
+cancellation should use nonblocking operation where available.
+
+The same restriction applies to other non-local exits which abandon an OpenSSL
+call in progress, including direct thread exit, long jumps, and language
+exceptions.
+
 =head1 SEE ALSO
 
-CRYPTO_THREAD_run_once(3),
+L<CRYPTO_THREAD_run_once(3)>, L<OPENSSL_thread_stop(3)>,
+L<openssl-quic-concurrency(7)>,
 local system threads documentation.
 
 =head1 BUGS
@@ -103,7 +129,7 @@ This page is admittedly very incomplete.
 
 =head1 COPYRIGHT
 
-Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2021-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
POSIX `poll` and `select` are cancellation points where deferred cancellation can take effect. OpenSSL installs no cancellation cleanup handler around QUIC waiter registration and polling, so cancellation of a thread blocked in `SSL_poll` can bypass cleanup of internal QUIC wait state. Because one `items` array can span multiple QUIC domains, a single interrupted call can leave stale state in several domains, after which later calls on those domains can block indefinitely, including `SSL_poll` with a finite timeout.

This is independent of #32130 and the proposed fix in #32137: that change corrects cleanup ordering on the normal return path, whereas thread cancellation can bypass cleanup entirely.

This is an instance of a broader current limitation: OpenSSL doesn't guarantee that a call already in progress can be abandoned safely by thread cancellation or forced termination of the individual thread. An interruption can leave locks held, resources unreleased, or shared state inconsistent, and automatic cleanup of resources associated with a thread doesn't perform the interrupted call's cleanup. The risk exists beyond blocking calls: nonblocking QUIC event processing can perform network I/O while synchronization that covers the entire domain is held.

The documentation states the general limitation and the consequences across a QUIC domain, clarifies that a finite `SSL_poll` timeout is not cancellation safety, and recommends cooperative cancellation between calls or an event loop managed by the application.

Validation:

- `make -s doc-nits`
- POD syntax and rendering with `podchecker`, `pod2text` and `pod2man`
- `git diff --check`

##### Checklist

- [x] documentation is added or updated
