### PR TITLE
Integration regression: Fix variable shadowing in TLS write retry path

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1924,9 +1924,9 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl)
              */
             if (TLS_BUFFER_is_app_buffer(thiswb)
                 && (rl->mode & SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER) != 0) {
-                size_t left = TLS_BUFFER_get_left(thiswb);
                 unsigned char *buf;
 
+                left = TLS_BUFFER_get_left(thiswb);
                 buf = OPENSSL_malloc(left);
                 if (buf == NULL) {
                     RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);


### PR DESCRIPTION
Commit 5f3db0d811 from PR #31021 introduced a function-scope `left` variable in `tls_retry_write_records`. The app-buffer recovery block added its own `left` before the PR was merged, causing builds using `-Werror=shadow` to fail.

Remove the redundant inner declaration and reuse the value captured at the start of the loop. No code on this retry/error path changes the buffer length before the recovery block, so behavior is unchanged.