### PR TITLE
Stop CMS and PKCS7 abusing ASN.1 internals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -268,6 +268,13 @@ OpenSSL Releases
 
    *Daniel Kubec*
 
+ * Deprecated `CMS_stream()` and `PKCS7_stream()`.  These are internal
+   plumbing that leaked into the public API, and no longer return a
+   streaming boundary.  Use `BIO_new_CMS()` or `BIO_new_PKCS7()` to stream
+   CMS and PKCS7 content.
+
+   *Bob Beck*
+
  * Added `OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES` option for `OSSL_CMP_CTX` and
    a corresponding `-nonmatched_error_nonces` option for the `openssl cmp` command.
 

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -111,6 +111,8 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
     if (aux->asn1_cb(ASN1_OP_GET0_STREAM_CONTENT, &val, it, &content) > 0
         && content != NULL)
         content->flags |= ASN1_STRING_FLAG_NDEF;
+    else
+        content = NULL; /* Don't leave a junk borrowed pointer to play with */
 
     /*
      * We must not fail now because the callback has prepended additional

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -11,6 +11,7 @@
 #include <openssl/asn1t.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
+#include "crypto/asn1.h"
 
 #include <stdio.h>
 
@@ -36,8 +37,11 @@ typedef struct ndef_aux_st {
     BIO *ndef_bio;
     /* Output BIO */
     BIO *out;
-    /* Boundary where content is inserted */
-    unsigned char **boundary;
+    /*
+     * Content octet string in which the encoder records where the content
+     * belongs.  Borrowed from the caller.
+     */
+    ASN1_STRING *content;
     /* DER buffer start */
     unsigned char *derbuf;
 } NDEF_SUPPORT;
