### PR TITLE
Additional cleansing of intermediate (potentially sensitive) data in ML-KEM, ML-DSA and SLH-DSA (3.6)

### DIFF
--- a/crypto/ml_dsa/ml_dsa_encoders.c
+++ b/crypto/ml_dsa/ml_dsa_encoders.c
@@ -935,6 +935,9 @@ int ossl_ml_dsa_sig_encode(const ML_DSA_SIG *sig, const ML_DSA_PARAMS *params,
     ret = 1;
 err:
     WPACKET_finish(&pkt);
+    /* Erase any partial signature output on failure */
+    if (ret == 0)
+        OPENSSL_cleanse(out, params->sig_len);
     return ret;
 }
 

--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -353,10 +353,15 @@ static int public_from_private(const ML_DSA_KEY *key, EVP_MD_CTX *md_ctx,
     /* Compress t */
     vector_power2_round(&t, t1, t0);
 
-    /* Zeroize secret */
-    vector_zero(&s1_ntt);
     ret = 1;
 err:
+    /*
+     * The low bits of |t| are private and |s1_ntt| is secret, wipe both.
+     * The trailing |a_ntt| matrix is not wiped: per FIPS 204 section 3.6.3
+     * the matrix A is easily computed from the public key and does not
+     * require any special protections.
+     */
+    OPENSSL_cleanse(polys, (k + l) * sizeof(*polys));
     OPENSSL_free(polys);
     return ret;
 }
@@ -377,6 +382,7 @@ int ossl_ml_dsa_key_public_from_private(ML_DSA_KEY *key)
         && shake_xof(md_ctx, key->shake256_md,
             key->pub_encoding, key->params->pk_len,
             key->tr, sizeof(key->tr));
+    vector_zero(&t0);
     vector_free(&t0);
     EVP_MD_CTX_free(md_ctx);
     return ret;
@@ -408,7 +414,7 @@ int ossl_ml_dsa_key_pairwise_check(const ML_DSA_KEY *key)
     ret = vector_equal(&t1, &key->t1) && vector_equal(&t0, &key->t0);
 err:
     EVP_MD_CTX_free(md_ctx);
-    OPENSSL_free(polys);
+    OPENSSL_clear_free(polys, 2 * k * sizeof(*polys));
     return ret;
 }
 

--- a/crypto/ml_dsa/ml_dsa_matrix.c
+++ b/crypto/ml_dsa/ml_dsa_matrix.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/crypto.h>
 #include "ml_dsa_local.h"
 #include "ml_dsa_vector.h"
 #include "ml_dsa_matrix.h"
@@ -25,15 +26,16 @@ void ossl_ml_dsa_matrix_mult_vector(const MATRIX *a, const VECTOR *s,
 {
     size_t i, j;
     POLY *poly = a->m_poly;
+    POLY product;
 
     vector_zero(t);
 
     for (i = 0; i < a->k; i++) {
         for (j = 0; j < a->l; j++) {
-            POLY product;
-
             ossl_ml_dsa_poly_ntt_mult(poly++, &s->poly[j], &product);
             poly_add(&product, &t->poly[i], &t->poly[i]);
         }
     }
+
+    OPENSSL_cleanse(&product, sizeof(product));
 }

--- a/crypto/ml_dsa/ml_dsa_sample.c
+++ b/crypto/ml_dsa/ml_dsa_sample.c
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/byteorder.h>
+#include <openssl/crypto.h>
 #include "ml_dsa_local.h"
 #include "ml_dsa_vector.h"
 #include "ml_dsa_matrix.h"
@@ -159,13 +160,14 @@ static int rej_bounded_poly(EVP_MD_CTX *h_ctx, const EVP_MD *md,
     COEFF_FROM_NIBBLE_FUNC *coef_from_nibble,
     const uint8_t *seed, size_t seed_len, POLY *out)
 {
+    int ret = 0;
     int j = 0;
     uint32_t z0, z1;
     uint8_t blocks[SHAKE256_BLOCKSIZE], *b, *end = blocks + sizeof(blocks);
 
     /* Instead of just squeezing 1 byte at a time, we grab a whole block */
     if (!shake_xof(h_ctx, md, seed, seed_len, blocks, sizeof(blocks)))
-        return 0;
+        goto err;
 
     while (1) {
         for (b = blocks; b < end; b++) {
@@ -173,15 +175,22 @@ static int rej_bounded_poly(EVP_MD_CTX *h_ctx, const EVP_MD *md,
             z1 = *b >> 4; /* high nibble of byte */
 
             if (coef_from_nibble(z0, &out->coeff[j])
-                && ++j >= ML_DSA_NUM_POLY_COEFFICIENTS)
-                return 1;
+                && ++j >= ML_DSA_NUM_POLY_COEFFICIENTS) {
+                ret = 1;
+                goto err;
+            }
             if (coef_from_nibble(z1, &out->coeff[j])
-                && ++j >= ML_DSA_NUM_POLY_COEFFICIENTS)
-                return 1;
+                && ++j >= ML_DSA_NUM_POLY_COEFFICIENTS) {
+                ret = 1;
+                goto err;
+            }
         }
         if (!EVP_DigestSqueeze(h_ctx, blocks, sizeof(blocks)))
-            return 0;
+            goto err;
     }
+err:
+    OPENSSL_cleanse(blocks, sizeof(blocks));
+    return ret;
 }
 
 /**
@@ -204,6 +213,13 @@ int ossl_ml_dsa_matrix_expand_A(EVP_MD_CTX *g_ctx, const EVP_MD *md,
     size_t i, j;
     uint8_t derived_seed[ML_DSA_RHO_BYTES + 2];
     POLY *poly = out->m_poly;
+
+    /*
+     * The seeds derived below and the sampling buffers in rej_ntt_poly() are
+     * not cleansed: per FIPS 204 section 3.6.3 the matrix A is easily
+     * computed from the public key and does not require any special
+     * protections.
+     */
 
     /* The seed used for each matrix element is rho + column_index + row_index */
     memcpy(derived_seed, rho, ML_DSA_RHO_BYTES);
@@ -274,6 +290,7 @@ int ossl_ml_dsa_vector_expand_S(EVP_MD_CTX *h_ctx, const EVP_MD *md, int eta,
     }
     ret = 1;
 err:
+    OPENSSL_cleanse(derived_seed, sizeof(derived_seed));
     return ret;
 }
 
@@ -284,9 +301,11 @@ int ossl_ml_dsa_poly_expand_mask(POLY *out, const uint8_t *seed, size_t seed_len
 {
     uint8_t buf[32 * 20];
     size_t buf_len = 32 * (gamma1 == ML_DSA_GAMMA1_TWO_POWER_19 ? 20 : 18);
-
-    return shake_xof(h_ctx, md, seed, seed_len, buf, buf_len)
+    int ret = shake_xof(h_ctx, md, seed, seed_len, buf, buf_len)
         && ossl_ml_dsa_poly_decode_expand_mask(out, buf, buf_len, gamma1);
+
+    OPENSSL_cleanse(buf, sizeof(buf));
+    return ret;
 }
 
 /*
@@ -311,13 +330,14 @@ int ossl_ml_dsa_poly_sample_in_ball(POLY *out_c, const uint8_t *seed, int seed_l
     uint64_t signs;
     int offset = 8;
     size_t end;
+    int ret = 0;
 
     /*
      * Rather than squeeze 8 bytes followed by lots of 1 byte squeezes
      * the SHAKE blocksize is squeezed each time and buffered into 'block'.
      */
     if (!shake_xof(h_ctx, md, seed, seed_len, block, sizeof(block)))
-        return 0;
+        goto err;
 
     /*
      * grab the first 64 bits - since tau < 64
@@ -336,7 +356,7 @@ int ossl_ml_dsa_poly_sample_in_ball(POLY *out_c, const uint8_t *seed, int seed_l
             if (offset == sizeof(block)) {
                 /* squeeze another block if the bytes from block have been used */
                 if (!EVP_DigestSqueeze(h_ctx, block, sizeof(block)))
-                    return 0;
+                    goto err;
                 offset = 0;
             }
 
