### PR TITLE
Fix use-after-free in EC_GROUP_get_ecpkparameters()

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -466,11 +466,14 @@ ECPKPARAMETERS *EC_GROUP_get_ecpkparameters(const EC_GROUP *group,
             return NULL;
         }
     } else {
-        if (ret->type == ECPKPARAMETERS_TYPE_NAMED)
+        if (ret->type == ECPKPARAMETERS_TYPE_NAMED) {
             ASN1_OBJECT_free(ret->value.named_curve);
-        else if (ret->type == ECPKPARAMETERS_TYPE_EXPLICIT
-            && ret->value.parameters != NULL)
+            ret->value.named_curve = NULL;
+        } else if (ret->type == ECPKPARAMETERS_TYPE_EXPLICIT
+            && ret->value.parameters != NULL) {
             ECPARAMETERS_free(ret->value.parameters);
+            ret->value.parameters = NULL;
+        }
     }
 
     if (EC_GROUP_get_asn1_flag(group) == OPENSSL_EC_NAMED_CURVE) {

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -129,6 +129,11 @@ specified I<params> and
 EC_GROUP_new_from_ecpkparameters() will create a group from the specific PK
 I<params>.
 
+EC_GROUP_get_ecpkparameters() creates an ECPKPARAMETERS object for the given
+I<group>.  If I<params> is NULL a new object is allocated, otherwise
+I<params> is filled in and returned.  Please note that I<params> is freed on
+failure and must not be used or freed by the caller in such case.
+
 EC_GROUP_set_curve() sets the curve parameters I<p>, I<a> and I<b>. For a curve
 over Fp I<p> is the prime for the field. For a curve over F2^m I<p> represents
 the irreducible polynomial - each bit represents a term in the polynomial.

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -462,7 +462,9 @@ static int ecpkparams_reuse_error_test(void)
     if (!TEST_ptr_null(EC_GROUP_get_ecpkparameters(grp, params)))
         goto err;
     params = NULL;
-
+    params = EC_GROUP_get_ecpkparameters(grp, params);
+    if (!TEST_ptr_null(params))
+        goto err;
     testresult = 1;
 
 err:

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -436,6 +436,42 @@ err:
     return testresult;
 }
 
