### PR TITLE
ssl: add missing SSLfatal in TLSv1.3 finished MAC computation

### DIFF
--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -280,8 +280,10 @@ size_t tls13_final_finish_mac(SSL_CONNECTION *s, const char *str, size_t slen,
     OSSL_PARAM params[2], *p = params;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
-    if (md == NULL)
+    if (md == NULL) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
+    }
 
     /* Safe to cast away const here since we're not "getting" any data */
     if (sctx->propq != NULL)


### PR DESCRIPTION
tls13_final_finish_mac() returned failure on a NULL handshake digest without calling SSLfatal() or raising any error, while its callers on the Finished construction and processing paths assume the fatal state was already set. This should currently not happen as the handshake digest must have been fetched successfully earlier in the handshake, so this is just future proofing of the error handling.

It is currently untriggerable so the test is deferred for now (would need a tls13_final_finish_mac specific integration test).