@@ -354,5 +374,8 @@ int ossl_ml_dsa_poly_sample_in_ball(POLY *out_c, const uint8_t *seed, int seed_l
         out_c->coeff[index] = mod_sub(1, 2 * (signs & 1));
         signs >>= 1; /* grab the next random bit */
     }
-    return 1;
+    ret = 1;
+err:
+    OPENSSL_cleanse(block, sizeof(block));
+    return ret;
 }

--- a/crypto/ml_dsa/ml_dsa_sign.c
+++ b/crypto/ml_dsa/ml_dsa_sign.c
@@ -297,6 +297,7 @@ err:
     EVP_MD_CTX_free(md_ctx);
     OPENSSL_clear_free(alloc, alloc_len);
     OPENSSL_cleanse(rho_prime, sizeof(rho_prime));
+    OPENSSL_cleanse(c_tilde, sizeof(c_tilde));
     return ret;
 }
 
@@ -454,6 +455,7 @@ int ossl_ml_dsa_sign(const ML_DSA_KEY *priv, int msg_is_mu,
 
 err:
     EVP_MD_CTX_free(md_ctx);
+    OPENSSL_cleanse(mu, sizeof(mu));
     return ret;
 }
 
@@ -493,5 +495,6 @@ int ossl_ml_dsa_verify(const ML_DSA_KEY *pub, int msg_is_mu,
     ret = ml_dsa_verify_internal(pub, mu_ptr, mu_len, sig, sig_len);
 err:
     EVP_MD_CTX_free(md_ctx);
+    OPENSSL_cleanse(mu, sizeof(mu));
     return ret;
 }

--- a/crypto/ml_dsa/ml_dsa_vector.h
+++ b/crypto/ml_dsa/ml_dsa_vector.h
@@ -8,6 +8,7 @@
  */
 
 #include <assert.h>
+#include <openssl/crypto.h>
 #include "ml_dsa_poly.h"
 
 struct vector_st {
@@ -169,6 +170,7 @@ vector_expand_mask(VECTOR *out, const uint8_t *rho_prime, size_t rho_prime_len,
         poly_expand_mask(out->poly + i, derived_seed, sizeof(derived_seed),
             gamma1, h_ctx, md);
     }
+    OPENSSL_cleanse(derived_seed, sizeof(derived_seed));
 }
 
 /* Scale back previously rounded value */

--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -1320,6 +1320,12 @@ static __owur int matrix_expand(EVP_MD_CTX *mdctx, ML_KEM_KEY *key)
     int rank = key->vinfo->rank;
     int i, j;
 
