### PR TITLE
CI: fix check_docs failures by pining mdl to 0.17.0

### DIFF
--- a/.github/workflows/ci-doc-changes.yml
+++ b/.github/workflows/ci-doc-changes.yml
@@ -32,7 +32,9 @@ jobs:
       run: make help
     - name: make md-nits
       run: |
-          sudo gem install mdl
+          # mdl 0.18.0 is incompatible with the runner's uri 0.12.x.
+          # See https://github.com/markdownlint/markdownlint/issues/605
+          sudo gem install mdl -v 0.17.0
           make md-nits
 
   # out-of-source-and-install checks multiple things at the same time:


### PR DESCRIPTION
The `check_docs` job installs the latest available `mdl` gem. Since the release of `mdl` 0.18.0, this causes `make md-nits` to fail for every pull request before any Markdown files are linted.

`mdl` 0.18.0 accesses `URI::RFC2396_PARSER` while loading its default ruleset, but that constant is not provided by the `uri` 0.12.x version on the `ubuntu-latest` runner.

Pin `mdl` to the last known-good release, 0.17.0, until the upstream regression is fixed. The workflow comment links to the upstream report:
<https://github.com/markdownlint/markdownlint/issues/605>.

Verification performed:

- `mdl` 0.17.0 successfully linted a clean OpenSSL tree using `util/markdownlint.rb`.
- The modified workflow parses successfully as YAML.