@@ -52,8 +56,6 @@ static int ndef_suffix_free(BIO *b, unsigned char **pbuf, int *plen,
 /*
  * On success, the returned BIO owns the input BIO as part of its BIO chain.
  * On failure, NULL is returned and the input BIO is owned by the caller.
- *
- * Unfortunately cannot constify this due to CMS_stream() and PKCS7_stream()
  */
 BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
 {
@@ -62,6 +64,7 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
     const ASN1_AUX *aux = it->funcs;
     ASN1_STREAM_ARG sarg;
     BIO *pop_bio = NULL;
+    ASN1_STRING *content = NULL;
 
     if (!aux || !aux->asn1_cb) {
         ERR_raise(ERR_LIB_ASN1, ASN1_R_STREAMING_NOT_SUPPORTED);
@@ -105,6 +108,10 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
         goto err;
     }
 
+    if (aux->asn1_cb(ASN1_OP_GET0_STREAM_CONTENT, &val, it, &content) > 0
+        && content != NULL)
+        content->flags |= ASN1_STRING_FLAG_NDEF;
+
     /*
      * We must not fail now because the callback has prepended additional
      * BIOs to the chain
@@ -113,7 +120,7 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
     ndef_aux->val = val;
     ndef_aux->it = it;
     ndef_aux->ndef_bio = sarg.ndef_bio;
-    ndef_aux->boundary = sarg.boundary;
+    ndef_aux->content = content;
     ndef_aux->out = out;
 
     return sarg.ndef_bio;
@@ -147,10 +154,10 @@ static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     *pbuf = p;
     ASN1_item_ndef_i2d(ndef_aux->val, &p, ndef_aux->it);
 
-    if (*ndef_aux->boundary == NULL)
+    if (ndef_aux->content == NULL || ndef_aux->content->data == NULL)
         return 0;
 
-    *plen = (int)(*ndef_aux->boundary - *pbuf);
+    *plen = (int)(ndef_aux->content->data - *pbuf);
 
     return 1;
 }
@@ -205,7 +212,7 @@ static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     /* Finalize structures */
     sarg.ndef_bio = ndef_aux->ndef_bio;
     sarg.out = ndef_aux->out;
-    sarg.boundary = ndef_aux->boundary;
+    sarg.boundary = NULL;
     if (aux->asn1_cb(ASN1_OP_STREAM_POST,
             &ndef_aux->val, ndef_aux->it, &sarg)
         <= 0)
@@ -221,10 +228,10 @@ static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     *pbuf = p;
     derlen = ASN1_item_ndef_i2d(ndef_aux->val, &p, ndef_aux->it);
 
-    if (*ndef_aux->boundary == NULL)
+    if (ndef_aux->content == NULL || ndef_aux->content->data == NULL)
         return 0;
-    *pbuf = *ndef_aux->boundary;
-    *plen = derlen - (int)(*ndef_aux->boundary - ndef_aux->derbuf);
+    *pbuf = ndef_aux->content->data;
+    *plen = derlen - (int)(ndef_aux->content->data - ndef_aux->derbuf);
 
     return 1;
 }

--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -358,7 +358,7 @@ static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     switch (operation) {
 
     case ASN1_OP_STREAM_PRE:
-        if (CMS_stream(&sarg->boundary, cms) <= 0)
+        if (ossl_cms_stream(cms) <= 0)
             return 0;
         /* fall through */
     case ASN1_OP_DETACHED_PRE:
@@ -372,6 +372,13 @@ static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         if (CMS_dataFinal(cms, sarg->ndef_bio) <= 0)
             return 0;
         break;
+
+    case ASN1_OP_GET0_STREAM_CONTENT: {
+        ASN1_STRING **content = exarg;
+        ASN1_OCTET_STRING **pos = CMS_get0_content(cms);
+
+        *content = pos == NULL ? NULL : *pos;
+    } break;
 
     case ASN1_OP_FREE_POST:
         OPENSSL_free(cms->ctx.propq);

--- a/crypto/cms/cms_io.c
+++ b/crypto/cms/cms_io.c
@@ -14,10 +14,7 @@
 #include <openssl/cms.h>
 #include "cms_local.h"
 
-#include <crypto/asn1.h>
-
-/* unfortunately cannot constify BIO_new_NDEF() due to this and PKCS7_stream() */
-int CMS_stream(unsigned char ***boundary, CMS_ContentInfo *cms)
+int ossl_cms_stream(CMS_ContentInfo *cms)
 {
     ASN1_OCTET_STRING **pos;
 
@@ -27,13 +24,16 @@ int CMS_stream(unsigned char ***boundary, CMS_ContentInfo *cms)
     if (*pos == NULL)
         *pos = ASN1_OCTET_STRING_new();
     if (*pos != NULL) {
-        (*pos)->flags |= ASN1_STRING_FLAG_NDEF;
         cms->contentIncomplete = 0;
-        *boundary = &(*pos)->data;
         return 1;
     }
     ERR_raise(ERR_LIB_CMS, ERR_R_CMS_LIB);
     return 0;
+}
+
+int CMS_stream(unsigned char ***boundary, CMS_ContentInfo *cms)
+{
+    return ossl_cms_stream(cms);
 }
 
 CMS_ContentInfo *d2i_CMS_bio(BIO *bp, CMS_ContentInfo **cms)

--- a/crypto/cms/cms_io.c
+++ b/crypto/cms/cms_io.c
@@ -31,10 +31,14 @@ int ossl_cms_stream(CMS_ContentInfo *cms)
     return 0;
 }
 
+#if !defined(OPENSSL_NO_DEPRECATED_4_1)
 int CMS_stream(unsigned char ***boundary, CMS_ContentInfo *cms)
 {
+    if (boundary != NULL)
+        *boundary = NULL;
     return ossl_cms_stream(cms);
 }
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 
 CMS_ContentInfo *d2i_CMS_bio(BIO *bp, CMS_ContentInfo **cms)
 {

--- a/crypto/cms/cms_io.c
+++ b/crypto/cms/cms_io.c
@@ -28,7 +28,7 @@ int CMS_stream(unsigned char ***boundary, CMS_ContentInfo *cms)
         *pos = ASN1_OCTET_STRING_new();
     if (*pos != NULL) {
         (*pos)->flags |= ASN1_STRING_FLAG_NDEF;
-        (*pos)->flags &= ~ASN1_STRING_FLAG_CONT;
+        cms->contentIncomplete = 0;
         *boundary = &(*pos)->data;
         return 1;
     }

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -137,7 +137,7 @@ BIO *ossl_cms_content_bio(CMS_ContentInfo *cms)
     /*
      * If content not detached and created return memory BIO
      */
-    if (*pos == NULL || ((*pos)->flags == ASN1_STRING_FLAG_CONT))
+    if (*pos == NULL || cms->contentIncomplete)
         return BIO_new(BIO_s_mem());
     /* Else content was read in: return read only BIO for it */
     return BIO_new_mem_buf((*pos)->data, (*pos)->length);
@@ -217,7 +217,7 @@ int ossl_cms_DataFinal(CMS_ContentInfo *cms, BIO *cmsbio, BIO *data,
     if (pos == NULL)
         return 0;
     /* If embedded content find memory BIO and set content */
-    if (*pos && ((*pos)->flags & ASN1_STRING_FLAG_CONT)) {
+    if (*pos && cms->contentIncomplete) {
         BIO *mbio;
         unsigned char *cont;
         long contlen;
@@ -231,7 +231,7 @@ int ossl_cms_DataFinal(CMS_ContentInfo *cms, BIO *cmsbio, BIO *data,
         BIO_set_flags(mbio, BIO_FLAGS_MEM_RDONLY);
         BIO_set_mem_eof_return(mbio, 0);
         ASN1_STRING_set0(*pos, cont, contlen);
-        (*pos)->flags &= ~ASN1_STRING_FLAG_CONT;
+        cms->contentIncomplete = 0;
     }
 
     switch (OBJ_obj2nid(cms->contentType)) {
@@ -387,15 +387,13 @@ int CMS_set_detached(CMS_ContentInfo *cms, int detached)
     if (detached) {
         ASN1_OCTET_STRING_free(*pos);
         *pos = NULL;
+        cms->contentIncomplete = 0;
         return 1;
     }
     if (*pos == NULL)
         *pos = ASN1_OCTET_STRING_new();
     if (*pos != NULL) {
-        /*
-         * NB: special flag to show content is created and not read in.
-         */
-        (*pos)->flags |= ASN1_STRING_FLAG_CONT;
+        cms->contentIncomplete = 1;
         return 1;
     }
     ERR_raise(ERR_LIB_CMS, ERR_R_ASN1_LIB);

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -441,6 +441,14 @@ CMS_ContentInfo *ossl_cms_Data_create(OSSL_LIB_CTX *ctx, const char *propq);
 int ossl_cms_DataFinal(CMS_ContentInfo *cms, BIO *cmsbio, BIO *data,
     const unsigned char *precomp_md,
     unsigned int precomp_mdlen);
+/**
+ * @brief Prepare the content of cms for indefinite-length streaming.
+ * The content octet string is created if it is not already present, and the
+ * content is recorded as created here rather than read in via d2i.
+ * @param cms the CMS_ContentInfo to prepare for streaming
+ * @returns 1 on success, 0 on failure
+ */
+int ossl_cms_stream(CMS_ContentInfo *cms);
 
 CMS_ContentInfo *ossl_cms_DigestedData_create(const EVP_MD *md,
     OSSL_LIB_CTX *libctx,

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -66,6 +66,16 @@ struct CMS_ContentInfo_st {
         void *otherData;
     } d;
     CMS_CTX ctx;
+    /*-
+     * Set when the content octet string is empty and is to be filled at
+     * dataFinal time from the memory BIO ossl_cms_content_bio() returns.
+     * Cleared:
+     * - once the string has been filled;
+     * - when the content is detached;
+     * - when streaming is set up, where the encoder writes the content out
+     *   and records its position in the string rather than filling it.
+     */
+    int contentIncomplete;
 };
 
 DEFINE_STACK_OF(CMS_CertificateChoices)

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -39,7 +39,7 @@ static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     switch (operation) {
 
     case ASN1_OP_STREAM_PRE:
-        if (PKCS7_stream(&sarg->boundary, *pp7) <= 0)
+        if (ossl_pkcs7_stream(*pp7) <= 0)
             return 0;
         /* fall through */
     case ASN1_OP_DETACHED_PRE:
@@ -53,6 +53,12 @@ static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         if (PKCS7_dataFinal(*pp7, sarg->ndef_bio) <= 0)
             return 0;
         break;
+
+    case ASN1_OP_GET0_STREAM_CONTENT: {
+        ASN1_STRING **content = exarg;
+
+        *content = ossl_pkcs7_get0_stream_content(*pp7);
+    } break;
     }
     return 1;
 }

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -56,7 +56,7 @@ ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7)
     return NULL;
 }
 
-static ASN1_OCTET_STRING *pkcs7_get1_data(PKCS7 *p7)
+static ASN1_OCTET_STRING *pkcs7_get1_data(PKCS7 *p7, int streaming)
 {
     ASN1_OCTET_STRING *os = PKCS7_get_octet_string(p7);
 
@@ -64,8 +64,7 @@ static ASN1_OCTET_STRING *pkcs7_get1_data(PKCS7 *p7)
         /* Edge case for MIME content, see RFC 5652 section-5.2.1 */
         ASN1_OCTET_STRING *osdup = ASN1_OCTET_STRING_dup(os);
 
-        if (osdup != NULL && (os->flags & ASN1_STRING_FLAG_NDEF))
-            /* ASN1_STRING_FLAG_NDEF flag is currently used by openssl-smime */
+        if (osdup != NULL && streaming)
             ASN1_STRING_set0(osdup, NULL, 0);
         return osdup;
     }
@@ -264,7 +263,8 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
     switch (i) {
     case NID_pkcs7_signed:
         md_sk = p7->d.sign->md_algs;
-        os = pkcs7_get1_data(p7->d.sign->contents);
+        os = pkcs7_get1_data(p7->d.sign->contents,
+            (p7->state & PKCS7_STATE_STREAMING) != 0);
         break;
     case NID_pkcs7_signedAndEnveloped:
         rsk = p7->d.signed_and_enveloped->recipientinfo;
@@ -287,7 +287,8 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
         break;
     case NID_pkcs7_digest:
         xa = p7->d.digest->md;
-        os = pkcs7_get1_data(p7->d.digest->contents);
+        os = pkcs7_get1_data(p7->d.digest->contents,
+            (p7->state & PKCS7_STATE_STREAMING) != 0);
         break;
     case NID_pkcs7_data:
         break;
@@ -899,7 +900,7 @@ int PKCS7_dataFinal(PKCS7 *p7, BIO *bio)
          */
         if (os == NULL)
             goto err;
-        if (!(os->flags & ASN1_STRING_FLAG_NDEF)) {
+        if (!(p7->state & PKCS7_STATE_STREAMING)) {
             char *cont;
             long contlen;
             btmp = BIO_find_type(bio, BIO_TYPE_MEM);

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -260,7 +260,6 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
     }
 
     i = OBJ_obj2nid(p7->type);
-    p7->state = PKCS7_S_HEADER;
 
     switch (i) {
     case NID_pkcs7_signed:
@@ -461,7 +460,6 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
     }
 
     i = OBJ_obj2nid(p7->type);
-    p7->state = PKCS7_S_HEADER;
 
     switch (i) {
     case NID_pkcs7_signed:
@@ -771,7 +769,6 @@ int PKCS7_dataFinal(PKCS7 *p7, BIO *bio)
     }
 
     i = OBJ_obj2nid(p7->type);
-    p7->state = PKCS7_S_HEADER;
 
     switch (i) {
     case NID_pkcs7_data:

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -716,8 +716,8 @@ int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher)
     return 1;
 }
 
-/* unfortunately cannot constify BIO_new_NDEF() due to this and CMS_stream() */
-int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7)
+/* Return the content octet string that indefinite-length streaming encodes */
+ASN1_OCTET_STRING *ossl_pkcs7_get0_stream_content(PKCS7 *p7)
 {
     ASN1_OCTET_STRING *os = NULL;
 
@@ -763,12 +763,22 @@ int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7)
         break;
     }
 
+    return os;
+}
+
+int ossl_pkcs7_stream(PKCS7 *p7)
+{
+    ASN1_OCTET_STRING *os = ossl_pkcs7_get0_stream_content(p7);
+
     if (os == NULL)
         return 0;
 
-    os->flags |= ASN1_STRING_FLAG_NDEF;
     p7->state |= PKCS7_STATE_STREAMING;
-    *boundary = &os->data;
 
     return 1;
+}
+
+int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7)
+{
+    return ossl_pkcs7_stream(p7);
 }

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -778,7 +778,11 @@ int ossl_pkcs7_stream(PKCS7 *p7)
     return 1;
 }
 
