### PR TITLE
[4.0, 3.6, 3.5, 3.4] .github/workflows/ci.yml: pin mdl to 0.17.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
       run: make help
     - name: make md-nits
       run: |
-          sudo gem install mdl
+          # mdl 0.18.0 is incompatible with the runner's uri 0.12.x.
+          # See https://github.com/markdownlint/markdownlint/issues/605
+          sudo gem install mdl -v 0.17.0
           make md-nits
 
   # This checks that we use ANSI C language syntax and semantics.


### PR DESCRIPTION
mdl 0.18.0 loads URI::RFC2396_PARSER before linting. The uri 0.12.x version on ubuntu-latest does not define that constant, so md-nits fails for every PR.

Pin the last known-good mdl release until the upstream regression is fixed:
https://github.com/markdownlint/markdownlint/issues/605

Original-Commit: 1a3455e2ce39 ".github/workflows/ci-doc-changes.yml: pin mdl to 0.17.0"
Original-PR: https://github.com/openssl/openssl/pull/32230