### PR TITLE
Remove openssl-3.1, openssl-3.2 and openssl-3.3 from CI jobs (4.0)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,12 +28,6 @@ jobs:
             branch: '3.4',
             cppflags: 'CPPFLAGS=-ansi'
           }, {
-            branch: '3.3',
-            cppflags: 'CPPFLAGS=-ansi',
-          }, {
-            branch: '3.2',
-            cppflags: 'CPPFLAGS=-ansi'
-          }, {
             branch: '3.0',
             cppflags: 'CPPFLAGS=-ansi'
           }

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -55,15 +55,6 @@ jobs:
               "branch": "openssl-3.4",
               "extra_config": "no-afalgeng enable-fips enable-tfo"
             }, {
-              "branch": "openssl-3.3",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            }, {
-              "branch": "openssl-3.2",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            }, {
-              "branch": "openssl-3.1",
-              "extra_config": "no-afalgeng enable-fips"
-            }, {
               "branch": "openssl-3.0",
               "extra_config": "no-afalgeng enable-fips"
             }, {

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -71,8 +71,6 @@ jobs:
           { openssl: 'openssl-3.6', openssh: 'openssl-3.6', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.5', openssh: 'openssl-3.5', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.4', openssh: 'openssl-3.4', openssl_config: 'no-docs'},
-          { openssl: 'openssl-3.3', openssh: 'openssl-3.3', openssl_config: 'no-docs'},
-          { openssl: 'openssl-3.2', openssh: 'openssl-3.2', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.0', openssh: 'openssl-3.0', openssl_config: ''}
         ]
     runs-on: ubuntu-latest

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -116,11 +116,6 @@ jobs:
             tgz: branch-3.0.tar.gz,
             extra_config: "",
           }, {
-            name: openssl-3.3,
-            dir: branch-3.3,
-            tgz: branch-3.3.tar.gz,
-            extra_config: "",
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -205,7 +200,7 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-3.6, branch-3.5, branch-3.4, branch-3.3, branch-3.0,
+        tree_a: [ branch-3.6, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
@@ -217,8 +212,6 @@ jobs:
             tree_b: branch-3.5
           - tree_a: PR
             tree_b: branch-3.4
-          - tree_a: PR
-            tree_b: branch-3.3
           - tree_a: PR
             tree_b: branch-3.0
     steps:

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -120,11 +120,6 @@ jobs:
             tgz: branch-3.0.tar.gz,
             extra_config: "",
           }, {
-            name: openssl-3.3,
-            dir: branch-3.3,
-            tgz: branch-3.3.tar.gz,
-            extra_config: "",
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -213,11 +208,9 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-master, branch-3.6, branch-3.5, branch-3.4, branch-3.3,
-                  branch-3.0,
+        tree_a: [ branch-master, branch-3.6, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
-        tree_b: [ branch-master, branch-3.6, branch-3.5, branch-3.4, branch-3.3,
-                  branch-3.0  ]
+        tree_b: [ branch-master, branch-3.6, branch-3.5, branch-3.4, branch-3.0 ]
     steps:
       - name: early exit checks
         id: early_exit


### PR DESCRIPTION
Remove openssl-3.1, openssl-3.2 and openssl-3.3 from CI jobs

These branches are EOL, so there is no need to keep running CI jobs for them.