+#if !defined(OPENSSL_NO_DEPRECATED_4_1)
 int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7)
 {
+    if (boundary != NULL)
+        *boundary = NULL;
     return ossl_pkcs7_stream(p7);
 }
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -767,6 +767,7 @@ int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7)
         return 0;
 
     os->flags |= ASN1_STRING_FLAG_NDEF;
+    p7->state |= PKCS7_STATE_STREAMING;
     *boundary = &os->data;
 
     return 1;

--- a/crypto/pkcs7/pk7_local.h
+++ b/crypto/pkcs7/pk7_local.h
@@ -24,6 +24,17 @@
  */
 #define PKCS7_STATE_STREAMING 0x100
 
+ASN1_OCTET_STRING *ossl_pkcs7_get0_stream_content(PKCS7 *p7);
+
+/**
+ * @brief Prepare the content of p7 for indefinite-length streaming.
+ * The content octet string is created if it is not already present, and the
+ * content is recorded as a streaming placeholder in the state field.
+ * @param p7 the PKCS7 to prepare for streaming
+ * @returns 1 on success, 0 on failure
+ */
+int ossl_pkcs7_stream(PKCS7 *p7);
+
 STACK_OF(X509) *pkcs7_get0_certificates(const PKCS7 *p7);
 const PKCS7_CTX *ossl_pkcs7_get0_ctx(const PKCS7 *p7);
 OSSL_LIB_CTX *ossl_pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx);

