### PR TITLE
Fix 5 bugs in the DTLS Listener/SSL_poll() implementation

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -565,7 +565,14 @@ int dtls1_handle_timeout(SSL_CONNECTION *s)
         dtls1_double_timeout(s);
 
     if (dtls1_check_timeout_num(s) < 0) {
-        /* SSLfatal() already called */
+        /*
+         * SSLfatal() already called, so the connection is finished. Stop the
+         * timer rather than returning with next_timeout left in the past:
+         * nothing will re-arm or clear it from here, so DTLSv1_get_timeout()
+         * would report "due now" for ever and spin any caller which waits on
+         * it.
+         */
+        dtls1_stop_timer(s);
         return -1;
     }
 

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -1344,6 +1344,25 @@ err:
 }
 
 /*
+ * dtls_listener_signal_notifier - wake threads blocked on this listener.
+ *
+ * Readiness may be produced by the thread which pumps the demux while a
+ * different thread is blocked in poll() on the network socket. That socket
+ * will not necessarily become readable again from the blocked thread's point
+ * of view, so the notifier is used to wake it.
+ *
+ * The caller must hold dl->mutex.
+ */
+static void dtls_listener_signal_notifier(DTLS_LISTENER *dl)
+{
+    if (dl->have_notifier && dl->cur_blocking_waiters > 0
+        && !dl->signalled_notifier) {
+        ossl_rio_notifier_signal(&dl->notifier);
+        dl->signalled_notifier = 1;
+    }
+}
+
+/*
  * dtls_listener_packet_handler - callback for handling incoming datagrams.
  *
  * This callback is invoked by the demux for each received datagram. It routes
@@ -1450,10 +1469,7 @@ static void dtls_listener_packet_handler(DGRAM_URXE *urxe, void *arg)
     ossl_dtls_rx_inject_urxe(sc->d1->rx, urxe);
 
     /* Signal notifier if needed */
-    if (dl->have_notifier && dl->cur_blocking_waiters > 0 && !dl->signalled_notifier) {
-        ossl_rio_notifier_signal(&dl->notifier);
-        dl->signalled_notifier = 1;
-    }
+    dtls_listener_signal_notifier(dl);
 
     ossl_crypto_mutex_unlock(dl->mutex);
     return;
@@ -2308,6 +2324,14 @@ static int dtls_listener_drive_pending(DTLS_LISTENER *dl)
             }
         }
     }
