### PR TITLE
Fix builds configured with no-md5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,16 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Fixed builds configured with `no-md5`, which previously failed to compile.
+   In such builds, the legacy (RFC 1421 style) PEM encryption routines and
+   `X509_REQ_to_X509()` now fail with an "unsupported" error, the MD5-based
+   options of `openssl passwd` (`-1`, `-apr1`, `-aixmd5`) and
+   `openssl rehash` (`-old`, `-compat`) are not available, and
+   `openssl passwd` requires an algorithm option since the MD5-based
+   default is unavailable.
+
+   *Matt Andreko*
+
  * Added `CMS_add_standard_smimecap_ex()`, which populates an SMIMECapabilities
    list using `EVP_CIPHER_fetch()` and `EVP_MD_fetch()` so that only algorithms
    available in the active providers are advertised.  `PKCS7_sign_add_signer()`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,16 @@ OpenSSL 4.1
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Fixed builds configured with `no-md5`, which previously failed to compile.
+   In such builds, the legacy (RFC 1421 style) PEM encryption routines and
+   `X509_REQ_to_X509()` now fail with an "unsupported" error, the MD5-based
+   options of `openssl passwd` (`-1`, `-apr1`, `-aixmd5`) and
+   `openssl rehash` (`-old`, `-compat`) are not available, and
+   `openssl passwd` requires an algorithm option since the MD5-based
+   default is unavailable.
+
+   *Matt Andreko*
+
  * Added support for DTLS 1.3 ([RFC 9147]).
    Refer to the `ossl-guide-dtlsv13(7)` manual page for details.
 

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -88,9 +88,11 @@ const OPTIONS passwd_options[] = {
     { "salt", OPT_SALT, 's', "Use provided salt" },
     { "6", OPT_6, '-', "SHA512-based password algorithm" },
     { "5", OPT_5, '-', "SHA256-based password algorithm" },
+#ifndef OPENSSL_NO_MD5
     { "apr1", OPT_APR1, '-', "MD5-based password algorithm, Apache variant" },
     { "1", OPT_1, '-', "MD5-based password algorithm" },
     { "aixmd5", OPT_AIXMD5, '-', "AIX MD5-based password algorithm" },
+#endif
 
     OPT_R_OPTIONS,
     OPT_PROV_OPTIONS,
@@ -208,8 +210,15 @@ int passwd_main(int argc, char **argv)
         goto end;
 
     if (mode == passwd_unset) {
+#ifndef OPENSSL_NO_MD5
         /* use default */
         mode = passwd_md5;
+#else
+        BIO_printf(bio_err,
+            "%s: MD5 is not available; select an algorithm with -5 or -6\n",
+            prog);
+        goto opthelp;
+#endif
     }
 
     if (infile != NULL && in_stdin) {
@@ -309,6 +318,7 @@ end:
     return ret;
 }
 
+#ifndef OPENSSL_NO_MD5
 /*
  * MD5-based password algorithm (should probably be available as a library
  * function; then the static buffer would not be acceptable). For magic
@@ -491,6 +501,7 @@ err:
     EVP_MD_CTX_free(md);
     return NULL;
 }
+#endif /* OPENSSL_NO_MD5 */
 
 /*
  * SHA based password algorithm, describe by Ulrich Drepper here:
@@ -830,10 +841,12 @@ static int do_passwd(int passed_salt, char **salt_p, char **salt_malloc_p,
     assert(strlen(passwd) <= pw_maxlen);
 
     /* now compute password hash */
+#ifndef OPENSSL_NO_MD5
     if (mode == passwd_md5 || mode == passwd_apr1)
         hash = md5crypt(passwd, (mode == passwd_md5 ? "1" : "apr1"), *salt_p);
     if (mode == passwd_aixmd5)
         hash = md5crypt(passwd, "", *salt_p);
+#endif
     if (mode == passwd_sha256 || mode == passwd_sha512)
         hash = shacrypt(passwd, (mode == passwd_sha256 ? "5" : "6"), *salt_p);
     assert(hash != NULL);

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -89,9 +89,11 @@ const OPTIONS passwd_options[] = {
     { "salt", OPT_SALT, 's', "Use provided salt" },
     { "6", OPT_6, '-', "SHA512-based password algorithm" },
     { "5", OPT_5, '-', "SHA256-based password algorithm" },
+#ifndef OPENSSL_NO_MD5
     { "apr1", OPT_APR1, '-', "MD5-based password algorithm, Apache variant" },
     { "1", OPT_1, '-', "MD5-based password algorithm" },
     { "aixmd5", OPT_AIXMD5, '-', "AIX MD5-based password algorithm" },
+#endif
 
     OPT_R_OPTIONS,
     OPT_PROV_OPTIONS,
@@ -209,8 +211,15 @@ int passwd_main(int argc, char **argv)
         goto end;
 
     if (mode == passwd_unset) {
+#ifndef OPENSSL_NO_MD5
         /* use default */
         mode = passwd_md5;
+#else
+        BIO_printf(bio_err,
+            "%s: MD5 is not available; select an algorithm with -5 or -6\n",
+            prog);
+        goto opthelp;
+#endif
     }
 
     if (infile != NULL && in_stdin) {
@@ -310,6 +319,7 @@ end:
     return ret;
 }
 
+#ifndef OPENSSL_NO_MD5
 /*
  * MD5-based password algorithm (should probably be available as a library
  * function; then the static buffer would not be acceptable). For magic
@@ -492,6 +502,7 @@ err:
     EVP_MD_CTX_free(md);
     return NULL;
 }
+#endif /* OPENSSL_NO_MD5 */
 
 /*
  * SHA based password algorithm, describe by Ulrich Drepper here:
@@ -831,10 +842,12 @@ static int do_passwd(int passed_salt, char **salt_p, char **salt_malloc_p,
     assert(strlen(passwd) <= pw_maxlen);
 
     /* now compute password hash */
+#ifndef OPENSSL_NO_MD5
     if (mode == passwd_md5 || mode == passwd_apr1)
         hash = md5crypt(passwd, (mode == passwd_md5 ? "1" : "apr1"), *salt_p);
     if (mode == passwd_aixmd5)
         hash = md5crypt(passwd, "", *salt_p);
+#endif
     if (mode == passwd_sha256 || mode == passwd_sha512)
         hash = shacrypt(passwd, (mode == passwd_sha256 ? "5" : "6"), *salt_p);
     assert(hash != NULL);

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -316,9 +316,11 @@ static int do_file(const char *filename, const char *fullpath, enum Hash h)
                 errs++;
             }
         }