+/*
+ * Test that reusing an ECPKPARAMETERS object for a call that fails does not
+ * touch the CHOICE member that was released on entry.
+ */
+static int ecpkparams_reuse_error_test(void)
+{
+    EC_GROUP *grp = NULL;
+    ECPKPARAMETERS *params = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(grp = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1)))
+        goto err;
+
+    /* Populate the explicit parameters arm of the CHOICE. */
+    EC_GROUP_set_asn1_flag(grp, OPENSSL_EC_EXPLICIT_CURVE);
+    if (!TEST_ptr(params = EC_GROUP_get_ecpkparameters(grp, NULL)))
+        goto err;
+
+    /* Take the named curve arm and make the OID lookup fail. */
+    EC_GROUP_set_curve_name(grp, NID_undef);
+    EC_GROUP_set_asn1_flag(grp, OPENSSL_EC_NAMED_CURVE);
+
+    /* On failure the passed in object is consumed, so do not free it again. */
+    if (!TEST_ptr_null(EC_GROUP_get_ecpkparameters(grp, params)))
+        goto err;
+    params = NULL;
+
+    testresult = 1;
+
+err:
+    ECPKPARAMETERS_free(params);
+    EC_GROUP_free(grp);
+
+    return testresult;
+}
+
 static int ecpkparams_i2d2i_test(int n)
 {
     EC_GROUP *g1 = NULL, *g2 = NULL;
@@ -556,6 +592,7 @@ int setup_tests(void)
 #endif
     ADD_TEST(set_private_key);
     ADD_TEST(decoded_flag_test);
+    ADD_TEST(ecpkparams_reuse_error_test);
     ADD_ALL_TESTS(ecpkparams_i2d2i_test, (int)crv_len);
     ADD_TEST(named_group_creation_test);
 

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -454,7 +454,7 @@ static int ecpkparams_reuse_error_test(void)
     if (!TEST_ptr(params = EC_GROUP_get_ecpkparameters(grp, NULL)))
         goto err;
 
-    /* Take the named curve arm and make the OID lookup fail. */
+    /* Take the named curve arm and make it fail on the undefined NID. */
     EC_GROUP_set_curve_name(grp, NID_undef);
     EC_GROUP_set_asn1_flag(grp, OPENSSL_EC_NAMED_CURVE);
 

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -459,9 +459,6 @@ static int ecpkparams_reuse_error_test(void)
     EC_GROUP_set_asn1_flag(grp, OPENSSL_EC_NAMED_CURVE);
 
     /* On failure the passed in object is consumed, so do not free it again. */
-    if (!TEST_ptr_null(EC_GROUP_get_ecpkparameters(grp, params)))
-        goto err;
-    params = NULL;
     params = EC_GROUP_get_ecpkparameters(grp, params);
     if (!TEST_ptr_null(params))
         goto err;


### PR DESCRIPTION
`EC_GROUP_get_ecpkparameters()` accepts an optional caller-provided `ECPKPARAMETERS` object. When one is passed in, the function releases the CHOICE member the object already holds:

```c
if (ret->type == ECPKPARAMETERS_TYPE_NAMED)
    ASN1_OBJECT_free(ret->value.named_curve);
else if (ret->type == ECPKPARAMETERS_TYPE_EXPLICIT
    && ret->value.parameters != NULL)
    ECPARAMETERS_free(ret->value.parameters);
```

The union pointer is left dangling and the CHOICE selector still points at it. If a later step fails, the error exit runs `ECPKPARAMETERS_free(ret)`, which follows the still valid selector and frees the already released member a second time.

Reachable error paths that leave the object in this state are the two failure cases of the named-curve branch: an unknown curve NID, and an OID lookup that yields a NULL or zero-length object.

This PR clears each pointer once it has been released, so the error exit has nothing left to free.

### Reproducer

```c
EC_GROUP *grp = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
ECPKPARAMETERS *params;

/* Populate the explicit parameters arm of the CHOICE. */
EC_GROUP_set_asn1_flag(grp, OPENSSL_EC_EXPLICIT_CURVE);
params = EC_GROUP_get_ecpkparameters(grp, NULL);

/* Take the named curve arm and make the OID lookup fail. */
EC_GROUP_set_curve_name(grp, NID_undef);
EC_GROUP_set_asn1_flag(grp, OPENSSL_EC_NAMED_CURVE);

EC_GROUP_get_ecpkparameters(grp, params);   /* heap-use-after-free */
```

Built with `./Configure -d enable-asan enable-ubsan` (gcc 11.4.0, Ubuntu 22.04):

```
==2835456==ERROR: AddressSanitizer: heap-use-after-free on address 0x5040000146b8
READ of size 8 at 0x5040000146b8 thread T0
    #0 ossl_asn1_primitive_free crypto/asn1/tasn_fre.c:183
    #1 ossl_asn1_item_embed_free crypto/asn1/tasn_fre.c:51
    #2 ossl_asn1_template_free crypto/asn1/tasn_fre.c:146
    #3 ossl_asn1_item_embed_free crypto/asn1/tasn_fre.c:114
    #4 ossl_asn1_template_free crypto/asn1/tasn_fre.c:146
    #5 ossl_asn1_item_embed_free crypto/asn1/tasn_fre.c:70
    #6 ASN1_item_free crypto/asn1/tasn_fre.c:20
    #7 ECPKPARAMETERS_free crypto/ec/ec_asn1.c:157
    #8 EC_GROUP_get_ecpkparameters crypto/ec/ec_asn1.c:503

freed by thread T0 here:
    #1 CRYPTO_free crypto/mem.c:331
    #2 ossl_asn1_item_embed_free crypto/asn1/tasn_fre.c:119
    #3 ASN1_item_free crypto/asn1/tasn_fre.c:20
    #4 ECPARAMETERS_free crypto/ec/ec_asn1.c:147
    #5 EC_GROUP_get_ecpkparameters crypto/ec/ec_asn1.c:473
```

### Test

`ecpkparams_reuse_error_test` in `test/ec_internal_test.c` reproduces the sequence above. Note that it only fails on a sanitizer build: `struct ecpk_parameters_st` is private to `ec_asn1.c`, so the test cannot inspect the selector or the union directly and has to rely on ASan to observe the second free. Verified to fail before the change and pass after it.

### Scope

This does not change the fact that a caller-supplied object is freed on error, which is a separate and surprising part of the contract (the sibling `EC_GROUP_get_ecparameters()` only frees the object it allocated itself). That behaviour is left as is here.

### Reporting

This was reported to openssl-security@openssl.org on 2026-07-28. The security team assessed that there is no realistic way for an attacker to trigger it and asked for it to be handled as a regular bug fix pull request.

### AI assistance

The regression test and this pull request description were written with AI assistance, declared via the `Assisted-by` trailer on the commit.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
