### PR TITLE
Keep ECH pub/pub_len consistent when the allocation fails

### DIFF
--- a/ssl/ech/ech_internal.c
+++ b/ssl/ech/ech_internal.c
@@ -1371,11 +1371,13 @@ static int ech_decode_inbound_ech(SSL_CONNECTION *s, PACKET *pkt,
         }
         /* squirrel away that value in case of future HRR */
         OPENSSL_free(s->ext.ech.pub);
-        s->ext.ech.pub_len = extval->enc_len;
+        s->ext.ech.pub = NULL;
+        s->ext.ech.pub_len = 0;
         s->ext.ech.pub = OPENSSL_malloc(extval->enc_len);
         if (s->ext.ech.pub == NULL)
             goto err;
         memcpy(s->ext.ech.pub, extval->enc, extval->enc_len);
+        s->ext.ech.pub_len = extval->enc_len;
     }
     /* payload - the encrypted CH */
     *payload_offset = PACKET_data(pkt) - startofech;


### PR DESCRIPTION
`ech_decode_inbound_ech()` stores the client's HPKE sender public share in `s->ext.ech.pub` / `s->ext.ech.pub_len` so it can be compared against the value sent in a second ClientHello after a HelloRetryRequest.

The length was assigned before the buffer existed:

```c
/* squirrel away that value in case of future HRR */
OPENSSL_free(s->ext.ech.pub);
s->ext.ech.pub_len = extval->enc_len;
s->ext.ech.pub = OPENSSL_malloc(extval->enc_len);
if (s->ext.ech.pub == NULL)
    goto err;
memcpy(s->ext.ech.pub, extval->enc, extval->enc_len);
```

If `OPENSSL_malloc()` fails, `pub` is `NULL` while `pub_len` has already been set to a non-zero length, so the two fields disagree.

### Impact

Low, and I want to be precise rather than overstate it. Both HRR paths in this same function already test the two fields together:

```c
if (s->ext.ech.pub == NULL || s->ext.ech.pub_len == 0) {
```

so no current caller is misled, and this is not reachable as a NULL dereference today. The problem is that the object is left in a state its own invariant forbids, which is a trap for any future code that checks only the length — a reasonable thing to do when a non-zero length is supposed to imply a buffer.

### Change

Clear both fields before allocating, and set the length only once the copy has succeeded, so the pair is consistent on every path:

```c
OPENSSL_free(s->ext.ech.pub);
s->ext.ech.pub = NULL;
s->ext.ech.pub_len = 0;
s->ext.ech.pub = OPENSSL_malloc(extval->enc_len);
if (s->ext.ech.pub == NULL)
    goto err;
memcpy(s->ext.ech.pub, extval->enc, extval->enc_len);
s->ext.ech.pub_len = extval->enc_len;
```

## Testing

Built with `./Configure linux-x86_64 --strict-warnings` (which includes `-Werror`) and ran the full suite:

```
All tests successful.
Files=381, Tests=4558
Result: PASS
```

No test is added. The only way to reach the changed path is an allocation failure, which needs `enable-allocfail-tests` plus a way to target this specific call site; the fix is a state-consistency change with no observable behaviour difference otherwise. If reviewers would like coverage via the allocation-failure framework, I am glad to add it.

Assisted-by: Claude:claude-opus-5
