### PR TITLE
Additional cleansing of intermediate (potentially sensitive) data in ML-KEM, ML-DSA and SLH-DSA (4.0)

### DIFF
--- a/crypto/ml_dsa/ml_dsa_encoders.c
+++ b/crypto/ml_dsa/ml_dsa_encoders.c
@@ -935,6 +935,9 @@ int ossl_ml_dsa_sig_encode(const ML_DSA_SIG *sig, const ML_DSA_PARAMS *params,
     ret = 1;
 err:
     WPACKET_finish(&pkt);
+    /* Erase any partial signature output on failure */
+    if (ret == 0)
+        OPENSSL_cleanse(out, params->sig_len);
     return ret;
 }
 

--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -353,10 +353,15 @@ static int public_from_private(const ML_DSA_KEY *key, EVP_MD_CTX *md_ctx,
     /* Compress t */
     vector_power2_round(&t, t1, t0);
 
-    /* Zeroize secret */
-    vector_zero(&s1_ntt);
     ret = 1;
 err:
+    /*
+     * The low bits of |t| are private and |s1_ntt| is secret, wipe both.
+     * The trailing |a_ntt| matrix is not wiped: per FIPS 204 section 3.6.3
+     * the matrix A is easily computed from the public key and does not
+     * require any special protections.
+     */
+    OPENSSL_cleanse(polys, (k + l) * sizeof(*polys));
     OPENSSL_free(polys);
     return ret;
 }
@@ -377,6 +382,7 @@ int ossl_ml_dsa_key_public_from_private(ML_DSA_KEY *key)
         && shake_xof(md_ctx, key->shake256_md,
             key->pub_encoding, key->params->pk_len,
             key->tr, sizeof(key->tr));
+    vector_zero(&t0);
     vector_free(&t0);
     EVP_MD_CTX_free(md_ctx);
     return ret;
@@ -408,7 +414,7 @@ int ossl_ml_dsa_key_pairwise_check(const ML_DSA_KEY *key)
     ret = vector_equal(&t1, &key->t1) && vector_equal(&t0, &key->t0);
 err:
     EVP_MD_CTX_free(md_ctx);
-    OPENSSL_free(polys);
+    OPENSSL_clear_free(polys, 2 * k * sizeof(*polys));
     return ret;
 }
 

--- a/crypto/ml_dsa/ml_dsa_matrix.c
+++ b/crypto/ml_dsa/ml_dsa_matrix.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/crypto.h>
 #include "ml_dsa_local.h"
 #include "ml_dsa_vector.h"
 #include "ml_dsa_matrix.h"
@@ -25,15 +26,16 @@ void ossl_ml_dsa_matrix_mult_vector(const MATRIX *a, const VECTOR *s,
 {
     size_t i, j;
     POLY *poly = a->m_poly;
+    POLY product;
 
     vector_zero(t);
 
     for (i = 0; i < a->k; i++) {
         for (j = 0; j < a->l; j++) {
-            POLY product;
-
             ossl_ml_dsa_poly_ntt_mult(poly++, &s->poly[j], &product);
             poly_add(&product, &t->poly[i], &t->poly[i]);
         }
     }
+
+    OPENSSL_cleanse(&product, sizeof(product));
 }

--- a/crypto/ml_dsa/ml_dsa_sample.c
+++ b/crypto/ml_dsa/ml_dsa_sample.c
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/byteorder.h>
+#include <openssl/crypto.h>
 #include "ml_dsa_local.h"
 #include "ml_dsa_vector.h"
 #include "ml_dsa_matrix.h"
@@ -159,13 +160,14 @@ static int rej_bounded_poly(EVP_MD_CTX *h_ctx, const EVP_MD *md,
     COEFF_FROM_NIBBLE_FUNC *coef_from_nibble,
     const uint8_t *seed, size_t seed_len, POLY *out)
 {
+    int ret = 0;
     int j = 0;
     uint32_t z0, z1;
     uint8_t blocks[SHAKE256_BLOCKSIZE], *b, *end = blocks + sizeof(blocks);
 
     /* Instead of just squeezing 1 byte at a time, we grab a whole block */
     if (!shake_xof(h_ctx, md, seed, seed_len, blocks, sizeof(blocks)))
-        return 0;
+        goto err;
 
     while (1) {
         for (b = blocks; b < end; b++) {
@@ -173,15 +175,22 @@ static int rej_bounded_poly(EVP_MD_CTX *h_ctx, const EVP_MD *md,
             z1 = *b >> 4; /* high nibble of byte */
 
             if (coef_from_nibble(z0, &out->coeff[j])
-                && ++j >= ML_DSA_NUM_POLY_COEFFICIENTS)
-                return 1;
+                && ++j >= ML_DSA_NUM_POLY_COEFFICIENTS) {
+                ret = 1;
+                goto err;
+            }
             if (coef_from_nibble(z1, &out->coeff[j])
-                && ++j >= ML_DSA_NUM_POLY_COEFFICIENTS)
-                return 1;
+                && ++j >= ML_DSA_NUM_POLY_COEFFICIENTS) {
+                ret = 1;
+                goto err;
+            }
         }
         if (!EVP_DigestSqueeze(h_ctx, blocks, sizeof(blocks)))
-            return 0;
+            goto err;
     }
+err:
+    OPENSSL_cleanse(blocks, sizeof(blocks));
+    return ret;
 }
 
 /**
@@ -204,6 +213,13 @@ int ossl_ml_dsa_matrix_expand_A(EVP_MD_CTX *g_ctx, const EVP_MD *md,
     size_t i, j;
     uint8_t derived_seed[ML_DSA_RHO_BYTES + 2];
     POLY *poly = out->m_poly;
+
+    /*
+     * The seeds derived below and the sampling buffers in rej_ntt_poly() are
+     * not cleansed: per FIPS 204 section 3.6.3 the matrix A is easily
+     * computed from the public key and does not require any special
+     * protections.
+     */
 
     /* The seed used for each matrix element is rho + column_index + row_index */
     memcpy(derived_seed, rho, ML_DSA_RHO_BYTES);
@@ -274,6 +290,7 @@ int ossl_ml_dsa_vector_expand_S(EVP_MD_CTX *h_ctx, const EVP_MD *md, int eta,
     }
     ret = 1;
 err:
+    OPENSSL_cleanse(derived_seed, sizeof(derived_seed));
     return ret;
 }
 
@@ -284,9 +301,11 @@ int ossl_ml_dsa_poly_expand_mask(POLY *out, const uint8_t *seed, size_t seed_len
 {
     uint8_t buf[32 * 20];
     size_t buf_len = 32 * (gamma1 == ML_DSA_GAMMA1_TWO_POWER_19 ? 20 : 18);
-
-    return shake_xof(h_ctx, md, seed, seed_len, buf, buf_len)
+    int ret = shake_xof(h_ctx, md, seed, seed_len, buf, buf_len)
         && ossl_ml_dsa_poly_decode_expand_mask(out, buf, buf_len, gamma1);
+
+    OPENSSL_cleanse(buf, sizeof(buf));
+    return ret;
 }
 
 /*
@@ -311,13 +330,14 @@ int ossl_ml_dsa_poly_sample_in_ball(POLY *out_c, const uint8_t *seed, int seed_l
     uint64_t signs;
     int offset = 8;
     size_t end;
+    int ret = 0;
 
     /*
      * Rather than squeeze 8 bytes followed by lots of 1 byte squeezes
      * the SHAKE blocksize is squeezed each time and buffered into 'block'.
      */
     if (!shake_xof(h_ctx, md, seed, seed_len, block, sizeof(block)))
-        return 0;
+        goto err;
 
     /*
      * grab the first 64 bits - since tau < 64
@@ -336,7 +356,7 @@ int ossl_ml_dsa_poly_sample_in_ball(POLY *out_c, const uint8_t *seed, int seed_l
             if (offset == sizeof(block)) {
                 /* squeeze another block if the bytes from block have been used */
                 if (!EVP_DigestSqueeze(h_ctx, block, sizeof(block)))
-                    return 0;
+                    goto err;
                 offset = 0;
             }
 
@@ -354,5 +374,8 @@ int ossl_ml_dsa_poly_sample_in_ball(POLY *out_c, const uint8_t *seed, int seed_l
         out_c->coeff[index] = mod_sub(1, 2 * (signs & 1));
         signs >>= 1; /* grab the next random bit */
     }
-    return 1;
+    ret = 1;
+err:
+    OPENSSL_cleanse(block, sizeof(block));
+    return ret;
 }

--- a/crypto/ml_dsa/ml_dsa_sign.c
+++ b/crypto/ml_dsa/ml_dsa_sign.c
@@ -302,6 +302,7 @@ err:
     EVP_MD_CTX_free(md_ctx);
     OPENSSL_clear_free(alloc, alloc_len);
     OPENSSL_cleanse(rho_prime, sizeof(rho_prime));
