### PR TITLE
Fix BIT STRING handling in X509_ATTRIBUTE_set1_data()

### DIFF
--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -364,8 +364,24 @@ int X509_ATTRIBUTE_set1_data(X509_ATTRIBUTE *attr, int attrtype,
         }
         atype = stmp->type;
     } else if (len != -1) {
-        if ((stmp = ASN1_STRING_type_new(attrtype)) == NULL
-            || !ASN1_STRING_set_data(stmp, data, len)) {
+        if ((stmp = ASN1_STRING_type_new(attrtype)) == NULL) {
+            ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
+            goto err;
+        }
+        if (attrtype == V_ASN1_BIT_STRING) {
+            /*
+             * ASN1_STRING_set_data() rejects bit strings, so use the
+             * dedicated bit string setter, with zero unused bits.
+             */
+            if (data == NULL && len > 0) {
+                ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+                goto err;
+            }
+            if (!ASN1_BIT_STRING_set1(stmp, data, len, 0)) {
+                ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
+                goto err;
+            }
+        } else if (!ASN1_STRING_set_data(stmp, data, len)) {
             ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
             goto err;
         }

--- a/doc/man3/X509_ATTRIBUTE.pod
+++ b/doc/man3/X509_ATTRIBUTE.pod
@@ -152,6 +152,9 @@ ASN1_STRING_set_by_NID(), and the passed in I<data> must be in the format
 required for that object type or an error will occur.
 If I<len> is not -1 then internally ASN1_STRING_type_new() is
 used with the passed in I<attrtype>.
+If I<attrtype> is B<V_ASN1_BIT_STRING> and I<len> is not -1, I<data> is
+taken as complete octets of the bit string, so the resulting
+B<ASN1_BIT_STRING> is created with zero unused bits.
 If I<attrtype> is 0 the call does nothing except return 1.
 
 X509_ATTRIBUTE_create() creates a new B<X509_ATTRIBUTE> using the I<nid>

--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -180,7 +180,7 @@ ok(grep(/Trusted key usage (Oracle)/, @pkcs12info) == 0,
 # keyBag (created with -keypbe NONE) rather than a shrouded keyBag.
 {
     my $keybag = "keybag.p12";
-    ok(run(app(["openssl", "pkcs12", "-export", "-keypbe", "NONE",
+    ok(run(app(["openssl", "pkcs12", "-export", "-keyex", "-keypbe", "NONE",
                 "-certpbe", "NONE", "-nomac",
                 "-inkey", srctop_file(@path, "cert-key-cert.pem"),
                 "-in", srctop_file(@path, "cert-key-cert.pem"),

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -957,6 +957,35 @@ err:
     return test;
 }
 
+/*
+ * X509_ATTRIBUTE_create_by_NID() must accept a BIT STRING value supplied as
+ * raw bytes plus an explicit length, as PKCS8_add_keyusage() does for
+ * 'openssl pkcs12 -export -keyex' (0x10) and '-keysig' (0x80).
+ * Regression test for https://github.com/openssl/openssl/issues/32234
+ */
+static int test_x509_attribute_bit_string(int idx)
+{
+    unsigned char usage = idx == 0 ? 0x10 : 0x80;
+    X509_ATTRIBUTE *attr = NULL;
+    const ASN1_BIT_STRING *bs;
+    size_t length = 0;
+    int unused_bits = -1, ret = 0;
+
+    if (!TEST_ptr(attr = X509_ATTRIBUTE_create_by_NID(NULL, NID_key_usage,
+                      V_ASN1_BIT_STRING, &usage, 1))
+        || !TEST_ptr(bs = X509_ATTRIBUTE_get0_data(attr, 0, V_ASN1_BIT_STRING,
+                         NULL))
+        || !TEST_true(ASN1_BIT_STRING_get_length(bs, &length, &unused_bits))
+        || !TEST_size_t_eq(length, 1)
+        || !TEST_int_eq(unused_bits, 0)
+        || !TEST_mem_eq(ASN1_STRING_get0_data(bs), 1, &usage, 1))
+        goto err;
+    ret = 1;
+err:
+    X509_ATTRIBUTE_free(attr);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_standard_exts);
@@ -970,6 +999,7 @@ int setup_tests(void)
     ADD_TEST(tests_x509_check_ext_duplicity);
     ADD_TEST(tests_x509_check_ext_duplicity_nid_undef);
     ADD_TEST(tests_x509_check_ext_duplicity_nid_dynamic);
+    ADD_ALL_TESTS(test_x509_attribute_bit_string, 2);
 
     return 1;
 }


### PR DESCRIPTION
Commit 9044e5f42556 from PR #31194 `ASN1_STRING_set` with `ASN1_STRING_set_data` in `X509_ATTRIBUTE_set1_data`. The latter rejects the `V_ASN1_BIT_STRING` value created by the explicit-length path, breaking the public X509 attribute APIs and, through `PKCS8_add_keyusage`, PKCS#12 creation with a non-zero `keytype` (`-keyex` or `-keysig`).

Use `ASN1_BIT_STRING_set1` with zero unused bits for this type and retain `ASN1_STRING_set_data` for all others. The API can't express another unused-bit count, so its input represents complete octets. This restores the encoding produced by OpenSSL 4.0 and by master before the regression.

Tests cover `KEY_EX` (`0x10`) and `KEY_SIG` (`0x80`) at the common X509 attribute boundary, checking the type, value, length, and unused-bit count.
The PKCS#12 recipe also exercises an export with `-keyex`.

Validation performed:

- `make test TESTS='test_asn1_string test_pkcs12 test_internal_x509'`
- `test_pkcs12` in a `no-ec no-shared` build
- CLI exports with both `-keyex` and `-keysig`
- `make doc-nits`, clang-format 21.1.6, and codespell

Fixes #32234

##### Checklist

- [x] documentation is added or updated
- [x] tests are added or updated