### PR TITLE
Add OPENSSL_NONSTRING and apply it to ASN1_STRING's data field.

### DIFF
--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -50,7 +50,7 @@
 struct asn1_string_st {
     int length;
     int type;
-    unsigned char *data;
+    unsigned char *data OPENSSL_NONSTRING;
     /*
      * The value of the following field depends on the type being held.  It
      * is mostly being used for BIT_STRING so if the input data has a

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -284,6 +284,22 @@ typedef uint64_t ossl_uintmax_t;
 #define ossl_unused
 #endif
 
+/*
+ * OPENSSL_NONSTRING: mark a char/unsigned char buffer object or struct field
+ * whose contents are not necessarily NUL terminated, so that misuse with C
+ * string functions (strlen(), strcpy(), "%s", ...) is diagnosed by compilers
+ * that support the attribute. It has no effect elsewhere.
+ */
+#if defined(__has_attribute)
+# if __has_attribute(nonstring)
+#  define OPENSSL_NONSTRING __attribute__((nonstring))
+# else
+#  define OPENSSL_NONSTRING
+# endif
+#else
+# define OPENSSL_NONSTRING
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
OPENSSL_NONSTRING expands to __attribute__((nonstring)) where the compiler supports it and to nothing otherwise. ASN1_STRING data has an explicit length and is not necessarily NUL terminated, so marking the field lets GCC diagnose direct use of it with C string functions such as strlen(), strcpy() or "%s".

The diagnostic fires only on GCC under an optimised build; other compilers, including current Clang, accept the attribute but do not warn.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