+    OPENSSL_cleanse(c_tilde, sizeof(c_tilde));
     return ret;
 }
 
@@ -459,6 +460,7 @@ int ossl_ml_dsa_sign(const ML_DSA_KEY *priv,
 
 err:
     EVP_MD_CTX_free(md_ctx);
+    OPENSSL_cleanse(mu, sizeof(mu));
     return ret;
 }
 
@@ -498,5 +500,6 @@ int ossl_ml_dsa_verify(const ML_DSA_KEY *pub,
     ret = ml_dsa_verify_internal(pub, mu_ptr, mu_len, sig, sig_len);
 err:
     EVP_MD_CTX_free(md_ctx);
+    OPENSSL_cleanse(mu, sizeof(mu));
     return ret;
 }

--- a/crypto/ml_dsa/ml_dsa_vector.h
+++ b/crypto/ml_dsa/ml_dsa_vector.h
@@ -8,6 +8,7 @@
  */
 
 #include <assert.h>
+#include <openssl/crypto.h>
 #include "ml_dsa_poly.h"
 
 struct vector_st {
@@ -169,6 +170,7 @@ vector_expand_mask(VECTOR *out, const uint8_t *rho_prime, size_t rho_prime_len,
         poly_expand_mask(out->poly + i, derived_seed, sizeof(derived_seed),
             gamma1, h_ctx, md);
     }
+    OPENSSL_cleanse(derived_seed, sizeof(derived_seed));
 }
 
 /* Scale back previously rounded value */

--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -984,6 +984,12 @@ static __owur int matrix_expand(EVP_MD_CTX *mdctx, ML_KEM_KEY *key)
     int rank = key->vinfo->rank;
     int i, j;
 
