### PR TITLE
Reject degenerate SRP parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,13 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Reject degenerate SRP parameters.
+   The modulus `N` must be at least 1024 bits.
+   The generator `g` must satisfy `1 < g < N - 1`.
+   The verifier `v` must satisfy `1 < v < N`.
+
+   *Viktor Dukhovni*
+
  * Added `CMS_add_standard_smimecap_ex()`, which populates an SMIMECapabilities
    list using `EVP_CIPHER_fetch()` and `EVP_MD_fetch()` so that only algorithms
    available in the active providers are advertised.  `PKCS7_sign_add_signer()`

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -28,6 +28,8 @@
 #define SRP_RANDOM_SALT_LEN 20
 #define MAX_LEN 2500
 
+static void SRP_gN_cache_free(SRP_gN_cache *gN_cache);
+
 /*
  * Note that SRP uses its own variant of base 64 encoding. A different base64
  * alphabet is used and no padding '=' characters are added. Instead we pad to
@@ -303,7 +305,7 @@ void SRP_VBASE_free(SRP_VBASE *vb)
     if (!vb)
         return;
     sk_SRP_user_pwd_pop_free(vb->users_pwd, SRP_user_pwd_free);
-    sk_SRP_gN_cache_free(vb->gN_cache);
+    sk_SRP_gN_cache_pop_free(vb->gN_cache, SRP_gN_cache_free);
     OPENSSL_free(vb->seed_key);
     OPENSSL_free(vb);
 }
@@ -333,7 +335,7 @@ err:
     return NULL;
 }
 
-static void SRP_gN_free(SRP_gN_cache *gN_cache)
+static void SRP_gN_cache_free(SRP_gN_cache *gN_cache)
 {
     if (gN_cache == NULL)
         return;
@@ -375,10 +377,18 @@ static BIGNUM *SRP_gN_place_bn(STACK_OF(SRP_gN_cache) *gN_cache, char *ch)
         if (newgN) {
             if (sk_SRP_gN_cache_insert(gN_cache, newgN, 0) > 0)
                 return newgN->bn;
-            SRP_gN_free(newgN);
+            SRP_gN_cache_free(newgN);
         }
     }
     return NULL;
+}
+
+static void SRP_gN_free(SRP_gN *gN)
+{
+    if (gN == NULL)
+        return;
+    OPENSSL_free(gN->id);
+    OPENSSL_free(gN);
 }
 
 /*
@@ -435,7 +445,7 @@ int SRP_VBASE_init(SRP_VBASE *vb, char *verifier_file)
              * we add this couple in the internal Stack
              */
 
-            if ((gN = OPENSSL_malloc(sizeof(*gN))) == NULL)
+            if ((gN = OPENSSL_zalloc(sizeof(*gN))) == NULL)
                 goto err;
 
             if ((gN->id = OPENSSL_strdup(pp[DB_srpid])) == NULL
@@ -494,17 +504,12 @@ err:
      * terminates most likely
      */
 
-    if (gN != NULL) {
-        OPENSSL_free(gN->id);
-        OPENSSL_free(gN);
-    }
-
+    SRP_gN_free(gN);
+    sk_SRP_gN_pop_free(SRP_gN_tab, SRP_gN_free);
     SRP_user_pwd_free(user_pwd);
 
     TXT_DB_free(tmpdb);
     BIO_free_all(in);
-
-    sk_SRP_gN_free(SRP_gN_tab);
 
     return error_code;
 }

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -203,6 +203,48 @@ SRP_user_pwd *SRP_user_pwd_new(void)
     return ret;
 }
 
