### PR TITLE
[3.6] Reject explicitly supplied invalid tags and generate tags for empty AEAD messages

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_siv_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv_hw.c
@@ -267,11 +267,17 @@ static int aes_gcm_siv_finish(PROV_AES_GCM_SIV_CTX *ctx)
 {
     int ret = 0;
 
-    if (ctx->enc)
+    if (ctx->enc) {
+        /* Generate the tag when Final is the first empty-message operation. */
+        if (ctx->generated_tag == 0
+            && aes_gcm_siv_encrypt(ctx, NULL, NULL, 0) == 0)
+            return 0;
         return ctx->generated_tag;
-    if (!ctx->generated_tag)
-        aes_gcm_siv_decrypt(ctx, NULL, NULL, 0);
-    ret = !CRYPTO_memcmp(ctx->tag, ctx->user_tag, sizeof(ctx->tag));
+    }
+    if (ctx->generated_tag == 0
+        && aes_gcm_siv_decrypt(ctx, NULL, NULL, 0) == 0)
+        return 0;
+    ret = CRYPTO_memcmp(ctx->tag, ctx->user_tag, sizeof(ctx->tag)) == 0;
     ret &= ctx->have_user_tag;
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -507,6 +507,10 @@ static int aes_ocb_cipher(void *vctx, unsigned char *out, size_t *outl,
     if (!ossl_prov_is_running())
         return 0;
 
+    /* NULL input indicates Final, which must generate or check the tag. */
+    if (in == NULL)
+        return aes_ocb_block_final(vctx, out, outl, outsize);
+
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -36,11 +36,11 @@ static OSSL_FUNC_cipher_get_params_fn chacha20_poly1305_get_params;
 static OSSL_FUNC_cipher_get_ctx_params_fn chacha20_poly1305_get_ctx_params;
 static OSSL_FUNC_cipher_set_ctx_params_fn chacha20_poly1305_set_ctx_params;
 static OSSL_FUNC_cipher_cipher_fn chacha20_poly1305_cipher;
+static OSSL_FUNC_cipher_update_fn chacha20_poly1305_update;
 static OSSL_FUNC_cipher_final_fn chacha20_poly1305_final;
 static OSSL_FUNC_cipher_gettable_ctx_params_fn chacha20_poly1305_gettable_ctx_params;
 static OSSL_FUNC_cipher_settable_ctx_params_fn chacha20_poly1305_settable_ctx_params;
 #define chacha20_poly1305_gettable_params ossl_cipher_generic_gettable_params
-#define chacha20_poly1305_update chacha20_poly1305_cipher
 
 static void *chacha20_poly1305_newctx(void *provctx)
 {
@@ -311,11 +311,6 @@ static int chacha20_poly1305_cipher(void *vctx, unsigned char *out,
     if (!ossl_prov_is_running())
         return 0;
 
-    if (inl == 0) {
-        *outl = 0;
-        return 1;
-    }
-
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;
@@ -325,6 +320,24 @@ static int chacha20_poly1305_cipher(void *vctx, unsigned char *out,
         return 0;
 
     return 1;
+}
+
+static int chacha20_poly1305_update(void *vctx, unsigned char *out,
+    size_t *outl, size_t outsize,
+    const unsigned char *in, size_t inl)
+{
+    /*
+     * A zero-length update is a no-op. Only EVP_Cipher() and Final produce or
+     * check the authentication tag.
+     */
+    if (inl == 0) {
+        if (!ossl_prov_is_running())
+            return 0;
+        *outl = 0;
+        return 1;
+    }
+
+    return chacha20_poly1305_cipher(vctx, out, outl, outsize, in, inl);
 }
 
 static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -7332,6 +7332,12 @@ static const AEAD_ONESHOT_CFG aead_oneshot_cfgs[] = {
     { "ChaCha20-Poly1305", 32, 12, 16, 0 }
 };
 
+static const AEAD_ONESHOT_CFG aead_oneshot_zerolen_cfgs[] = {
+    { "AES-128-OCB", 16, 12, 16, 0 },
+    { "ChaCha20-Poly1305", 32, 12, 16, 0 },
+    { "AES-128-GCM-SIV", 16, 12, 16, 0 }
+};
+
 /*
  * Drive an encrypt or decrypt operation.  AAD always via EVP_CipherUpdate.
  * Body via EVP_Cipher() when oneshot_body is non-zero, EVP_CipherUpdate
@@ -7550,6 +7556,119 @@ static int test_aead_oneshot_roundtrip(int idx)
     ok = 1;
 end:
     return ok;
+}
+
+static EVP_CIPHER_CTX *aead_oneshot_zerolen_ctx(const EVP_CIPHER *cipher,
+    int enc, const unsigned char *key, const unsigned char *iv,
+    const unsigned char *aad, size_t aad_len,
+    const unsigned char *tag, size_t tag_len)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    int outl = 0;
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_true(EVP_CipherInit_ex2(ctx, cipher, key, iv, enc, NULL))
+        || (aad_len > 0
+            && !TEST_true(EVP_CipherUpdate(ctx, NULL, &outl, aad,
+                (int)aad_len)))
+        || (!enc
+            && !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG,
+                                (int)tag_len, (void *)tag),
+                0))) {
+        EVP_CIPHER_CTX_free(ctx);
+        return NULL;
+    }
+    return ctx;
+}
+
+/*
+ * For these built-in provider implementations, a NULL-input EVP_Cipher() call
+ * must produce or check the empty-message tag even when no payload Update was
+ * made.
+ */
+static int test_aead_oneshot_zerolen(int idx)
+{
+    static const unsigned char key[32] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
+    };
+    static const unsigned char iv[12] = {
+        0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+        0xa8, 0xa9, 0xaa, 0xab
+    };
+    static const unsigned char aad[] = "empty message context";
+    const AEAD_ONESHOT_CFG *cfg = &aead_oneshot_zerolen_cfgs[idx / 2];
+    int with_aad = idx % 2;
+    size_t aad_len = with_aad ? sizeof(aad) - 1 : 0;
+    EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER_CTX *ctx_oracle = NULL, *ctx_oneshot = NULL;
+    EVP_CIPHER_CTX *ctx_dec = NULL, *ctx_dec_bad = NULL;
+    static const unsigned char empty = 0;
+    unsigned char out[16] = { 0 };
+    unsigned char tag_oracle[16] = { 0 };
+    unsigned char tag_oneshot[16] = { 0 };
+    unsigned char tag_bad[16] = { 0 };
+    int outl = 0, ret = 0;
+
+    ERR_set_mark();
+    cipher = EVP_CIPHER_fetch(testctx, cfg->name, testpropq);
+    ERR_pop_to_mark();
+    if (cipher == NULL)
+        return TEST_skip("'%s' is not available", cfg->name);
+
+    /*
+     * The explicit zero-length Update provides an oracle that also works on
+     * the unpatched GCM-SIV implementation, whose empty Final cannot generate
+     * a tag.
+     */
+    ctx_oracle = aead_oneshot_zerolen_ctx(cipher, 1, key, iv, aad, aad_len,
+        NULL, cfg->taglen);
+    if (!TEST_ptr(ctx_oracle)
+        || !TEST_true(EVP_EncryptUpdate(ctx_oracle, out, &outl, &empty, 0))
+        || !TEST_true(EVP_EncryptFinal_ex(ctx_oracle, out, &outl))
+        || !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx_oracle, EVP_CTRL_AEAD_GET_TAG,
+                            (int)cfg->taglen, tag_oracle),
+            0))
+        goto end;
+
+    ctx_dec = aead_oneshot_zerolen_ctx(cipher, 0, key, iv, aad, aad_len,
+        tag_oracle, cfg->taglen);
+    if (!TEST_ptr(ctx_dec)
+        || !TEST_int_ge(EVP_Cipher(ctx_dec, out, NULL, 0), 0))
+        goto end;
+
+    memcpy(tag_bad, tag_oracle, cfg->taglen);
+    tag_bad[0] ^= 1;
+    ctx_dec_bad = aead_oneshot_zerolen_ctx(cipher, 0, key, iv, aad, aad_len,
+        tag_bad, cfg->taglen);
+    if (!TEST_ptr(ctx_dec_bad)
+        || !TEST_int_lt(EVP_Cipher(ctx_dec_bad, out, NULL, 0), 0))
+        goto end;
+
+    ctx_oneshot = aead_oneshot_zerolen_ctx(cipher, 1, key, iv, aad, aad_len,
+        NULL, cfg->taglen);
+    if (!TEST_ptr(ctx_oneshot)
+        || !TEST_int_ge(EVP_Cipher(ctx_oneshot, out, NULL, 0), 0)
+        || !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx_oneshot, EVP_CTRL_AEAD_GET_TAG,
+                            (int)cfg->taglen, tag_oneshot),
+            0)
+        || !TEST_mem_eq(tag_oneshot, cfg->taglen,
+            tag_oracle, cfg->taglen))
+        goto end;
+
+    ret = 1;
+end:
+    if (!ret)
+        TEST_info("zero-length %s test failed (%s)", cfg->name,
+            with_aad ? "with AAD" : "no AAD");
+    EVP_CIPHER_CTX_free(ctx_oracle);
+    EVP_CIPHER_CTX_free(ctx_oneshot);
+    EVP_CIPHER_CTX_free(ctx_dec);
+    EVP_CIPHER_CTX_free(ctx_dec_bad);
+    EVP_CIPHER_free(cipher);
+    return ret;
 }
 
 #ifndef OPENSSL_NO_DES