--- a/crypto/pkcs7/pk7_local.h
+++ b/crypto/pkcs7/pk7_local.h
@@ -12,6 +12,18 @@
 
 #include "crypto/pkcs7.h"
 
+/*
+ * The public PKCS7 state field once held PKCS7_S_HEADER/BODY/TAIL; those
+ * values are no longer used but remain public.  Use a separate bit of the
+ * field, clear of the public values, as an internal flag.
+ *
+ * Set when streaming is set up, where the encoder writes the content out.
+ * When it is not set and the content is not detached, the content octet
+ * string is filled at dataFinal time from the memory BIO PKCS7_dataInit()
+ * creates.
+ */
+#define PKCS7_STATE_STREAMING 0x100
+
 STACK_OF(X509) *pkcs7_get0_certificates(const PKCS7 *p7);
 const PKCS7_CTX *ossl_pkcs7_get0_ctx(const PKCS7 *p7);
 OSSL_LIB_CTX *ossl_pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx);

--- a/doc/man3/ASN1_aux_cb.pod
+++ b/doc/man3/ASN1_aux_cb.pod
@@ -223,6 +223,16 @@ Invoked in order to obtain the property query string associated with an
 B<ASN1_VALUE> if any. A pointer to the property query string should be stored in
 I<*exarg> if such a value exists.
 
