### PR TITLE
statem: fail ClientHello construction on ECH GREASE failure

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -2637,7 +2637,7 @@ EXT_RETURN tls_construct_ctos_ech(SSL_CONNECTION *s, WPACKET *pkt,
             s->ext.ech.attempted_type = TLSEXT_TYPE_ech;
         if (ossl_ech_send_grease(s, pkt) != 1) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-            return EXT_RETURN_NOT_SENT;
+            return EXT_RETURN_FAIL;
         }
         return EXT_RETURN_SENT;
     }


### PR DESCRIPTION
tls_construct_ctos_ech() called SSLfatal() on an ECH GREASE construction failure but returned EXT_RETURN_NOT_SENT, so extension construction reported success while the connection was already in the fatal error state. The ClientHello would still be sent together with the fatal alert and the state machine kept running until it tripped over the error state later. Return EXT_RETURN_FAIL to fail the construction immediately.

It will need an ECH mfail test that I plan to create later (master only so it needs a separate PR anyway).