### PR TITLE
ci: trigger backports on label changes

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,10 +7,16 @@
 
 name: Backports CI
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
+
+concurrency:
+  group: backports-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check_backports:


### PR DESCRIPTION
The check_backports job gates every step on the branch label being present in github.event.pull_request.labels. That value is a snapshot of the event payload taken when the run is created, and the bare "on: [pull_request]" trigger only covers opened, synchronize and reopened.

A label added after the last push is therefore invisible to any existing run, and re-running does not help because a re-run replays the original payload. Every step skips and the job reports success in a few seconds.

Add labeled and unlabeled to the trigger types so the check is evaluated against the current label set.
