### PR TITLE
Fix ASN1_TYPE memory leak in asn1_multi()

### DIFF
--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -426,8 +426,11 @@ static ASN1_TYPE *asn1_multi(int utype, const char *section, X509V3_CTX *cnf,
                 depth + 1, perr);
             if (!typ)
                 goto bad;
-            if (!sk_ASN1_TYPE_push(sk, typ))
+
+            if (!sk_ASN1_TYPE_push(sk, typ)) {
+                ASN1_TYPE_free(typ);
                 goto bad;
+            }
         }
     }
 


### PR DESCRIPTION
In asn1_gen.c `asn1_multi()` function variable allocated as `ASN1_TYPE *typ = generate_v3()` is not freed if
`if (!sk_ASN1_TYPE_push(sk, typ))` branch fails.

Bug found by x509v3 fuzzer MFAIL test.
Example input:
```
[default]
1.2.3.4 = ASN1:SEQUENCE:items

[items]
value = INTEGER:1
```

Fuzzer: https://github.com/openssl/openssl/pull/32143