### PR TITLE
[3.5] `util/other.syms`: sort `OPENSSL_*cap` lexicographically, add missing variables

### DIFF
--- a/util/other.syms
+++ b/util/other.syms
@@ -2,10 +2,12 @@
 # that don't appear in lib*.num -- because they are define's, in
 # assembly language, etc.
 #
+OPENSSL_armcap                          environment
 OPENSSL_ia32cap                         environment
 OPENSSL_ppccap                          environment
-OPENSSL_s390xcap                        environment
 OPENSSL_riscvcap                        environment
+OPENSSL_s390xcap                        environment
+OPENSSL_sparcv9cap                      environment
 OPENSSL_MALLOC_FD                       environment
 OPENSSL_MALLOC_FAILURES                 environment
 OPENSSL_instrument_bus                  assembler


### PR DESCRIPTION
The list includes `OPENSSL_ia32cap`, `OPENSSL_ppccap`, `OPENSSL_riscvcap`, and `OPENSSL_s390xcap`, but not `OPENSSL_armcap` or `OPENSSL_sparcv9cap`;  fix that.

This is a backport of commit 5e34e6a57396 "util/other.syms: sort OPENSSL_*cap lexicographically, add missing variables" from openssl-env(7) update patch set[1];  OPENSSL_ppccap has been added separately in commit 17411f0c42c6 "other.syms: Add OPENSSL_ppccap as it is now documented" (instead of backporting this commit, for some reason). It fixes `check_docs` CI workflow breakage induced by inclusion of `OPENSSL_armcap` manual page[2].

[1] https://github.com/openssl/openssl/pull/28025
[2] https://github.com/openssl/openssl/pull/31749

Complements: e0c81d800471 "Add documentation for OPENSSL_armcap"
Complements: 17411f0c42c6 "other.syms: Add OPENSSL_ppccap as it is now documented"
Original-Commit: 5e34e6a57396 "util/other.syms: sort OPENSSL_*cap lexicographically, add missing variables"
Original-PR: https://github.com/openssl/openssl/pull/28025