+=item B<ASN1_OP_GET0_STREAM_CONTENT>
+
+Invoked while setting up indefinite length streaming, after
+B<ASN1_OP_STREAM_PRE>, in order to obtain the content octet string of the
+B<ASN1_VALUE> being streamed. A pointer to the B<ASN1_STRING> should be stored
+in I<*exarg> if such a value exists. The caller marks that string for
+indefinite length encoding and records the position of the content in it on
+every encoding pass, so it must remain valid for as long as the streaming
+B<BIO> is in use.
+
 =back
 
 An B<ASN1_PRINT_ARG> object is used during processing of B<ASN1_OP_PRINT_PRE>
@@ -261,7 +271,9 @@ The B<BIO> with filters appended
 
 =item I<boundary>
 
-The streaming I/O boundary.
+The streaming I/O boundary. This field is no longer used: the position of the
+content is taken from the content octet string obtained with
+B<ASN1_OP_GET0_STREAM_CONTENT>.
 
 =back
 
@@ -311,6 +323,8 @@ L<ASN1_item_new_ex(3)>
 
 The ASN1_aux_const_cb() callback and the B<ASN1_OP_GET0_LIBCTX> and
 B<ASN1_OP_GET0_PROPQ> operation types were added in OpenSSL 3.0.
+
+The B<ASN1_OP_GET0_STREAM_CONTENT> operation type was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -27,14 +27,6 @@
  * inserted in the memory buffer
  */
 #define ASN1_STRING_FLAG_NDEF 0x010
-
-/*
- * This flag is used by the CMS code to indicate that a string is not
- * complete and is a place holder for content when it had all been accessed.
- * The flag will be reset when content has been written to it.
- */
-
-#define ASN1_STRING_FLAG_CONT 0x020
 /*
  * This flag is used by ASN1 code to indicate an ASN1_STRING is an MSTRING
  * type.

--- a/include/openssl/asn1t.h.in
+++ b/include/openssl/asn1t.h.in
@@ -747,6 +747,7 @@ typedef struct ASN1_STREAM_ARG_st {
 #define ASN1_OP_DUP_POST 15
 #define ASN1_OP_GET0_LIBCTX 16
 #define ASN1_OP_GET0_PROPQ 17
+#define ASN1_OP_GET0_STREAM_CONTENT 18
 
 /* Macro to implement a primitive type */
 #define IMPLEMENT_ASN1_TYPE(stname) IMPLEMENT_ASN1_TYPE_ex(stname, stname, 0)

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -118,7 +118,9 @@ int CMS_set_detached(CMS_ContentInfo *cms, int detached);
 #ifdef OPENSSL_PEM_H
 DECLARE_PEM_rw(CMS, CMS_ContentInfo)
 #endif
-int CMS_stream(unsigned char ***boundary, CMS_ContentInfo *cms);
+#if !defined(OPENSSL_NO_DEPRECATED_4_1)
+OSSL_DEPRECATEDIN_4_1 int CMS_stream(unsigned char ***boundary, CMS_ContentInfo *cms);
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 CMS_ContentInfo *d2i_CMS_bio(BIO *bp, CMS_ContentInfo **cms);
 int i2d_CMS_bio(BIO *bp, CMS_ContentInfo *cms);
 

--- a/include/openssl/pkcs7.h.in
+++ b/include/openssl/pkcs7.h.in
@@ -303,7 +303,9 @@ void PKCS7_RECIP_INFO_get0_alg(PKCS7_RECIP_INFO *ri, X509_ALGOR **penc);
 int PKCS7_add_recipient_info(PKCS7 *p7, PKCS7_RECIP_INFO *ri);
 int PKCS7_RECIP_INFO_set(PKCS7_RECIP_INFO *p7i, X509 *x509);
 int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher);
