### PR TITLE
statem: add missing SSLfatal in compressed certificate construction

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4227,8 +4227,10 @@ CON_FUNC_RETURN tls_construct_server_compressed_certificate(SSL_CONNECTION *sc, 
         || !WPACKET_put_bytes_u24(pkt, cc->orig_len)
         || !WPACKET_start_sub_packet_u24(pkt)
         || !WPACKET_memcpy(pkt, cc->data, cc->len)
-        || !WPACKET_close(pkt))
+        || !WPACKET_close(pkt)) {
+        SSLfatal(sc, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
+    }
 
     sc->s3.tmp.cert->cert_comp_used++;
     return 1;


### PR DESCRIPTION
A WPACKET failure in tls_construct_server_compressed_certificate() returned CON_FUNC_ERROR without calling SSLfatal(), unlike the identical failure handling in tls_construct_server_certificate(). This trips the check_fatal assertion in write_state_machine() on debug builds and skips the alert and error state otherwise.

The test is in https://github.com/openssl/openssl/pull/32184