+    /*
+     * The seeds derived below and the sampling buffers in sample_scalar()
+     * are not cleansed: per FIPS 203 section 3.3 the matrix A is easily
+     * computed from the public encapsulation key and does not require any
+     * special protections.
+     */
     memcpy(input, key->rho, ML_KEM_RANDOM_BYTES);
     for (i = 0; i < rank; i++) {
         for (j = 0; j < rank; j++) {
@@ -1350,8 +1356,10 @@ static __owur int cbd_2(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
     uint16_t value, mask;
     uint8_t b;
 
-    if (!prf(randbuf, sizeof(randbuf), in, mdctx, key))
+    if (!prf(randbuf, sizeof(randbuf), in, mdctx, key)) {
+        OPENSSL_cleanse((void *)randbuf, sizeof(randbuf));
         return 0;
+    }
 
     do {
         b = *r++;
@@ -1373,6 +1381,8 @@ static __owur int cbd_2(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
         mask = constish_time_non_zero(value >> 15);
         *curr++ = value + (kPrime & mask);
     } while (curr < end);
+
+    OPENSSL_cleanse((void *)randbuf, sizeof(randbuf));
     return 1;
 }
 
@@ -1390,8 +1400,10 @@ static __owur int cbd_3(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
     uint8_t b1, b2, b3;
     uint16_t value, mask;
 
-    if (!prf(randbuf, sizeof(randbuf), in, mdctx, key))
+    if (!prf(randbuf, sizeof(randbuf), in, mdctx, key)) {
+        OPENSSL_cleanse((void *)randbuf, sizeof(randbuf));
         return 0;
+    }
 
     do {
         b1 = *r++;
@@ -1425,6 +1437,8 @@ static __owur int cbd_3(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
         mask = constish_time_non_zero(value >> 15);
         *curr++ = value + (kPrime & mask);
     } while (curr < end);
+
+    OPENSSL_cleanse((void *)randbuf, sizeof(randbuf));
     return 1;
 }
 
@@ -1437,14 +1451,19 @@ static __owur int gencbd_vector(scalar *out, CBD_FUNC cbd, uint8_t *counter,
     EVP_MD_CTX *mdctx, const ML_KEM_KEY *key)
 {
     uint8_t input[ML_KEM_RANDOM_BYTES + 1];
+    int ret = 0;
 
     memcpy(input, seed, ML_KEM_RANDOM_BYTES);
     do {
         input[ML_KEM_RANDOM_BYTES] = (*counter)++;
         if (!cbd(out++, input, mdctx, key))
-            return 0;
+            goto end;
     } while (--rank > 0);
-    return 1;
+    ret = 1;
+
+end:
+    OPENSSL_cleanse((void *)input, sizeof(input));
+    return ret;
 }
 
 /*
@@ -1455,15 +1474,20 @@ static __owur int gencbd_vector_ntt(scalar *out, CBD_FUNC cbd, uint8_t *counter,
     EVP_MD_CTX *mdctx, const ML_KEM_KEY *key)
 {
     uint8_t input[ML_KEM_RANDOM_BYTES + 1];
+    int ret = 0;
 
     memcpy(input, seed, ML_KEM_RANDOM_BYTES);
     do {
         input[ML_KEM_RANDOM_BYTES] = (*counter)++;
         if (!cbd(out, input, mdctx, key))
-            return 0;
+            goto end;
         scalar_ntt(out++);
     } while (--rank > 0);
-    return 1;
+    ret = 1;
+
+end:
+    OPENSSL_cleanse((void *)input, sizeof(input));
+    return ret;
 }
 
 /* The |ETA1| value for ML-KEM-512 is 3, the rest and all ETA2 values are 2. */
@@ -1502,10 +1526,11 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
     uint8_t counter = 0;
     int du = vinfo->du;
     int dv = vinfo->dv;
+    int ret = 0;
 
     /* FIPS 203 "y" vector */
     if (!gencbd_vector_ntt(y, cbd_1, &counter, r, rank, mdctx, key))
-        return 0;
+        goto end;
     /* FIPS 203 "v" scalar */
     inner_product(&v, key->t, y, rank);
     scalar_inverse_ntt(&v);
@@ -1514,7 +1539,7 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
 
     /* All done with |y|, now free to reuse tmp[0] for FIPS 203 |e1| */
     if (!gencbd_vector(e1, cbd_2, &counter, r, rank, mdctx, key))
-        return 0;
+        goto end;
     vector_add(u, e1, rank);
     vector_compress(u, du, rank);
     vector_encode(out, u, du, rank);
@@ -1523,14 +1548,19 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
     memcpy(input, r, ML_KEM_RANDOM_BYTES);
     input[ML_KEM_RANDOM_BYTES] = counter;
     if (!cbd_2(e2, input, mdctx, key))
-        return 0;
+        goto end;
     scalar_add(&v, e2);
 
     /* Combine message with |v| */
     scalar_decode_decompress_add(&v, message);
     scalar_compress(&v, dv);
     scalar_encode(out + vinfo->u_vector_bytes, &v, dv);
-    return 1;
+    ret = 1;
+
+end:
+    OPENSSL_cleanse((void *)input, sizeof(input));
+    OPENSSL_cleanse((void *)&v, sizeof(v));
+    return ret;
 }
 
 /*
@@ -1554,6 +1584,9 @@ decrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
     scalar_sub(&v, &mask);
     scalar_compress(&v, 1);
     scalar_encode_1(out, &v);
+
+    OPENSSL_cleanse((void *)&v, sizeof(v));
+    OPENSSL_cleanse((void *)&mask, sizeof(mask));
 }
 
 /*-
@@ -1747,8 +1780,8 @@ static __owur int genkey(const uint8_t seed[ML_KEM_SEED_BYTES],
 
     ret = 1;
 end:
-    OPENSSL_cleanse((void *)augmented_seed, ML_KEM_RANDOM_BYTES);
-    OPENSSL_cleanse((void *)sigma, ML_KEM_RANDOM_BYTES);
+    OPENSSL_cleanse((void *)augmented_seed, sizeof(augmented_seed));
+    OPENSSL_cleanse((void *)hashed, sizeof(hashed));
     if (ret == 0) {
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR,
             "internal error while generating %s private key",
@@ -1786,6 +1819,7 @@ static int encap(uint8_t *ctext, uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR,
             "internal error while performing %s encapsulation",
             key->vinfo->algorithm_name);
+    OPENSSL_cleanse((void *)Kr, sizeof(Kr));
     return ret;
 }
 
@@ -1832,6 +1866,7 @@ static int decap(uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR,
             "internal error while performing %s decapsulation",
             vinfo->algorithm_name);
+        OPENSSL_cleanse(failure_key, sizeof(failure_key));
         return 0;
     }
     decrypt_cpa(decrypted, ctext, tmp, key);
@@ -1840,6 +1875,8 @@ static int decap(uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
         || !encrypt_cpa(tmp_ctext, decrypted, r, tmp, mdctx, key)) {
         memcpy(secret, failure_key, ML_KEM_SHARED_SECRET_BYTES);
         OPENSSL_cleanse(decrypted, ML_KEM_SHARED_SECRET_BYTES);
+        OPENSSL_cleanse(Kr, sizeof(Kr));
+        OPENSSL_cleanse(failure_key, sizeof(failure_key));
         return 1;
     }
     mask = constant_time_eq_int_8(0,
@@ -1848,6 +1885,7 @@ static int decap(uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
         secret[i] = constant_time_select_8(mask, Kr[i], failure_key[i]);
     OPENSSL_cleanse(decrypted, ML_KEM_SHARED_SECRET_BYTES);
     OPENSSL_cleanse(Kr, sizeof(Kr));
+    OPENSSL_cleanse(failure_key, sizeof(failure_key));
     return 1;
 }
 
@@ -2235,6 +2273,9 @@ int ossl_ml_kem_genkey(uint8_t *pubenc, size_t publen, ML_KEM_KEY *key)
 
     EVP_MD_CTX_free(mdctx);
     if (!ret) {
+        /* Erase any partial public key output */
+        if (pubenc != NULL)
+            OPENSSL_cleanse(pubenc, vinfo->pubkey_bytes);
         ossl_ml_kem_key_reset(key);
         return 0;
     }
@@ -2293,6 +2334,10 @@ int ossl_ml_kem_encap_seed(uint8_t *ctext, size_t clen,
     }
 #undef case_encap_seed
 
+    /* Erase any partial ciphertext output on failure */
+    if (!ret)
+        OPENSSL_cleanse(ctext, clen);
+
     /* Declassify secret inputs and derived outputs before returning control */
     CONSTTIME_DECLASSIFY(entropy, elen);
     CONSTTIME_DECLASSIFY(ctext, clen);
@@ -2307,6 +2352,7 @@ int ossl_ml_kem_encap_rand(uint8_t *ctext, size_t clen,
     const ML_KEM_KEY *key)
 {
     uint8_t r[ML_KEM_RANDOM_BYTES];
+    int ret;
 
     if (key == NULL)
         return 0;
@@ -2316,8 +2362,11 @@ int ossl_ml_kem_encap_rand(uint8_t *ctext, size_t clen,
         < 1)
         return 0;
 
-    return ossl_ml_kem_encap_seed(ctext, clen, shared_secret, slen,
+    ret = ossl_ml_kem_encap_seed(ctext, clen, shared_secret, slen,
         r, sizeof(r), key);
+
+    OPENSSL_cleanse((void *)r, sizeof(r));
+    return ret;
 }
 
 int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
@@ -2367,6 +2416,7 @@ int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
                                                                   \
         ret = decap(shared_secret, ctext, cbuf, tmp, mdctx, key); \
         OPENSSL_cleanse((void *)tmp, sizeof(tmp));                \
+        OPENSSL_cleanse((void *)cbuf, sizeof(cbuf));              \
         break;                                                    \
     }
     switch (vinfo->evp_type) {

--- a/crypto/slh_dsa/slh_dsa.c
+++ b/crypto/slh_dsa/slh_dsa.c
@@ -8,6 +8,7 @@
  */
 #include <stddef.h>
 #include <string.h>
+#include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/proverr.h>
 #include "slh_dsa_local.h"
@@ -122,8 +123,13 @@ static int slh_sign_internal(SLH_DSA_HASH_CTX *hctx,
 err:
     if (!WPACKET_finish(wpkt))
         ret = 0;
+    OPENSSL_cleanse(m_digest, sizeof(m_digest));
+    OPENSSL_cleanse(pk_fors, sizeof(pk_fors));
     if (ret)
         *sig_len = sig_len_expected;
+    else
+        /* Erase any partial signature output */
+        OPENSSL_cleanse(sig, sig_len_expected);
     return ret;
 }
 
@@ -148,6 +154,7 @@ static int slh_verify_internal(SLH_DSA_HASH_CTX *hctx,
     const uint8_t *msg, size_t msg_len,
     const uint8_t *sig, size_t sig_len)
 {
+    int ret = 0;
     const SLH_DSA_KEY *pub = hctx->key;
     SLH_HASH_FUNC_DECLARE(pub, hashf);
     SLH_ADRS_FUNC_DECLARE(pub, adrsf);
@@ -185,7 +192,7 @@ static int slh_verify_internal(SLH_DSA_HASH_CTX *hctx,
 
     if (!hashf->H_MSG(hctx, r, pk_seed, pk_root, msg, msg_len,
             m_digest, sizeof(m_digest)))
-        return 0;
+        goto err;
 
     /*
      * Get md (the first md_len bytes of m_digest to use in
@@ -195,16 +202,20 @@ static int slh_verify_internal(SLH_DSA_HASH_CTX *hctx,
     if (!PACKET_buf_init(m_digest_rpkt, m_digest, sizeof(m_digest))
         || !PACKET_get_bytes(m_digest_rpkt, &md, md_len)
         || !get_tree_ids(m_digest_rpkt, params, &tree_id, &leaf_id))
-        return 0;
+        goto err;
 
     adrsf->set_tree_address(adrs, tree_id);
     adrsf->set_type_and_clear(adrs, SLH_ADRS_TYPE_FORS_TREE);
     adrsf->set_keypair_address(adrs, leaf_id);
-    return ossl_slh_fors_pk_from_sig(hctx, sig_rpkt, md, pk_seed, adrs,
-               pk_fors, sizeof(pk_fors))
+    ret = ossl_slh_fors_pk_from_sig(hctx, sig_rpkt, md, pk_seed, adrs,
+              pk_fors, sizeof(pk_fors))
         && ossl_slh_ht_verify(hctx, pk_fors, sig_rpkt, pk_seed,
             tree_id, leaf_id, pk_root)
         && PACKET_remaining(sig_rpkt) == 0;
+err:
+    OPENSSL_cleanse(m_digest, sizeof(m_digest));
+    OPENSSL_cleanse(pk_fors, sizeof(pk_fors));
+    return ret;
 }
 
 /**
@@ -292,8 +303,13 @@ int ossl_slh_dsa_sign(SLH_DSA_HASH_CTX *slh_ctx,
             return 0;
     }
     ret = slh_sign_internal(slh_ctx, m, m_len, sig, siglen, sigsize, add_rand);
-    if (m != msg && m != m_tmp)
-        OPENSSL_free(m);
+    /* The encoded message may contain confidential message content */
+    if (m != msg) {
+        if (m != m_tmp)
+            OPENSSL_clear_free(m, m_len);
+        else
+            OPENSSL_cleanse(m_tmp, sizeof(m_tmp));
+    }
     return ret;
 }
 
@@ -317,8 +333,13 @@ int ossl_slh_dsa_verify(SLH_DSA_HASH_CTX *slh_ctx,
         return 0;
 
     ret = slh_verify_internal(slh_ctx, m, m_len, sig, sig_len);
-    if (m != msg && m != m_tmp)
-        OPENSSL_free(m);
+    /* The encoded message may contain confidential message content */
+    if (m != msg) {
+        if (m != m_tmp)
+            OPENSSL_clear_free(m, m_len);
+        else
+            OPENSSL_cleanse(m_tmp, sizeof(m_tmp));
+    }
     return ret;
 }
 

--- a/crypto/slh_dsa/slh_dsa_hash_ctx.c
+++ b/crypto/slh_dsa/slh_dsa_hash_ctx.c
@@ -109,5 +109,6 @@ void ossl_slh_dsa_hash_ctx_free(SLH_DSA_HASH_CTX *ctx)
     if (ctx->md_big_ctx != ctx->md_ctx)
         EVP_MD_CTX_free(ctx->md_big_ctx);
     EVP_MAC_CTX_free(ctx->hmac_ctx);
-    OPENSSL_free(ctx);
+    /* Erases the |scratch| hash intermediates */
+    OPENSSL_clear_free(ctx, sizeof(*ctx));
 }

--- a/crypto/slh_dsa/slh_dsa_key.c
+++ b/crypto/slh_dsa/slh_dsa_key.c
@@ -311,6 +311,12 @@ int ossl_slh_dsa_key_fromdata(SLH_DSA_KEY *key, const OSSL_PARAM *param_pub,
     key->pub = p;
     return 1;
 err:
+    /*
+     * A private key of unexpected length may have been copied into |priv|
+     * before |has_priv| was set, in which case the reset below would not
+     * erase it, so cleanse unconditionally.
+     */
+    OPENSSL_cleanse(key->priv, sizeof(key->priv));
     ossl_slh_dsa_key_reset(key);
     return 0;
 }

--- a/crypto/slh_dsa/slh_dsa_local.h
+++ b/crypto/slh_dsa/slh_dsa_local.h
@@ -45,12 +45,24 @@
  * NOTE: Any changes to this structure will need updating in
  * ossl_slh_dsa_hash_ctx_dup().
  */
+/* A SHA-512 digest plus two |n| byte node values */
+#define SLH_DSA_HASH_SCRATCH_LEN (64 + 2 * SLH_MAX_N)
+
 struct slh_dsa_hash_ctx_st {
     const SLH_DSA_KEY *key; /* This key is not owned by this object */
     EVP_MD_CTX *md_ctx; /* Either SHAKE OR SHA-256 */
     EVP_MD_CTX *md_big_ctx; /* Either SHA-512 or points to |md_ctx| for SHA-256*/
     EVP_MAC_CTX *hmac_ctx; /* required by SHA algorithms for PRFmsg() */
     int hmac_digest_used; /* Used for lazy init of hmac_ctx digest */
+    /*
+     * Working storage for the SHA2 hash function intermediates, used in
+     * place of local stack copies, so that potentially sensitive
+     * intermediate data lives in one place and is erased when this object
+     * is freed (FIPS 205 section 3.1).  The SHAKE hash functions write
+     * their output directly to the caller's buffer and need no scratch.
+     * Not used concurrently.
+     */
+    uint8_t scratch[SLH_DSA_HASH_SCRATCH_LEN];
 };
 
 __owur int ossl_slh_wots_pk_gen(SLH_DSA_HASH_CTX *ctx, const uint8_t *sk_seed,

--- a/crypto/slh_dsa/slh_fors.c
+++ b/crypto/slh_dsa/slh_fors.c
@@ -17,8 +17,8 @@
 /* a = 6, 8, 9, 12 or 14  - There are (2^a) merkle trees */
 #define SLH_MAX_A 9
 
-#define SLH_MAX_K_TIMES_A (SLH_MAX_A * SLH_MAX_K)
-#define SLH_MAX_ROOTS (SLH_MAX_K_TIMES_A * SLH_MAX_N)
+/* The FORS public key is computed from the roots of k Merkle trees */
+#define SLH_MAX_ROOTS (SLH_MAX_K * SLH_MAX_N)
 
 static void slh_base_2b(const uint8_t *in, uint32_t b, uint32_t *out, size_t out_len);
 
@@ -87,25 +87,25 @@ static int slh_fors_node(SLH_DSA_HASH_CTX *ctx, const uint8_t *sk_seed,
 
     if (height == 0) {
         /* Gets here for leaf nodes */
-        if (!slh_fors_sk_gen(ctx, sk_seed, pk_seed, adrs, node_id, sk, sizeof(sk)))
-            return 0;
-        adrsf->set_tree_height(adrs, 0);
-        adrsf->set_tree_index(adrs, node_id);
-        ret = key->hash_func->F(ctx, pk_seed, adrs, sk, n, node, node_len);
+        if (slh_fors_sk_gen(ctx, sk_seed, pk_seed, adrs, node_id, sk, sizeof(sk))) {
+            adrsf->set_tree_height(adrs, 0);
+            adrsf->set_tree_index(adrs, node_id);
+            ret = key->hash_func->F(ctx, pk_seed, adrs, sk, n, node, node_len);
+        }
         OPENSSL_cleanse(sk, n);
-        return ret;
     } else {
-        if (!slh_fors_node(ctx, sk_seed, pk_seed, adrs, 2 * node_id, height - 1,
-                lnode, sizeof(rnode))
-            || !slh_fors_node(ctx, sk_seed, pk_seed, adrs, 2 * node_id + 1,
-                height - 1, rnode, sizeof(rnode)))
-            return 0;
-        adrsf->set_tree_height(adrs, height);
-        adrsf->set_tree_index(adrs, node_id);
-        if (!key->hash_func->H(ctx, pk_seed, adrs, lnode, rnode, node, node_len))
-            return 0;
+        if (slh_fors_node(ctx, sk_seed, pk_seed, adrs, 2 * node_id, height - 1,
+                lnode, sizeof(lnode))
+            && slh_fors_node(ctx, sk_seed, pk_seed, adrs, 2 * node_id + 1,
+                height - 1, rnode, sizeof(rnode))) {
+            adrsf->set_tree_height(adrs, height);
+            adrsf->set_tree_index(adrs, node_id);
+            ret = key->hash_func->H(ctx, pk_seed, adrs, lnode, rnode, node, node_len);
+        }
+        OPENSSL_cleanse(lnode, sizeof(lnode));
+        OPENSSL_cleanse(rnode, sizeof(rnode));
     }
-    return 1;
+    return ret;
 }
 
 /**
@@ -132,6 +132,7 @@ int ossl_slh_fors_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *md,
     const uint8_t *sk_seed, const uint8_t *pk_seed,
     uint8_t *adrs, WPACKET *sig_wpkt)
 {
+    int ret = 0;
     const SLH_DSA_KEY *key = ctx->key;
     uint32_t tree_id, layer, s, tree_offset;
     uint32_t ids[SLH_MAX_K];
@@ -165,7 +166,7 @@ int ossl_slh_fors_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *md,
         if (!slh_fors_sk_gen(ctx, sk_seed, pk_seed, adrs,
                 node_id + tree_id_times_two_power_a, out, sizeof(out))
             || !WPACKET_memcpy(sig_wpkt, out, n))
-            return 0;
+            goto err;
 
         /*
          * Traverse from the bottom of the tree (layer = 0)
@@ -178,15 +179,18 @@ int ossl_slh_fors_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *md,
             s = node_id ^ 1; /* XOR gets the index of the other child in a binary tree */
             if (!slh_fors_node(ctx, sk_seed, pk_seed, adrs,
                     s + tree_offset, layer, out, sizeof(out)))
-                return 0;
+                goto err;
             node_id >>= 1; /* Get the parent node id */
             tree_offset >>= 1; /* Each layer up has half as many nodes */
             if (!WPACKET_memcpy(sig_wpkt, out, n))
-                return 0;
+                goto err;
         }
         tree_id_times_two_power_a += two_power_a;
     }
-    return 1;
+    ret = 1;
+err:
+    OPENSSL_cleanse(out, sizeof(out));
+    return ret;
 }
 
 /**
@@ -288,6 +292,8 @@ int ossl_slh_fors_pk_from_sig(SLH_DSA_HASH_CTX *ctx, PACKET *fors_sig_rpkt,
 err:
     if (!WPACKET_finish(wroot_pkt))
         ret = 0;
+    /* At most one |n| byte root per tree was written */
+    OPENSSL_cleanse(roots, k * n);
     return ret;
 }
 

