### PR TITLE
ssl: restore missing SSLfatal in keylog output

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7213,8 +7213,10 @@ static int nss_keylog_int(const char *prefix,
      */
     prefix_len = strlen(prefix);
     out_len = prefix_len + (2 * parameter_1_len) + (2 * parameter_2_len) + 3;
-    if ((out = cursor = OPENSSL_malloc(out_len)) == NULL)
+    if ((out = cursor = OPENSSL_malloc(out_len)) == NULL) {
+        SSLfatal(sc, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
         return 0;
+    }
 
     memcpy(cursor, prefix, prefix_len);
     cursor += prefix_len;

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -621,7 +621,7 @@ int tls13_change_cipher_state(SSL_CONNECTION *s, int which)
 
             if (!ssl_log_secret(s, EARLY_EXPORTER_SECRET_LABEL,
                     s->early_exporter_master_secret, hashlen)) {
-                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                /* SSLfatal() already called */
                 goto err;
             }
         } else if (which & SSL3_CC_HANDSHAKE) {


### PR DESCRIPTION
Commit e077455e9e dropped the SSLfatal() call together with the ERR_R_MALLOC_FAILURE cleanup in nss_keylog_int(). Since then an allocation failure there propagates a plain zero return through ssl_log_secret() and ssl_log_rsa_client_key_exchange() callers whose "SSLfatal() already called" comments no longer hold, tripping the check_fatal assertion in the state machine on debug builds when a keylog callback is set.

The test is in https://github.com/openssl/openssl/pull/32184