### PR TITLE
statem: fix missing SSLfatal in TLSv1.3 ticket construction

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4545,7 +4545,7 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
             SSL_SESSION *new_sess = ssl_session_dup(s->session, 0);
 
             if (new_sess == NULL) {
-                /* SSLfatal already called */
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_SSL_LIB);
                 goto err;
             }
 


### PR DESCRIPTION
tls_construct_new_session_ticket() assumed ssl_session_dup() calls SSLfatal() on failure but it never does, unlike all its other call sites which call SSLfatal() themselves. An allocation failure there made the construct function return CON_FUNC_ERROR without entering the fatal state, tripping the check_fatal assertion in write_state_machine() on debug builds.

The test is in #32184