### PR TITLE
Fix NULL dereference in v2i_AUTHORITY_KEYID()

### DIFF
--- a/crypto/x509/v3_akid.c
+++ b/crypto/x509/v3_akid.c
@@ -184,7 +184,10 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
         i = X509_get_ext_by_NID(issuer_cert, NID_subject_key_identifier, -1);
         if (i >= 0 && (ext = X509_get_ext(issuer_cert, i)) != NULL
             && !(same_issuer && !ss)) {
-            ikeyid = X509V3_EXT_d2i(ext);
+
+            if ((ikeyid = X509V3_EXT_d2i(ext)) == NULL)
+                goto err;
+
             /* Ignore empty keyids in the issuer cert */
             if (ASN1_STRING_length_ex(ikeyid) == 0) {
                 ASN1_OCTET_STRING_free(ikeyid);


### PR DESCRIPTION
X509V3_EXT_d2i() may return NULL on malformed input or on allocation failure. v2i_AUTHORITY_KEYID() passed that NULL to ASN1_STRING_length_ex() causing NULL dereference.

Found by x509v3 fuzzer. Example fuzzer input:
```
[default]
subjectKeyIdentifier = DER:05:00
authorityKeyIdentifier = keyid
```

Fuzzer : https://github.com/openssl/openssl/pull/32143
