### PR TITLE
TLS 1.3: Apply the cap to the lifetime hint in the session

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3183,7 +3183,7 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
          * tickets for longer than 7 days.
          */
         if (ticket_lifetime_hint > 604800) {
-            ticket_lifetime_hint = 604800;
+            s->session->ext.tick_lifetime_hint = 604800;
         }
 
         if (!PACKET_as_length_prefixed_2(pkt, &extpkt)


### PR DESCRIPTION
Commit 5a85e4152d added a 7 day cap on the TLSv1.3 ticket lifetime as required by RFC 9846, but applied it to a local variable after the value had already been stored in the session and after its last use, so it had no effect. The uncapped value was still returned by SSL_SESSION_get_ticket_lifetime_hint() and used by the client when deciding whether to offer the ticket for resumption. Apply the cap to the lifetime hint in the session.

-  RFC 9846 4.7.1: Servers MUST NOT use any value greater than 604800 seconds  (7 days). The value of zero indicates that the ticket should be discarded immediately. Clients MUST NOT use tickets for longer than 7 days after issuance, regardless of the ticket_lifetime, and MAY delete tickets earlier based on local policy.

The test is set aside in a separate PR and is on hold due to backports and conflicts with other ongoing work related to PSK. https://github.com/openssl/openssl/pull/32475

Fixes #32244
 