+
+    /*
+     * A connection became acceptable. Any thread blocked waiting for one is
+     * polling the network socket, which will not necessarily become readable
+     * again on its behalf, so wake it explicitly.
+     */
+    if (result)
+        dtls_listener_signal_notifier(dl);
 
     /* Remove failed connections (after releasing refs so ref count is 1) */
     for (i = 0; i < sk_SSL_num(ctx.failed_conns); i++) {

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -3048,6 +3048,18 @@ int ossl_dtls_conn_poll_events(SSL *s, uint64_t events, int do_tick,
         ossl_dtls_tick(dl);
     }
 
+    /*
+     * Handle events for the connection itself, which for DTLS means servicing
+     * the retransmission timer. The caller may have blocked until that timer
+     * expired, so if nothing retransmits here then nothing will, and the
+     * deadline would be recomputed as "now" on every subsequent wait.
+     *
+     * A failure here leaves the connection in a fatal error state, which the
+     * SSL_POLL_EVENT_EC check below reports.
+     */
+    if (do_tick)
+        SSL_handle_events(s);
+
     if ((events & SSL_POLL_EVENT_R) != 0) {
         if (SSL_has_pending(s) || SSL_pending(s) > 0) {
             result |= SSL_POLL_EVENT_R;

--- a/ssl/rio/poll_builder.c
+++ b/ssl/rio/poll_builder.c
@@ -135,9 +135,39 @@ int ossl_rio_poll_builder_add_fd(RIO_POLL_BUILDER *rpb, int fd,
 #endif
 }
 
+/* Returns 1 if no file descriptors have been added to the poll builder. */
+static int rio_poll_builder_is_empty(const RIO_POLL_BUILDER *rpb)
+{
+#if RIO_POLL_METHOD == RIO_POLL_METHOD_SELECT
+    return rpb->hwm_fd < 0;
+#elif RIO_POLL_METHOD == RIO_POLL_METHOD_POLL
+    return rpb->pfd_num == 0;
+#else
+    return 1;
+#endif
+}
+
 int ossl_rio_poll_builder_poll(RIO_POLL_BUILDER *rpb, OSSL_TIME deadline)
 {
     int rc;
+
+    /*
+     * Waiting with no file descriptors is legitimate: a DTLS connection whose
+     * BIO cannot provide a poll descriptor has no readiness to wait for, but
+     * still has a retransmission deadline to wake for. Handle that here rather
+     * than leaving it to the OS, because poll() treats an empty descriptor set
+     * as a plain sleep whereas Windows' select() rejects it outright.
+     *
+     * With no descriptors and no deadline nothing could ever wake us, so that
+     * is a caller error rather than an indefinite sleep.
+     */
+    if (rio_poll_builder_is_empty(rpb)) {
+        if (ossl_time_is_infinite(deadline))
+            return 0;
+
+        OSSL_sleep(ossl_time2ms(ossl_time_subtract(deadline, ossl_time_now())));
+        return 1;
+    }
 
 #if RIO_POLL_METHOD == RIO_POLL_METHOD_SELECT
     do {

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -169,10 +169,14 @@ static void postpoll_translation_cleanup_ssl_quic(SSL *ssl,
 #ifndef OPENSSL_NO_DTLS
 static int poll_translate_ssl_dtls_listener(SSL *ssl,
     RIO_POLL_BUILDER *rpb,
-    uint64_t events)
+    uint64_t events,
+    int *abort_blocking)
 {
     BIO *rbio;
     BIO_POLL_DESCRIPTOR desc;
+    DTLS_LISTENER *dl = (DTLS_LISTENER *)ssl;
+    uint64_t revents = 0;
+    int nfd;
 
     rbio = SSL_get_rbio(ssl);
     if (rbio == NULL)
@@ -187,6 +191,41 @@ static int poll_translate_ssl_dtls_listener(SSL *ssl,
 
     if (!ossl_rio_poll_builder_add_fd(rpb, desc.value.fd, /*r=*/1, /*w=*/0))
         return 0;
+
+    /*
+     * Add the notifier FD for the DTLS listener (if multi-threaded mode is
+     * enabled). Another thread may queue an incoming connection for us, or
+     * demux data to one of our connections, without the underlying network
+     * socket ever becoming readable from our perspective.
+     */
+    if (dl->have_notifier) {
+        nfd = ossl_rio_notifier_as_fd(&dl->notifier);
+        if (nfd != -1) {
+            if (!ossl_rio_poll_builder_add_fd(rpb, nfd, /*r=*/1, /*w=*/0))
+                return 0;
+
+            /* Tell the listener we need to receive notifications. */
+            ossl_dtls_listener_enter_blocking_section(ssl);
+
+            /*
+             * Only after the above call returns is it guaranteed that any
+             * readiness events will cause the notifier to become readable.
+             * Therefore it is possible the listener became ready after the
+             * readout which decided we needed to block. Re-check now.
+             */
+            if (!ossl_dtls_listener_poll_events(ssl, events, /*do_tick=*/0,
+                    &revents)) {
+                ossl_dtls_listener_leave_blocking_section(ssl);
+                return 0;
+            }
+
+            if (revents != 0) {
+                ossl_dtls_listener_leave_blocking_section(ssl);
+                *abort_blocking = 1;
+                return 1;
+            }
+        }
+    }
 
     return 1;
 }
@@ -310,6 +349,15 @@ static int poll_translate_ssl_dtls_conn(SSL *ssl,
     return 1;
 }
 
+static void postpoll_translation_cleanup_ssl_dtls_listener(SSL *ssl)
+{
+    DTLS_LISTENER *dl = (DTLS_LISTENER *)ssl;
+
+    /* Need to mirror the enter blocking section call */
+    if (dl->have_notifier && ossl_rio_notifier_as_fd(&dl->notifier) != -1)
+        ossl_dtls_listener_leave_blocking_section(ssl);
+}
+
 static void postpoll_translation_cleanup_ssl_dtls_conn(SSL *ssl, uint64_t events)
 {
     SSL_CONNECTION *sc;
@@ -366,7 +414,7 @@ static void postpoll_translation_cleanup(SSL_POLL_ITEM *items,
 
 #ifndef OPENSSL_NO_DTLS
             case SSL_TYPE_DTLS_LISTENER:
-                /* Listeners don't enter blocking sections */
+                postpoll_translation_cleanup_ssl_dtls_listener(ssl);
                 break;
             case SSL_TYPE_SSL_CONNECTION:
                 if (SSL_is_dtls(ssl))
@@ -440,8 +488,13 @@ static int poll_translate(SSL_POLL_ITEM *items,
 
 #ifndef OPENSSL_NO_DTLS
             case SSL_TYPE_DTLS_LISTENER:
-                if (!poll_translate_ssl_dtls_listener(ssl, rpb, item->events))
+                if (!poll_translate_ssl_dtls_listener(ssl, rpb, item->events,
+                        abort_blocking))
                     FAIL_ITEM(i);
+
+                if (*abort_blocking)
+                    goto out;
+
                 break;
             case SSL_TYPE_SSL_CONNECTION:
                 if (SSL_is_dtls(ssl)) {

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -446,7 +446,7 @@ static int poll_translate(SSL_POLL_ITEM *items,
     size_t result_count = 0;
     SSL *ssl;
     OSSL_TIME earliest_wakeup_deadline = ossl_time_infinite();
-#ifndef OPENSSL_NO_QUIC
+#if !defined(OPENSSL_NO_QUIC) || !defined(OPENSSL_NO_DTLS)
     struct timeval timeout;
     int is_infinite = 0;
 #endif
@@ -504,6 +504,20 @@ static int poll_translate(SSL_POLL_ITEM *items,
 
                     if (*abort_blocking)
                         goto out;
+
+                    /*
+                     * Bound the wait by the DTLS retransmission timer,
+                     * otherwise a poll with no timeout sleeps straight through
+                     * the point at which we should be retransmitting.
+                     */
+                    if (!SSL_get_event_timeout(ssl, &timeout, &is_infinite))
+                        FAIL_ITEM(i++); /* need to clean up this item too */
+
+                    if (!is_infinite)
+                        earliest_wakeup_deadline
+                            = ossl_time_min(earliest_wakeup_deadline,
+                                ossl_time_add(ossl_time_now(),
+                                    ossl_time_from_timeval(timeout)));
 
                 } else {
                     ERR_raise_data(ERR_LIB_SSL, SSL_R_POLL_REQUEST_NOT_SUPPORTED,

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5333,7 +5333,7 @@ static int test_dtls_poll_conn_honours_retransmit_timer(void)
             &poll_result)))
         goto end;
 
-    if (!TEST_size_t_gt(short_timer_cb_count, 0))
+    if (!TEST_uint_gt(short_timer_cb_count, 0))
         goto end;
 
     testresult = 1;

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5168,6 +5168,81 @@ static unsigned int short_timer_cb(SSL *s, unsigned int timer_us)
 }
 
 /*
+ * Force a retransmission timeout short enough that it is always already
+ * expired, so the timeout can be driven repeatedly without waiting. Anything
+ * at or below 15ms is treated as expired by dtls1_get_timeout().
+ */
+static unsigned int tiny_timer_cb(SSL *s, unsigned int timer_us)
+{
+    return 1000; /* 1ms */
+}
+
+/*
+ * Test that the DTLS retransmission timer is stopped once the connection gives
+ * up retransmitting.
+ *
+ * dtls1_handle_timeout() fails the connection after DTLS1_TMO_ALERT_COUNT
+ * unanswered retransmissions. It must not leave the timer armed in the past
+ * when it does: nothing will re-arm or clear it afterwards, so every later
+ * query reports the timeout as due immediately, and any caller which waits on
+ * it spins instead of sleeping - whether that is an application using
+ * DTLSv1_get_timeout() with select(), or SSL_poll() bounding its own wait.
+ */
+static int test_dtls_timer_stopped_when_retransmits_exhausted(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    struct timeval timer_left;
+    int is_infinite = 0;
+    int retc, rets;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_VERSION, 0, &sctx, &cctx, cert,
+            privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    DTLS_set_timer_cb(serverssl, tiny_timer_cb);
+
+    retc = SSL_connect(clientssl);
+    if (!TEST_int_le(retc, 0)
+        || !TEST_int_eq(SSL_get_error(clientssl, retc), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /*
+     * With a timeout this short the server's timer is expired on every read
+     * attempt, so the accept retransmits until the budget runs out and fails
+     * the connection by itself. The client is never fed, so nothing is ever
+     * acknowledged.
+     *
+     * The retransmissions happen in dtls1_read_bytes(), which calls
+     * dtls1_handle_timeout() and, when it reports that it retransmitted, goes
+     * back to its start label to try the read again.
+     */
+    rets = SSL_accept(serverssl);
+    if (!TEST_int_le(rets, 0)
+        || !TEST_int_eq(SSL_get_error(serverssl, rets), SSL_ERROR_SSL))
+        goto end;
+
+    /* The timer must not have been left armed in the past. */
+    if (!TEST_true(SSL_get_event_timeout(serverssl, &timer_left, &is_infinite))
+        || !TEST_true(is_infinite))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
  * Test that a blocking SSL_poll() on a DTLS connection honours the
  * retransmission timer.
  *
@@ -5381,6 +5456,7 @@ int setup_tests(void)
     ADD_TEST(test_dtls_poll_listener_enters_blocking_section);
 #endif
     ADD_TEST(test_dtls_poll_conn_honours_retransmit_timer);
+    ADD_TEST(test_dtls_timer_stopped_when_retransmits_exhausted);
 
     return 1;
 }

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -27,6 +27,7 @@
 #include <openssl/conf.h>
 #include "internal/time.h"
 #include "internal/sockets.h"
+#include "internal/dgram_demux.h"
 #include "helpers/ssltestlib.h"
 #include "testutil.h"
 #include "../ssl/ssl_local.h"
@@ -4841,6 +4842,185 @@ static int test_new_pending_cb_alternate(void)
     return run_new_pending_cb_scenario(100, 1, 2, 1, 2, 0);
 }
 
+/*
+ * The test below needs a listener with a notifier, which only exists
+ * when the listener is created without SSL_LISTENER_FLAG_SINGLE_THREAD. In a
+ * no-threads build that listener cannot be created at all, because the
+ * condition variable it needs is unavailable.
+ */
+#if defined(OPENSSL_THREADS)
+/*
+ * Test that queueing a connection for accept signals the listener's notifier.
+ *
+ * A thread waiting in SSL_poll() for SSL_POLL_EVENT_IC is blocked on the
+ * listener's network socket and on its notifier. Where another thread does the
+ * demuxing, that socket does not necessarily become readable on the waiter's
+ * behalf, so the notifier is what has to wake it.
+ *
+ * Most of the time the bug this covers is masked. Every connection reaching
+ * the accept queue got there because a datagram was demuxed into its receive
+ * queue, and the packet handler has always signalled on that injection, so the
+ * waiter is woken, ticks the listener itself during its readout, and finds the
+ * connection. What is not covered by that is the window in which the injection
+ * and the queue push straddle a waiter registering, because signalling is
+ * conditional on there being a waiter at the time.
+ *
+ * The numbered steps below are that window - the interleaving of two threads
+ * which the fix exists to handle. They are not what this test does, and are
+ * given only so that what it does assert makes sense; see the end of this
+ * comment for how it is actually checked.
+ *
+ *   1. Accept thread A polls the listener for SSL_POLL_EVENT_IC. Its readout
+ *      ticks the listener, finds nothing, and it decides to block. It is not
+ *      a registered waiter yet.
+ *   2. Worker thread B polls one of its own connections, which also ticks the
+ *      listener. The pump reads a client's final ClientHello and injects it
+ *      into that pending connection's queue. There are no waiters, so nothing
+ *      is signalled.
+ *   3. A enters the blocking section. Its re-check runs without ticking, so it
+ *      sees only the accept queue, which is still empty, and it blocks.
+ *   4. B's tick reaches dtls_listener_drive_pending(), which completes the
+ *      connection against the buffered ClientHello and pushes it onto the
+ *      accept queue.
+ *
+ * Without a signal at step 4, A sleeps on with a validated connection sitting
+ * ready, until some unrelated datagram makes the socket readable again. B
+ * consumed the only one in flight, and the client is now waiting on the
+ * server, so on a quiet listener that is until the client retransmits.
+ *
+ * That interleaving cannot be forced from outside the library, so rather than
+ * reproducing the steps above, this drives their essential part by hand and on
+ * one thread: pumping the demux directly performs step 2, the signal it raises
+ * is then cleared, and the tick which follows can only signal by way of step 4.
+ * Asserting that it did is therefore asserting that a queue push signals.
+ *
+ * signalled_notifier is protected by the listener mutex in the library, which
+ * has to assume concurrent access. This test is single threaded throughout, so
+ * it reads the field directly without holding the mutex.
+ */
+static int test_dtls_notifier_signalled_on_accept_queue_push(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *listener = NULL, *clientssl = NULL;
+    BIO_ADDR *server_addr = NULL;
+    DTLS_LISTENER *dl;
+    SSL_POLL_ITEM poll_item;
+    struct timeval poll_timeout;
+    size_t poll_result = 0;
+    int server_fd = -1, client_fd = -1;
+    int in_blocking_section = 0;
+    int abortctr, retc, err_code;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_VERSION, 0, &sctx, &cctx, cert,
+            privkey)))
+        goto end;
+
+    /*
+     * Multi-threaded mode (no SSL_LISTENER_FLAG_SINGLE_THREAD) so that the
+     * listener has a notifier at all.
+     */
+    if (!TEST_true(create_dtls_listener(sctx,
+            SSL_LISTENER_FLAG_REQUIRE_HVR | SSL_LISTENER_FLAG_REQUIRE_HRR,
+            &listener, &server_addr, &server_fd)))
+        goto end;
+
+    dl = (DTLS_LISTENER *)listener;
+    if (!TEST_true(dl->have_notifier))
+        goto end;
+
+    if (!TEST_true(create_dtls_client_for_addr(cctx, server_addr, &clientssl,
+            &client_fd)))
+        goto end;
+
+    /* Pose as a thread waiting for readiness, so signalling is enabled. */
+    ossl_dtls_listener_enter_blocking_section(listener);
+    in_blocking_section = 1;
+
+    /*
+     * Drive the cookie exchange, splitting each round into its two halves so
+     * that the two signalling opportunities can be told apart:
+     *
+     *   - demuxing a datagram to a connection's receive queue, which the
+     *     packet handler has always signalled, and
+     *   - completing a connection and pushing it onto the accept queue.
+     *
+     * Pumping the demux directly performs only the first. The signal it
+     * raises is then cleared, so when the listener is next ticked the pump
+     * finds nothing new and only the accept queue push can signal.
+     *
+     * There is no public API for that split: SSL_poll() and
+     * SSL_accept_connection() both tick the listener, which does the two
+     * together.
+     */
+    poll_item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+    poll_item.desc.value.ssl = listener;
+    poll_timeout.tv_sec = 0;
+    poll_timeout.tv_usec = 0;
+
+    SSL_set_connect_state(clientssl);
+    for (abortctr = 0; abortctr < 100; abortctr++) {
+        retc = SSL_connect(clientssl);
+        err_code = SSL_get_error(clientssl, retc);
+        if (retc <= 0
+            && err_code != SSL_ERROR_WANT_READ
+            && err_code != SSL_ERROR_WANT_WRITE) {
+            TEST_error("SSL_connect failed (err %d)", err_code);
+            goto end;
+        }
+
+        ossl_dgram_demux_pump(dl->demux);
+
+        ossl_dtls_listener_leave_blocking_section(listener);
+        in_blocking_section = 0;
+        if (!TEST_int_eq(dl->signalled_notifier, 0))
+            goto end;
+        ossl_dtls_listener_enter_blocking_section(listener);
+        in_blocking_section = 1;
+
+        /*
+         * A zero timeout, so this ticks the listener and reads out the result
+         * without ever blocking, and therefore without itself entering a
+         * blocking section and clearing the signal we are watching for.
+         */
+        poll_item.events = SSL_POLL_EVENT_IC;
+        poll_item.revents = 0;
+
+        if (!TEST_true(SSL_poll(&poll_item, 1, sizeof(poll_item), &poll_timeout,
+                0, &poll_result)))
+            goto end;
+
+        if ((poll_item.revents & SSL_POLL_EVENT_IC) != 0)
+            break;
+    }
+
+    if (!TEST_size_t_gt(SSL_get_accept_connection_queue_len(listener), 0))
+        goto end;
+
+    /* The accept queue push must have woken any waiter. */
+    if (!TEST_int_eq(dl->signalled_notifier, 1))
+        goto end;
+
+    testresult = 1;
+end:
+    if (in_blocking_section)
+        ossl_dtls_listener_leave_blocking_section(listener);
+    SSL_free(clientssl);
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    if (client_fd >= 0)
+        BIO_closesocket(client_fd);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+#endif /* OPENSSL_THREADS */
+
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
@@ -4946,5 +5126,11 @@ int setup_tests(void)
     ADD_TEST(test_new_pending_cb_blocked_by_cap);
     ADD_TEST(test_new_pending_cb_all_denied_under_cap);
     ADD_TEST(test_new_pending_cb_alternate);
+    /* Blocking SSL_poll() wakeup tests */
+#if defined(OPENSSL_THREADS)
+    ADD_TEST(test_dtls_notifier_signalled_on_accept_queue_push);
+#endif
+
+
     return 1;
 }

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -4843,7 +4843,7 @@ static int test_new_pending_cb_alternate(void)
 }
 
 /*
- * The test below needs a listener with a notifier, which only exists
+ * The two tests below need a listener with a notifier, which only exists
  * when the listener is created without SSL_LISTENER_FLAG_SINGLE_THREAD. In a
  * no-threads build that listener cannot be created at all, because the
  * condition variable it needs is unavailable.
@@ -5018,6 +5018,144 @@ end:
     return testresult;
 }
 
+/*
+ * Test that a blocking SSL_poll() on a listener enters a blocking section.
+ *
+ * Unless it does, three things follow: the notifier is not in the poll set, so
+ * it cannot wake this thread; cur_blocking_waiters is never incremented, and
+ * since signalling is conditional on there being a waiter, no other thread
+ * even attempts to signal; and there is no re-check after registering, so
+ * readiness arising between the readout and the wait is lost.
+ *
+ * Polling the socket alone is not enough, though not because a wakeup can be
+ * missed outright. poll() reports whatever is currently sitting in the socket
+ * buffer and returns immediately if there is any, so a thread cannot miss a
+ * datagram just by being outside poll() when it arrives. What it can miss is a
+ * datagram another thread has already taken. With several threads polling the
+ * one shared socket that happens constantly: an arriving datagram wakes all of
+ * them, only one gets it, and the rest find nothing. Any of them can be the
+ * one that takes it, because SSL_read() on a connection pumps the demux and
+ * SSL_poll() on a connection ticks the whole listener.
+ *
+ *   1. Accept thread A polls the listener for SSL_POLL_EVENT_IC. Its readout
+ *      ticks the listener, finds nothing, and it decides to block.
+ *   2. A client's final ClientHello lands on the shared socket.
+ *   3. Worker thread B, polling one of its own connections, ticks the listener
+ *      and is the one that takes the datagram. Its tick completes the pending
+ *      connection and pushes it onto the accept queue. Signalling is attempted,
+ *      but A never registered as a waiter, so nothing is signalled.
+ *   4. A reaches its poll, watching the socket alone. B drained it, so it is
+ *      empty, and A sleeps with a validated connection sitting on the accept
+ *      queue.
+ *
+ * A's readout, back at step 1, would have found that connection had it run
+ * after step 3 rather than before it. Registering as a waiter and re-checking
+ * is what removes the dependency on that ordering.
+ *
+ * Note that the signal added for the step 3 queue push is itself conditional on
+ * a registered waiter, so it does nothing for a thread polling the listener
+ * until that thread registers. The two fixes are complementary.
+ *
+ * None of that has a public observable, and this deliberately does not time
+ * the wait. Instead it relies on the last waiter out of a blocking section
+ * draining a raised notifier signal: raise one beforehand, poll briefly with
+ * nothing ready, and check afterwards. Drained means a blocking section was
+ * entered and left, since only a leave drains it and only an enter can be left;
+ * still standing means neither happened.
+ *
+ * signalled_notifier is protected by the listener mutex in the library, which
+ * has to assume concurrent access. This test is single threaded throughout, so
+ * it reads and writes the field directly without holding the mutex.
+ *
+ * Note what this does not cover. That the notifier is in the poll set, and so
+ * can actually deliver a wakeup, is not checked: with a signal raised the poll
+ * returns at once if the notifier is being watched and sleeps out its timeout
+ * if it is not, and only timing separates those. A longer timeout would not
+ * help, because the first iteration's leave drains the notifier and the next
+ * one sleeps out the remainder either way. The re-check after registering is
+ * not covered either, since readiness arriving between the readout and the
+ * registration cannot be produced from a single thread.
+ */
+static int test_dtls_poll_listener_enters_blocking_section(void)
+{
+    SSL_CTX *sctx = NULL;
+    SSL *listener = NULL;
+    BIO_ADDR *server_addr = NULL;
+    DTLS_LISTENER *dl;
+    SSL_POLL_ITEM poll_item;
+    struct timeval poll_timeout;
+    size_t poll_result = 0;
+    int server_fd = -1, nfd = -1;
+    int testresult = 0;
+
+    if (!TEST_ptr(sctx = SSL_CTX_new(DTLS_server_method())))
+        goto end;
+
+    if (!TEST_true(create_dtls_listener(sctx, 0, &listener, &server_addr,
+            &server_fd)))
+        goto end;
+
+    dl = (DTLS_LISTENER *)listener;
+    if (!TEST_true(dl->have_notifier))
+        goto end;
+
+    /*
+     * Raise the notifier as another thread reporting readiness would, which
+     * means both writing to the notifier and recording that it is raised, as
+     * dtls_listener_signal_notifier() does.
+     */
+    if (!TEST_true(ossl_rio_notifier_signal(&dl->notifier)))
+        goto end;
+    dl->signalled_notifier = 1;
+
+    nfd = ossl_rio_notifier_as_fd(&dl->notifier);
+    if (!TEST_int_ge(nfd, 0)
+        || !TEST_int_gt(BIO_socket_ready(nfd, /*for_read=*/1), 0))
+        goto end;
+
+    /*
+     * Poll with a short timeout. No client exists, so nothing is ever ready
+     * and SSL_poll() must block, which is what drives the translation that
+     * enters the blocking section.
+     */
+    poll_item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+    poll_item.desc.value.ssl = listener;
+    poll_item.events = SSL_POLL_EVENT_IC;
+    poll_item.revents = 0;
+    poll_timeout.tv_sec = 0;
+    poll_timeout.tv_usec = 100000;
+
+    if (!TEST_true(SSL_poll(&poll_item, 1, sizeof(poll_item), &poll_timeout, 0,
+            &poll_result)))
+        goto end;
+
+    if (!TEST_size_t_eq(poll_result, 0))
+        goto end;
+
+    /*
+     * Leaving the blocking section must have drained the notifier. Check the
+     * notifier itself and not only the flag recording its state, since it is
+     * the notifier being readable that would spuriously wake a later waiter.
+     */
+    if (!TEST_int_eq(BIO_socket_ready(nfd, /*for_read=*/1), 0))
+        goto end;
+
+    if (!TEST_int_eq(dl->signalled_notifier, 0))
+        goto end;
+
+    if (!TEST_size_t_eq(dl->cur_blocking_waiters, 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
 #endif /* OPENSSL_THREADS */
 
 
@@ -5129,6 +5267,7 @@ int setup_tests(void)
     /* Blocking SSL_poll() wakeup tests */
 #if defined(OPENSSL_THREADS)
     ADD_TEST(test_dtls_notifier_signalled_on_accept_queue_push);
+    ADD_TEST(test_dtls_poll_listener_enters_blocking_section);
 #endif
 
 

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5158,6 +5158,117 @@ end:
 
 #endif /* OPENSSL_THREADS */
 
+static unsigned int short_timer_cb_count;
+
+/* Force a short retransmission timeout and count how often it is consulted. */
+static unsigned int short_timer_cb(SSL *s, unsigned int timer_us)
+{
+    ++short_timer_cb_count;
+    return 50000; /* 50ms */
+}
+
+/*
+ * Test that a blocking SSL_poll() on a DTLS connection honours the
+ * retransmission timer.
+ *
+ * SSL_poll() bounds its wait by the per-object event timeout so that timer
+ * driven work is not delayed. For a DTLS connection that timeout is the
+ * handshake retransmission timer: if it is ignored, a poll with a long user
+ * timeout sleeps straight through the point at which the flight should have
+ * been resent, and if the peer had lost that flight neither side progresses.
+ *
+ * This does not time the wait. The retransmission timeout is forced down to
+ * 50ms and the poll is given much longer, so a correct implementation must
+ * wake and retransmit at least once before the poll deadline; an
+ * implementation which ignores the timer retransmits not at all.
+ */
+static int test_dtls_poll_conn_honours_retransmit_timer(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_POLL_ITEM poll_item;
+    struct timeval poll_timeout, timer_left;
+    size_t poll_result = 0;
+    int is_infinite = 0;
+    int retc, rets, err_code;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_VERSION, 0, &sctx, &cctx, cert,
+            privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    /*
+     * Install the short timeout before the server sends anything, so that it
+     * is picked up when the retransmission timer is first started rather than
+     * only on a later expiry.
+     */
+    DTLS_set_timer_cb(serverssl, short_timer_cb);
+
+    /*
+     * Drive just far enough for the server to send its first flight and start
+     * its retransmission timer. The client is then left alone, so the flight
+     * stays unacknowledged for the duration of the poll.
+     */
+    retc = SSL_connect(clientssl);
+    if (!TEST_int_le(retc, 0)
+        || !TEST_int_eq(SSL_get_error(clientssl, retc), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /*
+     * The server consumes the ClientHello, sends its flight and then waits for
+     * the client, so this does not complete the handshake.
+     */
+    rets = SSL_accept(serverssl);
+    if (!TEST_int_le(rets, 0))
+        goto end;
+
+    err_code = SSL_get_error(serverssl, rets);
+    if (!TEST_true(err_code == SSL_ERROR_WANT_READ
+            || err_code == SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    /*
+     * Assert the precondition through the same call SSL_poll() uses to compute
+     * its deadline: a running timer is reported as a finite timeout.
+     */
+    if (!TEST_true(SSL_get_event_timeout(serverssl, &timer_left, &is_infinite))
+        || !TEST_false(is_infinite))
+        goto end;
+
+    short_timer_cb_count = 0;
+
+    /*
+     * Nothing will arrive for this connection during the poll, so it runs to
+     * its deadline. Along the way the retransmission timer must expire and be
+     * serviced, which re-arms the timer via the callback.
+     */
+    poll_item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+    poll_item.desc.value.ssl = serverssl;
+    poll_item.events = SSL_POLL_EVENT_R;
+    poll_item.revents = 0;
+    poll_timeout.tv_sec = 0;
+    poll_timeout.tv_usec = 500000;
+
+    if (!TEST_true(SSL_poll(&poll_item, 1, sizeof(poll_item), &poll_timeout, 0,
+            &poll_result)))
+        goto end;
+
+    if (!TEST_size_t_gt(short_timer_cb_count, 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
 
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
@@ -5269,7 +5380,7 @@ int setup_tests(void)
     ADD_TEST(test_dtls_notifier_signalled_on_accept_queue_push);
     ADD_TEST(test_dtls_poll_listener_enters_blocking_section);
 #endif
-
+    ADD_TEST(test_dtls_poll_conn_honours_retransmit_timer);
 
     return 1;
 }


### PR DESCRIPTION
Five independent fixes to SSL_poll() on the DTLS listener.

1. Signal the listener notifier on accept queue push. dtls_listener_drive_pending() queued a completed connection without signalling the notifier, even though that is the readiness event a thread blocked on SSL_POLL_EVENT_IC is waiting for. Where another thread does the demuxing, the shared socket does not necessarily become readable on the waiter's behalf, so it slept with a validated connection sitting on the accept queue.

2. Enter a blocking section when polling a DTLS listener. A listener poll added only the network socket to the poll set: the notifier could not wake it, it never registered as a waiter, and it never re-checked for readiness arising between the readout and the wait. Until this lands, the signal added by the previous commit reaches only connection pollers, which have no interest in incoming connections.

3. Honour the DTLS retransmit timer in SSL_poll(). The wakeup deadline was bounded by the QUIC event timeout but not the DTLS one, so a poll with no user timeout slept straight through the point at which the handshake should have been retransmitted. Waking at the deadline also needs something to service the timer, so the readout now calls SSL_handle_events().

4. Stop the DTLS timer when the retransmit budget is exhausted. After DTLS1_TMO_ALERT_COUNT unanswered retransmissions, dtls1_handle_timeout() fails the connection but returns before re-arming, leaving next_timeout holding a time in the past. Nothing clears it afterwards, so every later query reports the timeout as due immediately and a caller that waits on it never waits — the documented DTLSv1_get_timeout() plus select() loop becomes a busy loop consuming a core. Stopping the timer makes it report as not running, so callers fall back to whatever other deadline they have.

5. Wait consistently across platforms when there is nothing to poll. A DTLS connection whose BIO cannot supply a poll descriptor has no readiness to wait for, but still has a retransmission deadline to wake for, so SSL_poll() legitimately ends up waiting on an empty descriptor set. That set was handed to the OS, where behaviour diverges: poll() treats it as a plain sleep, while Windows' select() rejects a call with no descriptors and SSL_poll() failed with it. The wait is now performed explicitly instead of relying on the platform.

The first  three are only reachable when SSL_poll() actually blocks. Every existing DTLS listener test passes a zero timeout, which is why they survived. The last two are longstanding bugs rather than regressions; the earlier commits in this series are simply the first in-tree code to reach them.
