### PR TITLE
ssl: add missing SSLfatal in PSK premaster secret generation

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -5307,8 +5307,10 @@ int ssl_generate_master_secret(SSL_CONNECTION *s, unsigned char *pms,
 
         pskpmslen = 4 + pmslen + psklen;
         pskpms = OPENSSL_malloc(pskpmslen);
-        if (pskpms == NULL)
+        if (pskpms == NULL) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             goto err;
+        }
         t = pskpms;
         s2n(pmslen, t);
         if (alg_k & SSL_kPSK)
@@ -5332,6 +5334,7 @@ int ssl_generate_master_secret(SSL_CONNECTION *s, unsigned char *pms,
         OPENSSL_clear_free(pskpms, pskpmslen);
 #else
         /* Should never happen */
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
 #endif
     } else {


### PR DESCRIPTION
An allocation failure for the PSK premaster secret buffer in ssl_generate_master_secret() returned failure without calling SSLfatal(), while its callers on both the client key exchange construction and processing paths assume the fatal state was already set. Also cover the unreachable no-PSK fallback branch.

The test is in #32184