### PR TITLE
Add X509v3 configuration fuzzer

### DIFF
--- a/crypto/x509/v3_pci.c
+++ b/crypto/x509/v3_pci.c
@@ -166,6 +166,13 @@ static int process_pci_value(CONF_VALUE *val,
         } else if (CHECK_AND_SKIP_PREFIX(valp, "file:")) {
             unsigned char buf[2048];
             int n;
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            /*
+             * Prevent fuzzer from mutating input to reading random files.
+             */
+            valp = NULL;
+#endif
             BIO *b = BIO_new_file(valp, "r");
             if (!b) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_BIO_LIB);

--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -12,7 +12,7 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   PROGRAMS{noinst}=asn1 asn1parse bignum bndiv client conf crl server smime
   PROGRAMS{noinst}=pkcs7_verify
   PROGRAMS{noinst}=pkcs12 punycode pem decoder hashtable acert
-  PROGRAMS{noinst}=v3name
+  PROGRAMS{noinst}=v3name x509v3
   PROGRAMS{noinst}=provider
 
   IF[{- !$disabled{"ml-kem"} -}]
@@ -147,6 +147,10 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   INCLUDE[v3name]=../include {- $ex_inc -}
   DEPEND[v3name]=../libcrypto.a {- $ex_lib -}
 
+  SOURCE[x509v3]=x509v3.c driver.c
+  INCLUDE[x509v3]=../include {- $ex_inc -}
+  DEPEND[x509v3]=../libcrypto.a {- $ex_lib -}
+
   SOURCE[quic-client]=quic-client.c driver.c fuzz_rand.c
   INCLUDE[quic-client]=../include {- $ex_inc -}
   DEPEND[quic-client]=../libcrypto.a ../libssl.a {- $ex_lib -}
@@ -194,7 +198,7 @@ IF[{- !$disabled{tests} -}]
   PROGRAMS{noinst}=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test smime-test
   PROGRAMS{noinst}=pkcs7_verify-test
   PROGRAMS{noinst}=pkcs12-test punycode-test pem-test decoder-test hashtable-test acert-test
-  PROGRAMS{noinst}=v3name-test
+  PROGRAMS{noinst}=v3name-test x509v3-test
   PROGRAMS{noinst}=provider-test
 
   IF[{- !$disabled{"ml-kem"} -}]
@@ -341,6 +345,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[v3name-test]=v3name.c $FUZZTESTSRC
   INCLUDE[v3name-test]=../include ../test/mfail
   DEPEND[v3name-test]=../libcrypto.a
+
+  SOURCE[x509v3-test]=x509v3.c $FUZZTESTSRC
+  INCLUDE[x509v3-test]=../include ../test/mfail
+  DEPEND[x509v3-test]=../libcrypto.a
 
   SOURCE[quic-client-test]=quic-client.c $FUZZTESTSRC fuzz_rand.c
   INCLUDE[quic-client-test]=../include ../test/mfail

--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -11,7 +11,7 @@
 IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   PROGRAMS{noinst}=asn1 asn1parse bignum bndiv client conf crl server smime
   PROGRAMS{noinst}=pkcs12 punycode pem decoder hashtable acert
-  PROGRAMS{noinst}=v3name
+  PROGRAMS{noinst}=v3name x509v3
   PROGRAMS{noinst}=provider
 
   IF[{- !$disabled{"ml-kem"} -}]
@@ -142,6 +142,10 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   INCLUDE[v3name]=../include {- $ex_inc -}
   DEPEND[v3name]=../libcrypto.a {- $ex_lib -}
 
+  SOURCE[x509v3]=x509v3.c driver.c
+  INCLUDE[x509v3]=../include {- $ex_inc -}
+  DEPEND[x509v3]=../libcrypto.a {- $ex_lib -}
+
   SOURCE[quic-client]=quic-client.c driver.c fuzz_rand.c
   INCLUDE[quic-client]=../include {- $ex_inc -}
   DEPEND[quic-client]=../libcrypto.a ../libssl.a {- $ex_lib -}
@@ -188,7 +192,7 @@ IF[{- !$disabled{tests} -}]
 
   PROGRAMS{noinst}=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test smime-test
   PROGRAMS{noinst}=pkcs12-test punycode-test pem-test decoder-test hashtable-test acert-test