+#ifndef OPENSSL_NO_MD5
         if ((h == HASH_OLD) || (h == HASH_BOTH))
             errs += add_entry(type, X509_NAME_hash_old(name),
                 filename, digest, 1, ~0);
+#endif
     }
 
 end:
@@ -506,8 +508,10 @@ const OPTIONS rehash_options[] = {
     OPT_SECTION("General"),
     { "help", OPT_HELP, '-', "Display this summary" },
     { "h", OPT_HELP, '-', "Display this summary" },
+#ifndef OPENSSL_NO_MD5
     { "compat", OPT_COMPAT, '-', "Create both new- and old-style hash links" },
     { "old", OPT_OLD, '-', "Use old-style hash to generate links" },
+#endif
     { "n", OPT_N, '-', "Do not remove existing links" },
 
     OPT_SECTION("Output"),

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -330,6 +330,11 @@ PEM_ASN1_write_bio_internal(
     unsigned char iv[EVP_MAX_IV_LENGTH];
 
     if (enc != NULL) {
+#ifdef OPENSSL_NO_MD5
+        /* Traditional PEM encryption derives its key using MD5 */
+        ERR_raise(ERR_LIB_PEM, PEM_R_UNSUPPORTED_ENCRYPTION);
+        goto err;
+#else
         objstr = EVP_CIPHER_get0_name(enc);
         if (objstr == NULL || EVP_CIPHER_get_iv_length(enc) == 0
             || EVP_CIPHER_get_iv_length(enc) > (int)sizeof(iv)
@@ -342,6 +347,7 @@ PEM_ASN1_write_bio_internal(
             ERR_raise(ERR_LIB_PEM, PEM_R_UNSUPPORTED_CIPHER);
             goto err;
         }
+#endif
     }
 
     if (i2d == NULL && i2d_ctx == NULL) {
@@ -385,8 +391,10 @@ PEM_ASN1_write_bio_internal(
          * The 'iv' is used as the iv and as a salt.  It is NOT taken from
          * the BytesToKey function
          */
+#ifndef OPENSSL_NO_MD5
         if (!EVP_BytesToKey(enc, EVP_md5(), iv, kstr, klen, 1, key, NULL))
             goto err;
+#endif
 
         if (kstr == (unsigned char *)buf)
             OPENSSL_cleanse(buf, PEM_BUFSIZE);
@@ -459,6 +467,13 @@ int PEM_do_header(EVP_CIPHER_INFO *cipher, unsigned char *data, long *plen,
 
     if (cipher->cipher == NULL)
         return 1;
+
+#ifdef OPENSSL_NO_MD5
+    /* Traditional PEM encryption derives its key using MD5 */
+    ERR_raise(ERR_LIB_PEM, PEM_R_UNSUPPORTED_ENCRYPTION);
+    return 0;
+#endif
+
     if (callback == NULL)
         keylen = PEM_def_callback(buf, PEM_BUFSIZE, 0, u);
     else
@@ -472,9 +487,11 @@ int PEM_do_header(EVP_CIPHER_INFO *cipher, unsigned char *data, long *plen,
     ebcdic2ascii(buf, buf, keylen);
 #endif
 
+#ifndef OPENSSL_NO_MD5
     if (!EVP_BytesToKey(cipher->cipher, EVP_md5(), &(cipher->iv[0]),
             (unsigned char *)buf, keylen, 1, key, NULL))
         return 0;
+#endif
 
     ctx = EVP_CIPHER_CTX_new();
     if (ctx == NULL)

--- a/crypto/x509/x509_r2x.c
+++ b/crypto/x509/x509_r2x.c
@@ -56,9 +56,14 @@ X509 *X509_REQ_to_X509(const X509_REQ *r, int days, EVP_PKEY *pkey)
     if (pubkey == NULL || !X509_set_pubkey(ret, pubkey))
         goto err;
 
+#ifndef OPENSSL_NO_MD5
     if (!X509_sign(ret, pkey, EVP_md5()))
         goto err;
     return ret;
+#else
+    /* Signing uses MD5, which is not available in this build */
+    ERR_raise(ERR_LIB_X509, X509_R_UNSUPPORTED_ALGORITHM);
+#endif
 
 err:
     X509_free(ret);

--- a/doc/man1/openssl-passwd.pod.in
+++ b/doc/man1/openssl-passwd.pod.in
@@ -43,14 +43,18 @@ Print out a usage message.
 =item B<-1>
 
 Use the MD5 based BSD password algorithm B<1> (default).
+This option exists only if OpenSSL was built with MD5 support; without it
+there is no default and one of the other algorithm options must be given.
 
 =item B<-apr1>
 
 Use the B<apr1> algorithm (Apache variant of the BSD algorithm).
+This option exists only if OpenSSL was built with MD5 support.
 
 =item B<-aixmd5>
 
 Use the B<AIX MD5> algorithm (AIX variant of the BSD algorithm).
+This option exists only if OpenSSL was built with MD5 support.
 
 =item B<-5>
 

--- a/doc/man1/openssl-rehash.pod.in
+++ b/doc/man1/openssl-rehash.pod.in
@@ -79,6 +79,7 @@ Display a brief usage message.
 Use old-style hashing (MD5, as opposed to SHA-1) for generating
 links to be used for releases before 1.0.0.
 Note that current versions will not use the old style.
+This option exists only if OpenSSL was built with MD5 support.
 
 =item B<-n>
 
@@ -90,6 +91,7 @@ This is needed when keeping new and old-style links in the same directory.
 Generate links for both old-style (MD5) and new-style (SHA1) hashing.
 This allows releases before 1.0.0 to use these links along-side newer
 releases.
+This option exists only if OpenSSL was built with MD5 support.
 
 =item B<-v>
 

--- a/doc/man3/PEM_read.pod
+++ b/doc/man3/PEM_read.pod
@@ -118,6 +118,10 @@ This is because the underlying PEM encryption format is obsolete, and should
 be avoided.
 It uses an encryption format with an OpenSSL-specific key-derivation function,
 which employs MD5 with an iteration count of 1!
+If OpenSSL was built without MD5 support, this key derivation is not
+available: PEM_do_header() then fails for encrypted payloads and adds
+B<PEM_R_UNSUPPORTED_ENCRYPTION> to the error stack, and writing encrypted
+PEM data fails in the same way.
 Instead, private keys should be stored in PKCS#8 form, with a strong PKCS#5
 v2.0 PBE.
 See L<PEM_write_PrivateKey(3)> and L<d2i_PKCS8PrivateKey_bio(3)>.

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -60,7 +60,9 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     X509_print(bio, x509_1);
     BIO_free(bio);
 
+#ifndef OPENSSL_NO_MD5
     X509_issuer_and_serial_hash(x509_1);
+#endif
 
     i2d_X509(x509_1, &der);
     OPENSSL_free(der);

--- a/ssl/record/methods/ssl3_cbc.c
+++ b/ssl/record/methods/ssl3_cbc.c
@@ -23,7 +23,7 @@
 #include "internal/deprecated.h"
 
 #include <openssl/evp.h>
-#ifndef FIPS_MODULE
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_MD5)
 #include <openssl/md5.h>
 #endif
 #include <openssl/sha.h>
@@ -45,7 +45,7 @@
  */
 #define MAX_HASH_BLOCK_SIZE 128
 
-#ifndef FIPS_MODULE
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_MD5)
 /*
  * u32toLE serializes an unsigned, 32-bit number (n) as four bytes at (p) in
  * little-endian order. The value of p is advanced by four.
@@ -70,7 +70,7 @@ static void tls1_md5_final_raw(void *ctx, unsigned char *md_out)
     u32toLE(md5->C, md_out);
     u32toLE(md5->D, md_out);
 }
-#endif /* FIPS_MODULE */
+#endif /* !FIPS_MODULE && !OPENSSL_NO_MD5 */
 
 static void tls1_sha1_final_raw(void *ctx, unsigned char *md_out)
 {
@@ -165,7 +165,7 @@ int ssl3_cbc_digest_record(const EVP_MD *md,
         return 0;
 
     if (EVP_MD_is_a(md, "MD5")) {
-#ifdef FIPS_MODULE
+#if defined(FIPS_MODULE) || defined(OPENSSL_NO_MD5)
         return 0;
 #else
         if (MD5_Init((MD5_CTX *)md_state.c) <= 0)

--- a/test/build.info
+++ b/test/build.info
@@ -51,7 +51,7 @@ IF[{- !$disabled{tests} -}]
           evp_pkey_provided_test evp_test evp_extra_test evp_extra_test2 \
           evp_fetch_prov_test evp_libctx_test ossl_store_test \
           v3nametest v3ext byteorder_test punycode_test evp_byname_test \
-          crltest danetest bad_dtls_test lhash_test sparse_array_test \
+          crltest danetest lhash_test sparse_array_test \
           conf_include_test params_api_test params_conversion_test \
           constant_time_test crypto_memcmp_test safe_math_test verify_extra_test clienthellotest \
           packettest asynctest secmemtest srptest memleaktest stack_test \
@@ -108,6 +108,10 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{dtls} -}]
     PROGRAMS{noinst}=dtls_ccs_reorder_test
+  ENDIF
+
+  IF[{- !$disabled{md5} -}]
+    PROGRAMS{noinst}=bad_dtls_test
   ENDIF
 
   SOURCE[confdump]=confdump.c
@@ -388,9 +392,11 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[clienthellotest]=../include ../apps/include
   DEPEND[clienthellotest]=../libcrypto ../libssl libtestutil.a
 
-  SOURCE[bad_dtls_test]=bad_dtls_test.c
-  INCLUDE[bad_dtls_test]=../include ../apps/include
-  DEPEND[bad_dtls_test]=../libcrypto ../libssl libtestutil.a
+  IF[{- !$disabled{md5} -}]
+      SOURCE[bad_dtls_test]=bad_dtls_test.c
+      INCLUDE[bad_dtls_test]=../include ../apps/include
+      DEPEND[bad_dtls_test]=../libcrypto ../libssl libtestutil.a
+  ENDIF
 
   SOURCE[packettest]=packettest.c ../crypto/quic_vlint.c
   INCLUDE[packettest]=../include ../apps/include

--- a/test/build.info
+++ b/test/build.info
@@ -54,7 +54,7 @@ IF[{- !$disabled{tests} -}]
           evp_pkey_provided_test evp_test evp_extra_test evp_extra_test2 \
           evp_fetch_prov_test evp_libctx_test ossl_store_test \
           v3nametest v3ext byteorder_test punycode_test evp_byname_test \
-          crltest danetest bad_dtls_test lhash_test sparse_array_test \
+          crltest danetest lhash_test sparse_array_test \
           conf_include_test params_api_test params_conversion_test \
           constant_time_test crypto_memcmp_test ct_validation_helpers_test \
           safe_math_test verify_extra_test clienthellotest \
@@ -117,6 +117,10 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{dtls1_2} -}]
     PROGRAMS{noinst}=dtlsv1listentest
+  ENDIF
+
+  IF[{- !$disabled{md5} -}]
+    PROGRAMS{noinst}=bad_dtls_test
   ENDIF
 
   SOURCE[confdump]=confdump.c
@@ -413,9 +417,11 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[clienthellotest]=../include ../apps/include
   DEPEND[clienthellotest]=../libcrypto ../libssl libtestutil.a
 
-  SOURCE[bad_dtls_test]=bad_dtls_test.c
-  INCLUDE[bad_dtls_test]=../include ../apps/include
-  DEPEND[bad_dtls_test]=../libcrypto ../libssl libtestutil.a
+  IF[{- !$disabled{md5} -}]
+      SOURCE[bad_dtls_test]=bad_dtls_test.c
+      INCLUDE[bad_dtls_test]=../include ../apps/include
+      DEPEND[bad_dtls_test]=../libcrypto ../libssl libtestutil.a
+  ENDIF
 
   SOURCE[packettest]=packettest.c ../crypto/quic_vlint.c
   INCLUDE[packettest]=../include ../apps/include

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -31,7 +31,6 @@
 
 #include "testutil.h"
 
-#ifndef OPENSSL_NO_MD5
 static struct test_st {
     const unsigned char key[16];
     int key_len;
@@ -80,7 +79,6 @@ static struct test_st {
     { "12345", 5, "My test data again", 18,
         "a12396ceddd2a85f4c656bc1e0aa50c78cffde3e" }
 };
-#endif
 
 static char *pt(unsigned char *md, unsigned int len);
 
@@ -298,7 +296,6 @@ err:
     return res;
 }
 
-#ifndef OPENSSL_NO_MD5
 #define OSSL_HEX_CHARS_PER_BYTE 2
 static char *pt(unsigned char *md, unsigned int len)
 {
@@ -312,7 +309,6 @@ static char *pt(unsigned char *md, unsigned int len)
             OSSL_HEX_CHARS_PER_BYTE + 1, "%02x", md[i]);
     return buf;
 }
-#endif
 
 static struct test_chunks_st {
     const char *md_name;
@@ -434,7 +430,9 @@ err:
 
 int setup_tests(void)
 {
+#ifndef OPENSSL_NO_MD5
     ADD_ALL_TESTS(test_hmac_md5, 4);
+#endif
     ADD_TEST(test_hmac_single_shot);
     ADD_TEST(test_hmac_bad);
     ADD_TEST(test_hmac_run);

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -174,6 +174,7 @@ static int ossltest_dgst_update(void *ctx, const void *data,
     return 1;
 }
 
+#ifndef OPENSSL_NO_MD5
 /**
  * @brief Finalize the digest output.
  *
@@ -189,6 +190,7 @@ static int ossltest_MD5_final(unsigned char *md, void *ctx)
     fill_known_data(md, MD5_DIGEST_LENGTH);
     return 1;
 }
+#endif
 
 /**
  * @brief Finalize the digest output.
@@ -265,14 +267,18 @@ static int ossltest_SHA512_final(unsigned char *md, void *ctx)
  * mark them as such here.  They won't get exported anyway as p_ossltest only gets built as
  * a DSO, and the linker map we use doesn't list them as exported
  */
+#ifndef OPENSSL_NO_MD5
 extern const OSSL_DISPATCH ossl_testmd5_functions[];
+#endif
 extern const OSSL_DISPATCH ossl_testsha1_functions[];
 extern const OSSL_DISPATCH ossl_testsha256_functions[];
 extern const OSSL_DISPATCH ossl_testsha384_functions[];
 extern const OSSL_DISPATCH ossl_testsha512_functions[];
 
+#ifndef OPENSSL_NO_MD5
 IMPLEMENT_digest_functions(testmd5, MD5_CTX, MD5_CBLOCK, MD5_DIGEST_LENGTH, 0,
     ossltest_dgst_init, ossltest_dgst_update, ossltest_MD5_final)
+#endif
 
 #define SHA2_FLAGS PROV_DIGEST_FLAG_ALGID_ABSENT
 IMPLEMENT_digest_functions(testsha1, SHA_CTX, SHA_CBLOCK, SHA_DIGEST_LENGTH, SHA2_FLAGS,
@@ -294,7 +300,9 @@ IMPLEMENT_digest_functions(testsha512, SHA512_CTX,
     { NAMES, "provider=p_ossltest", FUNC }
 
 static const OSSL_ALGORITHM ossltest_digests[] = {
+#ifndef OPENSSL_NO_MD5
     ALG(PROV_NAMES_MD5, ossl_testmd5_functions),
+#endif
     ALG(PROV_NAMES_SHA1, ossl_testsha1_functions),
     ALG(PROV_NAMES_SHA2_256, ossl_testsha256_functions),
     ALG(PROV_NAMES_SHA2_384, ossl_testsha384_functions),

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -175,6 +175,7 @@ static int ossltest_dgst_update(void *ctx, const void *data,
     return 1;
 }
 
+#ifndef OPENSSL_NO_MD5
 /**
  * @brief Finalize the digest output.
  *
@@ -190,6 +191,7 @@ static int ossltest_MD5_final(unsigned char *md, void *ctx)
     fill_known_data(md, MD5_DIGEST_LENGTH);
     return 1;
 }
+#endif
 
 /**
  * @brief Finalize the digest output.
@@ -266,14 +268,18 @@ static int ossltest_SHA512_final(unsigned char *md, void *ctx)
  * mark them as such here.  They won't get exported anyway as p_ossltest only gets built as
  * a DSO, and the linker map we use doesn't list them as exported
  */
+#ifndef OPENSSL_NO_MD5
 extern const OSSL_DISPATCH ossl_testmd5_functions[];
+#endif
 extern const OSSL_DISPATCH ossl_testsha1_functions[];
 extern const OSSL_DISPATCH ossl_testsha256_functions[];
 extern const OSSL_DISPATCH ossl_testsha384_functions[];
 extern const OSSL_DISPATCH ossl_testsha512_functions[];
 
+#ifndef OPENSSL_NO_MD5
 IMPLEMENT_digest_functions(testmd5, MD5_CTX, MD5_CBLOCK, MD5_DIGEST_LENGTH, 0,
     ossltest_dgst_init, ossltest_dgst_update, ossltest_MD5_final)
+#endif
 
 #define SHA2_FLAGS PROV_DIGEST_FLAG_ALGID_ABSENT
 IMPLEMENT_digest_functions(testsha1, SHA_CTX, SHA_CBLOCK, SHA_DIGEST_LENGTH, SHA2_FLAGS,
@@ -295,7 +301,9 @@ IMPLEMENT_digest_functions(testsha512, SHA512_CTX,
     { NAMES, "provider=p_ossltest", FUNC }
 
 static const OSSL_ALGORITHM ossltest_digests[] = {
+#ifndef OPENSSL_NO_MD5
     ALG(PROV_NAMES_MD5, ossl_testmd5_functions),
+#endif
     ALG(PROV_NAMES_SHA1, ossl_testsha1_functions),
     ALG(PROV_NAMES_SHA2_256, ossl_testsha256_functions),
     ALG(PROV_NAMES_SHA2_384, ossl_testsha384_functions),

--- a/test/recipes/20-test_passwd.t
+++ b/test/recipes/20-test_passwd.t
@@ -83,21 +83,26 @@ my @sha_high_rounds_tests =
 plan tests => 9 + scalar @sha_tests + scalar @sha_high_rounds_tests;
 
 
-ok(compare1stline_re([qw{openssl passwd -1 password}], '^\$1\$.{8}\$.{22}\R$'),
-   'BSD style MD5 password with random salt');
-ok(compare1stline_re([qw{openssl passwd -apr1 password}], '^\$apr1\$.{8}\$.{22}\R$'),
-   'Apache style MD5 password with random salt');
+SKIP: {
+    skip "MD5 is not supported by this OpenSSL build", 5
+        if disabled("md5");
+
+    ok(compare1stline_re([qw{openssl passwd -1 password}], '^\$1\$.{8}\$.{22}\R$'),
+       'BSD style MD5 password with random salt');
+    ok(compare1stline_re([qw{openssl passwd -apr1 password}], '^\$apr1\$.{8}\$.{22}\R$'),
+       'Apache style MD5 password with random salt');
+    ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -1 password}], '$1$xxxxxxxx$UYCIxa628.9qXjpQCjM4a.'),
+       'BSD style MD5 password with salt xxxxxxxx');
+    ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -apr1 password}], '$apr1$xxxxxxxx$dxHfLAsjHkDRmG83UXe8K0'),
+       'Apache style MD5 password with salt xxxxxxxx');
+    ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -aixmd5 password}], 'xxxxxxxx$8Oaipk/GPKhC64w/YVeFD/'),
+       'AIX style MD5 password with salt xxxxxxxx');
+}
+
 ok(compare1stline_re([qw{openssl passwd -5 password}], '^\$5\$.{16}\$.{43}\R$'),
    'SHA256 password with random salt');
 ok(compare1stline_re([qw{openssl passwd -6 password}], '^\$6\$.{16}\$.{86}\R$'),
    'Apache SHA512 password with random salt');