--- a/crypto/slh_dsa/slh_hash.c
+++ b/crypto/slh_dsa/slh_hash.c
@@ -92,12 +92,15 @@ slh_prf_msg_shake(SLH_DSA_HASH_CTX *ctx, const uint8_t *sk_prf,
     const uint8_t *opt_rand, const uint8_t *msg, size_t msg_len,
     WPACKET *pkt)
 {
+    int ret;
     unsigned char out[SLH_MAX_N];
     const SLH_DSA_PARAMS *params = ctx->key->params;
     size_t n = params->n;
 
-    return xof_digest_3(ctx->md_ctx, sk_prf, n, opt_rand, n, msg, msg_len, out, n)
+    ret = xof_digest_3(ctx->md_ctx, sk_prf, n, opt_rand, n, msg, msg_len, out, n)
         && WPACKET_memcpy(pkt, out, n);
+    OPENSSL_cleanse(out, sizeof(out));
+    return ret;
 }
 
 static int
@@ -151,6 +154,7 @@ slh_hmsg_sha2(SLH_DSA_HASH_CTX *hctx, const uint8_t *r, const uint8_t *pk_seed,
     const uint8_t *pk_root, const uint8_t *msg, size_t msg_len,
     uint8_t *out, size_t out_len)
 {
+    int ret;
     const SLH_DSA_PARAMS *params = hctx->key->params;
     size_t m = params->m;
     size_t n = params->n;
@@ -163,9 +167,11 @@ slh_hmsg_sha2(SLH_DSA_HASH_CTX *hctx, const uint8_t *r, const uint8_t *pk_seed,
 
     memcpy(seed, r, n);
     memcpy(seed + n, pk_seed, n);
-    return digest_4(hctx->md_big_ctx, r, n, pk_seed, n, pk_root, n, msg, msg_len,
-               seed + 2 * n)
+    ret = digest_4(hctx->md_big_ctx, r, n, pk_seed, n, pk_root, n, msg, msg_len,
+              seed + 2 * n)
         && (PKCS1_MGF1(out, (long)m, seed, (long)seed_len, hctx->key->md_big) == 0);
+    OPENSSL_cleanse(seed, sizeof(seed));
+    return ret;
 }
 
 static int
@@ -205,16 +211,23 @@ slh_prf_msg_sha2(SLH_DSA_HASH_CTX *hctx,
         && EVP_MAC_update(mctx, msg, msg_len) == 1
         && EVP_MAC_final(mctx, mac, NULL, sizeof(mac)) == 1
         && WPACKET_memcpy(pkt, mac, n); /* Truncate output to n bytes */
+    OPENSSL_cleanse(mac, sizeof(mac));
     return ret;
 }
 
+/*
+ * The |digest| scratch storage in the hash context is used in place of a
+ * local stack buffer, and is erased when the hash context is freed
+ * (FIPS 205 section 3.1).  On the PRF path it holds a derived chain secret.
+ */
 static ossl_inline int
-do_hash(EVP_MD_CTX *ctx, size_t n, const uint8_t *pk_seed, const uint8_t *adrs,
+do_hash(SLH_DSA_HASH_CTX *hctx, EVP_MD_CTX *ctx, size_t n,
+    const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *m, size_t m_len, size_t b, uint8_t *out, size_t out_len)
 {
     int ret;
     uint8_t zeros[128] = { 0 };
-    uint8_t digest[MAX_DIGEST_SIZE];
+    uint8_t *digest = hctx->scratch;
 
     ret = digest_4(ctx, pk_seed, n, zeros, b - n, adrs, SLH_ADRSC_SIZE,
         m, m_len, digest);
@@ -230,7 +243,7 @@ slh_prf_sha2(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed,
 {
     size_t n = hctx->key->params->n;
 
-    return do_hash(hctx->md_ctx, n, pk_seed, adrs, sk_seed, n,
+    return do_hash(hctx, hctx->md_ctx, n, pk_seed, adrs, sk_seed, n,
         OSSL_SLH_DSA_SHA2_NUM_ZEROS_H_AND_T_BOUND1, out, out_len);
 }
 
@@ -238,21 +251,22 @@ static int
 slh_f_sha2(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *m1, size_t m1_len, uint8_t *out, size_t out_len)
 {
-    return do_hash(hctx->md_ctx, hctx->key->params->n, pk_seed, adrs, m1, m1_len,
-        OSSL_SLH_DSA_SHA2_NUM_ZEROS_H_AND_T_BOUND1, out, out_len);
+    return do_hash(hctx, hctx->md_ctx, hctx->key->params->n, pk_seed, adrs,
+        m1, m1_len, OSSL_SLH_DSA_SHA2_NUM_ZEROS_H_AND_T_BOUND1, out, out_len);
 }
 
 static int
 slh_h_sha2(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
     const uint8_t *m1, const uint8_t *m2, uint8_t *out, size_t out_len)
 {
-    uint8_t m[SLH_MAX_N * 2];
+    /* The concatenated children go in the scratch after the digest */
+    uint8_t *m = hctx->scratch + MAX_DIGEST_SIZE;
     const SLH_DSA_PARAMS *prms = hctx->key->params;
     size_t n = prms->n;
 
     memcpy(m, m1, n);
     memcpy(m + n, m2, n);
-    return do_hash(hctx->md_big_ctx, n, pk_seed, adrs, m, 2 * n,
+    return do_hash(hctx, hctx->md_big_ctx, n, pk_seed, adrs, m, 2 * n,
         prms->sha2_h_and_t_bound, out, out_len);
 }
 
@@ -262,7 +276,7 @@ slh_t_sha2(SLH_DSA_HASH_CTX *hctx, const uint8_t *pk_seed, const uint8_t *adrs,
 {
     const SLH_DSA_PARAMS *prms = hctx->key->params;
 
-    return do_hash(hctx->md_big_ctx, prms->n, pk_seed, adrs, ml, ml_len,
+    return do_hash(hctx, hctx->md_big_ctx, prms->n, pk_seed, adrs, ml, ml_len,
         prms->sha2_h_and_t_bound, out, out_len);
 }
 

--- a/crypto/slh_dsa/slh_hypertree.c
+++ b/crypto/slh_dsa/slh_hypertree.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <openssl/crypto.h>
 #include "slh_dsa_local.h"
 #include "slh_dsa_key.h"
 
@@ -33,6 +34,7 @@ int ossl_slh_ht_sign(SLH_DSA_HASH_CTX *ctx,
     const uint8_t *pk_seed,
     uint64_t tree_id, uint32_t leaf_id, WPACKET *sig_wpkt)
 {
+    int ret = 0;
     const SLH_DSA_KEY *key = ctx->key;
     SLH_ADRS_FUNC_DECLARE(key, adrsf);
     SLH_ADRS_DECLARE(adrs);
@@ -70,7 +72,7 @@ int ossl_slh_ht_sign(SLH_DSA_HASH_CTX *ctx,
         psig = WPACKET_get_curr(sig_wpkt);
         if (!ossl_slh_xmss_sign(ctx, root, sk_seed, leaf_id, pk_seed, adrs,
                 sig_wpkt))
-            return 0;
+            goto err;
         /*
          * On the last loop it skips getting the public key since it is not needed
          * to calculate another signature. If this was called it should equal
@@ -79,15 +81,18 @@ int ossl_slh_ht_sign(SLH_DSA_HASH_CTX *ctx,
         if (layer < d - 1) {
             if (!PACKET_buf_init(xmss_sig_rpkt, psig,
                     WPACKET_get_curr(sig_wpkt) - psig))
-                return 0;
+                goto err;
             if (!ossl_slh_xmss_pk_from_sig(ctx, leaf_id, xmss_sig_rpkt, root,
                     pk_seed, adrs, root, sizeof(root)))
-                return 0;
+                goto err;
             leaf_id = tree_id & mask;
             tree_id >>= hm;
         }
     }
-    return 1;
+    ret = 1;
+err:
+    OPENSSL_cleanse(root, sizeof(root));
+    return ret;
 }
 
 /**
@@ -108,6 +113,7 @@ int ossl_slh_ht_verify(SLH_DSA_HASH_CTX *ctx, const uint8_t *msg, PACKET *sig_pk
     const uint8_t *pk_seed, uint64_t tree_id, uint32_t leaf_id,
     const uint8_t *pk_root)
 {
+    int ret = 0;
     const SLH_DSA_KEY *key = ctx->key;
     SLH_ADRS_FUNC_DECLARE(key, adrsf);
     SLH_ADRS_DECLARE(adrs);
@@ -127,9 +133,12 @@ int ossl_slh_ht_verify(SLH_DSA_HASH_CTX *ctx, const uint8_t *msg, PACKET *sig_pk
         adrsf->set_tree_address(adrs, tree_id);
         if (!ossl_slh_xmss_pk_from_sig(ctx, leaf_id, sig_pkt, node,
                 pk_seed, adrs, node, sizeof(node)))
-            return 0;
+            goto err;
         leaf_id = tree_id & mask;
         tree_id >>= tree_height;
     }
-    return (memcmp(node, pk_root, n) == 0);
+    ret = (memcmp(node, pk_root, n) == 0);
+err:
+    OPENSSL_cleanse(node, sizeof(node));
+    return ret;
 }

--- a/crypto/slh_dsa/slh_wots.c
+++ b/crypto/slh_dsa/slh_wots.c
@@ -244,6 +244,8 @@ int ossl_slh_wots_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *msg,
     }
     ret = 1;
 err:
+    OPENSSL_cleanse(sk, sizeof(sk));
+    OPENSSL_cleanse(msg_and_csum_nibbles, sizeof(msg_and_csum_nibbles));
     return ret;
 }
 
@@ -311,5 +313,7 @@ int ossl_slh_wots_pk_from_sig(SLH_DSA_HASH_CTX *ctx,
 err:
     if (!WPACKET_finish(tmp_pkt))
         ret = 0;
+    OPENSSL_cleanse(tmp, sizeof(tmp));
+    OPENSSL_cleanse(msg_and_csum_nibbles, sizeof(msg_and_csum_nibbles));
     return ret;
 }

--- a/crypto/slh_dsa/slh_xmss.c
+++ b/crypto/slh_dsa/slh_xmss.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <openssl/crypto.h>
 #include "slh_dsa_local.h"
 #include "slh_dsa_key.h"
 
@@ -39,29 +40,31 @@ int ossl_slh_xmss_node(SLH_DSA_HASH_CTX *ctx, const uint8_t *sk_seed,
 {
     const SLH_DSA_KEY *key = ctx->key;
     SLH_ADRS_FUNC_DECLARE(key, adrsf);
+    int ret = 0;
 
     if (h == 0) {
         /* For leaf nodes generate the public key */
         adrsf->set_type_and_clear(adrs, SLH_ADRS_TYPE_WOTS_HASH);
         adrsf->set_keypair_address(adrs, node_id);
-        if (!ossl_slh_wots_pk_gen(ctx, sk_seed, pk_seed, adrs,
+        if (ossl_slh_wots_pk_gen(ctx, sk_seed, pk_seed, adrs,
                 pk_out, pk_out_len))
-            return 0;
+            ret = 1;
     } else {
         uint8_t lnode[SLH_MAX_N], rnode[SLH_MAX_N];
 
-        if (!ossl_slh_xmss_node(ctx, sk_seed, 2 * node_id, h - 1, pk_seed, adrs,
+        if (ossl_slh_xmss_node(ctx, sk_seed, 2 * node_id, h - 1, pk_seed, adrs,
                 lnode, sizeof(lnode))
-            || !ossl_slh_xmss_node(ctx, sk_seed, 2 * node_id + 1, h - 1,
-                pk_seed, adrs, rnode, sizeof(rnode)))
-            return 0;
-        adrsf->set_type_and_clear(adrs, SLH_ADRS_TYPE_TREE);
-        adrsf->set_tree_height(adrs, h);
-        adrsf->set_tree_index(adrs, node_id);
-        if (!key->hash_func->H(ctx, pk_seed, adrs, lnode, rnode, pk_out, pk_out_len))
-            return 0;
+            && ossl_slh_xmss_node(ctx, sk_seed, 2 * node_id + 1, h - 1,
+                pk_seed, adrs, rnode, sizeof(rnode))) {
+            adrsf->set_type_and_clear(adrs, SLH_ADRS_TYPE_TREE);
+            adrsf->set_tree_height(adrs, h);
+            adrsf->set_tree_index(adrs, node_id);
+            ret = key->hash_func->H(ctx, pk_seed, adrs, lnode, rnode, pk_out, pk_out_len);
+        }
+        OPENSSL_cleanse(lnode, sizeof(lnode));
+        OPENSSL_cleanse(rnode, sizeof(rnode));
     }
-    return 1;
+    return ret;
 }
 
 /**

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -584,7 +584,7 @@ static const OSSL_ALGORITHM fips_asym_kem[] = {
     { PROV_NAMES_ML_KEM_1024, FIPS_DEFAULT_PROPERTIES, ossl_ml_kem_asym_kem_functions },
 #if !defined(OPENSSL_NO_ECX)
     { "X25519MLKEM768", FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
-    { "X448MLKEM1024", FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
+    { "X448MLKEM1024", FIPS_UNAPPROVED_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
 #endif
 #if !defined(OPENSSL_NO_EC)
     { "SecP256r1MLKEM768", FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
@@ -655,7 +655,7 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
 #if !defined(OPENSSL_NO_ECX)
     { PROV_NAMES_X25519MLKEM768, FIPS_DEFAULT_PROPERTIES, ossl_mlx_x25519_kem_kmgmt_functions,
         PROV_DESCS_X25519MLKEM768 },
-    { PROV_NAMES_X448MLKEM1024, FIPS_DEFAULT_PROPERTIES, ossl_mlx_x448_kem_kmgmt_functions,
+    { PROV_NAMES_X448MLKEM1024, FIPS_UNAPPROVED_PROPERTIES, ossl_mlx_x448_kem_kmgmt_functions,
         PROV_DESCS_X448MLKEM1024 },
 #endif
 #if !defined(OPENSSL_NO_EC)

--- a/providers/implementations/kem/ml_kem_kem.c.in
+++ b/providers/implementations/kem/ml_kem_kem.c.in
@@ -133,6 +133,7 @@ static int ml_kem_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 
         /* Possibly, but much less likely wrong type */
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_SEED_LENGTH);
+        OPENSSL_cleanse((void *)ctx->entropy_buf, sizeof(ctx->entropy_buf));
         ctx->entropy = NULL;
         return 0;
     }

--- a/providers/implementations/kem/mlx_kem.c
+++ b/providers/implementations/kem/mlx_kem.c
@@ -118,7 +118,7 @@ static int mlx_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
 
     if (!mlx_kem_have_pubkey(key)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
-        goto end;
+        return 0;
     }
     encap_clen = key->minfo->ctext_bytes + key->xinfo->pubkey_bytes;
     encap_slen = ML_KEM_SHARED_SECRET_BYTES + key->xinfo->shsec_bytes;
@@ -236,6 +236,10 @@ static int mlx_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
 
     ret = 1;
 end:
+    /* Erase any partial shared secret on failure */
+    if (ret == 0)
+        OPENSSL_cleanse(shsec,
+            ML_KEM_SHARED_SECRET_BYTES + key->xinfo->shsec_bytes);
     EVP_PKEY_free(xkey);
     EVP_PKEY_CTX_free(ctx);
     return ret;
@@ -324,6 +328,10 @@ static int mlx_kem_decapsulate(void *vctx, uint8_t *shsec, size_t *slen,
 
     ret = 1;
 end:
+    /* Erase any partial shared secret on failure */
+    if (ret == 0)
+        OPENSSL_cleanse(shsec,
+            ML_KEM_SHARED_SECRET_BYTES + key->xinfo->shsec_bytes);
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(xkey);
     return ret;

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
@@ -100,6 +100,7 @@ static int ml_dsa_pairwise_test(const ML_DSA_KEY *key)
 err:
     OSSL_SELF_TEST_onend(st, ret);
     OSSL_SELF_TEST_free(st);
+    OPENSSL_cleanse(sig, sizeof(sig));
     return ret;
 }
 #endif
@@ -568,7 +569,7 @@ static void ml_dsa_gen_cleanup(void *genctx)
     if (gctx == NULL)
         return;
 
-    OPENSSL_cleanse(gctx->entropy, gctx->entropy_len);
+    OPENSSL_cleanse(gctx->entropy, sizeof(gctx->entropy));
     OPENSSL_free(gctx->propq);
     OPENSSL_free(gctx);
 }

--- a/providers/implementations/keymgmt/ml_kem_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_kem_kmgmt.c.in
@@ -118,10 +118,6 @@ static int ml_kem_pairwise_test(const ML_KEM_KEY *key, int key_flags)
 
     memset(out, 0, sizeof(out));
 
-    /*
-     * The pairwise test is skipped unless either RANDOM or FIXED entropy PCTs
-     * are enabled.
-     */
     if (key_flags & ML_KEM_KEY_RANDOM_PCT) {
         operation_result = ossl_ml_kem_encap_rand(ctext, v->ctext_bytes,
             secret, sizeof(secret), key);
@@ -156,7 +152,10 @@ err:
             v->algorithm_name);
     }
 #endif
-    OPENSSL_free(ctext);
+    OPENSSL_cleanse((void *)entropy, sizeof(entropy));
+    OPENSSL_cleanse((void *)secret, sizeof(secret));
+    OPENSSL_cleanse((void *)out, sizeof(out));
+    OPENSSL_clear_free(ctext, v->ctext_bytes);
     return ret;
 }
 
@@ -246,7 +245,7 @@ static int ml_kem_export(void *vkey, int selection, OSSL_CALLBACK *param_cb,
 {
     ML_KEM_KEY *key = vkey;
     OSSL_PARAM_BLD *tmpl = NULL;
-    OSSL_PARAM *params = NULL;
+    OSSL_PARAM *params = NULL, *p;
     const ML_KEM_VINFO *v;
     uint8_t *pubenc = NULL, *prvenc = NULL, *seedenc = NULL;
     size_t prvlen = 0, seedlen = 0;
@@ -325,13 +324,19 @@ static int ml_kem_export(void *vkey, int selection, OSSL_CALLBACK *param_cb,
         goto err;
 
     ret = param_cb(params, cbarg);
+    /*
+     * OSSL_PARAM_free() only wipes the secure-heap data block,
+     * so wipe the key material copies held in the params first.
+     */
+    for (p = params; p->key != NULL; p++)
+        OPENSSL_cleanse(p->data, p->data_size);
     OSSL_PARAM_free(params);
 
 err:
     OSSL_PARAM_BLD_free(tmpl);
     OPENSSL_secure_clear_free(seedenc, seedlen);
     OPENSSL_secure_clear_free(prvenc, prvlen);
-    OPENSSL_free(pubenc);
+    OPENSSL_clear_free(pubenc, v->pubkey_bytes);
     return ret;
 }
 
@@ -554,12 +559,14 @@ static void *ml_kem_load(const void *reference, size_t reference_sz)
                 goto err;
         }
         OPENSSL_secure_clear_free(encoded_dk, key->vinfo->prvkey_bytes);
+        OPENSSL_cleanse((void *)seed, sizeof(seed));
         return key;
     }
 
 err:
     if (key != NULL && key->vinfo != NULL)
         OPENSSL_secure_clear_free(encoded_dk, key->vinfo->prvkey_bytes);
+    OPENSSL_cleanse((void *)seed, sizeof(seed));
     ossl_ml_kem_key_free(key);
     return NULL;
 }
@@ -741,6 +748,7 @@ static int ml_kem_gen_set_params(void *vgctx, const OSSL_PARAM params[])
 
         /* Possibly, but less likely wrong data type */
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_SEED_LENGTH);
+        OPENSSL_cleanse((void *)gctx->seedbuf, sizeof(gctx->seedbuf));
         gctx->seed = NULL;
         return 0;
     }
@@ -797,8 +805,10 @@ static void *ml_kem_gen(void *vgctx, OSSL_CALLBACK *osslcb, void *cbarg)
     if ((gctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
         return key;
 
-    if (seed != NULL && !ossl_ml_kem_set_seed(seed, ML_KEM_SEED_BYTES, key))
+    if (seed != NULL && !ossl_ml_kem_set_seed(seed, ML_KEM_SEED_BYTES, key)) {
+        ossl_ml_kem_key_free(key);
         return NULL;
+    }
     genok = ossl_ml_kem_genkey(nopub, 0, key);
 
     /* Erase the single-use seed */

--- a/providers/implementations/keymgmt/mlx_kmgmt.c.in
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c.in
@@ -256,7 +256,7 @@ static int mlx_kem_export(void *vkey, int selection, OSSL_CALLBACK *param_cb,
 {
     MLX_KEY *key = vkey;
     OSSL_PARAM_BLD *tmpl = NULL;
-    OSSL_PARAM *params = NULL;
+    OSSL_PARAM *params = NULL, *p;
     size_t publen;
     size_t prvlen;
     int ret = 0;
@@ -318,12 +318,18 @@ static int mlx_kem_export(void *vkey, int selection, OSSL_CALLBACK *param_cb,
         goto err;
 
     ret = param_cb(params, cbarg);
+    /*
+     * OSSL_PARAM_free() only wipes the secure-heap data block,
+     * so wipe the key material copies held in the params first.
+     */
+    for (p = params; p->key != NULL; p++)
+        OPENSSL_cleanse(p->data, p->data_size);
     OSSL_PARAM_free(params);
 
 err:
     OSSL_PARAM_BLD_free(tmpl);
     OPENSSL_secure_clear_free(sub_arg.prvenc, prvlen);
-    OPENSSL_free(sub_arg.pubenc);
+    OPENSSL_clear_free(sub_arg.pubenc, publen);
     return ret;
 }
 
@@ -578,12 +584,18 @@ static int mlx_kem_get_params(void *vkey, OSSL_PARAM params[])
         selection |= OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS;
 
     /* Extract sub-component key material */
-    if (!export_sub(&sub_arg, selection, key))
+    if (!export_sub(&sub_arg, selection, key)
+        || (pub != NULL && sub_arg.pubcount != 2)
+        || (prv != NULL && sub_arg.prvcount != 2)) {
+        /* Erase any partial key material on failure */
+        if (sub_arg.pubenc != NULL)
+            OPENSSL_cleanse(sub_arg.pubenc,
+                key->minfo->pubkey_bytes + key->xinfo->pubkey_bytes);
+        if (sub_arg.prvenc != NULL)
+            OPENSSL_cleanse(sub_arg.prvenc,
+                key->minfo->prvkey_bytes + key->xinfo->prvkey_bytes);
         return 0;
-
-    if ((pub != NULL && sub_arg.pubcount != 2)
-        || (prv != NULL && sub_arg.prvcount != 2))
-        return 0;
+    }
 
     return 1;
 }

--- a/providers/implementations/keymgmt/slh_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/slh_dsa_kmgmt.c.in
@@ -238,7 +238,7 @@ static int slh_dsa_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
 {
     SLH_DSA_KEY *key = keydata;
     OSSL_PARAM_BLD *tmpl;
-    OSSL_PARAM *params = NULL;
+    OSSL_PARAM *params = NULL, *p;
     int ret = 0;
 
     if (!ossl_prov_is_running() || key == NULL)
@@ -259,6 +259,12 @@ static int slh_dsa_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         goto err;
 
     ret = param_cb(params, cbarg);
+    /*
+     * OSSL_PARAM_free() only wipes the secure-heap data block,
+     * so wipe the key material copies held in the params first.
+     */
+    for (p = params; p->key != NULL; p++)
+        OPENSSL_cleanse(p->data, p->data_size);
     OSSL_PARAM_free(params);
 err:
     OSSL_PARAM_BLD_free(tmpl);
@@ -313,7 +319,7 @@ static int slh_dsa_fips140_pairwise_test(const SLH_DSA_KEY *key,
     uint8_t msg[16] = { 0 };
     size_t msg_len = sizeof(msg);
     uint8_t *sig = NULL;
-    size_t sig_len;
+    size_t sig_len = 0;
     OSSL_LIB_CTX *lib_ctx;
     int alloc_ctx = 0;
 
@@ -356,7 +362,7 @@ static int slh_dsa_fips140_pairwise_test(const SLH_DSA_KEY *key,
 err:
     if (alloc_ctx)
         ossl_slh_dsa_hash_ctx_free(ctx);
-    OPENSSL_free(sig);
+    OPENSSL_clear_free(sig, sig_len);
     OSSL_SELF_TEST_onend(st, ret);
     OSSL_SELF_TEST_free(st);
     return ret;
@@ -443,7 +449,7 @@ static void slh_dsa_gen_cleanup(void *genctx)
     if (gctx == NULL)
         return;
 
-    OPENSSL_cleanse(gctx->entropy, gctx->entropy_len);
+    OPENSSL_cleanse(gctx->entropy, sizeof(gctx->entropy));
     OPENSSL_free(gctx->propq);
     OPENSSL_free(gctx);
 }

--- a/providers/implementations/signature/ml_dsa_sig.c.in
+++ b/providers/implementations/signature/ml_dsa_sig.c.in
@@ -273,14 +273,17 @@ static int ml_dsa_sign_msg_final(void *vctx, unsigned char *sig,
                 return 0;
         }
 
-        if (!ossl_ml_dsa_mu_finalize(ctx->md_ctx, mu, sizeof(mu)))
+        if (!ossl_ml_dsa_mu_finalize(ctx->md_ctx, mu, sizeof(mu))) {
+            OPENSSL_cleanse(mu, sizeof(mu));
             return 0;
+        }
     }
 
     ret = ossl_ml_dsa_sign(ctx->key, 1, mu, sizeof(mu), NULL, 0, rnd,
         sizeof(rand_tmp), 0, sig, siglen, sigsize);
     if (rnd != ctx->test_entropy)
         OPENSSL_cleanse(rand_tmp, sizeof(rand_tmp));
+    OPENSSL_cleanse(mu, sizeof(mu));
     return ret;
 }
 
@@ -331,6 +334,7 @@ static int ml_dsa_verify_msg_final(void *vctx)
 {
     PROV_ML_DSA_CTX *ctx = (PROV_ML_DSA_CTX *)vctx;
     uint8_t mu[ML_DSA_MU_BYTES];
+    int ret = 0;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -338,11 +342,12 @@ static int ml_dsa_verify_msg_final(void *vctx)
     if (ctx->md_ctx == NULL)
         return 0;
 
-    if (!ossl_ml_dsa_mu_finalize(ctx->md_ctx, mu, sizeof(mu)))
-        return 0;
+    if (ossl_ml_dsa_mu_finalize(ctx->md_ctx, mu, sizeof(mu)))
+        ret = ossl_ml_dsa_verify(ctx->key, 1, mu, sizeof(mu), NULL, 0, 0,
+            ctx->sig, ctx->siglen);
 
-    return ossl_ml_dsa_verify(ctx->key, 1, mu, sizeof(mu), NULL, 0, 0,
-        ctx->sig, ctx->siglen);
+    OPENSSL_cleanse(mu, sizeof(mu));
+    return ret;
 }
 
 static int ml_dsa_verify(void *vctx, const uint8_t *sig, size_t siglen,

--- a/providers/implementations/signature/slh_dsa_sig.c.in
+++ b/providers/implementations/signature/slh_dsa_sig.c.in
@@ -67,7 +67,7 @@ static void slh_dsa_freectx(void *vctx)
 
     ossl_slh_dsa_hash_ctx_free(ctx->hash_ctx);
     OPENSSL_free(ctx->propq);
-    OPENSSL_cleanse(ctx->add_random, ctx->add_random_len);
+    OPENSSL_cleanse(ctx->add_random, sizeof(ctx->add_random));
     OPENSSL_free(ctx);
 }
 


### PR DESCRIPTION
Core PQ cryptographic primitives now behave more like mathematical functions with fewer "side-effects" (such as leaving potentially sensitive data on the stack).

Backport of https://github.com/openssl/openssl/pull/32148