### PR TITLE
apps/x509: Fix new output detection for -key signing

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -713,7 +713,7 @@ int x509_main(int argc, char **argv)
     if (!opt_check_md(digest))
         goto opthelp;
 
-    if (reqfile || newcert || privkey != NULL || CAfile != NULL)
+    if (reqfile || newcert || privkeyfile != NULL || CAfile != NULL)
         newout = 1;
     else if (sno != NULL
         || not_before != NULL

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2015-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2015-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -17,7 +17,7 @@ use File::Compare qw/compare_text/;
 
 setup("test_x509");
 
-plan tests => 155;
+plan tests => 156;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -597,6 +597,30 @@ my $invextfile = srctop_file('test', 'invalid-x509.cnf');
 ok(!run(app(["openssl", "x509", "-req", "-in", $in_csr, "-signkey", $in_key,
             "-out", "/dev/null", "-days", "3650" , "-extensions", "ext",
             "-extfile", $invextfile])));
+
+subtest "signing output detection with -key" => sub {
+    plan tests => 5;
+
+    my $v1_cert = srctop_file("test", "testx509.pem");
+    my $with_days_cert = "x509-resigned-with-days.pem";
+    my $default_ext_cert = "x509-resigned-with-default-ext.pem";
+    my $request = "x509-to-request-with-ext.pem";
+
+    ok(!run(app(["openssl", "x509", "-in", $v1_cert, "-noout",
+                 "-days", "1"])),
+       "reject -days when no signed output is requested");
+    ok(run(app(["openssl", "x509", "-in", $v1_cert, "-signkey", $in_key,
+                "-days", "1", "-out", $with_days_cert])),
+       "accept -days when re-signing with -signkey");
+    ok(run(app(["openssl", "x509", "-in", $v1_cert, "-key", $in_key,
+                "-out", $default_ext_cert])),
+       "re-sign a certificate with -key");
+    has_SKID($default_ext_cert, 1);
+    ok(run(app(["openssl", "x509", "-in", $v1_cert, "-x509toreq",
+                "-key", $in_key, "-extfile", $cnf,
+                "-extensions", "v3_req", "-out", $request])),
+       "accept extension options when signing a request with -key");
+};
 
 # Tests for issue #16080 (fixed in 1.1.1o)
 my $b_key = "b-key.pem";


### PR DESCRIPTION
The signing-only option validation runs before `load_key()`, so `privkey` is always `NULL` when `newout` is determined. As a result, `-key` or `-signkey` alone doesn't identify re-signing an input certificate or signing an `-x509toreq` output.

Check `privkeyfile` at this stage, which records that the option was supplied.
Keep the later `privkey` check unchanged because the key has been loaded by then.

Regression tests verify that:

- signing-only options remain rejected without a signing operation
- `-signkey -days` works when re-signing
- plain `-key` re-signing loads the default extensions section
- extension options work with `-x509toreq -key`

Fixes #32150

##### Checklist
- [x] tests are added or updated
