### PR TITLE
ssl: store capped TLS1.3 ticket lifetime hint

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3184,6 +3184,7 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
          */
         if (ticket_lifetime_hint > 604800) {
             ticket_lifetime_hint = 604800;
+            s->session->ext.tick_lifetime_hint = ticket_lifetime_hint;
         }
 
         if (!PACKET_as_length_prefixed_2(pkt, &extpkt)

--- a/test/recipes/70-test_tls13ticket_lifetime.t
+++ b/test/recipes/70-test_tls13ticket_lifetime.t
@@ -1,0 +1,109 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
+use OpenSSL::Test::Utils;
+use TLSProxy::Proxy;
+use File::Temp qw(tempfile);
+use Cwd qw(abs_path);
+
+package TLSProxy::RawNewSessionTicket;
+
+use vars '@ISA';
+push @ISA, 'TLSProxy::NewSessionTicket';
+
+# Preserve the TLS 1.3 NewSessionTicket body set by the test filter.
+sub set_message_contents
+{
+}
+
+package main;
+
+my $test_name = "test_tls13ticket_lifetime";
+setup($test_name);
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
+plan skip_all => "TLSProxy isn't usable on $^O"
+    if $^O =~ /^(VMS)$/;
+
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
+
+plan skip_all => "$test_name needs the sock feature enabled"
+    if disabled("sock");
+
+plan skip_all => "$test_name needs TLSv1.3 enabled"
+    if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
+
+use constant ONE_WEEK_SEC => 7 * 24 * 60 * 60;
+
+my $ticket_lifetime;
+
+sub oversized_ticket_lifetime_filter
+{
+    my $proxy = shift;
+
+    foreach my $message (@{$proxy->message_list}) {
+        next if $message->mt != TLSProxy::Message::MT_NEW_SESSION_TICKET;
+
+        my $data = $message->data;
+
+        substr($data, 0, 4, pack('N', $ticket_lifetime));
+        $message->data($data);
+        bless $message, 'TLSProxy::RawNewSessionTicket';
+        $message->repack();
+    }
+}
+
+plan tests => 2;
+
+my $proxy = TLSProxy::Proxy->new(
+    \&oversized_ticket_lifetime_filter,
+    cmdstr(app(["openssl"]), display => 1),
+    srctop_file("apps", "server.pem"),
+    (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE}),
+    have_IPv6()
+);
+
+test_ticket_lifetime($proxy, ONE_WEEK_SEC, ONE_WEEK_SEC,
+    "Ticket lifetime at the limit is unchanged");
+$proxy->clear();
+test_ticket_lifetime($proxy, ONE_WEEK_SEC + 1, ONE_WEEK_SEC,
+    "Ticket lifetime above the limit is capped");
+
+sub test_ticket_lifetime
+{
+    my ($proxy, $sent_lifetime, $stored_lifetime, $name) = @_;
+    my $stored_lifetime_hex = sprintf('%X', $stored_lifetime);
+
+    subtest $name => sub {
+        (undef, my $session) = tempfile();
+
+        plan tests => 2;
+        $ticket_lifetime = $sent_lifetime;
+        $proxy->clientflags("-sess_out " . $session);
+        $proxy->sessionfile($session);
+
+        ok($proxy->start() && TLSProxy::Message->success(),
+            "TLS 1.3 handshake succeeds");
+
+        my $session_asn1 = join('', run(app([
+            "openssl", "asn1parse", "-in", $session
+        ]), capture => 1));
+
+        like($session_asn1,
+            qr/cont \[ 9 \].*?INTEGER\s+:0*\Q$stored_lifetime_hex\E\b/s,
+            "Client stores the expected ticket lifetime hint");
+
+        unlink $session;
+    };
+}


### PR DESCRIPTION
fix #32244

Clamp `tick_lifetime_hint` to 604800 and keep it reflected in session state so cached tickets always use the RFC-mandated 7-day max.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