+/*
+ * Sanity-check (N, g) for SRP: 1 < g < N - 1, with N at least 1024 bits.
+ * Cheaper than SRP_check_known_gN_param() and does not enforce RFC 5054
+ * group membership, so legitimate custom groups still load; this is the
+ * minimum needed to keep BN_mod_exp() from being handed degenerate input.
+ *
+ * Returns 0 if (N, g) pass, else the ERR_R_ reason code describing the
+ * failure.  Invalid values are also reported on the error stack; a memory
+ * failure is already raised by the allocator.
+ */
+static int srp_check_Ng(const BIGNUM *N, const BIGNUM *g)
+{
+    BIGNUM *Nm1;
+    int ok;
+
+    if (N == NULL || g == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return ERR_R_PASSED_NULL_PARAMETER;
+    }
+    if (BN_num_bits(N) < 1024) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "SRP modulus N must be at least 1024 bits");
+        return ERR_R_PASSED_INVALID_ARGUMENT;
+    }
+    if ((Nm1 = BN_dup(N)) == NULL)
+        return ERR_R_MALLOC_FAILURE;
+    if (!BN_sub_word(Nm1, 1)) {
+        BN_free(Nm1);
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_BN_LIB);
+        return ERR_R_BN_LIB;
+    }
+    ok = BN_cmp(g, BN_value_one()) > 0 /* g >= 2 */
+        && BN_cmp(g, Nm1) < 0; /* g <= N - 2 */
+    BN_free(Nm1);
+    if (!ok) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "SRP generator g must satisfy 1 < g < N - 1");
+        return ERR_R_PASSED_INVALID_ARGUMENT;
+    }
+    return 0;
+}
+
 void SRP_user_pwd_set_gN(SRP_user_pwd *vinfo, const BIGNUM *g,
     const BIGNUM *N)
 {
@@ -236,6 +278,14 @@ static int SRP_user_pwd_set_sv(SRP_user_pwd *vinfo, const char *s,
         return 0;
     if (NULL == (vinfo->v = BN_bin2bn(tmp, len, NULL)))
         return 0;
+    /* 1 < v < N; vinfo->N is set by the preceding SRP_user_pwd_set_gN(). */
+    if (vinfo->N == NULL
+        || BN_cmp(vinfo->v, BN_value_one()) <= 0
+        || BN_cmp(vinfo->v, vinfo->N) >= 0) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "SRP verifier v must satisfy 1 < v < N");
+        goto err;
+    }
     len = t_fromb64(tmp, sizeof(tmp), s);
     if (len < 0)
         goto err;
@@ -406,7 +456,7 @@ int SRP_VBASE_init(SRP_VBASE *vb, char *verifier_file)
     int error_code = SRP_ERR_MEMORY;
     STACK_OF(SRP_gN) *SRP_gN_tab = sk_SRP_gN_new_null();
     char *last_index = NULL;
-    int i;
+    int i, reason;
     char **pp;
 
     SRP_gN *gN = NULL;
@@ -452,8 +502,16 @@ int SRP_VBASE_init(SRP_VBASE *vb, char *verifier_file)
                 || (gN->N = SRP_gN_place_bn(vb->gN_cache, pp[DB_srpverifier]))
                     == NULL
                 || (gN->g = SRP_gN_place_bn(vb->gN_cache, pp[DB_srpsalt]))
-                    == NULL
-                || sk_SRP_gN_insert(SRP_gN_tab, gN, 0) == 0)
+                    == NULL)
+                goto err;
+
+            if ((reason = srp_check_Ng(gN->N, gN->g)) != 0) {
+                if (reason != ERR_R_MALLOC_FAILURE)
+                    error_code = SRP_ERR_VBASE_BN_LIB;
+                goto err;
+            }
+
+            if (sk_SRP_gN_insert(SRP_gN_tab, gN, 0) == 0)
                 goto err;
 
             gN = NULL;
@@ -642,6 +700,8 @@ char *SRP_create_verifier_ex(const char *user, const char *pass, char **salt,
         if (g_bn_alloc == NULL)
             goto err;
         g_bn = g_bn_alloc;
+        if (srp_check_Ng(N_bn, g_bn) != 0)
+            goto err;
         defgNid = "*";
     } else {
         SRP_gN *gN = SRP_get_default_gN(g);

--- a/test/srptest.c
+++ b/test/srptest.c
@@ -16,13 +16,14 @@
 #include <openssl/opensslconf.h>
 #include "testutil.h"
 
-#ifdef OPENSSL_NO_SRP
 #include <stdio.h>
-#else
+
+#ifndef OPENSSL_NO_SRP
 
 #include <openssl/srp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
+#include <openssl/bio.h>
 
 #define RANDOM_SIZE 32 /* use 256 bits on each side */
 
@@ -255,6 +256,162 @@ err:
     return ret;
 }
 
