### PR TITLE
CCM: authenticate empty Final when payload Update is skipped

### DIFF
--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -286,13 +286,19 @@ int ossl_ccm_stream_final(void *vctx, unsigned char *out, size_t *outl,
     size_t outsize)
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
-    int i;
+    unsigned char dummy_in = 0, dummy_out = 0;
 
     if (!ossl_prov_is_running())
         return 0;
 
-    i = ccm_cipher_internal(ctx, out, outl, NULL, 0);
-    if (i <= 0)
+    /*
+     * Encryption sets tag_set after processing the payload, while successful
+     * decryption clears iv_set. Use those transitions to avoid processing an
+     * operation twice.
+     */
+    if (!ctx->key_set
+        || (ctx->iv_set && (!ctx->enc || !ctx->tag_set)
+            && ccm_cipher_internal(ctx, &dummy_out, outl, &dummy_in, 0) <= 0))
         return 0;
 
     *outl = 0;
@@ -306,6 +312,9 @@ int ossl_ccm_cipher(void *vctx, unsigned char *out, size_t *outl, size_t outsize
 
     if (!ossl_prov_is_running())
         return 0;
+
+    if (in == NULL)
+        return ossl_ccm_stream_final(vctx, out, outl, outsize);
 
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5845,12 +5845,29 @@ err:
     return testresult;
 }
 
