### PR TITLE
QUIC: allow fully drained streams to be garbage collected

### DIFF
--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -299,7 +299,11 @@ static ossl_unused int qsm_send_part_permits_gc(const QUIC_STREAM *qs)
 
 static int qsm_ready_for_gc(QUIC_STREAM_MAP *qsm, QUIC_STREAM *qs)
 {
-    int recv_stream_fully_drained = 0; /* TODO(QUIC FUTURE): Optimisation */
+    int recv_stream_fully_drained
+        = qs->recv_state == QUIC_RSTREAM_STATE_DATA_RECVD
+        || qs->recv_state == QUIC_RSTREAM_STATE_DATA_READ
+        || qs->recv_state == QUIC_RSTREAM_STATE_RESET_RECVD
+        || qs->recv_state == QUIC_RSTREAM_STATE_RESET_READ;
 
     /*
      * If sstream has no FIN, we auto-reset it at marked-for-deletion time, so


### PR DESCRIPTION
### Description

Allow deleted QUIC streams to become eligible for garbage collection once their receive side is terminal.

`qsm_ready_for_gc()` previously hardcoded the receive-side `recv_stream_fully_drained` condition to false. A normally completed receive stream reaches `QUIC_RSTREAM_STATE_DATA_READ` after the application consumes its data and FIN, but stream deletion does not send `STOP_SENDING` in that state. The stream therefore remained in the map indefinitely because `acked_stop_sending` could never become true.

Treat the terminal receive states as fully drained:

- `QUIC_RSTREAM_STATE_DATA_RECVD`
- `QUIC_RSTREAM_STATE_DATA_READ`
- `QUIC_RSTREAM_STATE_RESET_RECVD`
- `QUIC_RSTREAM_STATE_RESET_READ`

This matches the existing state-machine behavior: once a FIN or RESET has completed the receive obligation, no further `STOP_SENDING` acknowledgement is needed for a deleted stream.

### Testing

Not run locally because this environment has no OpenSSL source checkout/build toolchain. The change is confined to existing QUIC receive-state constants and will be exercised by the repository CI.
