### PR TITLE
ssl: add missing SSLfatal on session ID lock failure

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -394,8 +394,10 @@ int ssl_generate_session_id(SSL_CONNECTION *s, SSL_SESSION *ss)
     }
 
     /* Choose which callback will set the session ID */
-    if (!CRYPTO_THREAD_read_lock(SSL_CONNECTION_GET_SSL(s)->lock))
+    if (!CRYPTO_THREAD_read_lock(SSL_CONNECTION_GET_SSL(s)->lock)) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
+    }
     if (!CRYPTO_THREAD_read_lock(s->session_ctx->lock)) {
         CRYPTO_THREAD_unlock(ssl->lock);
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,


### PR DESCRIPTION
The first CRYPTO_THREAD_read_lock() failure in ssl_generate_session_id() returned failure without calling SSLfatal() while the second lock right below does, and callers such as tls_construct_new_session_ticket() assume the fatal state was already set. This should currently not happen as the read lock does not realistically fail, so this is just future proofing of the error handling.

It is currently untriggerable so the test is deferred for now (it would need ssl_generate_session_id specific integration test).