-
-ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -1 password}], '$1$xxxxxxxx$UYCIxa628.9qXjpQCjM4a.'),
-   'BSD style MD5 password with salt xxxxxxxx');
-ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -apr1 password}], '$apr1$xxxxxxxx$dxHfLAsjHkDRmG83UXe8K0'),
-   'Apache style MD5 password with salt xxxxxxxx');
-ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -aixmd5 password}], 'xxxxxxxx$8Oaipk/GPKhC64w/YVeFD/'),
-   'AIX style MD5 password with salt xxxxxxxx');
 ok(compare1stline([qw{openssl passwd -salt xxxxxxxxxxxxxxxx -5 password}], '$5$xxxxxxxxxxxxxxxx$fHytsM.wVD..zPN/h3i40WJRggt/1f73XkAC/gkelkB'),
    'SHA256 password with salt xxxxxxxxxxxxxxxx');
 ok(compare1stline([qw{openssl passwd -salt xxxxxxxxxxxxxxxx -6 password}], '$6$xxxxxxxxxxxxxxxx$VjGUrXBG6/8yW0f6ikBJVOb/lK/Tm9LxHJmFfwMvT7cpk64N9BW7ZQhNeMXAYFbOJ6HDG7wb0QpxJyYQn0rh81'),

--- a/test/recipes/70-test_bad_dtls.t
+++ b/test/recipes/70-test_bad_dtls.t
@@ -15,6 +15,9 @@ setup("test_bad_dtls");
 plan skip_all => "DTLSv1 is not supported by this OpenSSL build"
     if disabled("dtls1");
 
+plan skip_all => "MD5 is not supported by this OpenSSL build"
+    if disabled("md5");
+
 plan tests => 1;
 
 ok(run(test(["bad_dtls_test"])), "running bad_dtls_test");


### PR DESCRIPTION
While working on openssl/openssl#30431, a reviewer pointed out that `EVP_md5()` is guarded by `OPENSSL_NO_MD5`, so my test needed a guard too. This PR should help ensure that the rest of the build succeeds with no-md5 support, since it was failing with errors like: 

```
$ ./Configure no-md5 && make
...
crypto/pem/pem_lib.c:388:34: error: implicit declaration of function 'EVP_md5'
```

After fixing that one, I kept finding more broken sections, and kept fixing them. `md5` is in Configure's list of disableable algorithms, but judging by the git history nobody has successfully built with it disabled in a very long time (pem_lib.c has never had a guard, as far as I can tell).

This PR adds the missing `OPENSSL_NO_MD5` guards everywhere they were missing, using the same pattern pvkfmt.c already uses for `no-rc4`.

Docs are updated to match: the openssl-passwd and openssl-rehash man pages now say which options need MD5 support (borrowing the phrasing openssl-enc uses for its zlib-only -z option), PEM_read(3) notes that legacy PEM decryption fails with `PEM_R_UNSUPPORTED_ENCRYPTION` when MD5 is out, and there's a CHANGES.md entry.

Verified:
- `./Configure no-md5 && make` passes, as does `--strict-warnings no-md5` with zero warnings
- `make doc-nits` is clean
- sanity-checked the binaries: `openssl passwd -6` works, encrypted traditional PEM gives a clean error instead of a crash, `rehash -help` no longer advertises options that can't work



##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
