### PR TITLE
Add a migration entry for ASN1_STRINGs

### DIFF
--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -80,7 +80,7 @@ store the terminator.
 Applications must use the data only together with its length, obtained from
 L<ASN1_STRING_get_length(3)>, and never derive the length from the data.
 Applications should be cautious of passing a NULL data pointer when an
-ASN1_STRING has a length of 0 to functions where this behaviour may be
+B<ASN1_STRING> has a length of 0 to functions where this behaviour may be
 undefined.
 
 Applications which wish to use the content of an B<ASN1_STRING> as a C string

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -60,6 +60,34 @@ by registering a handler for B<TLSEXT_TYPE_padding> with
 L<SSL_CTX_add_custom_ext(3)>. Registering a handler for this extension type
 was previously refused.
 
+=head3 B<ASN1_STRING> values have never been NUL byte terminated
+
+The bytes returned by L<ASN1_STRING_get0_data(3)> have never been guaranteed to
+be NUL byte terminated, and the documentation has said so since 2002. Values
+constructed as pointers into parsed DER never have been. Applications treating
+them as C strings have always relied on behaviour that was never promised.
+
+Such code usually escaped consequences because ASN1_STRING_set() allocated one
+byte more than the requested length and wrote a NUL byte into it. That byte was
+never counted in the length reported by ASN1_STRING_length().
+
+ASN1_STRING_set() is now deprecated. Its replacements,
+L<ASN1_STRING_set1_data(3)> and L<ASN1_STRING_set1_string(3)>, allocate exactly
+the requested number of bytes and append nothing. This includes
+ASN1_STRING_set1_string(): it takes a NUL byte terminated C string, but does not
+store the terminator.
+
+Applications must use the data only together with its length, obtained from
+L<ASN1_STRING_get_length(3)>, and never derive the length from the data.
+Applications should be cautious of passing a NULL data pointer when an
+ASN1_STRING has a length of 0 to functions where this behaviour may be
+undefined.
+
+Applications which wish to use the content of an B<ASN1_STRING> as a C string
+should make a copy of the data, NUL byte terminate it, and when appropriate,
+sanitize it for embedded NUL bytes. They should never have been using the
+B<ASN1_STRING> data directly.
+
 =head1 OPENSSL 4.0
 
 =head2 Main Changes from OpenSSL 3.6


### PR DESCRIPTION
Re-document that ASN1_STRINGs are not NUL byte terminated, and have been documented as such for over 20 years.

ASN1_STRING data has never been guaranteed to be NUL byte terminated. ASN1_STRING_set() added one anyway; its replacements do not, so code relying on UB, and treating it as a C string is more likely to break.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
