### PR TITLE
fix module extension on non-.so platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,6 +296,8 @@ providers/implementations/rands/test_rng.inc
 /test-runs
 /test/buildtest_*
 /test/provider_internal_test.cnf
+/test/pathed.cnf
+/test/nocache-and-default.cnf
 /test/fipsmodule.cnf
 /providers/fipsmodule.cnf
 

--- a/test/build.info
+++ b/test/build.info
@@ -1295,6 +1295,10 @@ IF[{- !$disabled{tests} -}]
   ENDIF
   DEPEND[]=provider_internal_test.cnf
   GENERATE[provider_internal_test.cnf]=provider_internal_test.cnf.in
+  DEPEND[]=pathed.cnf
+  GENERATE[pathed.cnf]=pathed.cnf.in
+  DEPEND[]=nocache-and-default.cnf
+  GENERATE[nocache-and-default.cnf]=nocache-and-default.cnf.in
 
   PROGRAMS{noinst}=provider_fallback_test
   SOURCE[provider_fallback_test]=provider_fallback_test.c

--- a/test/nocache-and-default.cnf.in
+++ b/test/nocache-and-default.cnf.in
@@ -1,3 +1,4 @@
+{- use platform -}
 openssl_conf = openssl_init
 
 # Comment out the next line to ignore configuration errors
@@ -11,7 +12,7 @@ test    = test_sect
 default = default_sect
 
 [test_sect]
-module = ../test/p_test.so
+module = ../test/{- platform->dso("p_test") -}
 activate = true
 
 [default_sect]

--- a/test/pathed.cnf.in
+++ b/test/pathed.cnf.in
@@ -1,3 +1,4 @@
+{- use platform -}
 openssl_conf = openssl_init
 
 # Comment out the next line to ignore configuration errors
@@ -12,7 +13,7 @@ legacy  = legacy_sect
 test    = test_sect
 
 [test_sect]
-module = ../test/p_test.so
+module = ../test/{- platform->dso("p_test") -}
 activate = false
 
 [default_sect]

--- a/test/prov_config_test.c
+++ b/test/prov_config_test.c
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 #include <openssl/evp.h>
 #include <openssl/conf.h>
+#include "crypto/dso_conf.h"
 #include "testutil.h"
 
 static char *configfile = NULL;
@@ -67,7 +68,7 @@ err:
     return testresult;
 }
 
-#define P_TEST_PATH "/../test/p_test.so"
+#define P_TEST_PATH "/../test/p_test" DSO_EXTENSION
 static int test_path_config(void)
 {
     OSSL_LIB_CTX *ctx = NULL;

--- a/test/recipes/30-test_prov_config.t
+++ b/test/recipes/30-test_prov_config.t
@@ -8,7 +8,7 @@
 
 
 use OpenSSL::Test::Simple;
-use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir/;
+use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir bldtop_file/;
 use OpenSSL::Test::Utils;
 
 BEGIN {
@@ -24,7 +24,7 @@ plan tests => 2;
 
 ok(run(test(["prov_config_test", srctop_file("test", "default.cnf"),
                                  srctop_file("test", "recursive.cnf"),
-                                 srctop_file("test", "pathed.cnf")])),
+                                 bldtop_file("test", "pathed.cnf")])),
     "running prov_config_test default.cnf");
 
 SKIP: {
@@ -32,6 +32,6 @@ SKIP: {
 
     ok(run(test(["prov_config_test", srctop_file("test", "fips.cnf"),
                                      srctop_file("test", "recursive.cnf"),
-                                     srctop_file("test", "pathed.cnf")])),
+                                     bldtop_file("test", "pathed.cnf")])),
        "running prov_config_test fips.cnf");
 }


### PR DESCRIPTION
pathed.cnf and nocache-and-default.cnf hardcoded "p_test.so", but provider modules use the platform's DSO extension (e.g. .dylib on macOS), so the file never existed there.

Convert both configs to build-time templates to fill in the correct extension.

Update prov_config_test.c's existence check to use DSO_EXTENSION, and have 30-test_prov_config.t read the generated file.

Assisted-by: Claude:claude-sonnet-5

Fixes https://github.com/openssl/project/issues/2041

##### Checklist

- [ ] documentation is added or updated
- [x] tests are added or updated
