### PR TITLE
[3.4] util/other.syms: sort OPENSSL_*cap lexicographically, add missing variables

### DIFF
--- a/util/other.syms
+++ b/util/other.syms
@@ -2,9 +2,12 @@
 # that don't appear in lib*.num -- because they are define's, in
 # assembly language, etc.
 #
+OPENSSL_armcap                          environment
 OPENSSL_ia32cap                         environment
-OPENSSL_s390xcap                        environment
+OPENSSL_ppccap                          environment
 OPENSSL_riscvcap                        environment
+OPENSSL_s390xcap                        environment
+OPENSSL_sparcv9cap                      environment
 OPENSSL_MALLOC_FD                       environment
 OPENSSL_MALLOC_FAILURES                 environment
 OPENSSL_instrument_bus                  assembler


### PR DESCRIPTION
The list includes `OPENSSL_ia32cap`, `OPENSSL_riscvcap`, and `OPENSSL_s390xcap`, but not `OPENSSL_armcap`, `OPENSSL_ppccap`, or `OPENSSL_sparcv9cap`;  fix that.

Signed-off-by: Eugene Syromiatnikov <esyr@openssl.org>

Reviewed-by: Neil Horman <nhorman@openssl.org>
Reviewed-by: Tomas Mraz <tomas@openssl.org>
Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
(Merged from https://github.com/openssl/openssl/pull/28025)

----
This a backport of a commit from [1] that updates `util/other.syms` to include all the `OPENSSL_*cap` environment variables. It fixes `make doc-nits` failure induced by inclusion of `OPENSSL_armcap` manual page[2].

[1] https://github.com/openssl/openssl/pull/28025
[2] https://github.com/openssl/openssl/pull/31749