### PR TITLE
statem: add missing SSLfatal in padding extension construction

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1272,8 +1272,10 @@ EXT_RETURN tls_construct_ctos_padding(SSL_CONNECTION *s, WPACKET *pkt,
              */
             int md_size = EVP_MD_get_size(md);
 
-            if (md_size <= 0)
+            if (md_size <= 0) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 return EXT_RETURN_FAIL;
+            }
             hlen += PSK_PRE_BINDER_OVERHEAD + s->session->ext.ticklen
                 + md_size;
         }


### PR DESCRIPTION
tls_construct_ctos_padding() returned EXT_RETURN_FAIL on a non-positive digest size without calling SSLfatal(), propagating to CON_FUNC_ERROR in the ClientHello construction without the fatal state set. This should currently not happen as ssl_md() only returns digests with a positive size, so this is just future proofing of the error handling.

It is currently untriggerable so the test is deferred for now (it would need tls_construct_ctos_padding specific integration test).
