### PR TITLE
Validate outer CH compression methods when reconstituting inner CH

### DIFF
--- a/ssl/ech/ech_internal.c
+++ b/ssl/ech/ech_internal.c
@@ -1588,9 +1588,17 @@ static int ech_reconstitute_inner(SSL_CONNECTION *s, WPACKET *di, PACKET *ei,
         || !WPACKET_put_bytes_u16(di, pi_tmp)
         || !WPACKET_memcpy(di, pp_tmp, pi_tmp)
 
-        /* compression len & meth */
+        /*
+         * compression len & meth - reading this as a single 16 bit quantity
+         * is only correct when there is exactly one, null, compression
+         * method, which is what TLSv1.3 mandates.  ech_find_outers() already
+         * checks that for the encoded inner CH; check it for the outer CH
+         * too, otherwise any other value silently mis-parses here and
+         * desynchronises the rest of this walk over the outer CH.
+         */
         || !PACKET_get_net_2(ei, &pi_tmp)
         || !PACKET_get_net_2(&outer, &pi_tmp)
+        || pi_tmp != 0x0100
         || !WPACKET_put_bytes_u16(di, pi_tmp)) {
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
         goto err;


### PR DESCRIPTION
`ech_reconstitute_inner()` walks the outer ClientHello in parallel with the decrypted `EncodedClientHelloInner`, copying fields from one to the other. It reads the outer `legacy_compression_methods` field as a single 16-bit quantity:

```c
/* compression len & meth */
|| !PACKET_get_net_2(ei, &pi_tmp)
|| !PACKET_get_net_2(&outer, &pi_tmp)
|| !WPACKET_put_bytes_u16(di, pi_tmp)) {
```

That is only correct when the field is exactly `{ 0x01, 0x00 }` — one compression method, and that method is null. `ech_find_outers()` already enforces exactly this for the encoded inner CH:

```c
|| !PACKET_get_1(pkt, &pi_tmp)  /* compression meths */
|| pi_tmp != 0x01               /* 1 octet of comressions */
|| !PACKET_get_1(pkt, &pi_tmp)  /* compression meths */
|| pi_tmp != 0x00               /* 1 octet of no comressions */
```

but there is no equivalent check for the outer CH. An outer ClientHello advertising any other number of compression methods is therefore mis-parsed here: the following octets are taken as the extensions length, and the remainder of the walk over the outer CH — including the extension block that `ech_copy_ext()` later scans — is desynchronised.

This PR adds the same check.

### What this is, and what it is not

**It is not a memory safety issue.** Every access goes through the bounds-checked `PACKET` API, so the desynchronised reads either fail outright or operate on a shifted but in-bounds window. I could not produce a crash, and I am not claiming one exists.

**Why it is still worth fixing:** ECH processing runs at the very top of `tls_process_client_hello()`, *before* the normal ClientHello validation. So the usual answer to this class of report — "the later checks reject it anyway" — does not apply to this particular parser. It sees values the rest of the stack would refuse, and it is the one place where the outer CH is walked by hand rather than through the regular extension machinery. Having the inner and outer CH validated to the same standard in adjacent functions also seems worth the one line on its own.

### Compatibility

Conforming clients are unaffected:

* RFC 8446 §4.1.2 requires `legacy_compression_methods` to contain exactly one byte, set to zero, for every TLS 1.3 ClientHello.
* This code is only reached once an ECH payload has been successfully decrypted, so the peer is necessarily an ECH-capable TLS 1.3 client.
* The inner CH is already held to this exact requirement by `ech_find_outers()`.

## Testing

Built with `./Configure linux-x86_64 --strict-warnings` (which includes `-Werror`) and ran the full suite:

```
All tests successful.
Files=381, Tests=4558
Result: PASS
```

The ECH recipes specifically — including `30-test_ech_corrupt.t`, which exercises deliberately corrupted ClientHello and EncodedClientHelloInner values — all pass:

```
30-test_ech_corrupt.t ........ ok
82-test_ech_client_server.t .. ok
20-test_app_ech.t ............ ok
30-test_ech.t ................ ok
All tests successful.  Files=4, Tests=44
Result: PASS
```

Separately, I ran a local fuzzing harness against the server-side ECH path — a memory-BIO server with an ECH key configured, feeding HPKE-sealed `EncodedClientHelloInner` values (the server's ECH public key is published in DNS, so an attacker can encrypt arbitrary inner CHs; a harness that only mutates ClientHello bytes never gets past the AEAD). Roughly 10.2M iterations under ASan+UBSan produced no findings, but it did make this parsing asymmetry visible. I would be glad to clean that harness up into a `fuzz/` target in a separate PR if there is interest — as far as I can tell `fuzz/server.c` never configures an ECH key, and `fuzz/echconfiglist_parser.c` only covers `OSSL_ECHSTORE_read_echconfiglist()`, so the decompression path has no fuzz coverage today.

Assisted-by: Claude:claude-opus-5