-  PROGRAMS{noinst}=v3name-test
+  PROGRAMS{noinst}=v3name-test x509v3-test
   PROGRAMS{noinst}=provider-test
 
   IF[{- !$disabled{"ml-kem"} -}]
@@ -331,6 +335,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[v3name-test]=v3name.c $FUZZTESTSRC
   INCLUDE[v3name-test]=../include ../test/mfail
   DEPEND[v3name-test]=../libcrypto.a
+
+  SOURCE[x509v3-test]=x509v3.c $FUZZTESTSRC
+  INCLUDE[x509v3-test]=../include ../test/mfail
+  DEPEND[x509v3-test]=../libcrypto.a
 
   SOURCE[quic-client-test]=quic-client.c $FUZZTESTSRC fuzz_rand.c
   INCLUDE[quic-client-test]=../include ../test/mfail

--- a/fuzz/x509v3.c
+++ b/fuzz/x509v3.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+#include <openssl/bio.h>
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include "fuzzer.h"
+
+/*
+ * Repeated section references in the string-based extension APIs can cause
+ * quadratic output growth. Limit input size
+ * to keep individual fuzzing iterations small. See:
+ * https://github.com/google/boringssl/blob/f1f2556a5dfa59e147d9d47279cc3f7f8a18b433/fuzz/conf.cc#L22-L25
+ * https://issues.chromium.org/issues/42290485
+ */
+#define MAX_INPUT_SIZE (8 * 1024)
+
+int FuzzerInitialize(int *argc, char ***argv)
+{
+    return 1;
+}
+
+int FuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+    BIO *in = NULL;
+    CONF *conf = NULL;
+    X509 *cert = NULL;
+    X509V3_CTX ctx;
+
+    if (len == 0)
+        return 0;
+
+    if (len > MAX_INPUT_SIZE)
+        len = MAX_INPUT_SIZE;
+
+    in = BIO_new(BIO_s_mem());
+    if (in == NULL)
+        goto end;
+
+    if ((size_t)BIO_write(in, buf, (int)len) != len)
+        goto end;
+
+    conf = NCONF_new(NULL);
+    if (conf == NULL)
+        goto end;
+
+    if (NCONF_load_bio(conf, in, NULL) <= 0)
+        goto end;
+
+    cert = X509_new();
+    if (cert != NULL) {
+        X509V3_set_ctx(&ctx, cert, cert, NULL, NULL, 0);
+        X509V3_set_nconf(&ctx, conf);
+        X509V3_EXT_add_nconf(conf, &ctx, "default", cert);
+        X509_free(cert);
+        cert = NULL;
+    }
+
+    cert = X509_new();
+    if (cert != NULL) {
+        X509V3_set_ctx(&ctx, NULL, NULL, NULL, NULL, 0);
+        X509V3_set_nconf(&ctx, conf);
+        X509V3_EXT_add_nconf(conf, &ctx, "default", cert);
+    }
+
+end:
+    X509_free(cert);
+    NCONF_free(conf);
+    BIO_free(in);
+    ERR_clear_error();
+
+    return 0;
+}
+
+void FuzzerCleanup(void)
+{
+}

--- a/test/recipes/99-test_fuzz_x509v3.t
+++ b/test/recipes/99-test_fuzz_x509v3.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+my $fuzzer = "x509v3";
+setup("test_fuzz_${fuzzer}");
+
+plan tests => 2; # one more due to below require_ok(...)
+
+require_ok(srctop_file('test','recipes','fuzz.pl'));
+
+fuzz_ok($fuzzer);


### PR DESCRIPTION
Exercises x509v3 configuration, with limited input size (8 * 1024 bytes).
Two paths are covered:
1.  With issuer + subject certificate present in context
2. No issuer or subject certificate present in context

Motivation : Boringssl fuzzer missing from openssl. https://github.com/google/boringssl/blob/f1f2556a5dfa59e147d9d47279cc3f7f8a18b433/fuzz/conf.cc#L21

Corpus: https://github.com/openssl/fuzz-corpora/pull/35