### PR TITLE
Add support for ML-DSA shake optimizations for armv8 using SHA3_features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,10 @@ OpenSSL Releases
 
    *Viktor Dukhovni*
 
+ * Added AARCH64 optimized SHAKE x2 operations for ML-DSA on `armv8`.
+
+   *Shane Lontis*
+
  * Added AVX512 optimized SHAKE x4 operations for ML-DSA on `x86_64`.
 
    *Marcel Cornu and Tomasz Kantecki*

--- a/crypto/ml_dsa/ml_dsa_sample.c
+++ b/crypto/ml_dsa/ml_dsa_sample.c
@@ -418,9 +418,10 @@ static const OSSL_ML_DSA_SAMPLE_OPS ml_dsa_sample_generic_meth = {
     vector_expand_mask_scalar
 };
 
-#if defined(KECCAK1600_ASM)                                                               \
-    && (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)) \
-    && !defined(OPENSSL_NO_ASM)
+#if defined(KECCAK1600_ASM) && !defined(OPENSSL_NO_ASM) \
+    && ((defined(__aarch64__) && defined(__AARCH64EL__)) \
+        || defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
+#if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
 #include "ml_dsa_sample_hw_x86_64.inc"
 const OSSL_ML_DSA_SAMPLE_OPS *ossl_ml_dsa_sample_ops(void)
 {
@@ -428,6 +429,15 @@ const OSSL_ML_DSA_SAMPLE_OPS *ossl_ml_dsa_sample_ops(void)
         return &ml_dsa_sample_x86_64;
     return &ml_dsa_sample_generic_meth;
 }
+#elif defined(__aarch64__)
+#include "ml_dsa_sample_hw_armv8.inc"
+const OSSL_ML_DSA_SAMPLE_OPS *ossl_ml_dsa_sample_ops(void)
+{
+    if (ossl_shakex2_sha3_capable_armv8())
+        return &ml_dsa_sample_armv8;
+    return &ml_dsa_sample_generic_meth;
+}
+#endif
 #else
 const OSSL_ML_DSA_SAMPLE_OPS *ossl_ml_dsa_sample_ops(void)
 {

--- a/crypto/ml_dsa/ml_dsa_sample.c
+++ b/crypto/ml_dsa/ml_dsa_sample.c
@@ -418,7 +418,7 @@ static const OSSL_ML_DSA_SAMPLE_OPS ml_dsa_sample_generic_meth = {
     vector_expand_mask_scalar
 };
 
-#if defined(KECCAK1600_ASM) && !defined(OPENSSL_NO_ASM) \
+#if defined(KECCAK1600_ASM) && !defined(OPENSSL_NO_ASM)  \
     && ((defined(__aarch64__) && defined(__AARCH64EL__)) \
         || defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
 #if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)

--- a/crypto/ml_dsa/ml_dsa_sample_hw_armv8.inc
+++ b/crypto/ml_dsa/ml_dsa_sample_hw_armv8.inc
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/common.h"
+
+#define BLOCK_ALIGNED(sz, algn) (algn) * (1 + (sz) / (algn))
+
+#define SHAKE128_RATE SHA3_BLOCKSIZE(128)
+#define SHAKE128_WORDS (SHAKE128_RATE * 8 / 64)
+#define SHAKE256_RATE SHA3_BLOCKSIZE(256)
+#define SHAKE256_WORDS (SHAKE256_RATE * 8 / 64)
+
+#define ML_DSA_SHAKE_X2_BATCH_SIZE 2
+#define ML_DSA_EXPAND_MASK_BYTES_PER_COEFF 32
+#define ML_DSA_EXPAND_MASK_COEFFS_GAMMA1_19 20
+#define ML_DSA_EXPAND_MASK_COEFFS_GAMMA1_17 18
+#define ML_DSA_EXPAND_MASK_BUF_SIZE_GAMMA1_19 \
+    (ML_DSA_EXPAND_MASK_BYTES_PER_COEFF * ML_DSA_EXPAND_MASK_COEFFS_GAMMA1_19)
+#define ML_DSA_EXPAND_MASK_BUF_SIZE_GAMMA1_17 \
+    (ML_DSA_EXPAND_MASK_BYTES_PER_COEFF * ML_DSA_EXPAND_MASK_COEFFS_GAMMA1_17)
+#define ML_DSA_EXPAND_MASK_BUF_SIZE(gamma1)         \
+    ((gamma1) == ML_DSA_GAMMA1_TWO_POWER_19         \
+            ? ML_DSA_EXPAND_MASK_BUF_SIZE_GAMMA1_19 \
+            : ML_DSA_EXPAND_MASK_BUF_SIZE_GAMMA1_17)
+#define ML_DSA_EXPAND_MASK_BUF_SIZE_BLOCKS(gamma1) \
+    ((gamma1) == ML_DSA_GAMMA1_TWO_POWER_19         \
+            ? BLOCK_ALIGNED(ML_DSA_EXPAND_MASK_BUF_SIZE_GAMMA1_19, SHAKE256_RATE) \
+            : BLOCK_ALIGNED(ML_DSA_EXPAND_MASK_BUF_SIZE_GAMMA1_17, SHAKE256_RATE))
+#define ML_DSA_EXPAND_MASK_BLOCKS_MAX ML_DSA_EXPAND_MASK_BUF_SIZE_BLOCKS(ML_DSA_GAMMA1_TWO_POWER_19)
+
+/* Assembler API */
+extern void ossl_shake128_2x_oneshot_singleblock_absorb_interleaved_squeeze(uint64_t *statex2_out, const uint64_t *in_interleaved, uint8_t *out1, uint8_t *out2);
+extern void ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_squeeze(uint64_t *statex2_out, const uint64_t *in_interleaved, uint8_t *out1, uint8_t *out2);
+extern void ossl_shake128_2x_squeeze_singleblock(uint64_t *statex2, uint8_t *out1, uint8_t *out2);
+extern void ossl_shake256_2x_squeeze_singleblock(uint64_t *statex2, uint8_t *out1, uint8_t *out2);
+extern void ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_squeeze(const uint64_t *in_interleaved, uint8_t *out1, uint8_t *out2, size_t outlen);
+extern void SHA3_secure_vector_clear_armv8(void);
+
+/*
+ * The data used for sampling are all of a known size, so we can store the 2
+ * parallel inputs in interleaved form and simplify the assembler so that the
+ * input is passed in the following form:
+ *   words[0] = input1 first 8 bytes,  words[1] = input2 first 8 bytes
+ *   words[2] = input1 next 8 bytes,   words[3] = input2 next 8 bytes
+ * The rate for SHAKE128 is 168 which is 21 * uint64 values
+ * The rate for SHAKE256 is 136 which is 17 * uint64 values
+ * The end of the absorb does padding, so we can the ending 0x80 here.
+ * The inputs used in ML-DSA for shake are all less than the capacity, and all
+ * 3 variants input a small fixed seed of 32 or 64 bytes that is used multiple
+ * times, so we just do this once. This is followed by a variable index that
+ * can change. We return the index of this changing value which can then be passed
+ * to set_index()
+ */
+static uint64_t *absorb_once_shake128(uint64_t *state, const uint8_t *in, size_t inlen)
+{
+    size_t i;
+
+    memset((uint8_t *)state, 0, 168*2);
+    /* write trailing interleaved bytes for SHAKE128 */
+    state[40] = 0x8000000000000000; /* 20 * 2 */
+    state[41] = 0x8000000000000000;
+
+    /*
+     * Assuming inlen is a multiple of 8 bytes
+     * Store this value twice into uint64_t interleaved blocks
+     * Which is the order required for 2 x parallel processing on armv8.
+     */
+    for (i = 0; i < inlen/4; i += 2) {
+        uint64_t val;
+        in = OPENSSL_load_u64_le(&val, in);
+        state[i] = val;
+        state[i+1] = val;
+    }
+    return state+i;
+}
+
+static uint64_t *absorb_once_shake256(uint64_t *state, const uint8_t *in, size_t inlen)
+{
+    size_t i;
+
+    memset((uint8_t *)state, 0, 136*2);
+
+    /*
+     * Assuming inlen is a multiple of 8 bytes
+     * Store this value twice into uint64_t interleaved blocks
+     * Which is the order required for 2 x parallel processing on armv8.
+     */
+    for (i = 0; i < inlen/4; i+=2) {
+        uint64_t val;
+        in = OPENSSL_load_u64_le(&val, in);
+        state[i] = val;
+        state[i+1] = val;
+    }
+    /* write trailing 0x80 interleaved bytes for SHAKE256 */
+    state[32] = 0x8000000000000000;
+    state[33] = 0x8000000000000000;
+    return state+i;
+}
+
+/*
+ * After calling the absorb_once() to set the seed, the 3 variants all
+ * Write a 2 byte index that changes.
+ * As this is the  end of the input we set the SHAKE related 0x1F padding also.
+ * As this is interleaved data it inputs 2 separate indexes.
+ */
+static void set_index(uint64_t *state, uint64_t index1, uint64_t index2)
+{
+    state[0] = index1 | ((uint64_t)0x1F0000);
+    state[1] = index2 | ((uint64_t)0x1F0000);
+}
+
+static ossl_unused int rej_ntt_poly_mb(const uint64_t *words,
+    POLY *outs[ML_DSA_SHAKE_X2_BATCH_SIZE])
+{
+    KECCAK1600_X2_ARMV8_CTX ctx;
+    ALIGN16 uint8_t blocks[ML_DSA_SHAKE_X2_BATCH_SIZE][SHAKE128_BLOCKSIZE];
+    int coeff_idx[ML_DSA_SHAKE_X2_BATCH_SIZE] = { 0, 0 };
+    size_t lane;
+
+    ossl_shake128_2x_oneshot_singleblock_absorb_interleaved_squeeze(ctx.A, words, blocks[0], blocks[1]);
+    while(1) {
+        int finished = 0;
+        for (lane = 0; lane < ML_DSA_SHAKE_X2_BATCH_SIZE; ++lane) {
+            const uint8_t *b = blocks[lane];
+            const uint8_t *end = b + SHAKE128_BLOCKSIZE;
+            uint32_t *coeff = outs[lane]->coeff;
+            int j = coeff_idx[lane];
+
+            if (j == ML_DSA_NUM_POLY_COEFFICIENTS) {
+                finished++;
+                continue;
+            }
+            for (; b < end; b += 3) {
+                if (coeff_from_three_bytes(b, coeff+j)) {
+                    if (++j == ML_DSA_NUM_POLY_COEFFICIENTS)
+                        break;
+                }
+            }
+            coeff_idx[lane] = j;
+        }
+        if (finished == 2)
+            break;
+        /*
+         * This loop is likely to run 5 times which produces 5 * 168 bytes
+         * (840 bytes) and with no failures 3 * 256 = 768 bytes are consumed,
+         * so there is a very small chance that one lane will consume more
+         * than this. In this rare case it will take the hit of consuming
+         * another parallel block (even though it may only use one of them).
+         */
+        ossl_shake128_2x_squeeze_singleblock(ctx.A, blocks[0], blocks[1]);
+    }
+    ossl_shakex2_cleanup_armv8(&ctx);
+    return 1;
+}
+
+static void vector_expand_mask_mb(VECTOR *out,
+    const uint8_t rho_prime[ML_DSA_RHO_PRIME_BYTES], const uint32_t kappa, const uint32_t gamma1,
+    EVP_MD_CTX *h_ctx, const EVP_MD *md)
+{
+    ALIGN16 uint64_t words[2 * SHAKE256_WORDS]; /* 21 = 168 bytes * 8 / 64 */
+    ALIGN16 uint8_t buffers[ML_DSA_SHAKE_X2_BATCH_SIZE][ML_DSA_EXPAND_MASK_BLOCKS_MAX];
+    size_t i;
+    const size_t num_polys = out->num_poly;
+    const size_t buf_size = ML_DSA_EXPAND_MASK_BUF_SIZE(gamma1);
+    const size_t buf_size_blocks = ML_DSA_EXPAND_MASK_BUF_SIZE_BLOCKS(gamma1);
+    uint64_t *pindx = absorb_once_shake256(words, rho_prime, ML_DSA_RHO_PRIME_BYTES);
+
+    for (i = 0; i + (ML_DSA_SHAKE_X2_BATCH_SIZE - 1) < num_polys; i += ML_DSA_SHAKE_X2_BATCH_SIZE) {
+        set_index(pindx, (uint64_t)(kappa + i), (uint64_t)(kappa + i + 1));
+        ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_squeeze(words, buffers[0], buffers[1], buf_size_blocks);
+        ossl_ml_dsa_poly_decode_expand_mask(&out->poly[i + 0], buffers[0], buf_size, gamma1);
+        ossl_ml_dsa_poly_decode_expand_mask(&out->poly[i + 1], buffers[1], buf_size, gamma1);
+    }
+    /*
+     * num_polys is always 4+4 (ML-DSA-44), 6+5 (ML-DSA-65), or 8+7 (ML-DSA-87)
+     * As we run 2 in parallel, there will be 1 left over for ML-DSA-65 and ML-DSA-87.
+     * We still process 2 lanes here, but only use the first result.
+     */
+    if (i < num_polys) {
+        set_index(pindx, (uint64_t)(kappa + i), (uint64_t)(kappa + i));
+        ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_squeeze(words, buffers[0], buffers[1], buf_size_blocks);
+        ossl_ml_dsa_poly_decode_expand_mask(&out->poly[i + 0], buffers[0], buf_size, gamma1);
+    }
+
+    OPENSSL_cleanse(buffers, sizeof(buffers));
+    OPENSSL_cleanse(words, sizeof(words));
+    SHA3_secure_vector_clear_armv8();
+}
+
+static ossl_unused int rej_bounded_poly_mb(COEFF_FROM_NIBBLE_FUNC *coef_from_nibble,
+    const uint64_t *words, POLY *outs[ML_DSA_SHAKE_X2_BATCH_SIZE], int count)
+{
+    KECCAK1600_X2_ARMV8_CTX ctx;
+    ALIGN16 uint8_t blocks[ML_DSA_SHAKE_X2_BATCH_SIZE][SHAKE256_BLOCKSIZE];
+    int coeff_idx[ML_DSA_SHAKE_X2_BATCH_SIZE] = { 0, 0 };
+    int lane;
+
+    ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_squeeze(ctx.A, words, blocks[0], blocks[1]);
+    while (1) {
+        int finished = 0;
+        for (lane = 0; lane < count; lane++) {
+            const uint8_t *b = blocks[lane];
+            const uint8_t *end = b + SHAKE256_BLOCKSIZE;
+            uint32_t *coeff = outs[lane]->coeff;
+            int j = coeff_idx[lane];
+
+            if (j == ML_DSA_NUM_POLY_COEFFICIENTS) {
+                finished++;
+                continue;
+            }
+
+            for (; b < end; b++) {
+                uint32_t z0 = *b & 0x0F;
+                uint32_t z1 = *b >> 4;
+
+                if (coef_from_nibble(z0, coeff + j)
+                    && ++j == ML_DSA_NUM_POLY_COEFFICIENTS) {
+                        finished++;
+                        break;
+                }
+                if (coef_from_nibble(z1, coeff + j)
+                    && ++j == ML_DSA_NUM_POLY_COEFFICIENTS) {
+                        finished++;
+                        break;
+                }
+            }
+            coeff_idx[lane] = j;
+        }
+        if (finished == count)
+            break;
+        ossl_shake256_2x_squeeze_singleblock(ctx.A, blocks[0], blocks[1]);
+    }
+    OPENSSL_cleanse(blocks, sizeof(blocks));
+    ossl_shakex2_cleanup_armv8(&ctx);
+    return 1;
+}
+
+static int matrix_expand_A_mb(EVP_MD_CTX *g_ctx, const EVP_MD *md,
+    const uint8_t *rho, MATRIX *out)
+{
+    ALIGN16 uint64_t words[2 * SHAKE128_WORDS];
+    uint64_t index;
+    size_t id, cols, rows;
+    POLY *polys[ML_DSA_SHAKE_X2_BATCH_SIZE];
+    POLY *poly = out->m_poly;
+    uint64_t *pindx = absorb_once_shake128(words, rho, ML_DSA_RHO_BYTES);
+
+    /*
+     * This code assume ML_DSA_SHAKE_X2_BATCH_SIZE = 2.
+     * ML_DSA rows are an even number of 4, 6 or 8, so traverse the
+     * matrix in rows pairs in order to avoid extra processing.
+     * The l * k matrix polynomial indexes are in column order.
+     */
+    for (cols = 0; cols < out->l; cols++) {
+        id = cols;
+        index = cols;
+        for (rows = 0; rows < out->k; rows += 2, index += (2<<8), id += (2*out->l)) {
+            set_index(pindx, index, index + (1<<8));
+            /* Generate the polynomial for each matrix element using a unique seed */
+            polys[0] = &poly[id];
+            polys[1] = &poly[id + out->l];
+            if (!rej_ntt_poly_mb(words, polys))
+                return 0;
+        }
+    }
+    /* The values produced here are not secret, so there is no cleanup. */
+    return 1;
+}
+
+static int vector_expand_S_mb(EVP_MD_CTX *h_ctx, const EVP_MD *md, const int eta,
+    const uint8_t *seed, VECTOR *s1, VECTOR *s2)
+{
+    ALIGN16 uint64_t words[2 * SHAKE256_WORDS];
+    int ret = 0;
+    size_t b, idx;
+    const size_t l = s1->num_poly;
+    const size_t total = l + s2->num_poly;
+    POLY *polys[ML_DSA_SHAKE_X2_BATCH_SIZE];
+    COEFF_FROM_NIBBLE_FUNC *coef_from_nibble_fn = (eta == ML_DSA_ETA_4) ? coeff_from_nibble_4 : coeff_from_nibble_2;
+    uint64_t *pindx = absorb_once_shake256(words, seed, ML_DSA_PRIV_SEED_BYTES);
+
+    for (idx = 0; (idx + ML_DSA_SHAKE_X2_BATCH_SIZE - 1) < total; idx += ML_DSA_SHAKE_X2_BATCH_SIZE) {
+        set_index(pindx, idx, idx + 1);
+        for (b = 0; b < ML_DSA_SHAKE_X2_BATCH_SIZE; b++) {
+            const uint64_t poly_idx = (uint64_t)(idx + b);
+            if (poly_idx < l)
+                polys[b] = &s1->poly[poly_idx];
+            else
+                polys[b] = &s2->poly[poly_idx - l];
+        }
+        if (!rej_bounded_poly_mb(coef_from_nibble_fn, words, polys, ML_DSA_SHAKE_X2_BATCH_SIZE))
+            goto err;
+    }
+
+    if (idx < total) {
+        uint64_t poly_idx = idx;
+        set_index(pindx, poly_idx, poly_idx);
+        polys[0] = &s2->poly[poly_idx - l];
+        if (!rej_bounded_poly_mb(coef_from_nibble_fn, words, polys, 1))
+            goto err;
+    }
+
+    ret = 1;
+err:
+    SHA3_secure_vector_clear_armv8();
+    OPENSSL_cleanse(words, sizeof(words));
+    return ret;
+}
+
+static const OSSL_ML_DSA_SAMPLE_OPS ml_dsa_sample_armv8 = {
+    matrix_expand_A_mb,
+    vector_expand_S_mb,
+    vector_expand_mask_mb
+};

--- a/crypto/sha/asm/keccak1600-armv8.pl
+++ b/crypto/sha/asm/keccak1600-armv8.pl
@@ -945,7 +945,7 @@ ___
 ##        You only can move directly into the state on the first absorb call. Subsequent
 ##        absorbs require XORing into the state.
 ## @param $inp Input buffer containing 2 lane Double Words. It Must be aligned to a 16 byte boundary.
-##            It is incremented by 64 (4 double words)
+##             It is post incremented by 64 (4 double words)
 ## @param $i The state double word index (Normally a multiple of 4).. Maps to q$i
 ## @param $j The state double word index (Normally a (multiple of 4) + 1)
 ## @param $k The state double word index (Normally a (multiple of 4) + 2)
@@ -965,7 +965,8 @@ ___
 }
 
 ## @brief Copy aligned input to 1 vector register representing the double word state
-## @param $inp Input buffer (Must be aligned to 16 byte boundary), It is not incremented
+## @param $inp Input buffer (Must be aligned to 16 byte boundary)
+##             It is not post incremented
 ## @param $i The state double word index. Maps to q$i
 sub copy_1x2_input_align16_to_qvectors {
     my ($inp, $i) = @_;
@@ -979,7 +980,8 @@ ___
 
 ## @brief Copy aligned input to 21 vector register representing the double word state
 ##        and clear the remaining 4 vector registers.
-## @param $inp Input buffer (Must be aligned to 16 byte boundary), It is not incremented
+## @param $inp Input buffer (Must be aligned to 16 byte boundary),
+##             It is not post incremented
 sub shake128_2x_copy_input_block_to_qvectors {
     my ($inp) = @_;
     copy_4x2_input_align16_to_qvectors($inp,0,1,2,3);
@@ -992,7 +994,8 @@ sub shake128_2x_copy_input_block_to_qvectors {
 }
 ## @brief Copy aligned input to 17 vector register representing the double word state
 ##        and clear the remaining 8 vector registers.
-## @param $inp Input buffer (Must be aligned to 16 byte boundary), It is not incremented
+## @param $inp Input buffer (Must be aligned to 16 byte boundary)
+##             It is not post incremented
 sub shake256_2x_copy_input_block_to_qvectors {
     my ($inp) = @_;
     copy_4x2_input_align16_to_qvectors($inp,0,1,2,3);
@@ -1005,7 +1008,8 @@ sub shake256_2x_copy_input_block_to_qvectors {
 }
 
 ## @brief Copy $state into 25 double words in q0..q24.
-## @param $state A 5*5 state of double words (Must be aligned to 16 byte boundary), It is not incremented.
+## @param $state A 5*5 state of double words (Must be aligned to 16 byte boundary).
+##               It is not post incremented.
 sub load_qvectors_from_aligned16_state {
     my ($state) = @_;
     for($i=0; $i<24; $i+=2) {
@@ -1022,7 +1026,8 @@ ___
 }
 
 ## @brief Save 4 Double word q vectors to $state
-## @param $state Output 5x5 double word state array (aligned to 16 byte boundary). It is not post incremented.
+## @param $state Output 5x5 double word state array (aligned to 16 byte boundary).
+##               It is not post incremented.
 ## @param $i Saves to 4 vectors starting at q$i
 sub save_4_qvectors_to_aligned16_state {
     my ($state, $i) = @_;
@@ -1036,7 +1041,8 @@ ___
 }
 
 ## @brief Save All 25 Double word q vectors to $state
-## @param $state A 5 by 5 double word state array (aligned to 16 byte boundary). It is not incremented.
+## @param $state A 5 by 5 double word state array (aligned to 16 byte boundary).
+##               It is not post incremented.
 ## @param $i Saves to 4 vectors starting at q$i
 sub save_qvectors_to_aligned16_state {
     my ($state) = @_;
@@ -1062,8 +1068,10 @@ ___
 
 ## @brief Move 4 double words from q$i..q($i+3) to 2 output buffers.
 ##        Each double word copies the first lane to $out1 and the second lane to $out2
-## @param out1 An output buffer for lane1 that can hold 4 words, It is incremented by 4 words. It must be 8 byte aligned.
-## @param out2 An Output buffer for lane2 that can hold 4 words, It is incremented by 4 words. In must be 8 byte alligned.
+## @param out1 An output buffer for lane1 that can hold 4 words,
+##        It is post incremented by 4 words. It must be 8 byte aligned.
+## @param out2 An Output buffer for lane2 that can hold 4 words.
+##        It is post incremented by 4 words. It must be 8 byte aligned.
 sub copy_4x2_qvectors_to_out2 {
     my ($out1, $out2, $i) = @_;
     my $j = $i+1;
@@ -1097,8 +1105,10 @@ ___
 }
 ## @brief Move 1 double word from q$i to 2 output buffers.
 ##        Each double word copies the first lane to $out1 and the second lane to $out2
-## @param out1 An output buffer for lane0 that can hold 1 word, It is incremented by 1 word. It must be 8 byte aligned.
-## @param out2 An Output buffer for lane1 that can hold 1 word, It is incremented by 1 word. In must be 8 byte alligned.
+## @param out1 An output buffer for lane0 that can hold 1 word,
+##             It is post incremented by 1 word. It must be 8 byte aligned.
+## @param out2 An Output buffer for lane1 that can hold 1 word,
+##             It is post incremented by 1 word. It must be 8 byte aligned.
 sub copy_1x2_qvectors_to_out2 {
     my ($out1, $out2, $i) = @_;
 $code.=<<___;
@@ -1220,7 +1230,7 @@ function_end('ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_bloc
 
 $code.=<<___;
 ## @brief To be called on completion if the values stored in the state are secret.
-##        This clears the temporary vectors q0..q7, q16..q31, It does not clear q8..q15 as they
+##        This clears the temporary vectors q0..q7, q16..q31. It does not clear q8..q15 as they
 ##        are saved and restored on each call.
 .globl SHA3_secure_vector_clear_armv8
 .type   SHA3_secure_vector_clear_armv8,%function

--- a/crypto/sha/asm/keccak1600-armv8.pl
+++ b/crypto/sha/asm/keccak1600-armv8.pl
@@ -491,11 +491,11 @@ SHA3_squeeze:
 
 .Loop_squeeze:
 	ldr	x4,[x0],#8
-	cmp	$len,#8
-	blo	.Lsqueeze_tail
 #ifdef	__AARCH64EB__
 	rev	x4,x4
 #endif
+	cmp	$len,#8
+	blo	.Lsqueeze_tail
 	str	x4,[$out],#8
 	subs	$len,$len,#8
 	beq	.Lsqueeze_done
@@ -546,7 +546,16 @@ SHA3_squeeze:
 .size	SHA3_squeeze,.-SHA3_squeeze
 ___
 }								}}}
+
 								{{{
+#
+# A 5*5 matrix of double words
+# Each double word represents data for 2 separate Streams.
+# Registers q0..q24 hold the state.
+# A word is 64 bits so .2d = double word
+# Note that XAR and RAX1 instructions actually use .2d not .16b
+# (since they operate on lanes - not 16 bytes)
+# This is fixed up in the foreach(split("\n",$code)) at the end of the file.
 my @A = map([ "v".$_.".16b", "v".($_+1).".16b", "v".($_+2).".16b",
                              "v".($_+3).".16b", "v".($_+4).".16b" ],
             (0, 5, 10, 15, 20));
@@ -554,6 +563,32 @@ my @A = map([ "v".$_.".16b", "v".($_+1).".16b", "v".($_+2).".16b",
 my @C = map("v$_.16b", (25..31));
 my @D = @C[4,5,6,2,3];
 
+#
+# @brief Internal KeccakF1600 function to process 2 lanes in parallel.
+# @details It does not save or restore any registers.
+#    As there are only 32 vector register to play with and 25 of them are used
+#    for just for the state, trying to interleave the permute steps nicely is
+#    tricky.
+# @param q0..q24 the input/output state of double words
+# @comment uses registers X9, X10, and q25..q31
+# @assumptions The SHA3 features eor3, rax1, xar, bcax are available
+#
+# The algorithm does 24 rounds of the following steps:
+# 1) Theta
+#    C[x] = A[x][0] ^ A[x][1] ^ A[x][2] ^ A[x][3] ^ A[x][4]
+#    D[x] = C[(x-1)%5] ^ ROTL1(C[(x+1)%5])
+#    A`[x][y] = A[x][y] ^ D[x]
+#  EOR3 can be used twice to form C[x].
+#  RAX1 is used by D[x] (rotate and XOR)
+#
+# 2) Rho and Pi
+#    B[y][(2x + 3y)%5] = ROL(A[x][y], r[x][y])
+# XAR (XOR and rotate right, to do ROL we rotate 64-x)
+# 3) Chi
+#    A`[x][y] = B[x][y] ^ (~B[(x+1)%5][y] AND B[(x+2)%5][y])
+# BCAX ((Bitwise clear = NOT) AND XOR)
+# 4) Iota
+#    A`[0][0] = A[0][0] ^ IotaRoundConstant
 $code.=<<___;
 .type	KeccakF1600_ce,%function
 .align	5
@@ -701,7 +736,6 @@ ___
 
 {
 my ($ctx,$inp,$len,$bsz) = map("x$_",(0..3));
-
 $code.=<<___;
 .globl	SHA3_absorb_cext
 .type	SHA3_absorb_cext,%function
@@ -756,11 +790,8 @@ $code.=<<___;
 	eor	$A[4][4],$A[4][4],v31.16b
 
 .Lprocess_block_ce:
-
 	bl	KeccakF1600_ce
-
 	b	.Loop_absorb_ce
-
 .align	4
 .Labsorbed_ce:
 ___
@@ -799,11 +830,11 @@ SHA3_squeeze_cext:
 
 .Loop_squeeze_ce:
 	ldr	x4,[x9],#8
-	cmp	$len,#8
-	blo	.Lsqueeze_tail_ce
 #ifdef	__AARCH64EB__
 	rev	x4,x4
 #endif
+	cmp	$len,#8
+	blo	.Lsqueeze_tail_ce
 	str	x4,[$out],#8
 	beq	.Lsqueeze_done_ce
 
@@ -852,6 +883,363 @@ SHA3_squeeze_cext:
 .size	SHA3_squeeze_cext,.-SHA3_squeeze_cext
 ___
 }								}}}
+
+{{{
+my $shake128_rate = 168; # 21 words
+my $shake256_rate = 136; # 17 words
+
+# @brief Call this at the start of a function, it saves the Frame Pointer,
+#        Return Address (LR), and the vector registers q8..q15
+#        Although the requirement is only to save the low part v8..v15,
+#        we need to save the hi part also, so that we can zeroize nicely
+#        when we are finished.
+# @param $name name of function, function_end() should have a matching name
+# @param $is_global set to 1 to indicate this function can be called externally.
+sub function_start {
+    my ($name, $is_global) = @_;
+    if ($is_global == 1) {
+$code.=<<___;
+.globl  $name
+___
+    }
+$code.=<<___;
+.type   $name,%function
+.align  5
+$name:
+    AARCH64_SIGN_LINK_REGISTER
+    stp x29,x30,[sp,#-144]!
+    add x29,sp,#0
+    stp q8,q9,[sp,#16]      // per ABI requirement
+    stp q10,q11,[sp,#48]
+    stp q12,q13,[sp,#80]
+    stp q14,q15,[sp,#112]
+___
+}
+
+# @brief Call this at the end of a function, it restores the Frame Pointer,
+#        Return Address (LR), and the vector registers q8..q15
+#        The q8..15 registers are also cleared from the stack.
+#        We restore q8..15 instead of v8..v15 because we need to clean up
+#.       q vectors when the squeeze has finished.
+# @param $name name of function, function_start() should have a matching name
+sub function_end {
+    my ($name) = @_;
+$code.=<<___;
+    eor v0.16b, v0.16b, v0.16b
+    ldp q8,q9,[sp,#16]
+    ldp q10,q11,[sp,#48]
+    ldp q12,q13,[sp,#80]
+    ldp q14,q15,[sp,#112]
+    stp q0, q0, [sp, #16]
+    stp q0, q0, [sp, #48]
+    stp q0, q0, [sp, #80]
+    stp q0, q0, [sp, #112]
+    ldp x29, x30, [sp], #144
+    AARCH64_VALIDATE_LINK_REGISTER
+    ret
+.size   $name,.-$name
+___
+}
+
+## @brief Copy aligned input to 4 vector registers representing the double word state
+##        You only can move directly into the state on the first absorb call. Subsequent
+##        absorbs require XORing into the state.
+## @param $inp Input buffer containing 2 lane Double Words. It Must be aligned to a 16 byte boundary.
+##            It is incremented by 64 (4 double words)
+## @param $i The state double word index (Normally a multiple of 4).. Maps to q$i
+## @param $j The state double word index (Normally a (multiple of 4) + 1)
+## @param $k The state double word index (Normally a (multiple of 4) + 2)
+## @param $l The state double word index (Normally a (multiple of 4) + 3)
+sub copy_4x2_input_align16_to_qvectors {
+    my ($inp, $i, $j, $k, $l) = @_;
+$code.=<<___;
+    ldp q$i,q$j,[$inp],#32
+    ldp q$k,q$l,[$inp],#32
+#ifdef __AARCH64EB__
+    rev64 q$i,q$i;
+    rev64 q$j,q$j;
+    rev64 q$k,q$k;
+    rev64 q$l,q$l;
+#endif
+___
+}
+
+## @brief Copy aligned input to 1 vector register representing the double word state
+## @param $inp Input buffer (Must be aligned to 16 byte boundary), It is not incremented
+## @param $i The state double word index. Maps to q$i
+sub copy_1x2_input_align16_to_qvectors {
+    my ($inp, $i) = @_;
+$code.=<<___;
+    ldr q$i,[$inp]
+#ifdef __AARCH64EB__
+    rev64 q$i,q$i;
+#endif
+___
+}
+
+## @brief Copy aligned input to 21 vector register representing the double word state
+##        and clear the remaining 4 vector registers.
+## @param $inp Input buffer (Must be aligned to 16 byte boundary), It is not incremented
+sub shake128_2x_copy_input_block_to_qvectors {
+    my ($inp) = @_;
+    copy_4x2_input_align16_to_qvectors($inp,0,1,2,3);
+    copy_4x2_input_align16_to_qvectors($inp,4,5,6,7);
+    copy_4x2_input_align16_to_qvectors($inp,8,9,10,11);
+    copy_4x2_input_align16_to_qvectors($inp,12,13,14,15);
+    copy_4x2_input_align16_to_qvectors($inp,16,17,18,19);
+    copy_1x2_input_align16_to_qvectors($inp,20);
+    zero_4_qvectors(21,22,23,24);
+}
+## @brief Copy aligned input to 17 vector register representing the double word state
+##        and clear the remaining 8 vector registers.
+## @param $inp Input buffer (Must be aligned to 16 byte boundary), It is not incremented
+sub shake256_2x_copy_input_block_to_qvectors {
+    my ($inp) = @_;
+    copy_4x2_input_align16_to_qvectors($inp,0,1,2,3);
+    copy_4x2_input_align16_to_qvectors($inp,4,5,6,7);
+    copy_4x2_input_align16_to_qvectors($inp,8,9,10,11);
+    copy_4x2_input_align16_to_qvectors($inp,12,13,14,15);
+    copy_1x2_input_align16_to_qvectors($inp,16);
+    zero_4_qvectors(17,18,19,20);
+    zero_4_qvectors(21,22,23,24);
+}
+
+## @brief Copy $state into 25 double words in q0..q24.
+## @param $state A 5*5 state of double words (Must be aligned to 16 byte boundary), It is not incremented.
+sub load_qvectors_from_aligned16_state {
+    my ($state) = @_;
+    for($i=0; $i<24; $i+=2) {
+        my $j=$i+1;
+        my $offs=16*$i;
+$code.=<<___;
+    ldp q$i,q$j,[$state,#$offs]
+___
+    }
+    my $offs=16*$i;
+$code.=<<___;
+    ldr q$i,[$state,#$offs]
+___
+}
+
+## @brief Save 4 Double word q vectors to $state
+## @param $state Output 5x5 double word state array (aligned to 16 byte boundary). It is not post incremented.
+## @param $i Saves to 4 vectors starting at q$i
+sub save_4_qvectors_to_aligned16_state {
+    my ($state, $i) = @_;
+    my $j = $i+1;
+    my $k = $i+2;
+    my $l = $i+3;
+$code.=<<___;
+    stp q$i,q$j,[$state,#16*$i]
+    stp q$k,q$l,[$state,#16*($i+2)]
+___
+}
+
+## @brief Save All 25 Double word q vectors to $state
+## @param $state A 5 by 5 double word state array (aligned to 16 byte boundary). It is not incremented.
+## @param $i Saves to 4 vectors starting at q$i
+sub save_qvectors_to_aligned16_state {
+    my ($state) = @_;
+    for ($i=0; $i<24; $i+=4) {
+        save_4_qvectors_to_aligned16_state($state,$i);
+    }
+$code.=<<___;
+    str q$i,[$state,#16*$i]
+___
+}
+
+## @brief Set 4 double words in q$i, q$j, q$k, q$l to zero.
+##        This is used to zero the state 'capacity' data after the rate words.
+sub zero_4_qvectors {
+    my ($i, $j, $k, $l) = @_;
+$code.=<<___;
+    eor v$i.16b,v$i.16b,v$i.16b
+    eor v$j.16b,v$j.16b,v$j.16b
+    eor v$k.16b,v$k.16b,v$k.16b
+    eor v$l.16b,v$l.16b,v$l.16b
+___
+}
+
+## @brief Move 4 double words from q$i..q($i+3) to 2 output buffers.
+##        Each double word copies the first lane to $out1 and the second lane to $out2
+## @param out1 An output buffer for lane1 that can hold 4 words, It is incremented by 4 words. It must be 8 byte aligned.
+## @param out2 An Output buffer for lane2 that can hold 4 words, It is incremented by 4 words. In must be 8 byte alligned.
+sub copy_4x2_qvectors_to_out2 {
+    my ($out1, $out2, $i) = @_;
+    my $j = $i+1;
+    my $k = $i+2;
+    my $l = $i+3;
+$code.=<<___;
+#ifdef __AARCH64EB__
+    rev64 v28.16b, v$i.16b
+    rev64 v29.16b, v$j.16b
+    rev64 v30.16b, v$k.16b
+    rev64 v31.16b, v$l.16b
+    st1 {v28.d}[0], [$out1], #8
+    st1 {v28.d}[1], [$out2], #8
+    st1 {v29.d}[0], [$out1], #8
+    st1 {v29.d}[1], [$out2], #8
+    st1 {v30.d}[0], [$out1], #8
+    st1 {v30.d}[1], [$out2], #8
+    st1 {v31.d}[0], [$out1], #8
+    st1 {v31.d}[1], [$out2], #8
+#else
+    st1 {v$i.d}[0], [$out1], #8
+    st1 {v$i.d}[1], [$out2], #8
+    st1 {v$j.d}[0], [$out1], #8
+    st1 {v$j.d}[1], [$out2], #8
+    st1 {v$k.d}[0], [$out1], #8
+    st1 {v$k.d}[1], [$out2], #8
+    st1 {v$l.d}[0], [$out1], #8
+    st1 {v$l.d}[1], [$out2], #8
+#endif
+___
+}
+## @brief Move 1 double word from q$i to 2 output buffers.
+##        Each double word copies the first lane to $out1 and the second lane to $out2
+## @param out1 An output buffer for lane0 that can hold 1 word, It is incremented by 1 word. It must be 8 byte aligned.
+## @param out2 An Output buffer for lane1 that can hold 1 word, It is incremented by 1 word. In must be 8 byte alligned.
+sub copy_1x2_qvectors_to_out2 {
+    my ($out1, $out2, $i) = @_;
+$code.=<<___;
+#ifdef __AARCH64EB__
+    rev64 v28.16b, v$i.16b
+    st1 {v28.d}[0], [$out1], #8
+    st1 {v28.d}[1], [$out2], #8
+#else
+    st1 {v$i.d}[0], [$out1], #8
+    st1 {v$i.d}[1], [$out2], #8
+#endif
+___
+}
+
+## @brief Copy 21 double words from q0..q20 to 2 output streams
+## @param out1 is post incremented by 21 words
+## @param out2 is post incremented by 21 words
+sub shake128_2x_copy_qvectors_to_out_block{
+    my ($out1, $out2) = @_;
+    for($i=0; $i<20; $i+=4) {
+        copy_4x2_qvectors_to_out2($out1, $out2, $i);
+    }
+    copy_1x2_qvectors_to_out2($out1, $out2, 20);
+}
+
+## @brief Copy 17 double words from q0..q16 to 2 output streams
+## @param out1 is post incremented by 17 words
+## @param out2 is post incremented by 17 words
+sub shake256_2x_copy_qvectors_to_out_block{
+    my ($out1, $out2) = @_;
+    for($i=0; $i<16; $i+=4) {
+        copy_4x2_qvectors_to_out2($out1, $out2, $i);
+    }
+    copy_1x2_qvectors_to_out2($out1, $out2, 16);
+}
+
+{
+# These functions are intended for a one shot absorb and squeeze of a single block
+
+## @param $inp 16 byte aligned interleaved message (21 double words)
+## @param $state_out Output state of 5x5 double words.
+## @param $out1 Output Stream1 of 168 bytes (Must be Aligned to an 8 byte boundary)
+## @param $out2 Output Stream2 of 168 bytes (Must be Aligned to an 8 byte boundary)
+my ($state_out,$inp,$out1,$out2) = map("x$_",(0..3));
+function_start('ossl_shake128_2x_oneshot_singleblock_absorb_interleaved_squeeze', 1);
+    shake128_2x_copy_input_block_to_qvectors($inp);
+$code.=<<___;
+    bl  KeccakF1600_ce
+___
+    shake128_2x_copy_qvectors_to_out_block($out1, $out2);
+    save_qvectors_to_aligned16_state($state_out);
+function_end('ossl_shake128_2x_oneshot_singleblock_absorb_interleaved_squeeze');
+
+## @param $inp 16 byte aligned interleaved message (17 double words)
+## @param $state_out Output state of 5x5 double words.
+## @param $out1 Output Stream1 of 136 bytes (Must be Aligned to an 8 byte boundary)
+## @param $out2 Output Stream2 of 136 bytes (Must be Aligned to an 8 byte boundary)
+my ($state_out,$inp,$out1,$out2) = map("x$_",(0..3));
+function_start('ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_squeeze', 1);
+    shake256_2x_copy_input_block_to_qvectors($inp);
+$code.=<<___;
+    bl  KeccakF1600_ce
+___
+    shake256_2x_copy_qvectors_to_out_block($out1, $out2);
+    save_qvectors_to_aligned16_state($state_out);
+function_end('ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_squeeze');
+
+# These functions are intended for multiple squeeze(s) of a single block
+# May be called multiple times after ossl_shake???_2x_oneshot_singleblock_absorb_interleaved_squeeze
+
+## @brief A 2 way SHAKE128 squeeze of a single block
+## @param $state The Input/Output state of 5x5 double words
+## @param $out1 Output Stream1 of 168 bytes (Must be Aligned to an 8 byte boundary)
+## @param $out2 Output Stream2 of 168 bytes (Must be Aligned to an 8 byte boundary)
+my ($state,$out1,$out2) = map("x$_",(0..2));
+function_start('ossl_shake128_2x_squeeze_singleblock', 1);
+    load_qvectors_from_aligned16_state($state);
+$code.=<<___;
+    bl  KeccakF1600_ce
+___
+    shake128_2x_copy_qvectors_to_out_block($out1, $out2);
+    save_qvectors_to_aligned16_state($state);
+function_end('ossl_shake128_2x_squeeze_singleblock');
+
+## @brief A 2 way SHAKE256 squeeze of a single block
+## @param $state The Input/Output state of 5x5 double words
+## @param $out1 Output Stream1 of 136 bytes (Must be Aligned to an 8 byte boundary)
+## @param $out2 Output Stream2 of 136 bytes (Must be Aligned to an 8 byte boundary)
+my ($state,$out1,$out2) = map("x$_",(0..2));
+function_start('ossl_shake256_2x_squeeze_singleblock', 1);
+    load_qvectors_from_aligned16_state($state);
+$code.=<<___;
+    bl  KeccakF1600_ce
+___
+    shake256_2x_copy_qvectors_to_out_block($out1, $out2);
+    save_qvectors_to_aligned16_state($state);
+function_end('ossl_shake256_2x_squeeze_singleblock');
+
+## @brief A 2 way SHAKE256 one shot function that does not use external state.
+##        it absorbs a single block, and assumes that 1 or more blocks will be squeezed at once
+## @param $inp 16 byte aligned interleaved message (17 double words)
+## @param $out1 Output Stream1 of outlen bytes (Must be Aligned to an 8 byte boundary)
+## @param $out2 Output Stream2 of outlen bytes (Must be Aligned to an 8 byte boundary)
+## @param $outlen Must be a non zero multiple of the rate (136)
+my ($inp,$out1,$out2,$outlen) = map("x$_",(0..4));
+function_start('ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_squeeze', 1);
+    shake256_2x_copy_input_block_to_qvectors($inp);
+$code.=<<___;
+.Loop_shake256_2x_squeeze:
+    bl  KeccakF1600_ce
+    subs $outlen,$outlen,#$shake256_rate
+___
+    shake256_2x_copy_qvectors_to_out_block($out1, $out2);
+$code.=<<___;
+    b.ne .Loop_shake256_2x_squeeze
+___
+function_end('ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_squeeze');
+}                               }}}
+
+$code.=<<___;
+## @brief To be called on completion if the values stored in the state are secret.
+##        This clears the temporary vectors q0..q7, q16..q31, It does not clear q8..q15 as they
+##        are saved and restored on each call.
+.globl SHA3_secure_vector_clear_armv8
+.type   SHA3_secure_vector_clear_armv8,%function
+.align  5
+SHA3_secure_vector_clear_armv8:
+___
+    zero_4_qvectors(0,1,2,3);
+    zero_4_qvectors(4,5,6,7);
+
+    zero_4_qvectors(16,17,18,19);
+    zero_4_qvectors(20,21,22,23);
+
+    zero_4_qvectors(24,25,26,27);
+    zero_4_qvectors(28,29,30,31);
+$code.=<<___;
+    ret
+.size  SHA3_secure_vector_clear_armv8,.-SHA3_secure_vector_clear_armv8
+___
+
 $code.=<<___;
 .asciz	"Keccak-1600 absorb and squeeze for ARMv8, CRYPTOGAMS by <https://github.com/dot-asm>"
 ___
@@ -874,7 +1262,6 @@ ___
 foreach(split("\n",$code)) {
 
 	s/\`([^\`]*)\`/eval($1)/ge;
-
 	m/\bld1r\b/ and s/\.16b/.2d/g	or
 	s/\b(eor3|rax1|xar|bcax)\s+(v.*)/unsha3($1,$2)/ge;
 

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -70,7 +70,7 @@ IF[{- !$disabled{asm} -}]
   $KECCAK1600ASM_s390x=keccak1600-s390x.S
 
   $KECCAK1600ASM_armv4=keccak1600-armv4.S
-  $KECCAK1600ASM_aarch64=keccak1600-armv8.S
+  $KECCAK1600ASM_aarch64=keccak1600-armv8.S sha3_x2_armv8.c
 
   $KECCAK1600ASM_ppc64=keccak1600-ppc64.s
 

--- a/crypto/sha/sha3_x2_armv8.c
+++ b/crypto/sha/sha3_x2_armv8.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This file is minimal because a generic non interleaved input implementation
+ * that handles multiple partial absorbs and partial squeezes is not required
+ * at this time. To implement this the partial blocks need to be buffered,
+ * The ML_DSA code has been adapted to operate on fully aligned blocks for both
+ * the absorb and squeeze.
+ * (The buffering would be similar to the approach used by the ossl_sha3_ functions).
+ */
+
+#include "arch/arm_arch.h"
+#include "internal/sha3.h"
+#include <openssl/crypto.h>
+#include <string.h>
+#include <openssl/byteorder.h>
+#include "internal/common.h"
+#if defined(__aarch64__) && defined(__AARCH64EL__) && defined(KECCAK1600_ASM) && !defined(OPENSSL_NO_ASM)
+
+int ossl_shakex2_sha3_capable_armv8(void)
+{
+    return (OPENSSL_armcap_P & ARMV8_SHA3);
+}
+
+void ossl_shakex2_cleanup_armv8(KECCAK1600_X2_ARMV8_CTX *ctx)
+{
+    OPENSSL_cleanse(ctx->A, sizeof(ctx->A));
+}
+
+#endif /* KECCAK1600_ASM && x86_64 && !OPENSSL_NO_ASM */

--- a/include/internal/sha3.h
+++ b/include/internal/sha3.h
@@ -14,6 +14,7 @@
 
 #include <openssl/e_os2.h>
 #include <stddef.h>
+#include "internal/common.h"
 
 #define KECCAK1600_WIDTH 1600
 #define SHA3_MDSIZE(bitlen) (bitlen / 8)
@@ -78,7 +79,7 @@ typedef struct {
     /* 4 interleaved Keccak states (800 bytes)
        plus 8 bytes to store the number of
        already absorbed or not yet squeezed bytes */
-    uint64_t A[(25 * 4) + 1];
+    ALIGN16 uint64_t A[(25 * 4) + 1];
     size_t rate; /* Rate in bytes: 168 (SHAKE-128) or 136 (SHAKE-256) */
     unsigned finalized; /* Has finalize been called? 0=no, 1=yes */
 } KECCAK1600_X4_AVX512VL_CTX;
@@ -135,5 +136,24 @@ void ossl_sha3_shake256_x4_avx512vl(
     size_t inlen);
 
 #endif /* KECCAK1600_ASM && x86_64 && !OPENSSL_NO_ASM */
+
+/* Multi-buffer (x2) Keccak-f[1600] context and API */
+#if defined(__aarch64__) && defined(KECCAK1600_ASM) && !defined(OPENSSL_NO_ASM)
+/*
+ * Context for 2-way parallel SHAKE operations.
+ * It only performs operations on a single interleaved
+ * absorb block and multiple squeeze blocks. Because it
+ * only handles full sized blocks, there is no need to
+ * handle partial blocks currently. The caller is responsible
+ * for handling interleaving and partial blocks.
+ */
+typedef struct {
+    ALIGN16 uint64_t A[25 * 2]; /* 2 interleaved Keccak states (400 bytes) */
+} KECCAK1600_X2_ARMV8_CTX;
+
+int ossl_shakex2_sha3_capable_armv8(void);
+void ossl_shakex2_cleanup_armv8(KECCAK1600_X2_ARMV8_CTX *ctx);
+
+#endif /* aarch64 && KECCAK1600_ASM && !OPENSSL_NO_ASM) */
 
 #endif /* OSSL_INTERNAL_SHA3_H */

--- a/test/build.info
+++ b/test/build.info
@@ -314,7 +314,7 @@ IF[{- !$disabled{tests} -}]
     INCLUDE[slh_dsa_test]=../include ../apps/include
     DEPEND[slh_dsa_test]=../libcrypto libtestutil.a
   ENDIF
-  
+
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=igetest bftest casttest
 
@@ -938,6 +938,7 @@ IF[{- !$disabled{tests} -}]
     ENDIF
 
     PROGRAMS{noinst}=sha3_x4_internal_test
+    PROGRAMS{noinst}=sha3_x2_internal_test
 
     SOURCE[poly1305_internal_test]=poly1305_internal_test.c
     INCLUDE[poly1305_internal_test]=.. ../include ../apps/include
@@ -950,6 +951,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[sha3_x4_internal_test]=sha3_x4_internal_test.c
     INCLUDE[sha3_x4_internal_test]=.. ../include ../apps/include
     DEPEND[sha3_x4_internal_test]=../libcrypto.a libtestutil.a
+
+    SOURCE[sha3_x2_internal_test]=sha3_x2_internal_test.c
+    INCLUDE[sha3_x2_internal_test]=.. ../include ../apps/include
+    DEPEND[sha3_x2_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[asn1_internal_test]=asn1_internal_test.c
     INCLUDE[asn1_internal_test]=.. ../include ../apps/include

--- a/test/sha3_x2_internal_test.c
+++ b/test/sha3_x2_internal_test.c
@@ -8,6 +8,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "testutil.h"
+
 #if defined(__aarch64__) && defined(__AARCH64EL__) && !defined(OPENSSL_NO_ASM)
 #ifndef KECCAK1600_ASM
 #define KECCAK1600_ASM
@@ -15,7 +17,6 @@
 #include <string.h>
 #include <openssl/byteorder.h>
 #include <openssl/rand.h>
-#include "testutil.h"
 #include "internal/sha3.h"
 
 #define SHAKE256_RATE SHA3_BLOCKSIZE(256)

--- a/test/sha3_x2_internal_test.c
+++ b/test/sha3_x2_internal_test.c
@@ -19,11 +19,11 @@
 #include "internal/sha3.h"
 
 #define SHAKE256_RATE SHA3_BLOCKSIZE(256)
-#define SHAKE256_WORDS (SHAKE256_RATE*8/64)
-#define SHAKE256_BUFFER_SZ 5*SHAKE256_RATE
+#define SHAKE256_WORDS (SHAKE256_RATE * 8 / 64)
+#define SHAKE256_BUFFER_SZ 5 * SHAKE256_RATE
 #define SHAKE128_RATE SHA3_BLOCKSIZE(128)
-#define SHAKE128_WORDS (SHAKE128_RATE*8/64)
-#define SHAKE128_BUFFER_SZ 5*SHAKE128_RATE
+#define SHAKE128_WORDS (SHAKE128_RATE * 8 / 64)
+#define SHAKE128_BUFFER_SZ 5 * SHAKE128_RATE
 
 extern void ossl_shake128_2x_oneshot_singleblock_absorb_interleaved_squeeze(uint64_t *statex2_out, const uint64_t *in_interleaved, uint8_t *out1, uint8_t *out2);
 extern void ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_squeeze(uint64_t *statex2_out, const uint64_t *in_interleaved, uint8_t *out1, uint8_t *out2);
@@ -33,7 +33,7 @@ extern void ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_
 extern void SHA3_secure_vector_clear_armv8(void);
 
 static int do_single_shake(const uint8_t *in1, const uint8_t *in2, size_t inlen,
-                           uint8_t *out1, uint8_t *out2, size_t outlen)
+    uint8_t *out1, uint8_t *out2, size_t outlen)
 {
     int ret = 0;
     EVP_MD *md = NULL;
@@ -68,14 +68,14 @@ err:
  */
 static void do_interleave(size_t rate, const uint8_t *in1, const uint8_t *in2, size_t inlen, uint64_t *out)
 {
-    size_t last_word, shft;
+    size_t last_word, shift;
     uint64_t val1, val2;
 
-    memset(out, 0, 2*rate);
+    memset(out, 0, 2 * rate);
     last_word = (rate / 8) - 1;
     /* write trailing 0x80 interleaved bytes for SHA3 padding */
-    out[2*last_word] = (uint64_t)0x80<<56;
-    out[2*last_word+1] = (uint64_t)0x80<<56;
+    out[2 * last_word] = (uint64_t)0x80 << 56;
+    out[2 * last_word + 1] = (uint64_t)0x80 << 56;
 
     while (inlen >= 8) {
         in1 = OPENSSL_load_u64_le(&val1, in1);
@@ -86,19 +86,19 @@ static void do_interleave(size_t rate, const uint8_t *in1, const uint8_t *in2, s
     }
     val1 = 0;
     val2 = 0;
-    for (shft = 0; inlen > 0; shft += 8, inlen--) {
-        val1 |= (*in1++)<<shft;
-        val2 |= (*in2++)<<shft;
+    for (shift = 0; inlen > 0; shift += 8, inlen--) {
+        val1 |= (*in1++) << shift;
+        val2 |= (*in2++) << shift;
     }
     /* Write 0x1f padding after the input data */
-    *out++ = val1 | (0x1f<<shft);
-    *out++ = val2 | (0x1f<<shft);
+    *out++ = val1 | (0x1f << shift);
+    *out++ = val2 | (0x1f << shift);
 }
 
 static int do_shake_single_absorb_multiblock_squeeze(size_t rate, size_t outlen)
 {
     KECCAK1600_X2_ARMV8_CTX ctx;
-    ALIGN16 uint64_t inx2[2*SHAKE128_WORDS];
+    ALIGN16 uint64_t inx2[2 * SHAKE128_WORDS];
     uint8_t out1[SHAKE128_BUFFER_SZ], out2[SHAKE128_BUFFER_SZ];
     uint8_t in1[34];
     uint8_t in2[34];
@@ -142,13 +142,13 @@ static int test_shake256_single_absorb_multiblock_squeeze(void)
 /* Test the one shot can squeeze multiple blocks */
 static int test_shake256_stateless_multiblock_squeeze_once(int tstid)
 {
-    ALIGN16 uint64_t inx2[2*SHAKE256_WORDS];
+    ALIGN16 uint64_t inx2[2 * SHAKE256_WORDS];
     uint8_t out1[SHAKE256_BUFFER_SZ], out2[SHAKE256_BUFFER_SZ];
     uint8_t expected_out1[SHAKE256_BUFFER_SZ], expected_out2[SHAKE256_BUFFER_SZ];
     uint8_t in1[2] = { 0x01, 0x02 };
     uint8_t in2[2] = { 0x11, 0x12 };
     size_t inlen = sizeof(in1);
-    size_t outlen = SHAKE256_RATE * (tstid+1);
+    size_t outlen = SHAKE256_RATE * (tstid + 1);
     int ret = 0;
 
     if (!do_single_shake(in1, in2, inlen, expected_out1, expected_out2, outlen))
@@ -166,7 +166,7 @@ err:
 /* Test the one shot absorb with different inputs */
 static int test_shake256_stateless_absorb_multiblock_squeeze_once(void)
 {
-    ALIGN16 uint64_t inx2[2*SHAKE256_WORDS];
+    ALIGN16 uint64_t inx2[2 * SHAKE256_WORDS];
     uint8_t out1[SHAKE256_BUFFER_SZ], out2[SHAKE256_BUFFER_SZ];
     uint8_t in1[66];
     uint8_t in2[66];

--- a/test/sha3_x2_internal_test.c
+++ b/test/sha3_x2_internal_test.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright (c) 2026 Intel Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#if defined(__aarch64__) && defined(__AARCH64EL__) && !defined(OPENSSL_NO_ASM)
+#ifndef KECCAK1600_ASM
+#define KECCAK1600_ASM
+#endif
+#include <string.h>
+#include <openssl/byteorder.h>
+#include <openssl/rand.h>
+#include "testutil.h"
+#include "internal/sha3.h"
+
+#define SHAKE256_RATE SHA3_BLOCKSIZE(256)
+#define SHAKE256_WORDS (SHAKE256_RATE*8/64)
+#define SHAKE256_BUFFER_SZ 5*SHAKE256_RATE
+#define SHAKE128_RATE SHA3_BLOCKSIZE(128)
+#define SHAKE128_WORDS (SHAKE128_RATE*8/64)
+#define SHAKE128_BUFFER_SZ 5*SHAKE128_RATE
+
+extern void ossl_shake128_2x_oneshot_singleblock_absorb_interleaved_squeeze(uint64_t *statex2_out, const uint64_t *in_interleaved, uint8_t *out1, uint8_t *out2);
+extern void ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_squeeze(uint64_t *statex2_out, const uint64_t *in_interleaved, uint8_t *out1, uint8_t *out2);
+extern void ossl_shake128_2x_squeeze_singleblock(uint64_t *statex2, uint8_t *out1, uint8_t *out2);
+extern void ossl_shake256_2x_squeeze_singleblock(uint64_t *statex2, uint8_t *out1, uint8_t *out2);
+extern void ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_squeeze(const uint64_t *in_interleaved, uint8_t *out1, uint8_t *out2, size_t outlen);
+extern void SHA3_secure_vector_clear_armv8(void);
+
+static int do_single_shake(const uint8_t *in1, const uint8_t *in2, size_t inlen,
+                           uint8_t *out1, uint8_t *out2, size_t outlen)
+{
+    int ret = 0;
+    EVP_MD *md = NULL;
+    EVP_MD_CTX *ctx = NULL;
+
+    if (!TEST_ptr(md = EVP_MD_fetch(NULL, "SHAKE256", NULL))
+        || !TEST_ptr(ctx = EVP_MD_CTX_new())
+        || !TEST_int_eq(EVP_DigestInit(ctx, md), 1)
+        || !TEST_int_eq(EVP_DigestUpdate(ctx, in1, inlen), 1)
+        || !TEST_int_eq(EVP_DigestFinalXOF(ctx, out1, outlen), 1)
+        || !TEST_int_eq(EVP_DigestInit(ctx, md), 1)
+        || !TEST_int_eq(EVP_DigestUpdate(ctx, in2, inlen), 1)
+        || !TEST_int_eq(EVP_DigestFinalXOF(ctx, out2, outlen), 1))
+        goto err;
+    ret = 1;
+err:
+    EVP_MD_free(md);
+    EVP_MD_CTX_free(ctx);
+    return ret;
+}
+
+/*
+ * Setup a single block of interleaved data for a 2 way absorb.
+ * It adds the padding data 0x1f, zeros, and a trailing 1 bit.
+ * This has the repeated format of 64 bits for stream 1, followed by
+ * 64 bits for stream 2.
+ * @param rate 136 for SHAKE256, 168 for SHAKE128
+ * @param in1 Byte stream 1.
+ * @param in2 Byte stream 2.
+ * @param The size of in1 and in2, it must be less than the rate.
+ * @param out Output 64 bit interleaved data of size (2 * rate / 8)
+ */
+static void do_interleave(size_t rate, const uint8_t *in1, const uint8_t *in2, size_t inlen, uint64_t *out)
+{
+    size_t last_word, shft;
+    uint64_t val1, val2;
+
+    memset(out, 0, 2*rate);
+    last_word = (rate / 8) - 1;
+    /* write trailing 0x80 interleaved bytes for SHA3 padding */
+    out[2*last_word] = (uint64_t)0x80<<56;
+    out[2*last_word+1] = (uint64_t)0x80<<56;
+
+    while (inlen >= 8) {
+        in1 = OPENSSL_load_u64_le(&val1, in1);
+        in2 = OPENSSL_load_u64_le(&val2, in2);
+        *out++ = val1;
+        *out++ = val2;
+        inlen -= 8;
+    }
+    val1 = 0;
+    val2 = 0;
+    for (shft = 0; inlen > 0; shft += 8, inlen--) {
+        val1 |= (*in1++)<<shft;
+        val2 |= (*in2++)<<shft;
+    }
+    /* Write 0x1f padding after the input data */
+    *out++ = val1 | (0x1f<<shft);
+    *out++ = val2 | (0x1f<<shft);
+}
+
+static int do_shake_single_absorb_multiblock_squeeze(size_t rate, size_t outlen)
+{
+    KECCAK1600_X2_ARMV8_CTX ctx;
+    ALIGN16 uint64_t inx2[2*SHAKE128_WORDS];
+    uint8_t out1[SHAKE128_BUFFER_SZ], out2[SHAKE128_BUFFER_SZ];
+    uint8_t in1[34];
+    uint8_t in2[34];
+    uint8_t expected_out1[SHAKE128_BUFFER_SZ], expected_out2[SHAKE128_BUFFER_SZ];
+    uint8_t *o1 = out1, *o2 = out2;
+    size_t inlen = sizeof(in1);
+    int ret = 0;
+
+    RAND_bytes(in1, sizeof(in1));
+    RAND_bytes(in2, sizeof(in2));
+    if (!do_single_shake(in1, in2, inlen, expected_out1, expected_out2, outlen))
+        goto err;
+    do_interleave(rate, in1, in2, inlen, inx2);
+    ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_squeeze(ctx.A, inx2, o1, o2);
+    outlen -= rate;
+    while (outlen > 0) {
+        o1 += rate;
+        o2 += rate;
+        ossl_shake256_2x_squeeze_singleblock(ctx.A, o1, o2);
+        outlen -= rate;
+    }
+    if (!TEST_mem_eq(out1, outlen, expected_out1, outlen)
+        || !TEST_mem_eq(out2, outlen, expected_out2, outlen))
+        goto err;
+    ret = 1;
+err:
+    SHA3_secure_vector_clear_armv8();
+    return ret;
+}
+
+static int test_shake128_single_absorb_multiblock_squeeze(void)
+{
+    return do_shake_single_absorb_multiblock_squeeze(SHAKE128_RATE, SHAKE128_BUFFER_SZ);
+}
+
+static int test_shake256_single_absorb_multiblock_squeeze(void)
+{
+    return do_shake_single_absorb_multiblock_squeeze(SHAKE256_RATE, SHAKE256_BUFFER_SZ);
+}
+
+/* Test the one shot can squeeze multiple blocks */
+static int test_shake256_stateless_multiblock_squeeze_once(int tstid)
+{
+    ALIGN16 uint64_t inx2[2*SHAKE256_WORDS];
+    uint8_t out1[SHAKE256_BUFFER_SZ], out2[SHAKE256_BUFFER_SZ];
+    uint8_t expected_out1[SHAKE256_BUFFER_SZ], expected_out2[SHAKE256_BUFFER_SZ];
+    uint8_t in1[2] = { 0x01, 0x02 };
+    uint8_t in2[2] = { 0x11, 0x12 };
+    size_t inlen = sizeof(in1);
+    size_t outlen = SHAKE256_RATE * (tstid+1);
+    int ret = 0;
+
+    if (!do_single_shake(in1, in2, inlen, expected_out1, expected_out2, outlen))
+        goto err;
+    do_interleave(SHAKE256_RATE, in1, in2, inlen, inx2);
+    ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_squeeze(inx2, out1, out2, outlen);
+    if (!TEST_mem_eq(out1, outlen, expected_out1, outlen)
+        || !TEST_mem_eq(out2, outlen, expected_out2, outlen))
+        goto err;
+    ret = 1;
+err:
+    return ret;
+}
+
+/* Test the one shot absorb with different inputs */
+static int test_shake256_stateless_absorb_multiblock_squeeze_once(void)
+{
+    ALIGN16 uint64_t inx2[2*SHAKE256_WORDS];
+    uint8_t out1[SHAKE256_BUFFER_SZ], out2[SHAKE256_BUFFER_SZ];
+    uint8_t in1[66];
+    uint8_t in2[66];
+    size_t inlen = sizeof(in1);
+    uint8_t expected_out1[SHAKE256_BUFFER_SZ], expected_out2[SHAKE256_BUFFER_SZ];
+    size_t outlen = 3 * SHAKE256_RATE;
+    int ret = 0;
+
+    RAND_bytes(in1, sizeof(in1));
+    RAND_bytes(in2, sizeof(in2));
+    if (!do_single_shake(in1, in2, inlen, expected_out1, expected_out2, outlen))
+        goto err;
+    do_interleave(SHAKE256_RATE, in1, in2, inlen, inx2);
+    ossl_shake256_2x_oneshot_singleblock_absorb_interleaved_multi_block_squeeze(inx2, out1, out2, outlen);
+    if (!TEST_mem_eq(out1, outlen, expected_out1, outlen)
+        || !TEST_mem_eq(out2, outlen, expected_out2, outlen))
+        goto err;
+    ret = 1;
+err:
+    return ret;
+}
+
+#endif /* KECCAK1600_ASM && aarch64 && !OPENSSL_NO_ASM */
+
+/* Test entry point */
+
+int setup_tests(void)
+{
+#ifdef OPENSSL_CPUID_OBJ
+    OPENSSL_cpuid_setup();
+#endif
+
+#if !defined(KECCAK1600_ASM) || !defined(__aarch64__) || defined(OPENSSL_NO_ASM)
+    return TEST_skip("SHAKE x2 AARCH64 API not available in this build");
+#else
+    if (!ossl_shakex2_sha3_capable_armv8())
+        return TEST_skip("ARM SHA3_FEAT not available; skipping SHAKE x2 tests");
+    ADD_TEST(test_shake128_single_absorb_multiblock_squeeze);
+    ADD_TEST(test_shake256_single_absorb_multiblock_squeeze);
+    ADD_TEST(test_shake256_stateless_absorb_multiblock_squeeze_once);
+    ADD_ALL_TESTS(test_shake256_stateless_multiblock_squeeze_once, 4);
+#endif
+
+    return 1;
+}


### PR DESCRIPTION
An underlying Keccack_ce function already existed that does 2 parallel shake operations. This uses 2 interleaved words (2 by 64 bits) for each of stream 1 and stream 2. The keccak state matrix is stored into vectors q0..q24 which are 128 bits each. The existing code that called this function only set the lower 64 bits for stream1. Shake specific assembler that absorbs interleaved data and squeezes parallel blocks has been added. Armv8 specific methods have been added to use the ML_DSA sample_ops method tables. It only supports Little Endian since this is the majority of use cases.
Because the input data for shake operations for ML_DSA is of the form of a 32 or 64 byte seed followed by 2 bytes of index, and only the index changes on many calls, the c code generates the padded interleaved data for the absorb once, and then uses this as the basis of the input.

There is ~20% improvement in keygen, >8% in sign, and ~20% and verify.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