+static int prepare_ccm_no_payload(EVP_CIPHER_CTX *ctx,
+    const EVP_CIPHER_TEST_INFO *info)
+{
+    static const unsigned char aad[] = "CCM empty-payload Final regression";
+    int outlen = 0;
+
+    if (info->mode != EVP_CIPH_CCM_MODE)
+        return 1;
+
+    return EVP_CipherUpdate(ctx, NULL, &outlen, NULL, 0) > 0
+        && EVP_CipherUpdate(ctx, NULL, &outlen, aad,
+               (int)sizeof(aad) - 1)
+        > 0;
+}
+
 /*-
  * A zero-length AEAD message driven through the one-shot EVP_Cipher() interface
  * must agree with the streaming EVP_CipherFinal_ex() path. This checks:
  * - an empty message yields the same tag via both interfaces
  * - the true tag passes verification on decrypt
  * - the modified tag fails verification on decrypt
+ * For CCM, each operation declares a zero payload length and supplies AAD, but
+ * deliberately omits the payload Update that would otherwise authenticate it.
  */
 static int test_evp_oneshot_aead_zerolen(int idx)
 {
@@ -5881,7 +5898,6 @@ static int test_evp_oneshot_aead_zerolen(int idx)
 
     /* filter out various modes */
     if (info->taglen == 0
-        || info->mode == EVP_CIPH_CCM_MODE
         /* skip TLS stitched MTE cipher */
         || EVP_CIPHER_is_a(info->ciph, "AES-128-CBC-HMAC-SHA1")
         /* skip TLS stitched MTE cipher */
@@ -5904,6 +5920,10 @@ static int test_evp_oneshot_aead_zerolen(int idx)
     }
     if (!TEST_true(EVP_EncryptInit_ex2(ctx_stream, info->ciph, key, iv, NULL))) {
         errmsg = "STREAM_INIT";
+        goto err;
+    }
+    if (!TEST_true(prepare_ccm_no_payload(ctx_stream, info))) {
+        errmsg = "STREAM_CCM_PREPARE";
         goto err;
     }
     if (!TEST_true(EVP_EncryptFinal_ex(ctx_stream, ct, &finlen))) {
@@ -5939,6 +5959,10 @@ static int test_evp_oneshot_aead_zerolen(int idx)
         errmsg = "ONESHOT_INIT";
         goto err;
     }
+    if (!TEST_true(prepare_ccm_no_payload(ctx_oneshot, info))) {
+        errmsg = "ONESHOT_CCM_PREPARE";
+        goto err;
+    }
     oneshot_flen = EVP_Cipher(ctx_oneshot, ct, NULL, 0);
     if (!TEST_int_ge(oneshot_flen, 0)) {
         errmsg = "ONESHOT_FINAL_NULL";
@@ -5972,6 +5996,10 @@ static int test_evp_oneshot_aead_zerolen(int idx)
         errmsg = "DEC_SET_TAG";
         goto err;
     }
+    if (!TEST_true(prepare_ccm_no_payload(ctx_dec, info))) {
+        errmsg = "DEC_CCM_PREPARE";
+        goto err;
+    }
     dec_flen = EVP_Cipher(ctx_dec, ct, NULL, 0);
     if (!TEST_int_ge(dec_flen, 0)) {
         errmsg = "DEC_VERIFY_NULL";
@@ -5999,6 +6027,10 @@ static int test_evp_oneshot_aead_zerolen(int idx)
         errmsg = "DEC_BAD_SET_TAG";
         goto err;
     }
+    if (!TEST_true(prepare_ccm_no_payload(ctx_dec_bad, info))) {
+        errmsg = "DEC_BAD_CCM_PREPARE";
+        goto err;
+    }
     if (!TEST_int_lt(EVP_Cipher(ctx_dec_bad, ct, NULL, 0), 0)) {
         errmsg = "DEC_BADTAG_NOT_REJECTED";
         goto err;
@@ -6019,6 +6051,10 @@ static int test_evp_oneshot_aead_zerolen(int idx)
         errmsg = "DEC_STREAM_SET_TAG";
         goto err;
     }
+    if (!TEST_true(prepare_ccm_no_payload(ctx_dec_s, info))) {
+        errmsg = "DEC_STREAM_CCM_PREPARE";
+        goto err;
+    }
     if (!TEST_true(EVP_DecryptFinal_ex(ctx_dec_s, ct, &finlen))) {
         errmsg = "DEC_STREAM_VERIFY";
         goto err;
@@ -6037,6 +6073,10 @@ static int test_evp_oneshot_aead_zerolen(int idx)
         tag_bad, taglen);
     if (!TEST_true(EVP_CIPHER_CTX_set_params(ctx_dec_s_bad, set_tagparams))) {
         errmsg = "DEC_STREAM_BAD_SET_TAG";
+        goto err;
+    }
+    if (!TEST_true(prepare_ccm_no_payload(ctx_dec_s_bad, info))) {
+        errmsg = "DEC_STREAM_BAD_CCM_PREPARE";
         goto err;
     }
     if (!TEST_false(EVP_DecryptFinal_ex(ctx_dec_s_bad, ct, &finlen))) {


### PR DESCRIPTION
CCM Final was routed through the update helper, which selects an operation from its input and output pointers. A call with NULL input either did nothing or declared a length. When an empty message had no payload Update, decryption could succeed without authenticating the tag, while encryption didn't produce a tag for `GET_TAG`.

This change:

- routes `EVP_Cipher` calls with NULL input through the existing Final function
- uses the existing state transitions after payload processing (`tag_set` for encryption and cleared `iv_set` for successful decryption) to avoid processing a completed operation twice
- passes an empty payload through the existing CCM path when no payload operation has occurred, using dummy buffers with valid addresses to select that operation

No new state or separate finish path is added. The existing explicit length and AAD Update dispatch remains unchanged.

The CCM implementations for AES, ARIA, and SM4 all use the shared helper.

## Tests

The generic zero length AEAD test now covers CCM. Each CCM context declares a zero payload length, supplies AAD, and deliberately skips the payload Update.
The existing streaming and direct call checks compare generated tags, accept the correct tag, and reject a modified tag through `EVP_Cipher` and `EVP_DecryptFinal_ex`.

Validation performed:

- `make test TESTS=test_evp_extra VERBOSE=1`
- `make test TESTS='test_evp test_evp_extra test_evp_libctx'`
- the issue reproducer, linked against the local build
- a clean `enable-fips no-shared` build, the zero length test under the FIPS configuration, and the issue reproducer against the FIPS provider
- targeted Valgrind runs of the zero length test and issue reproducer

Fixes #32253

Related to:
 - Empty AEAD finalization: #31555 and #32173
 - Final without a tag: #28730 and #28872

##### Checklist

- [x] tests are added or updated