+/*
+ * The RFC 5054 appendix A 1024-bit group in the SRP variant of base64,
+ * matching SRP_get_default_gN("1024"), and its generator g = 2.
+ */
+static const char b64_N_1024[] = "Ewl2hcjiutMd3Fu2lgFnUXWSc67TVyy2vwYCKoS9MLsrdJVT9RgWTCuEqWJrfB6u"
+                                 "E3LsE9GkOlaZabS7M29sj5TnzUqOLJMjiwEzArfiLr9WbMRANlF68N5AVLcPWvNx"
+                                 "6Zjl3m5Scp0BzJBz9TkgfhzKJZ.WtP3Mv/67I/0wmRZ";
+/*
+ * In the SRP base64 alphabet '0'-'9' encode the values 0-9, so these
+ * single-byte generators encode to strings that look like plain digits:
+ * "02" really is the SRP base64 encoding of g = 2.
+ */
+static const char b64_g_two[] = "02";
+
+/* N - 1 for the group above */
+static const char b64_N_1024_minus_1[] = "Ewl2hcjiutMd3Fu2lgFnUXWSc67TVyy2vwYCKoS9MLsrdJVT9RgWTCuEqWJrfB6u"
+                                         "E3LsE9GkOlaZabS7M29sj5TnzUqOLJMjiwEzArfiLr9WbMRANlF68N5AVLcPWvNx"
+                                         "6Zjl3m5Scp0BzJBz9TkgfhzKJZ.WtP3Mv/67I/0wmRY";
+
+/* Degenerate generators */
+static const char b64_g_one[] = "01";
+static const char b64_g_zero[] = "00";
+
+/* A 512-bit prime, below the 1024-bit minimum for N */
+static const char b64_N_512[] = "2LjDzcipQOr7FYsL0CdlJppNaT/zlgxNoExaATKv9X0XRO9HZdcWk77Wcgw5xtLJ"
+                                "WpMjOjEsn6w4FlHc9GEgtd";
+
+/*
+ * Check that SRP_create_verifier_ex() rejects (N, g), and show the error
+ * detail it raised so a curious maintainer can see the right bound failed.
+ */
+static int check_verifier_rejected(const char *label, const char *N,
+    const char *g)
+{
+    int ret;
+    char *salt = NULL, *verifier = NULL;
+
+    TEST_info("SRP_create_verifier_ex, expecting rejection: %s", label);
+    ret = TEST_ptr_null(SRP_create_verifier_ex("alice", "password", &salt,
+        &verifier, N, g, NULL, NULL));
+    TEST_openssl_errors();
+    OPENSSL_free(salt);
+    OPENSSL_free(verifier);
+    return ret;
+}
+
+/* Degenerate (N, g, v) inputs must not make it into a verifier */
+static int run_srp_create_verifier_checks(void)
+{
+    int ret = 0;
+    char *salt = NULL, *verifier = NULL;
+
+    /* A valid custom (N, g) still works */
+    if (!TEST_ptr(SRP_create_verifier_ex("alice", "password", &salt, &verifier,
+            b64_N_1024, b64_g_two, NULL, NULL)))
+        goto end;
+    OPENSSL_free(salt);
+    OPENSSL_free(verifier);
+    salt = NULL;
+    verifier = NULL;
+
+    /* g = 0, g = 1, g = N - 1 and g = N all violate 1 < g < N - 1 */
+    if (!check_verifier_rejected("g = 0", b64_N_1024, b64_g_zero)
+        || !check_verifier_rejected("g = 1", b64_N_1024, b64_g_one)
+        || !check_verifier_rejected("g = N - 1", b64_N_1024,
+            b64_N_1024_minus_1)
+        || !check_verifier_rejected("g = N", b64_N_1024, b64_N_1024)
+        /* N below the 1024-bit minimum */
+        || !check_verifier_rejected("N of 512 bits", b64_N_512, b64_g_two))
+        goto end;
+
+    ret = 1;
+end:
+    OPENSSL_free(salt);
+    OPENSSL_free(verifier);
+    return ret;
+}
+
+/*
+ * Write a one-group verifier file: an I row carrying (N, g) under group id
+ * "C" and, if v is non-NULL, a V row for user "alice" referencing it.
+ */
+static int write_vbase_file(const char *fname, const char *N, const char *g,
+    const char *v, const char *s)
+{
+    BIO *out;
+    int ret = 0;
+
+    if (!TEST_ptr(out = BIO_new_file(fname, "w")))
+        return 0;
+    if (!TEST_int_gt(BIO_printf(out, "I\t%s\t%s\tC\t\t\n", N, g), 0))
+        goto end;
+    if (v != NULL
+        && !TEST_int_gt(BIO_printf(out, "V\t%s\t%s\talice\tC\t\n", v, s), 0))
+        goto end;
+    ret = 1;
+end:
+    BIO_free(out);
+    return ret;
+}
+
+/* Degenerate (N, g, v) rows must not load from a verifier file */
+static int run_srp_vbase_checks(void)
+{
+    int ret = 0;
+    SRP_VBASE *vb = NULL;
+    SRP_user_pwd *user = NULL;
+    char *salt = NULL, *verifier = NULL;
+    char fname[] = "srp-vbase-test.txt";
+    char username[] = "alice";
+
+    /* A valid custom group and verifier round-trip through a file */
+    if (!TEST_ptr(SRP_create_verifier_ex(username, "password", &salt,
+            &verifier, b64_N_1024, b64_g_two, NULL, NULL)))
+        goto end;
+    if (!write_vbase_file(fname, b64_N_1024, b64_g_two, verifier, salt))
+        goto end;
+    if (!TEST_ptr(vb = SRP_VBASE_new(NULL))
+        || !TEST_int_eq(SRP_VBASE_init(vb, fname), SRP_NO_ERROR)
+        || !TEST_ptr(user = SRP_VBASE_get1_by_user(vb, username)))
+        goto end;
+    SRP_user_pwd_free(user);
+    user = NULL;
+    SRP_VBASE_free(vb);
+    vb = NULL;
+
+    /* An I row with g = 1 is rejected */
+    TEST_info("SRP_VBASE_init, expecting rejection: I row with g = 1");
+    if (!write_vbase_file(fname, b64_N_1024, b64_g_one, NULL, NULL))
+        goto end;
+    if (!TEST_ptr(vb = SRP_VBASE_new(NULL))
+        || !TEST_int_eq(SRP_VBASE_init(vb, fname), SRP_ERR_VBASE_BN_LIB))
+        goto end;
+    TEST_openssl_errors();
+    SRP_VBASE_free(vb);
+    vb = NULL;
+
+    /* A V row with v = N (violating 1 < v < N) is rejected */
+    TEST_info("SRP_VBASE_init, expecting rejection: V row with v = N");
+    if (!write_vbase_file(fname, b64_N_1024, b64_g_two, b64_N_1024, salt))
+        goto end;
+    if (!TEST_ptr(vb = SRP_VBASE_new(NULL))
+        || !TEST_int_eq(SRP_VBASE_init(vb, fname), SRP_ERR_VBASE_BN_LIB))
+        goto end;
+    TEST_openssl_errors();
+
+    ret = 1;
+end:
+    SRP_user_pwd_free(user);
+    SRP_VBASE_free(vb);
+    OPENSSL_free(salt);
+    OPENSSL_free(verifier);
+    remove(fname);
+    return ret;
+}
+
 static int run_srp_tests(void)
 {
     /* "Negative" test, expect a mismatch */
@@ -278,6 +435,8 @@ int setup_tests(void)
 #else
     ADD_TEST(run_srp_tests);
     ADD_TEST(run_srp_kat);
+    ADD_TEST(run_srp_create_verifier_checks);
+    ADD_TEST(run_srp_vbase_checks);
 #endif
     return 1;
 }


### PR DESCRIPTION
- N must have at least 1024 bits
- g must satisfy: 1 < g < N - 1
- v must satisfy: 1 < v < N.

The SRP API is deprecated and this is hardening only; no honest caller passes the rejected inputs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