+    /*
+     * The seeds derived below and the sampling buffers in sample_scalar()
+     * are not cleansed: per FIPS 203 section 3.3 the matrix A is easily
+     * computed from the public encapsulation key and does not require any
+     * special protections.
+     */
     memcpy(input, key->rho, ML_KEM_RANDOM_BYTES);
     for (i = 0; i < rank; i++) {
         for (j = 0; j < rank; j++) {
@@ -1014,8 +1020,10 @@ static __owur int cbd_2(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
     uint16_t value, mask;
     uint8_t b;
 
-    if (!prf(randbuf, sizeof(randbuf), in, mdctx, key))
+    if (!prf(randbuf, sizeof(randbuf), in, mdctx, key)) {
+        OPENSSL_cleanse((void *)randbuf, sizeof(randbuf));
         return 0;
+    }
 
     do {
         b = *r++;
@@ -1037,6 +1045,8 @@ static __owur int cbd_2(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
         mask = constish_time_non_zero(value >> 15);
         *curr++ = value + (kPrime & mask);
     } while (curr < end);
+
+    OPENSSL_cleanse((void *)randbuf, sizeof(randbuf));
     return 1;
 }
 
@@ -1054,8 +1064,10 @@ static __owur int cbd_3(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
     uint8_t b1, b2, b3;
     uint16_t value, mask;
 
-    if (!prf(randbuf, sizeof(randbuf), in, mdctx, key))
+    if (!prf(randbuf, sizeof(randbuf), in, mdctx, key)) {
+        OPENSSL_cleanse((void *)randbuf, sizeof(randbuf));
         return 0;
+    }
 
     do {
         b1 = *r++;
@@ -1089,6 +1101,8 @@ static __owur int cbd_3(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
         mask = constish_time_non_zero(value >> 15);
         *curr++ = value + (kPrime & mask);
     } while (curr < end);
+
+    OPENSSL_cleanse((void *)randbuf, sizeof(randbuf));
     return 1;
 }
 
@@ -1101,14 +1115,19 @@ static __owur int gencbd_vector(scalar *out, CBD_FUNC cbd, uint8_t *counter,
     EVP_MD_CTX *mdctx, const ML_KEM_KEY *key)
 {
     uint8_t input[ML_KEM_RANDOM_BYTES + 1];
+    int ret = 0;
 
     memcpy(input, seed, ML_KEM_RANDOM_BYTES);
     do {
         input[ML_KEM_RANDOM_BYTES] = (*counter)++;
         if (!cbd(out++, input, mdctx, key))
-            return 0;
+            goto end;
     } while (--rank > 0);
-    return 1;
+    ret = 1;
+
+end:
+    OPENSSL_cleanse((void *)input, sizeof(input));
+    return ret;
 }
 
 /*
@@ -1119,15 +1138,20 @@ static __owur int gencbd_vector_ntt(scalar *out, CBD_FUNC cbd, uint8_t *counter,
     EVP_MD_CTX *mdctx, const ML_KEM_KEY *key)
 {
     uint8_t input[ML_KEM_RANDOM_BYTES + 1];
+    int ret = 0;
 
     memcpy(input, seed, ML_KEM_RANDOM_BYTES);
     do {
         input[ML_KEM_RANDOM_BYTES] = (*counter)++;
         if (!cbd(out, input, mdctx, key))
-            return 0;
+            goto end;
         scalar_ntt(out++);
     } while (--rank > 0);
-    return 1;
+    ret = 1;
+
+end:
+    OPENSSL_cleanse((void *)input, sizeof(input));
+    return ret;
 }
 
 /* The |ETA1| value for ML-KEM-512 is 3, the rest and all ETA2 values are 2. */
@@ -1166,10 +1190,11 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
     uint8_t counter = 0;
     int du = vinfo->du;
     int dv = vinfo->dv;
+    int ret = 0;
 
     /* FIPS 203 "y" vector */
     if (!gencbd_vector_ntt(y, cbd_1, &counter, r, rank, mdctx, key))
-        return 0;
+        goto end;
     /* FIPS 203 "v" scalar */
     inner_product(&v, key->t, y, rank);
     scalar_inverse_ntt(&v);
@@ -1178,7 +1203,7 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
 
     /* All done with |y|, now free to reuse tmp[0] for FIPS 203 |e1| */
     if (!gencbd_vector(e1, cbd_2, &counter, r, rank, mdctx, key))
-        return 0;
+        goto end;
     vector_add(u, e1, rank);
     vector_compress(u, du, rank);
     vector_encode(out, u, du, rank);
@@ -1187,14 +1212,19 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
     memcpy(input, r, ML_KEM_RANDOM_BYTES);
     input[ML_KEM_RANDOM_BYTES] = counter;
     if (!cbd_2(e2, input, mdctx, key))
-        return 0;
+        goto end;
     scalar_add(&v, e2);
 
     /* Combine message with |v| */
     scalar_decode_decompress_add(&v, message);
     scalar_compress(&v, dv);
     scalar_encode(out + vinfo->u_vector_bytes, &v, dv);
-    return 1;
+    ret = 1;
+
+end:
+    OPENSSL_cleanse((void *)input, sizeof(input));
+    OPENSSL_cleanse((void *)&v, sizeof(v));
+    return ret;
 }
 
 /*
@@ -1218,6 +1248,9 @@ decrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
     scalar_sub(&v, &mask);
     scalar_compress(&v, 1);
     scalar_encode_1(out, &v);
+
+    OPENSSL_cleanse((void *)&v, sizeof(v));
+    OPENSSL_cleanse((void *)&mask, sizeof(mask));
 }
 
 /*-
@@ -1406,8 +1439,8 @@ static __owur int genkey(const uint8_t seed[ML_KEM_SEED_BYTES],
 
     ret = 1;
 end:
-    OPENSSL_cleanse((void *)augmented_seed, ML_KEM_RANDOM_BYTES);
-    OPENSSL_cleanse((void *)sigma, ML_KEM_RANDOM_BYTES);
+    OPENSSL_cleanse((void *)augmented_seed, sizeof(augmented_seed));
+    OPENSSL_cleanse((void *)hashed, sizeof(hashed));
     if (ret == 0) {
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR,
             "internal error while generating %s private key",
@@ -1445,6 +1478,7 @@ static int encap(uint8_t *ctext, uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR,
             "internal error while performing %s encapsulation",
             key->vinfo->algorithm_name);
+    OPENSSL_cleanse((void *)Kr, sizeof(Kr));
     return ret;
 }
 
@@ -1515,6 +1549,7 @@ static int decap(uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR,
             "internal error while performing %s decapsulation",
             vinfo->algorithm_name);
+        OPENSSL_cleanse(buf, DECAP_BUFFER_SZ);
         return 0;
     }
     decrypt_cpa(m, ctext, tmp, key);
@@ -1916,6 +1951,9 @@ int ossl_ml_kem_genkey(uint8_t *pubenc, size_t publen, ML_KEM_KEY *key)
 
     EVP_MD_CTX_free(mdctx);
     if (!ret) {
+        /* Erase any partial public key output */
+        if (pubenc != NULL)
+            OPENSSL_cleanse(pubenc, vinfo->pubkey_bytes);
         ossl_ml_kem_key_reset(key);
         return 0;
     }
@@ -1979,6 +2017,10 @@ int ossl_ml_kem_encap_seed(uint8_t *ctext, size_t clen,
     }
 #undef case_encap_seed
 
+    /* Erase any partial ciphertext output on failure */
+    if (!ret)
+        OPENSSL_cleanse(ctext, clen);
+
     /* Declassify secret inputs and derived outputs before returning control */
     CONSTTIME_DECLASSIFY(entropy, elen);
     CONSTTIME_DECLASSIFY(ctext, clen);
@@ -1993,6 +2035,7 @@ int ossl_ml_kem_encap_rand(uint8_t *ctext, size_t clen,
     const ML_KEM_KEY *key)
 {
     uint8_t r[ML_KEM_RANDOM_BYTES];
+    int ret;
 
     if (key == NULL)
         return 0;
@@ -2002,8 +2045,11 @@ int ossl_ml_kem_encap_rand(uint8_t *ctext, size_t clen,
         < 1)
         return 0;
 
-    return ossl_ml_kem_encap_seed(ctext, clen, shared_secret, slen,
+    ret = ossl_ml_kem_encap_seed(ctext, clen, shared_secret, slen,
         r, sizeof(r), key);
+
+    OPENSSL_cleanse((void *)r, sizeof(r));
+    return ret;
 }
 
 int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
@@ -2050,6 +2096,7 @@ int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
                                                                   \
         ret = decap(shared_secret, ctext, cbuf, tmp, mdctx, key); \
         OPENSSL_cleanse((void *)tmp, sizeof(tmp));                \
+        OPENSSL_cleanse((void *)cbuf, sizeof(cbuf));              \
     }
     switch (vinfo->evp_type) {
     case EVP_PKEY_ML_KEM_512:

--- a/crypto/slh_dsa/slh_dsa.c
+++ b/crypto/slh_dsa/slh_dsa.c
@@ -8,6 +8,7 @@
  */
 #include <stddef.h>
 #include <string.h>
+#include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/proverr.h>
 #include "slh_dsa_local.h"
@@ -122,8 +123,13 @@ static int slh_sign_internal(SLH_DSA_HASH_CTX *hctx,
 err:
     if (!WPACKET_finish(wpkt))
         ret = 0;
+    OPENSSL_cleanse(m_digest, sizeof(m_digest));
+    OPENSSL_cleanse(pk_fors, sizeof(pk_fors));
     if (ret)
         *sig_len = sig_len_expected;
+    else
+        /* Erase any partial signature output */
+        OPENSSL_cleanse(sig, sig_len_expected);
     return ret;
 }
 
@@ -148,6 +154,7 @@ static int slh_verify_internal(SLH_DSA_HASH_CTX *hctx,
     const uint8_t *msg, size_t msg_len,
     const uint8_t *sig, size_t sig_len)
 {
+    int ret = 0;
     const SLH_DSA_KEY *pub = hctx->key;
     SLH_HASH_FUNC_DECLARE(pub, hashf);
     SLH_ADRS_FUNC_DECLARE(pub, adrsf);
@@ -185,7 +192,7 @@ static int slh_verify_internal(SLH_DSA_HASH_CTX *hctx,
 
     if (!hashf->H_MSG(hctx, r, pk_seed, pk_root, msg, msg_len,
             m_digest, sizeof(m_digest)))
-        return 0;
+        goto err;
 
     /*
      * Get md (the first md_len bytes of m_digest to use in
@@ -195,16 +202,20 @@ static int slh_verify_internal(SLH_DSA_HASH_CTX *hctx,
     if (!PACKET_buf_init(m_digest_rpkt, m_digest, sizeof(m_digest))
         || !PACKET_get_bytes(m_digest_rpkt, &md, md_len)
         || !get_tree_ids(m_digest_rpkt, params, &tree_id, &leaf_id))
-        return 0;
+        goto err;
 
     adrsf->set_tree_address(adrs, tree_id);
     adrsf->set_type_and_clear(adrs, SLH_ADRS_TYPE_FORS_TREE);
     adrsf->set_keypair_address(adrs, leaf_id);
-    return ossl_slh_fors_pk_from_sig(hctx, sig_rpkt, md, pk_seed, adrs,
-               pk_fors, sizeof(pk_fors))
+    ret = ossl_slh_fors_pk_from_sig(hctx, sig_rpkt, md, pk_seed, adrs,
+              pk_fors, sizeof(pk_fors))
         && ossl_slh_ht_verify(hctx, pk_fors, sig_rpkt, pk_seed,
             tree_id, leaf_id, pk_root)
         && PACKET_remaining(sig_rpkt) == 0;
+err:
+    OPENSSL_cleanse(m_digest, sizeof(m_digest));
+    OPENSSL_cleanse(pk_fors, sizeof(pk_fors));
+    return ret;
 }
 
 /**
@@ -292,8 +303,13 @@ int ossl_slh_dsa_sign(SLH_DSA_HASH_CTX *slh_ctx,
             return 0;
     }
     ret = slh_sign_internal(slh_ctx, m, m_len, sig, siglen, sigsize, add_rand);
-    if (m != msg && m != m_tmp)
-        OPENSSL_free(m);
+    /* The encoded message may contain confidential message content */
+    if (m != msg) {
+        if (m != m_tmp)
+            OPENSSL_clear_free(m, m_len);
+        else
+            OPENSSL_cleanse(m_tmp, sizeof(m_tmp));
+    }
     return ret;
 }
 
@@ -317,8 +333,13 @@ int ossl_slh_dsa_verify(SLH_DSA_HASH_CTX *slh_ctx,
         return 0;
 
     ret = slh_verify_internal(slh_ctx, m, m_len, sig, sig_len);
-    if (m != msg && m != m_tmp)
-        OPENSSL_free(m);
+    /* The encoded message may contain confidential message content */
+    if (m != msg) {
+        if (m != m_tmp)
+            OPENSSL_clear_free(m, m_len);
+        else
+            OPENSSL_cleanse(m_tmp, sizeof(m_tmp));
+    }
     return ret;
 }
 

--- a/crypto/slh_dsa/slh_dsa_hash_ctx.c
+++ b/crypto/slh_dsa/slh_dsa_hash_ctx.c
@@ -98,8 +98,9 @@ void ossl_slh_dsa_hash_ctx_free(SLH_DSA_HASH_CTX *ctx)
 {
     if (ctx == NULL)
         return;
-    OPENSSL_free(ctx->shactx);
-    OPENSSL_free(ctx->shactx_pkseed);
+    OPENSSL_clear_free(ctx->shactx, ctx->shactx_len);
+    OPENSSL_clear_free(ctx->shactx_pkseed, ctx->shactx_len);
+    OPENSSL_clear_free(ctx->scratch, ctx->scratch_len);
     EVP_MAC_CTX_free(ctx->hmac_ctx);
     OPENSSL_free(ctx);
 }

--- a/crypto/slh_dsa/slh_dsa_key.c
+++ b/crypto/slh_dsa/slh_dsa_key.c
@@ -307,6 +307,12 @@ int ossl_slh_dsa_key_fromdata(SLH_DSA_KEY *key, const OSSL_PARAM *param_pub,
     key->pub = p;
     return 1;
 err:
+    /*
+     * A private key of unexpected length may have been copied into |priv|
+     * before |has_priv| was set, in which case the reset below would not
+     * erase it, so cleanse unconditionally.
+     */
+    OPENSSL_cleanse(key->priv, sizeof(key->priv));
     ossl_slh_dsa_key_reset(key);
     return 0;
 }

--- a/crypto/slh_dsa/slh_dsa_local.h
+++ b/crypto/slh_dsa/slh_dsa_local.h
@@ -49,6 +49,16 @@ struct slh_dsa_hash_ctx_st {
     const SLH_DSA_KEY *key; /* This key is not owned by this object */
     void *shactx; /* A low level SHAKE object */
     void *shactx_pkseed; /* A low level SHAKE or SHA256 object with PK.seed hashed in it */
+    size_t shactx_len; /* The size of the two hash contexts above */
+    /*
+     * A working hash context used by the hash functions in place of local
+     * stack copies, so that intermediate hash states derived from secrets
+     * live in one place and are erased when this object is freed.  It is
+     * also used for the one-shot SHA-512 contexts of the security category
+     * 3 and 5 SHA2 parameter sets.  Not used concurrently.
+     */
+    void *scratch;
+    size_t scratch_len;
     EVP_MAC_CTX *hmac_ctx; /* required by SHA algorithms for PRFmsg() */
     int hmac_digest_used; /* Used for lazy init of hmac_ctx digest */
 };

--- a/crypto/slh_dsa/slh_fors.c
+++ b/crypto/slh_dsa/slh_fors.c
@@ -17,8 +17,8 @@
 /* a = 6, 8, 9, 12 or 14  - There are (2^a) merkle trees */
 #define SLH_MAX_A 9
 
-#define SLH_MAX_K_TIMES_A (SLH_MAX_A * SLH_MAX_K)
-#define SLH_MAX_ROOTS (SLH_MAX_K_TIMES_A * SLH_MAX_N)
+/* The FORS public key is computed from the roots of k Merkle trees */
+#define SLH_MAX_ROOTS (SLH_MAX_K * SLH_MAX_N)
 
 static void slh_base_2b(const uint8_t *in, uint32_t b, uint32_t *out, size_t out_len);
 
@@ -87,25 +87,25 @@ static int slh_fors_node(SLH_DSA_HASH_CTX *ctx, const uint8_t *sk_seed,
 
     if (height == 0) {
         /* Gets here for leaf nodes */
-        if (!slh_fors_sk_gen(ctx, sk_seed, pk_seed, adrs, node_id, sk, sizeof(sk)))
-            return 0;
-        adrsf->set_tree_height(adrs, 0);
-        adrsf->set_tree_index(adrs, node_id);
-        ret = key->hash_func->F(ctx, pk_seed, adrs, sk, n, node, node_len);
+        if (slh_fors_sk_gen(ctx, sk_seed, pk_seed, adrs, node_id, sk, sizeof(sk))) {
+            adrsf->set_tree_height(adrs, 0);
+            adrsf->set_tree_index(adrs, node_id);
+            ret = key->hash_func->F(ctx, pk_seed, adrs, sk, n, node, node_len);
+        }
         OPENSSL_cleanse(sk, n);
-        return ret;
     } else {
-        if (!slh_fors_node(ctx, sk_seed, pk_seed, adrs, 2 * node_id, height - 1,
-                lnode, sizeof(rnode))
-            || !slh_fors_node(ctx, sk_seed, pk_seed, adrs, 2 * node_id + 1,
-                height - 1, rnode, sizeof(rnode)))
-            return 0;
-        adrsf->set_tree_height(adrs, height);
-        adrsf->set_tree_index(adrs, node_id);
-        if (!key->hash_func->H(ctx, pk_seed, adrs, lnode, rnode, node, node_len))
-            return 0;
+        if (slh_fors_node(ctx, sk_seed, pk_seed, adrs, 2 * node_id, height - 1,
+                lnode, sizeof(lnode))
+            && slh_fors_node(ctx, sk_seed, pk_seed, adrs, 2 * node_id + 1,
+                height - 1, rnode, sizeof(rnode))) {
+            adrsf->set_tree_height(adrs, height);
+            adrsf->set_tree_index(adrs, node_id);
+            ret = key->hash_func->H(ctx, pk_seed, adrs, lnode, rnode, node, node_len);
+        }
+        OPENSSL_cleanse(lnode, sizeof(lnode));
+        OPENSSL_cleanse(rnode, sizeof(rnode));
     }
-    return 1;
+    return ret;
 }
 
 /**
@@ -132,6 +132,7 @@ int ossl_slh_fors_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *md,
     const uint8_t *sk_seed, const uint8_t *pk_seed,
     uint8_t *adrs, WPACKET *sig_wpkt)
 {
+    int ret = 0;
     const SLH_DSA_KEY *key = ctx->key;
     uint32_t tree_id, layer, s, tree_offset;
     uint32_t ids[SLH_MAX_K];
@@ -165,7 +166,7 @@ int ossl_slh_fors_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *md,
         if (!slh_fors_sk_gen(ctx, sk_seed, pk_seed, adrs,
                 node_id + tree_id_times_two_power_a, out, sizeof(out))
             || !WPACKET_memcpy(sig_wpkt, out, n))
-            return 0;
+            goto err;
 
         /*
          * Traverse from the bottom of the tree (layer = 0)
@@ -178,15 +179,18 @@ int ossl_slh_fors_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *md,
             s = node_id ^ 1; /* XOR gets the index of the other child in a binary tree */
             if (!slh_fors_node(ctx, sk_seed, pk_seed, adrs,
                     s + tree_offset, layer, out, sizeof(out)))
-                return 0;
+                goto err;
             node_id >>= 1; /* Get the parent node id */
             tree_offset >>= 1; /* Each layer up has half as many nodes */
             if (!WPACKET_memcpy(sig_wpkt, out, n))
-                return 0;
+                goto err;
         }
         tree_id_times_two_power_a += two_power_a;
     }
-    return 1;
+    ret = 1;
+err:
+    OPENSSL_cleanse(out, sizeof(out));
+    return ret;
 }
 
 /**
@@ -288,6 +292,8 @@ int ossl_slh_fors_pk_from_sig(SLH_DSA_HASH_CTX *ctx, PACKET *fors_sig_rpkt,
 err:
     if (!WPACKET_finish(wroot_pkt))
         ret = 0;
+    /* At most one |n| byte root per tree was written */
+    OPENSSL_cleanse(roots, k * n);
     return ret;
 }
 