@@ -8026,6 +8145,8 @@ int setup_tests(void)
 #endif
 
     ADD_ALL_TESTS(test_aead_oneshot_roundtrip, 2 * OSSL_NELEM(aead_oneshot_cfgs));
+    ADD_ALL_TESTS(test_aead_oneshot_zerolen,
+        2 * OSSL_NELEM(aead_oneshot_zerolen_cfgs));
 
     ADD_ALL_TESTS(test_rsasve_degenerate_exponent, 2);
     ADD_ALL_TESTS(test_rsasve_degenerate_ciphertext, 3);


### PR DESCRIPTION
Fixes #32258

This backports #32173 (commit `5741d29`) to `openssl-3.6`, `openssl-3.5`, and `openssl-3.4`, with stable-branch adaptations and dedicated regression coverage.

Backport status:

- the PR head is based directly on the current `openssl-3.6` tip and is intended to target `openssl-3.6`
- the same two commits cherry-pick cleanly onto the current `openssl-3.5` and `openssl-3.4` tips, so this PR is intended for the `branch: 3.6`, `branch: 3.5`, and `branch: 3.4` labels
- `openssl-4.0` requires a separate branch-specific backport because its ChaCha20-Poly1305 callback layout differs

For the affected built-in provider implementations, a call to `EVP_Cipher(ctx, out, NULL, 0)` is dispatched to the `ccipher` callback as a NULL-input terminal call. These callbacks don't consistently perform the empty-message tag operation:

- ChaCha20-Poly1305 and AES-OCB decryption can return success without verifying an explicitly supplied authentication tag. This occurs with or without AAD, so a corrupted tag produces the same zero-byte success result as a valid tag.
- AES-GCM-SIV encryption fails to generate a tag when Final is the first empty-message operation. Its corresponding decryption path also doesn't propagate failures from empty-message tag recomputation.

An empty plaintext does not make authentication irrelevant: a valid tag computed under the expected key and nonce authenticates the empty ciphertext and any AAD. Accepting an invalid tag can therefore bypass transcript authentication, key confirmation, or authenticated state-transition checks in applications using tag-only AEAD messages.

The backport:

- routes NULL AES-OCB input through `aes_ocb_block_final`, which generates or verifies the tag
- introduces a dedicated ChaCha20-Poly1305 Update callback for the stable implementation, preserving zero-length Update as a no-op while allowing the NULL-input `ccipher` call to perform the terminal tag operation
- generates the AES-GCM-SIV tag when Final is the first empty-message operation and propagates empty-message tag recomputation failures during decryption
- adds regression tests covering correct-tag acceptance, corrupted-tag rejection, and encryption tag generation, with and without AAD.

The 3.6 version changes `cipher_chacha20_poly1305.c.in`. When the same commits are cherry-picked onto 3.5 and 3.4, Git correctly maps that change to those branches' `cipher_chacha20_poly1305.c` source file.

Validation:

- `openssl-3.6`: configured with `--strict-warnings no-shared enable-fips`, built with GCC 13.3 under WSL2, and passed `make test TESTS='test_evp test_evp_extra'` (176 tests).
- `openssl-3.5`: configured with `CPPFLAGS=-ansi`, `--strict-warnings`, `no-asm`, `no-shared`, `enable-fips`, and `-D_DEFAULT_SOURCE`; built with GCC 13.3 under WSL2 and passed `make test TESTS='test_evp test_evp_extra'` (175 tests).
- `openssl-3.4`: configured with the same options as 3.5, built with GCC 13.3 under WSL2, and passed `make test TESTS='test_evp test_evp_extra'` (126 tests).

The 4.0 implementation has a different ChaCha20-Poly1305 callback layout and is prepared as dedicated PR #32300.

##### Checklist

- [x] tests are added or updated