-int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7);
+#if !defined(OPENSSL_NO_DEPRECATED_4_1)
+OSSL_DEPRECATEDIN_4_1 int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7);
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 
 PKCS7_ISSUER_AND_SERIAL *PKCS7_get_issuer_and_serial(PKCS7 *p7, int idx);
 ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7);

--- a/test/bio_ndef_test.c
+++ b/test/bio_ndef_test.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Tests of BIO_new_NDEF() against a minimal streamable ASN.1 structure,
+ * independent of CMS and PKCS7.  The structure's callback implements the
+ * stream operations described in ASN1_aux_cb(3), and can be made to
+ * misbehave in ways a third-party callback plausibly would, to pin down
+ * how BIO_new_NDEF() holds up.  See also BIO_new_NDEF(3).
+ */
+
+#include <string.h>
+
+#include <openssl/asn1t.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+
+#include "testutil.h"
+
+typedef struct {
+    ASN1_OCTET_STRING *content;
+} NDEF_TEST_VAL;
+
+DECLARE_ASN1_FUNCTIONS(NDEF_TEST_VAL)
+
+/* How ndef_test_cb() behaves; a well written callback uses CB_NORMAL */
+enum {
+    CB_NORMAL,
+    CB_FAIL_STREAM_PRE, /* fail ASN1_OP_STREAM_PRE */
+    CB_NO_CONTENT, /* leave ASN1_OP_GET0_STREAM_CONTENT unhandled */
+    CB_CONTENT_THEN_FAIL /* store the content string, then report failure */
+};
+static int cb_mode = CB_NORMAL;
+
+static int ndef_test_cb(int operation, ASN1_VALUE **pval,
+    const ASN1_ITEM *it, void *exarg)
+{
+    NDEF_TEST_VAL *v = (NDEF_TEST_VAL *)*pval;
+    ASN1_STREAM_ARG *sarg = exarg;
+
+    switch (operation) {
+    case ASN1_OP_STREAM_PRE:
+        if (cb_mode == CB_FAIL_STREAM_PRE || v->content == NULL)
+            return 0;
+        /* Nothing to digest or encrypt: stream straight through */
+        sarg->ndef_bio = sarg->out;
+        break;
+
+    case ASN1_OP_GET0_STREAM_CONTENT:
+        if (cb_mode == CB_NO_CONTENT)
+            break;
+        *(ASN1_STRING **)exarg = v->content;
+        if (cb_mode == CB_CONTENT_THEN_FAIL)
+            return 0;
+        break;
+    }
+    return 1;
+}
+
+ASN1_NDEF_SEQUENCE_cb(NDEF_TEST_VAL, ndef_test_cb) = {
+    ASN1_SIMPLE(NDEF_TEST_VAL, content, ASN1_OCTET_STRING_NDEF)
+} ASN1_NDEF_SEQUENCE_END_cb(NDEF_TEST_VAL, NDEF_TEST_VAL)
+
+IMPLEMENT_ASN1_FUNCTIONS(NDEF_TEST_VAL)
+
+static const unsigned char payload[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+#define PAYLOAD_LEN ((int)sizeof(payload) - 1)
+#define PAYLOAD_SPLIT 10
+
+/* Free the filter BIOs down to, but not including, out */
+static void free_filter_bios(BIO *bio, BIO *out)
+{
+    while (bio != NULL && bio != out) {
+        BIO *next = BIO_pop(bio);
+
+        BIO_free(bio);
+        bio = next;
+    }
+}
+
+/* Stream a payload in two writes and check that it round-trips */
+static int test_ndef_stream_ok(void)
+{
+    NDEF_TEST_VAL *v = NULL, *parsed = NULL;
+    BIO *out = NULL, *bio = NULL;
+    unsigned char *encoded = NULL;
+    const unsigned char *der;
+    long encoded_len;
+    int ret = 0;
+
+    cb_mode = CB_NORMAL;
+
+    if (!TEST_ptr(v = NDEF_TEST_VAL_new())
+        || !TEST_ptr(out = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(bio = BIO_new_NDEF(out, (ASN1_VALUE *)v,
+                         ASN1_ITEM_rptr(NDEF_TEST_VAL))))
+        goto err;
+
+    if (!TEST_int_eq(BIO_write(bio, payload, PAYLOAD_SPLIT), PAYLOAD_SPLIT)
+        || !TEST_int_eq(BIO_write(bio, payload + PAYLOAD_SPLIT,
+                            PAYLOAD_LEN - PAYLOAD_SPLIT),
+            PAYLOAD_LEN - PAYLOAD_SPLIT)
+        || !TEST_int_gt(BIO_flush(bio), 0))
+        goto err;
+
+    free_filter_bios(bio, out);
+    bio = NULL;
+
+    encoded_len = BIO_get_mem_data(out, &encoded);
+    if (!TEST_long_gt(encoded_len, 0))
+        goto err;
+
+    der = encoded;
+    if (!TEST_ptr(parsed = d2i_NDEF_TEST_VAL(NULL, &der, encoded_len))
+        || !TEST_mem_eq(ASN1_STRING_get0_data(parsed->content),
+            ASN1_STRING_get_length(parsed->content),
+            payload, PAYLOAD_LEN))
+        goto err;
+
+    ret = 1;
+err:
+    free_filter_bios(bio, out);
+    BIO_free(out);
+    NDEF_TEST_VAL_free(parsed);
+    NDEF_TEST_VAL_free(v);
+    return ret;
+}
+
+/* An item with no callback cannot stream; out must stay usable */
+static int test_ndef_not_supported(void)
+{
+    ASN1_OCTET_STRING *os = NULL;
+    BIO *out = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(os = ASN1_OCTET_STRING_new())
+        || !TEST_ptr(out = BIO_new(BIO_s_mem())))
+        goto err;
+
+    ERR_clear_error();
+    if (!TEST_ptr_null(BIO_new_NDEF(out, (ASN1_VALUE *)os,
+            ASN1_ITEM_rptr(ASN1_OCTET_STRING)))
+        || !TEST_int_eq(ERR_GET_REASON(ERR_get_error()),
+            ASN1_R_STREAMING_NOT_SUPPORTED))
+        goto err;
+
+    /* On failure out remains owned by the caller and usable */
+    if (!TEST_int_eq(BIO_write(out, "x", 1), 1))
+        goto err;
+
+    ret = 1;
+err:
+    BIO_free(out);
+    ASN1_OCTET_STRING_free(os);
+    return ret;
+}
+
+/* A failed ASN1_OP_STREAM_PRE must unwind the half-built chain */
+static int test_ndef_stream_pre_fails(void)
+{
+    NDEF_TEST_VAL *v = NULL;
+    BIO *out = NULL;
+    int ret = 0;
+
+    cb_mode = CB_FAIL_STREAM_PRE;
+
+    if (!TEST_ptr(v = NDEF_TEST_VAL_new())
+        || !TEST_ptr(out = BIO_new(BIO_s_mem())))
+        goto err;
+
+    if (!TEST_ptr_null(BIO_new_NDEF(out, (ASN1_VALUE *)v,
+            ASN1_ITEM_rptr(NDEF_TEST_VAL))))
+        goto err;
+
+    /* On failure out remains owned by the caller and usable */
+    if (!TEST_int_eq(BIO_write(out, "x", 1), 1))
+        goto err;
+
+    ret = 1;
+err:
+    cb_mode = CB_NORMAL;
+    BIO_free(out);
+    NDEF_TEST_VAL_free(v);
+    return ret;
+}
+
+/*
+ * A callback that does not provide the content string, either by leaving
+ * ASN1_OP_GET0_STREAM_CONTENT unhandled (idx 0, the shape of a callback written
+ * before that operation existed) or by storing the string and then
+ * reporting failure (idx 1).  Setting up the BIO chain still succeeds,
+ * because the stream callbacks have already modified it, but the first
+ * write must fail cleanly instead of encoding through a content string
+ * that the encoder is not recording the content position in.
+ */
+static int test_ndef_content_missing(int idx)
+{
+    NDEF_TEST_VAL *v = NULL;
+    BIO *out = NULL, *bio = NULL;
+    int ret = 0;
+
+    cb_mode = idx == 0 ? CB_NO_CONTENT : CB_CONTENT_THEN_FAIL;
+
+    /* Content with data present makes a stale-position mistake detectable */
+    if (!TEST_ptr(v = NDEF_TEST_VAL_new())
+        || !TEST_true(ASN1_OCTET_STRING_set(v->content, payload, PAYLOAD_LEN))
+        || !TEST_ptr(out = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(bio = BIO_new_NDEF(out, (ASN1_VALUE *)v,
+                         ASN1_ITEM_rptr(NDEF_TEST_VAL))))
+        goto err;
+
+    if (!TEST_int_le(BIO_write(bio, payload, PAYLOAD_LEN), 0))
+        goto err;
+
+    ret = 1;
+err:
+    cb_mode = CB_NORMAL;
+    free_filter_bios(bio, out);
+    BIO_free(out);
+    NDEF_TEST_VAL_free(v);
+    return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_ndef_stream_ok);
+    ADD_TEST(test_ndef_not_supported);
+    ADD_TEST(test_ndef_stream_pre_fails);
+    ADD_ALL_TESTS(test_ndef_content_missing, 2);
+    return 1;
+}

--- a/test/build.info
+++ b/test/build.info
@@ -57,7 +57,7 @@ IF[{- !$disabled{tests} -}]
           packettest asynctest secmemtest srptest memleaktest stack_test \
           dtlsv1listentest ct_test threadstest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
-          bio_callback_test bio_memleak_test bio_core_test bio_dgram_test param_build_test \
+          bio_callback_test bio_memleak_test bio_ndef_test bio_core_test bio_dgram_test param_build_test \
           sslapitest ssl_handshake_rtt_test dtlstest sslcorrupttest \
           bio_base64_test bio_enc_test pkey_meth_kdf_test evp_kdf_test uitest \
           cipherbytes_test threadstest_fips threadpool_test \
@@ -594,6 +594,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[bio_memleak_test]=bio_memleak_test.c
   INCLUDE[bio_memleak_test]=../include ../apps/include
   DEPEND[bio_memleak_test]=../libcrypto libtestutil.a
+
+  SOURCE[bio_ndef_test]=bio_ndef_test.c
+  INCLUDE[bio_ndef_test]=../include ../apps/include
+  DEPEND[bio_ndef_test]=../libcrypto libtestutil.a
 
   SOURCE[bio_meth_test]=bio_meth_test.c
   INCLUDE[bio_meth_test]=../include ../apps/include

--- a/test/recipes/04-test_bio_ndef.t
+++ b/test/recipes/04-test_bio_ndef.t
@@ -1,0 +1,14 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_bio_ndef", "bio_ndef_test");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3228,7 +3228,7 @@ PEM_read_CMS                            3226	4_0_0	EXIST::FUNCTION:CMS,STDIO
 PEM_write_CMS                           3227	4_0_0	EXIST::FUNCTION:CMS,STDIO
 PEM_read_bio_CMS                        3228	4_0_0	EXIST::FUNCTION:CMS
 PEM_write_bio_CMS                       3229	4_0_0	EXIST::FUNCTION:CMS
-CMS_stream                              3230	4_0_0	EXIST::FUNCTION:CMS
+CMS_stream                              3230	4_0_0	EXIST::FUNCTION:CMS,DEPRECATEDIN_4_1
 d2i_CMS_bio                             3231	4_0_0	EXIST::FUNCTION:CMS
 i2d_CMS_bio                             3232	4_0_0	EXIST::FUNCTION:CMS
 BIO_new_CMS                             3233	4_0_0	EXIST::FUNCTION:CMS
@@ -4164,7 +4164,7 @@ PKCS7_RECIP_INFO_get0_alg               4161	4_0_0	EXIST::FUNCTION:
 PKCS7_add_recipient_info                4162	4_0_0	EXIST::FUNCTION:
 PKCS7_RECIP_INFO_set                    4163	4_0_0	EXIST::FUNCTION:
 PKCS7_set_cipher                        4164	4_0_0	EXIST::FUNCTION:
-PKCS7_stream                            4165	4_0_0	EXIST::FUNCTION:
+PKCS7_stream                            4165	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_1
 PKCS7_get_issuer_and_serial             4166	4_0_0	EXIST::FUNCTION:
 PKCS7_get_octet_string                  4167	4_0_0	EXIST::FUNCTION:
 PKCS7_digest_from_attributes            4168	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
CMS and PKCS7 reach into ASN1_STRING to set up indefinite length
streaming: they set ASN1_STRING_FLAG_NDEF on the content octet string,
and hand BIO_new_NDEF() the address of that string's data field, where
the encoder records the position at which the content belongs. CMS also
uses ASN1_STRING_FLAG_CONT to remember whether it created the content
itself.

BIO_new_NDEF() now obtains the content octet  through a new
ASN1_OP_STREAM_CONTENT callback operation, sets the flag itself, and
reads the content position back out of the string after each encoding
pass, so the flag is set only in crypto/asn1. ASN1_STRING_FLAG_CONT is
replaced by a field on CMS_ContentInfo and deleted; PKCS7 uses its
existing public state field, whose PKCS7_S_* values were unused.

The remains of CMS_stream() and PKCS7_stream() become internal functions
called from the ASN.1 callbacks. The public ones are undocumented
plumbing for BIO_new_NDEF() and are deprecated.

This is the first 5 commits of https://github.com/openssl/openssl/pull/32241
and are needed for it's goal, but this improvement stands on it's
own.


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
