### PR TITLE
evp/digest: Fix EVP_MD digest size bounds check against EVP_MAX_MD_SIZE

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -817,7 +817,7 @@ static int evp_md_cache_constants(EVP_MD *md)
         &algid_absent);
     params[4] = OSSL_PARAM_construct_end();
     ok = evp_do_md_getparams(md, params) > 0;
-    if (mdsize > INT_MAX || blksz > INT_MAX)
+    if ((mdsize > EVP_MAX_MD_SIZE) || (blksz > INT_MAX))
         ok = 0;
     if (ok) {
         md->block_size = (int)blksz;


### PR DESCRIPTION
evp_md_cache_constants() only validated the provider-reported digest size against `INT_MAX` before caching it into `md->md_size`. Every other consumer of `md_size` assumes it never exceeds `EVP_MAX_MD_SIZE`, so a provider reporting a size between `EVP_MAX_MD_SIZE` and `INT_MAX` could lead to buffer overflows in callers using EVP_MAX_MD_SIZE-sized output buffers.

Check mdsize against EVP_MAX_MD_SIZE instead of INT_MAX.

Fixes #32205

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
