### PR TITLE
Improve robustness of the Windows registry directory lookup

### DIFF
--- a/crypto/defaults.c
+++ b/crypto/defaults.c
@@ -56,10 +56,14 @@ static char *get_windows_regdirs(char *dst, DWORD dstsizebytes, LPCWSTR valuenam
 #ifdef REGISTRY_KEY
     DWORD keysizebytes;
     DWORD ktype;
-    HKEY hkey;
+    HKEY hkey = NULL;
     LSTATUS ret;
-    DWORD index = 0;
-    LPCWSTR tempstr = NULL;
+    WCHAR *tempstr = NULL;
+    int mblen;
+
+    if (dst == NULL || dstsizebytes == 0)
+        return NULL;
+    dst[0] = '\0';
 
     ret = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
         TEXT(REGISTRY_KEY), KEY_WOW64_32KEY,
@@ -76,6 +80,14 @@ static char *get_windows_regdirs(char *dst, DWORD dstsizebytes, LPCWSTR valuenam
         goto out;
     if (keysizebytes > MAX_PATH * sizeof(WCHAR))
         goto out;
+    /*
+     * A registry value may be stored with an arbitrary byte count, so a
+     * REG_SZ is not guaranteed to contain a whole number of WCHARs.  Reject
+     * such a value rather than reading a partial character out of the
+     * allocation below.
+     */
+    if (keysizebytes == 0 || (keysizebytes % sizeof(WCHAR)) != 0)
+        goto out;
 
     /*
      * RegQueryValueExW does not guarantee the buffer is null terminated,
@@ -91,14 +103,26 @@ static char *get_windows_regdirs(char *dst, DWORD dstsizebytes, LPCWSTR valuenam
         != ERROR_SUCCESS)
         goto out;
 
-    if (!WideCharToMultiByte(CP_UTF8, 0, tempstr, -1, dst, dstsizebytes,
-            NULL, NULL))
+    /*
+     * A UTF-8 encoding can be up to three times as long as its UTF-16 source,
+     * so the conversion can fail with ERROR_INSUFFICIENT_BUFFER even though
+     * the value passed the MAX_PATH check above.  In that case dst may hold a
+     * partial, unterminated result, so clear it instead of leaving a silently
+     * truncated directory behind.
+     */
+    mblen = WideCharToMultiByte(CP_UTF8, 0, tempstr, -1, dst, (int)dstsizebytes,
+        NULL, NULL);
+    if (mblen <= 0) {
+        dst[0] = '\0';
         goto out;
+    }
+    dst[dstsizebytes - 1] = '\0';
 
     retval = dst;
 out:
     OPENSSL_free(tempstr);
-    RegCloseKey(hkey);
+    if (hkey != NULL)
+        RegCloseKey(hkey);
 #endif /* REGISTRY_KEY */
     return retval;
 }
@@ -112,16 +136,19 @@ static CRYPTO_ONCE defaults_setup_init = CRYPTO_ONCE_STATIC_INIT;
  */
 DEFINE_RUN_ONCE_STATIC(do_defaults_setup)
 {
-    get_windows_regdirs(openssldir, sizeof(openssldir), L"OPENSSLDIR");
-    get_windows_regdirs(modulesdir, sizeof(modulesdir), L"MODULESDIR");
-
     /*
-     * Set our pointers only if the directories are fetched properly
+     * Set our pointers only if the directories are fetched properly.  The
+     * return value has to be checked: on failure get_windows_regdirs() makes
+     * no promise about the state of the destination buffer, so testing it
+     * with strlen() alone is not enough to tell a successful lookup from a
+     * failed one.
      */
-    if (strlen(openssldir) > 0)
+    if (get_windows_regdirs(openssldir, sizeof(openssldir), L"OPENSSLDIR") != NULL
+        && openssldir[0] != '\0')
         openssldirptr = openssldir;
 
-    if (strlen(modulesdir) > 0)
+    if (get_windows_regdirs(modulesdir, sizeof(modulesdir), L"MODULESDIR") != NULL
+        && modulesdir[0] != '\0')
         modulesdirptr = modulesdir;
 
     return 1;


### PR DESCRIPTION
`get_windows_regdirs()` in `crypto/defaults.c` reads `OPENSSLDIR` and `MODULESDIR` from `HKLM\SOFTWARE\WOW6432Node\OpenSSL-<maj>.<min>-<ctx>` on Windows builds configured with `-DOSSL_WINCTX`. Reviewing that function turned up four details that are not handled defensively. None of them is a security issue, but each is a latent trap.

### 1. `hkey` was uninitialised on the `RegOpenKeyEx()` failure path

```c
HKEY hkey;
...
ret = RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT(REGISTRY_KEY), KEY_WOW64_32KEY,
                   KEY_QUERY_VALUE, &hkey);
if (ret != ERROR_SUCCESS)
    goto out;
...
out:
    OPENSSL_free(tempstr);
    RegCloseKey(hkey);          /* hkey never written */
```

`RegOpenKeyEx()` is not documented to write to `phkResult` when it fails, so this read an indeterminate value and handed it to `RegCloseKey()`. This path is reached whenever the key is absent, which is the normal case on any machine where the installer did not create it.

I checked the actual behaviour before assuming the worst. On Windows 11 (26100) `RegOpenKeyExA` does store `NULL` in `phkResult` on failure, for both `ERROR_FILE_NOT_FOUND` and `ERROR_ACCESS_DENIED`:

```
missing key   : ret=2 (ERROR_FILE_NOT_FOUND)  hkey=0000000000000000  <-- overwritten
access denied : ret=5 (ERROR_ACCESS_DENIED)   hkey=0000000000000000  <-- overwritten
```

So there is no observable misbehaviour today, and I am explicitly **not** claiming this is exploitable. But the code should not rely on undocumented output-parameter behaviour. Initialise `hkey` and only close it when a key was actually opened.

### 2. The return value was ignored

`do_defaults_setup()` discarded the result and applied `strlen()` to the destination buffer regardless:

```c
get_windows_regdirs(openssldir, sizeof(openssldir), L"OPENSSLDIR");
...
if (strlen(openssldir) > 0)
    openssldirptr = openssldir;
```

On failure the function makes no promise about that buffer, so `strlen()` alone cannot distinguish a successful lookup from a failed one. The return value is now checked.

### 3. A registry value need not hold a whole number of `WCHAR`s

`RegSetValueEx()` accepts an arbitrary `cbData` for a `REG_SZ`. With an odd `keysizebytes` of `2k+1`, the allocation is `2k+3` bytes and reading the final `WCHAR` of the zero-filled copy touches offset `2k+2..2k+3`, one byte past the end. Writing such a value requires `HKLM` write access, i.e. administrator, so this is robustness rather than a vulnerability. Lengths that are not a multiple of `sizeof(WCHAR)` are now rejected.

### 4. `WideCharToMultiByte()` failure could leave a truncated path

`dst` is `MAX_PATH + 1` bytes, and the guard above only bounds the source at `MAX_PATH` UTF-16 code units. A UTF-8 encoding can be up to three times as long as its UTF-16 source, so the conversion can fail with `ERROR_INSUFFICIENT_BUFFER` for a value that passed that check. The buffer contents are then unspecified and may be a partial, unterminated result — which, combined with issue 2, could be published as `OPENSSLDIR`. Silently using a truncated directory is worse than using none, so `dst` is cleared on failure and explicitly terminated on success.

Also removes the unused `index` variable (`/W4` reports `C4189`) and gives `tempstr` a non-`const` type, since it is written through via `(LPBYTE)` and passed to `OPENSSL_free()`.

## Testing

This file is inside `#if defined(_WIN32) && defined(OSSL_WINCTX)`, so it is not built by the Linux CI configurations and I could not exercise it through `make test`.

I verified it with MSVC 14.50 instead, compiling the function with `/W4 /analyze`:

* **before**: `warning C4189: 'index': local variable is initialized but not referenced`
* **after**: no warning attributable to this code

(Both before and after emit `C6553` from `winreg.h` itself — that is a SAL annotation issue in the Windows SDK header, not in this file.)

No unit test is added: the function is `static`, Windows-only, gated on `-DOSSL_WINCTX`, and its behaviour depends on `HKLM` registry state, so a meaningful test would need a registry fixture and a Windows-only CI job. Happy to add one if reviewers would like it, and equally happy to split this into four separate commits if that is easier to review.

Assisted-by: Claude:claude-opus-5