--- a/crypto/slh_dsa/slh_hash.c
+++ b/crypto/slh_dsa/slh_hash.c
@@ -82,6 +82,7 @@ slh_prf_msg_shake(SLH_DSA_HASH_CTX *hctx, const uint8_t *sk_prf,
     const uint8_t *opt_rand, const uint8_t *msg, size_t msg_len,
     WPACKET *pkt)
 {
+    int ret;
     unsigned char out[SLH_MAX_N];
     const SLH_DSA_PARAMS *params = hctx->key->params;
     size_t n = params->n;
@@ -92,7 +93,9 @@ slh_prf_msg_shake(SLH_DSA_HASH_CTX *hctx, const uint8_t *sk_prf,
     ossl_sha3_absorb(sctx, opt_rand, n);
     ossl_sha3_absorb(sctx, msg, msg_len);
     ossl_sha3_squeeze(sctx, out, n);
-    return WPACKET_memcpy(pkt, out, n);
+    ret = WPACKET_memcpy(pkt, out, n);
+    OPENSSL_cleanse(out, sizeof(out));
+    return ret;
 }
 
 static int
@@ -101,11 +104,12 @@ slh_f_shake(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
 {
     const SLH_DSA_PARAMS *params = hctx->key->params;
     size_t n = params->n;
-    KECCAK1600_CTX sctx = *((KECCAK1600_CTX *)(hctx->shactx_pkseed));
+    KECCAK1600_CTX *sctx = (KECCAK1600_CTX *)(hctx->scratch);
 
-    ossl_sha3_absorb(&sctx, adrs, SLH_ADRS_SIZE);
-    ossl_sha3_absorb(&sctx, m1, m1_len);
-    ossl_sha3_squeeze(&sctx, out, n);
+    *sctx = *((KECCAK1600_CTX *)(hctx->shactx_pkseed));
+    ossl_sha3_absorb(sctx, adrs, SLH_ADRS_SIZE);
+    ossl_sha3_absorb(sctx, m1, m1_len);
+    ossl_sha3_squeeze(sctx, out, n);
     return 1;
 }
 
@@ -116,11 +120,12 @@ slh_prf_shake(SLH_DSA_HASH_CTX *hctx,
 {
     const SLH_DSA_PARAMS *params = hctx->key->params;
     size_t n = params->n;
-    KECCAK1600_CTX sctx = *((KECCAK1600_CTX *)(hctx->shactx_pkseed));
+    KECCAK1600_CTX *sctx = (KECCAK1600_CTX *)(hctx->scratch);
 
-    ossl_sha3_absorb(&sctx, adrs, SLH_ADRS_SIZE);
-    ossl_sha3_absorb(&sctx, sk_seed, n);
-    ossl_sha3_squeeze(&sctx, out, n);
+    *sctx = *((KECCAK1600_CTX *)(hctx->shactx_pkseed));
+    ossl_sha3_absorb(sctx, adrs, SLH_ADRS_SIZE);
+    ossl_sha3_absorb(sctx, sk_seed, n);
+    ossl_sha3_squeeze(sctx, out, n);
     return 1;
 }
 
@@ -128,10 +133,11 @@ static int
 slh_h_shake(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *m1, const uint8_t *m2, uint8_t *out, size_t out_len)
 {
-    KECCAK1600_CTX ctx = *((KECCAK1600_CTX *)(hctx->shactx_pkseed)), *sctx = &ctx;
+    KECCAK1600_CTX *sctx = (KECCAK1600_CTX *)(hctx->scratch);
     const SLH_DSA_PARAMS *params = hctx->key->params;
     size_t n = params->n;
 
+    *sctx = *((KECCAK1600_CTX *)(hctx->shactx_pkseed));
     ossl_sha3_absorb(sctx, adrs, SLH_ADRS_SIZE);
     ossl_sha3_absorb(sctx, m1, n);
     ossl_sha3_absorb(sctx, m2, n);
@@ -146,7 +152,8 @@ slh_hmsg_sha256(SLH_DSA_HASH_CTX *hctx, const uint8_t *r, const uint8_t *pk_seed
     const uint8_t *pk_root, const uint8_t *msg, size_t msg_len,
     uint8_t *out, size_t out_len)
 {
-    SHA256_CTX ctx, *sctx = &ctx;
+    int ret;
+    SHA256_CTX *sctx = (SHA256_CTX *)(hctx->scratch);
     const SLH_DSA_PARAMS *params = hctx->key->params;
     size_t m = params->m;
     size_t n = params->n;
@@ -161,8 +168,10 @@ slh_hmsg_sha256(SLH_DSA_HASH_CTX *hctx, const uint8_t *r, const uint8_t *pk_seed
     SHA256_Update(sctx, pk_seed, n);
     SHA256_Update(sctx, pk_root, n);
     SHA256_Update(sctx, msg, msg_len);
-    return SHA256_Final(seed + 2 * n, sctx)
+    ret = SHA256_Final(seed + 2 * n, sctx)
         && (PKCS1_MGF1(out, (long)m, seed, seed_len, hctx->key->md) == 0);
+    OPENSSL_cleanse(seed, sizeof(seed));
+    return ret;
 }
 
 static int
@@ -170,7 +179,8 @@ slh_hmsg_sha512(SLH_DSA_HASH_CTX *hctx, const uint8_t *r, const uint8_t *pk_seed
     const uint8_t *pk_root, const uint8_t *msg, size_t msg_len,
     uint8_t *out, size_t out_len)
 {
-    SHA512_CTX ctx, *sctx = &ctx;
+    int ret;
+    SHA512_CTX *sctx = (SHA512_CTX *)(hctx->scratch);
     const SLH_DSA_PARAMS *params = hctx->key->params;
     size_t m = params->m;
     size_t n = params->n;
@@ -185,8 +195,10 @@ slh_hmsg_sha512(SLH_DSA_HASH_CTX *hctx, const uint8_t *r, const uint8_t *pk_seed
     SHA512_Update(sctx, pk_seed, n);
     SHA512_Update(sctx, pk_root, n);
     SHA512_Update(sctx, msg, msg_len);
-    return SHA512_Final(seed + 2 * n, sctx)
+    ret = SHA512_Final(seed + 2 * n, sctx)
         && (PKCS1_MGF1(out, (long)m, seed, seed_len, hctx->key->md_sha512) == 0);
+    OPENSSL_cleanse(seed, sizeof(seed));
+    return ret;
 }
 
 static int
@@ -227,6 +239,7 @@ slh_prf_msg_sha2(SLH_DSA_HASH_CTX *hctx,
         && EVP_MAC_update(mctx, msg, msg_len) == 1
         && EVP_MAC_final(mctx, mac, NULL, sizeof(mac)) == 1
         && WPACKET_memcpy(pkt, mac, n); /* Truncate output to n bytes */
+    OPENSSL_cleanse(mac, sizeof(mac));
     return ret;
 }
 
@@ -235,9 +248,10 @@ slh_prf_sha256(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed,
     const uint8_t *sk_seed, const uint8_t *adrs,
     uint8_t *out, size_t out_len)
 {
-    SHA256_CTX ctx = *((SHA256_CTX *)hctx->shactx_pkseed), *sctx = &ctx;
+    SHA256_CTX *sctx = (SHA256_CTX *)(hctx->scratch);
     size_t n = hctx->key->params->n;
 
+    *sctx = *((SHA256_CTX *)hctx->shactx_pkseed);
     SHA256_Update(sctx, adrs, SLH_ADRSC_SIZE);
     SHA256_Update(sctx, sk_seed, n);
     sha256_final(sctx, out, n);
@@ -254,7 +268,7 @@ slh_wots_pk_gen_sha2(SLH_DSA_HASH_CTX *hctx,
     size_t i, j = 0, len = SLH_WOTS_LEN(n);
     uint8_t sk[SLH_MAX_N];
     SHA256_CTX *sctx = (SHA256_CTX *)(hctx->shactx_pkseed);
-    SHA256_CTX ctx;
+    SHA256_CTX *ctx = (SHA256_CTX *)(hctx->scratch);
     const SLH_ADRS_FUNC *adrsf = hctx->key->adrs_func;
     SLH_ADRS_DECLARE(sk_adrs);
     SLH_ADRS_FN_DECLARE(adrsf, set_chain_address);
@@ -268,24 +282,25 @@ slh_wots_pk_gen_sha2(SLH_DSA_HASH_CTX *hctx,
         set_chain_address(sk_adrs, (uint32_t)i);
 
         /* PRF */
-        ctx = *sctx;
-        SHA256_Update(&ctx, sk_adrs, SLH_ADRSC_SIZE);
-        SHA256_Update(&ctx, sk_seed, n);
-        sha256_final(&ctx, sk, n);
+        *ctx = *sctx;
+        SHA256_Update(ctx, sk_adrs, SLH_ADRSC_SIZE);
+        SHA256_Update(ctx, sk_seed, n);
+        sha256_final(ctx, sk, n);
 
         set_chain_address(adrs, (uint32_t)i);
         for (j = 0; j < NIBBLE_MASK; ++j) {
             set_hash_address(adrs, (uint32_t)j);
             /* F */
-            ctx = *sctx;
-            SHA256_Update(&ctx, adrs, SLH_ADRSC_SIZE);
-            SHA256_Update(&ctx, sk, n);
-            sha256_final(&ctx, sk, n);
+            *ctx = *sctx;
+            SHA256_Update(ctx, adrs, SLH_ADRSC_SIZE);
+            SHA256_Update(ctx, sk, n);
+            sha256_final(ctx, sk, n);
         }
         memcpy(pk_out, sk, n);
         pk_out += n;
     }
     ret = 1;
+    OPENSSL_cleanse(sk, sizeof(sk));
     return ret;
 }
 
@@ -302,7 +317,7 @@ int slh_wots_pk_gen_shake(SLH_DSA_HASH_CTX *hctx,
     SLH_ADRS_FN_DECLARE(adrsf, set_chain_address);
     SLH_ADRS_FN_DECLARE(adrsf, set_hash_address);
     KECCAK1600_CTX *sctx = (KECCAK1600_CTX *)(hctx->shactx_pkseed);
-    KECCAK1600_CTX ctx;
+    KECCAK1600_CTX *ctx = (KECCAK1600_CTX *)(hctx->scratch);
 
     adrsf->copy(sk_adrs, adrs);
     adrsf->set_type_and_clear(sk_adrs, SLH_ADRS_TYPE_WOTS_PRF);
@@ -312,24 +327,25 @@ int slh_wots_pk_gen_shake(SLH_DSA_HASH_CTX *hctx,
         set_chain_address(sk_adrs, (uint32_t)i);
 
         /* PRF */
-        ctx = *sctx;
-        ossl_sha3_absorb(&ctx, sk_adrs, SLH_ADRS_SIZE);
-        ossl_sha3_absorb(&ctx, sk_seed, n);
-        ossl_sha3_squeeze(&ctx, sk, n);
+        *ctx = *sctx;
+        ossl_sha3_absorb(ctx, sk_adrs, SLH_ADRS_SIZE);
+        ossl_sha3_absorb(ctx, sk_seed, n);
+        ossl_sha3_squeeze(ctx, sk, n);
 
         set_chain_address(adrs, (uint32_t)i);
         for (j = 0; j < NIBBLE_MASK; ++j) {
             set_hash_address(adrs, (uint32_t)j);
             /* F */
-            ctx = *sctx;
-            ossl_sha3_absorb(&ctx, adrs, SLH_ADRS_SIZE);
-            ossl_sha3_absorb(&ctx, sk, n);
-            ossl_sha3_squeeze(&ctx, sk, n);
+            *ctx = *sctx;
+            ossl_sha3_absorb(ctx, adrs, SLH_ADRS_SIZE);
+            ossl_sha3_absorb(ctx, sk, n);
+            ossl_sha3_squeeze(ctx, sk, n);
         }
         memcpy(pk_out, sk, n);
         pk_out += n;
     }
     ret = 1;
+    OPENSSL_cleanse(sk, sizeof(sk));
     return ret;
 }
 
@@ -337,8 +353,9 @@ static int
 slh_f_sha256(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *m1, size_t m1_len, uint8_t *out, size_t out_len)
 {
-    SHA256_CTX ctx = *((SHA256_CTX *)hctx->shactx_pkseed), *sctx = &ctx;
+    SHA256_CTX *sctx = (SHA256_CTX *)(hctx->scratch);
 
+    *sctx = *((SHA256_CTX *)hctx->shactx_pkseed);
     SHA256_Update(sctx, adrs, SLH_ADRSC_SIZE);
     SHA256_Update(sctx, m1, m1_len);
     sha256_final(sctx, out, hctx->key->params->n);
@@ -349,10 +366,11 @@ static int
 slh_h_sha256(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *m1, const uint8_t *m2, uint8_t *out, size_t out_len)
 {
-    SHA256_CTX ctx = *((SHA256_CTX *)hctx->shactx_pkseed), *sctx = &ctx;
+    SHA256_CTX *sctx = (SHA256_CTX *)(hctx->scratch);
     const SLH_DSA_PARAMS *prms = hctx->key->params;
     size_t n = prms->n;
 
+    *sctx = *((SHA256_CTX *)hctx->shactx_pkseed);
     SHA256_Update(sctx, adrs, SLH_ADRSC_SIZE);
     SHA256_Update(sctx, m1, n);
     SHA256_Update(sctx, m2, n);
@@ -364,7 +382,7 @@ static int
 slh_h_sha512(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *m1, const uint8_t *m2, uint8_t *out, size_t out_len)
 {
-    SHA512_CTX ctx, *sctx = &ctx;
+    SHA512_CTX *sctx = (SHA512_CTX *)(hctx->scratch);
     const SLH_DSA_PARAMS *prms = hctx->key->params;
     size_t n = prms->n;
 
@@ -382,8 +400,9 @@ static int
 slh_t_sha256(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *ml, size_t ml_len, uint8_t *out, size_t out_len)
 {
-    SHA256_CTX ctx = *((SHA256_CTX *)hctx->shactx_pkseed), *sctx = &ctx;
+    SHA256_CTX *sctx = (SHA256_CTX *)(hctx->scratch);
 
+    *sctx = *((SHA256_CTX *)hctx->shactx_pkseed);
     SHA256_Update(sctx, adrs, SLH_ADRSC_SIZE);
     SHA256_Update(sctx, ml, ml_len);
     sha256_final(sctx, out, hctx->key->params->n);
@@ -394,7 +413,7 @@ static int
 slh_t_sha512(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *ml, size_t ml_len, uint8_t *out, size_t out_len)
 {
-    SHA512_CTX ctx, *sctx = &ctx;
+    SHA512_CTX *sctx = (SHA512_CTX *)(hctx->scratch);
     const SLH_DSA_PARAMS *prms = hctx->key->params;
     size_t n = prms->n;
 
@@ -409,19 +428,25 @@ slh_t_sha512(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs
 
 static int slh_hash_shake_precache(SLH_DSA_HASH_CTX *hctx, const uint8_t *pkseed, size_t n)
 {
-    KECCAK1600_CTX *ctx = NULL, *seedctx = NULL;
+    KECCAK1600_CTX *ctx = NULL, *seedctx = NULL, *scratch = NULL;
 
     ctx = ossl_shake256_new();
     if (ctx == NULL)
         return 0;
     seedctx = OPENSSL_memdup(ctx, sizeof(*ctx));
-    if (seedctx == NULL) {
+    scratch = OPENSSL_malloc(sizeof(*scratch));
+    if (seedctx == NULL || scratch == NULL) {
         OPENSSL_free(ctx);
+        OPENSSL_free(seedctx);
+        OPENSSL_free(scratch);
         return 0;
     }
     ossl_sha3_absorb(seedctx, pkseed, n);
     hctx->shactx = (void *)ctx;
     hctx->shactx_pkseed = (void *)seedctx;
+    hctx->shactx_len = sizeof(*ctx);
+    hctx->scratch = (void *)scratch;
+    hctx->scratch_len = sizeof(*scratch);
     return 1;
 }
 
@@ -440,19 +465,38 @@ static int slh_hash_shake_dup(SLH_DSA_HASH_CTX *dst, const SLH_DSA_HASH_CTX *src
             return 0;
         }
     }
+    dst->shactx_len = src->shactx_len;
+    /* A prehashed context needs a scratch context, its content is transient */
+    if (dst->shactx_pkseed != NULL) {
+        dst->scratch = OPENSSL_malloc(sizeof(KECCAK1600_CTX));
+        if (dst->scratch == NULL)
+            return 0;
+        dst->scratch_len = sizeof(KECCAK1600_CTX);
+    } else {
+        dst->scratch = NULL;
+        dst->scratch_len = 0;
+    }
     return 1;
 }
 
 static int slh_hash_sha256_precache(SLH_DSA_HASH_CTX *hctx, const uint8_t *pkseed, size_t n)
 {
     SHA256_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+    /* The scratch context is also used as a SHA512_CTX by category 3 and 5 */
+    size_t scratch_len = sizeof(SHA512_CTX);
 
     if (ctx == NULL)
         return 0;
+    if ((hctx->scratch = OPENSSL_malloc(scratch_len)) == NULL) {
+        OPENSSL_free(ctx);
+        return 0;
+    }
+    hctx->scratch_len = scratch_len;
     SHA256_Init(ctx);
     SHA256_Update(ctx, pkseed, n);
     SHA256_Update(ctx, zeros, 64 - n);
     hctx->shactx_pkseed = (void *)ctx;
+    hctx->shactx_len = sizeof(*ctx);
     return 1;
 }
 
@@ -462,6 +506,21 @@ static int slh_hash_sha256_dup(SLH_DSA_HASH_CTX *dst, const SLH_DSA_HASH_CTX *sr
         dst->shactx_pkseed = OPENSSL_memdup(src->shactx_pkseed, sizeof(SHA256_CTX));
         if (dst->shactx_pkseed == NULL)
             return 0;
+    }
+    /*
+     * A prehashed context needs a scratch context, its content is transient.
+     * As in slh_hash_sha256_precache() the scratch context is sized to also
+     * serve as a SHA512_CTX for security categories 3 and 5.
+     */
+    dst->shactx_len = src->shactx_len;
+    if (dst->shactx_pkseed != NULL) {
+        dst->scratch = OPENSSL_malloc(sizeof(SHA512_CTX));
+        if (dst->scratch == NULL)
+            return 0;
+        dst->scratch_len = sizeof(SHA512_CTX);
+    } else {
+        dst->scratch = NULL;
+        dst->scratch_len = 0;
     }
     return 1;
 }

--- a/crypto/slh_dsa/slh_hypertree.c
+++ b/crypto/slh_dsa/slh_hypertree.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <openssl/crypto.h>
 #include "slh_dsa_local.h"
 #include "slh_dsa_key.h"
 
@@ -33,6 +34,7 @@ int ossl_slh_ht_sign(SLH_DSA_HASH_CTX *ctx,
     const uint8_t *pk_seed,
     uint64_t tree_id, uint32_t leaf_id, WPACKET *sig_wpkt)
 {
+    int ret = 0;
     const SLH_DSA_KEY *key = ctx->key;
     SLH_ADRS_FUNC_DECLARE(key, adrsf);
     SLH_ADRS_DECLARE(adrs);
@@ -70,7 +72,7 @@ int ossl_slh_ht_sign(SLH_DSA_HASH_CTX *ctx,
         psig = WPACKET_get_curr(sig_wpkt);
         if (!ossl_slh_xmss_sign(ctx, root, sk_seed, leaf_id, pk_seed, adrs,
                 sig_wpkt))
-            return 0;
+            goto err;
         /*
          * On the last loop it skips getting the public key since it is not needed
          * to calculate another signature. If this was called it should equal
@@ -79,15 +81,18 @@ int ossl_slh_ht_sign(SLH_DSA_HASH_CTX *ctx,
         if (layer < d - 1) {
             if (!PACKET_buf_init(xmss_sig_rpkt, psig,
                     WPACKET_get_curr(sig_wpkt) - psig))
-                return 0;
+                goto err;
             if (!ossl_slh_xmss_pk_from_sig(ctx, leaf_id, xmss_sig_rpkt, root,
                     pk_seed, adrs, root, sizeof(root)))
-                return 0;
+                goto err;
             leaf_id = tree_id & mask;
             tree_id >>= hm;
         }
     }
-    return 1;
+    ret = 1;
+err:
+    OPENSSL_cleanse(root, sizeof(root));
+    return ret;
 }
 
 /**
@@ -108,6 +113,7 @@ int ossl_slh_ht_verify(SLH_DSA_HASH_CTX *ctx, const uint8_t *msg, PACKET *sig_pk
     const uint8_t *pk_seed, uint64_t tree_id, uint32_t leaf_id,
     const uint8_t *pk_root)
 {
+    int ret = 0;
     const SLH_DSA_KEY *key = ctx->key;
     SLH_ADRS_FUNC_DECLARE(key, adrsf);
     SLH_ADRS_DECLARE(adrs);
@@ -127,9 +133,12 @@ int ossl_slh_ht_verify(SLH_DSA_HASH_CTX *ctx, const uint8_t *msg, PACKET *sig_pk
         adrsf->set_tree_address(adrs, tree_id);
         if (!ossl_slh_xmss_pk_from_sig(ctx, leaf_id, sig_pkt, node,
                 pk_seed, adrs, node, sizeof(node)))
-            return 0;
+            goto err;
         leaf_id = tree_id & mask;
         tree_id >>= tree_height;
     }
-    return (memcmp(node, pk_root, n) == 0);
+    ret = (memcmp(node, pk_root, n) == 0);
+err:
+    OPENSSL_cleanse(node, sizeof(node));
+    return ret;
 }

--- a/crypto/slh_dsa/slh_wots.c
+++ b/crypto/slh_dsa/slh_wots.c
@@ -158,6 +158,7 @@ int ossl_slh_wots_pk_gen(SLH_DSA_HASH_CTX *ctx,
     adrsf->copy_keypair_address(wots_pk_adrs, adrs);
     ret = hashf->T(ctx, pk_seed, wots_pk_adrs, tmp, tmp_len, pk_out, pk_out_len);
 end:
+    OPENSSL_cleanse(tmp, tmp_len);
     return ret;
 }
 
@@ -221,6 +222,8 @@ int ossl_slh_wots_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *msg,
     }
     ret = 1;
 err:
+    OPENSSL_cleanse(sk, sizeof(sk));
+    OPENSSL_cleanse(msg_and_csum_nibbles, sizeof(msg_and_csum_nibbles));
     return ret;
 }
 
@@ -288,5 +291,7 @@ int ossl_slh_wots_pk_from_sig(SLH_DSA_HASH_CTX *ctx,
 err:
     if (!WPACKET_finish(tmp_pkt))
         ret = 0;
+    OPENSSL_cleanse(tmp, sizeof(tmp));
+    OPENSSL_cleanse(msg_and_csum_nibbles, sizeof(msg_and_csum_nibbles));
     return ret;
 }

--- a/crypto/slh_dsa/slh_xmss.c
+++ b/crypto/slh_dsa/slh_xmss.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <openssl/crypto.h>
 #include "slh_dsa_local.h"
 #include "slh_dsa_key.h"
 
@@ -39,29 +40,31 @@ int ossl_slh_xmss_node(SLH_DSA_HASH_CTX *ctx, const uint8_t *sk_seed,
 {
     const SLH_DSA_KEY *key = ctx->key;
     SLH_ADRS_FUNC_DECLARE(key, adrsf);
+    int ret = 0;
 
     if (h == 0) {
         /* For leaf nodes generate the public key */
         adrsf->set_type_and_clear(adrs, SLH_ADRS_TYPE_WOTS_HASH);
         adrsf->set_keypair_address(adrs, node_id);
-        if (!ossl_slh_wots_pk_gen(ctx, sk_seed, pk_seed, adrs,
+        if (ossl_slh_wots_pk_gen(ctx, sk_seed, pk_seed, adrs,
                 pk_out, pk_out_len))
-            return 0;
+            ret = 1;
     } else {
         uint8_t lnode[SLH_MAX_N], rnode[SLH_MAX_N];
 
-        if (!ossl_slh_xmss_node(ctx, sk_seed, 2 * node_id, h - 1, pk_seed, adrs,
+        if (ossl_slh_xmss_node(ctx, sk_seed, 2 * node_id, h - 1, pk_seed, adrs,
                 lnode, sizeof(lnode))
-            || !ossl_slh_xmss_node(ctx, sk_seed, 2 * node_id + 1, h - 1,
-                pk_seed, adrs, rnode, sizeof(rnode)))
-            return 0;
-        adrsf->set_type_and_clear(adrs, SLH_ADRS_TYPE_TREE);
-        adrsf->set_tree_height(adrs, h);
-        adrsf->set_tree_index(adrs, node_id);
-        if (!key->hash_func->H(ctx, pk_seed, adrs, lnode, rnode, pk_out, pk_out_len))
-            return 0;
+            && ossl_slh_xmss_node(ctx, sk_seed, 2 * node_id + 1, h - 1,
+                pk_seed, adrs, rnode, sizeof(rnode))) {
+            adrsf->set_type_and_clear(adrs, SLH_ADRS_TYPE_TREE);
+            adrsf->set_tree_height(adrs, h);
+            adrsf->set_tree_index(adrs, node_id);
+            ret = key->hash_func->H(ctx, pk_seed, adrs, lnode, rnode, pk_out, pk_out_len);
+        }
+        OPENSSL_cleanse(lnode, sizeof(lnode));
+        OPENSSL_cleanse(rnode, sizeof(rnode));
     }
-    return 1;
+    return ret;
 }
 
 /**

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -639,7 +639,7 @@ static const OSSL_ALGORITHM fips_asym_kem[] = {
     { PROV_NAMES_ML_KEM_1024, FIPS_DEFAULT_PROPERTIES, ossl_ml_kem_asym_kem_functions },
 #if !defined(OPENSSL_NO_ECX)
     { PROV_NAMES_X25519MLKEM768, FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
-    { PROV_NAMES_X448MLKEM1024, FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
+    { PROV_NAMES_X448MLKEM1024, FIPS_UNAPPROVED_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
 #endif
 #if !defined(OPENSSL_NO_EC)
     { PROV_NAMES_SecP256r1MLKEM768, FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
@@ -710,7 +710,7 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
 #if !defined(OPENSSL_NO_ECX)
     { PROV_NAMES_X25519MLKEM768, FIPS_DEFAULT_PROPERTIES, ossl_mlx_x25519_kem_kmgmt_functions,
         PROV_DESCS_X25519MLKEM768 },
-    { PROV_NAMES_X448MLKEM1024, FIPS_DEFAULT_PROPERTIES, ossl_mlx_x448_kem_kmgmt_functions,
+    { PROV_NAMES_X448MLKEM1024, FIPS_UNAPPROVED_PROPERTIES, ossl_mlx_x448_kem_kmgmt_functions,
         PROV_DESCS_X448MLKEM1024 },
 #endif
 #if !defined(OPENSSL_NO_EC)

--- a/providers/implementations/digests/ml_dsa_mu_prov.c
+++ b/providers/implementations/digests/ml_dsa_mu_prov.c
@@ -83,7 +83,7 @@ static void mu_freectx(void *vctx)
     OPENSSL_free(ctx->propq);
     EVP_MD_free(ctx->md);
     EVP_MD_CTX_free(ctx->mdctx);
-    OPENSSL_free(ctx);
+    OPENSSL_clear_free(ctx, sizeof(*ctx));
 }
 
 static void *mu_dupctx(void *ctx)

--- a/providers/implementations/kem/ml_kem_kem.c
+++ b/providers/implementations/kem/ml_kem_kem.c
@@ -128,6 +128,7 @@ static int ml_kem_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 
         /* Possibly, but much less likely wrong type */
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_SEED_LENGTH);
+        OPENSSL_cleanse((void *)ctx->entropy_buf, sizeof(ctx->entropy_buf));
         ctx->entropy = NULL;
         return 0;
     }

--- a/providers/implementations/kem/mlx_kem.c
+++ b/providers/implementations/kem/mlx_kem.c
@@ -118,7 +118,7 @@ static int mlx_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
 
     if (!mlx_kem_have_pubkey(key)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
-        goto end;
+        return 0;
     }
     encap_clen = key->minfo->ctext_bytes + key->xinfo->pubkey_bytes;
     encap_slen = ML_KEM_SHARED_SECRET_BYTES + key->xinfo->shsec_bytes;
@@ -236,6 +236,10 @@ static int mlx_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
 
     ret = 1;
 end:
+    /* Erase any partial shared secret on failure */
+    if (ret == 0)
+        OPENSSL_cleanse(shsec,
+            ML_KEM_SHARED_SECRET_BYTES + key->xinfo->shsec_bytes);
     EVP_PKEY_free(xkey);
     EVP_PKEY_CTX_free(ctx);
     return ret;
@@ -324,6 +328,10 @@ static int mlx_kem_decapsulate(void *vctx, uint8_t *shsec, size_t *slen,
 
     ret = 1;
 end:
+    /* Erase any partial shared secret on failure */
+    if (ret == 0)
+        OPENSSL_cleanse(shsec,
+            ML_KEM_SHARED_SECRET_BYTES + key->xinfo->shsec_bytes);
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(xkey);
     return ret;

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c
@@ -97,6 +97,7 @@ static int ml_dsa_pairwise_test(const ML_DSA_KEY *key)
 err:
     OSSL_SELF_TEST_onend(st, ret);
     OSSL_SELF_TEST_free(st);
+    OPENSSL_cleanse(sig, sizeof(sig));
     return ret;
 }
 #endif
@@ -539,7 +540,7 @@ static void ml_dsa_gen_cleanup(void *genctx)
     if (gctx == NULL)
         return;
 
-    OPENSSL_cleanse(gctx->entropy, gctx->entropy_len);
+    OPENSSL_cleanse(gctx->entropy, sizeof(gctx->entropy));
     OPENSSL_free(gctx->propq);
     OPENSSL_free(gctx);
 }

--- a/providers/implementations/keymgmt/ml_kem_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_kem_kmgmt.c
@@ -116,10 +116,6 @@ static int ml_kem_pairwise_test(const ML_KEM_KEY *key, int key_flags)
 
     memset(out, 0, sizeof(out));
 
-    /*
-     * The pairwise test is skipped unless either RANDOM or FIXED entropy PCTs
-     * are enabled.
-     */
     if (key_flags & ML_KEM_KEY_RANDOM_PCT) {
         operation_result = ossl_ml_kem_encap_rand(ctext, v->ctext_bytes,
             secret, sizeof(secret), key);
@@ -154,7 +150,10 @@ err:
             v->algorithm_name);
     }
 #endif
-    OPENSSL_free(ctext);
+    OPENSSL_cleanse((void *)entropy, sizeof(entropy));
+    OPENSSL_cleanse((void *)secret, sizeof(secret));
+    OPENSSL_cleanse((void *)out, sizeof(out));
+    OPENSSL_clear_free(ctext, v->ctext_bytes);
     return ret;
 }
 
@@ -336,7 +335,7 @@ err:
     OSSL_PARAM_BLD_free(tmpl);
     OPENSSL_secure_clear_free(seedenc, seedlen);
     OPENSSL_secure_clear_free(prvenc, prvlen);
-    OPENSSL_free(pubenc);
+    OPENSSL_clear_free(pubenc, v->pubkey_bytes);
     return ret;
 }
 
@@ -533,12 +532,14 @@ static void *ml_kem_load(const void *reference, size_t reference_sz)
                 goto err;
         }
         OPENSSL_secure_clear_free(encoded_dk, key->vinfo->prvkey_bytes);
+        OPENSSL_cleanse((void *)seed, sizeof(seed));
         return key;
     }
 
 err:
     if (key != NULL && key->vinfo != NULL)
         OPENSSL_secure_clear_free(encoded_dk, key->vinfo->prvkey_bytes);
+    OPENSSL_cleanse((void *)seed, sizeof(seed));
     ossl_ml_kem_key_free(key);
     return NULL;
 }
@@ -707,6 +708,7 @@ static int ml_kem_gen_set_params(void *vgctx, const OSSL_PARAM params[])
 
         /* Possibly, but less likely wrong data type */
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_SEED_LENGTH);
+        OPENSSL_cleanse((void *)gctx->seedbuf, sizeof(gctx->seedbuf));
         gctx->seed = NULL;
         return 0;
     }
@@ -763,8 +765,10 @@ static void *ml_kem_gen(void *vgctx, OSSL_CALLBACK *osslcb, void *cbarg)
     if ((gctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
         return key;
 
-    if (seed != NULL && !ossl_ml_kem_set_seed(seed, ML_KEM_SEED_BYTES, key))
+    if (seed != NULL && !ossl_ml_kem_set_seed(seed, ML_KEM_SEED_BYTES, key)) {
+        ossl_ml_kem_key_free(key);
         return NULL;
+    }
     genok = ossl_ml_kem_genkey(nopub, 0, key);
 
     /* Erase the single-use seed */

--- a/providers/implementations/keymgmt/mlx_kmgmt.c
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c
@@ -320,7 +320,7 @@ static int mlx_kem_export(void *vkey, int selection, OSSL_CALLBACK *param_cb,
 err:
     OSSL_PARAM_BLD_free(tmpl);
     OPENSSL_secure_clear_free(sub_arg.prvenc, prvlen);
-    OPENSSL_free(sub_arg.pubenc);
+    OPENSSL_clear_free(sub_arg.pubenc, publen);
     return ret;
 }
 
@@ -564,12 +564,18 @@ static int mlx_kem_get_params(void *vkey, OSSL_PARAM params[])
         selection |= OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS;
 
     /* Extract sub-component key material */
-    if (!export_sub(&sub_arg, selection, key))
+    if (!export_sub(&sub_arg, selection, key)
+        || (pub != NULL && sub_arg.pubcount != 2)
+        || (prv != NULL && sub_arg.prvcount != 2)) {
+        /* Erase any partial key material on failure */
+        if (sub_arg.pubenc != NULL)
+            OPENSSL_cleanse(sub_arg.pubenc,
+                key->minfo->pubkey_bytes + key->xinfo->pubkey_bytes);
+        if (sub_arg.prvenc != NULL)
+            OPENSSL_cleanse(sub_arg.prvenc,
+                key->minfo->prvkey_bytes + key->xinfo->prvkey_bytes);
         return 0;
-
-    if ((pub != NULL && sub_arg.pubcount != 2)
-        || (prv != NULL && sub_arg.prvcount != 2))
-        return 0;
+    }
 
     return 1;
 }

--- a/providers/implementations/keymgmt/slh_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/slh_dsa_kmgmt.c
@@ -303,7 +303,7 @@ static int slh_dsa_fips140_pairwise_test(const SLH_DSA_KEY *key,
     uint8_t msg[16] = { 0 };
     size_t msg_len = sizeof(msg);
     uint8_t *sig = NULL;
-    size_t sig_len;
+    size_t sig_len = 0;
     OSSL_LIB_CTX *lib_ctx;
     int alloc_ctx = 0;
 
@@ -347,7 +347,7 @@ static int slh_dsa_fips140_pairwise_test(const SLH_DSA_KEY *key,
 err:
     if (alloc_ctx)
         ossl_slh_dsa_hash_ctx_free(ctx);
-    OPENSSL_free(sig);
+    OPENSSL_clear_free(sig, sig_len);
     OSSL_SELF_TEST_onend(st, ret);
     OSSL_SELF_TEST_free(st);
     return ret;
@@ -425,7 +425,7 @@ static void slh_dsa_gen_cleanup(void *genctx)
     if (gctx == NULL)
         return;
 
-    OPENSSL_cleanse(gctx->entropy, gctx->entropy_len);
+    OPENSSL_cleanse(gctx->entropy, sizeof(gctx->entropy));
     OPENSSL_free(gctx->propq);
     OPENSSL_free(gctx);
 }

--- a/providers/implementations/signature/ml_dsa_sig.c
+++ b/providers/implementations/signature/ml_dsa_sig.c
@@ -280,14 +280,17 @@ static int ml_dsa_sign_msg_final(void *vctx, unsigned char *sig,
                 return 0;
         }
 
-        if (!ossl_ml_dsa_mu_finalize(ctx->md_ctx, mu, sizeof(mu)))
+        if (!ossl_ml_dsa_mu_finalize(ctx->md_ctx, mu, sizeof(mu))) {
+            OPENSSL_cleanse(mu, sizeof(mu));
             return 0;
+        }
     }
 
     ret = ossl_ml_dsa_sign(ctx->key, 1, mu, sizeof(mu), NULL, 0, rnd,
         sizeof(rand_tmp), 0, sig, siglen, sigsize);
     if (rnd != ctx->test_entropy)
         OPENSSL_cleanse(rand_tmp, sizeof(rand_tmp));
+    OPENSSL_cleanse(mu, sizeof(mu));
     return ret;
 }
 
@@ -338,6 +341,7 @@ static int ml_dsa_verify_msg_final(void *vctx)
 {
     PROV_ML_DSA_CTX *ctx = (PROV_ML_DSA_CTX *)vctx;
     uint8_t mu[ML_DSA_MU_BYTES];
+    int ret = 0;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -345,11 +349,12 @@ static int ml_dsa_verify_msg_final(void *vctx)
     if (ctx->md_ctx == NULL)
         return 0;
 
-    if (!ossl_ml_dsa_mu_finalize(ctx->md_ctx, mu, sizeof(mu)))
-        return 0;
+    if (ossl_ml_dsa_mu_finalize(ctx->md_ctx, mu, sizeof(mu)))
+        ret = ossl_ml_dsa_verify(ctx->key, 1, mu, sizeof(mu), NULL, 0, 0,
+            ctx->sig, ctx->siglen);
 
-    return ossl_ml_dsa_verify(ctx->key, 1, mu, sizeof(mu), NULL, 0, 0,
-        ctx->sig, ctx->siglen);
+    OPENSSL_cleanse(mu, sizeof(mu));
+    return ret;
 }
 
 static int ml_dsa_verify(void *vctx, const uint8_t *sig, size_t siglen,

--- a/providers/implementations/signature/slh_dsa_sig.c
+++ b/providers/implementations/signature/slh_dsa_sig.c
@@ -80,7 +80,7 @@ static void slh_dsa_freectx(void *vctx)
 
     ossl_slh_dsa_hash_ctx_free(ctx->hash_ctx);
     OPENSSL_free(ctx->propq);
-    OPENSSL_cleanse(ctx->add_random, ctx->add_random_len);
+    OPENSSL_cleanse(ctx->add_random, sizeof(ctx->add_random));
     OPENSSL_free(ctx);
 }
 


### PR DESCRIPTION
Core PQ cryptographic primitives now behave more like mathematical functions with fewer "side-effects" (such as leaving potentially sensitive data on the stack).

Backport of https://github.com/openssl/openssl/pull/32148