### PR TITLE
Remove openssl-3.1, openssl-3.2 and openssl-3.3 from CI jobs (3.4)

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -25,15 +25,6 @@ jobs:
       matrix:
         branches: [
           {
-            branch: openssl-3.3,
-            extra_config: no-afalgeng enable-fips enable-tfo
-          }, {
-            branch: openssl-3.2,
-            extra_config: no-afalgeng enable-fips enable-tfo
-          }, {
-            branch: openssl-3.1,
-            extra_config: no-afalgeng enable-fips
-          }, {
             branch: openssl-3.0,
             extra_config: no-afalgeng enable-fips
           }, {

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         tag: [edge, latest]
         cc: [gcc, clang]
-        branch: [openssl-3.0, openssl-3.1, master]
+        branch: [openssl-3.0, master]
     runs-on: ubuntu-latest
     container:
       image: docker.io/library/alpine:${{ matrix.tag }}
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [openssl-3.0, openssl-3.1, master]
+        branch: [openssl-3.0, master]
         zoo:
           - image: docker.io/library/debian:11
             install: apt-get update && apt-get install -y gcc make perl
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [openssl-3.0, openssl-3.1, master]
+        branch: [openssl-3.0, master]
         os: [macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -114,10 +114,6 @@ jobs:
             dir: branch-3.0,
             tgz: branch-3.0.tar.gz,
           }, {
-            name: openssl-3.3,
-            dir: branch-3.3,
-            tgz: branch-3.3.tar.gz,
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -197,7 +193,7 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-3.6, branch-3.5, branch-3.4, branch-3.3, branch-3.0,
+        tree_a: [ branch-3.6, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
@@ -209,8 +205,6 @@ jobs:
             tree_b: branch-3.5
           - tree_a: PR
             tree_b: branch-3.4
-          - tree_a: PR
-            tree_b: branch-3.3
           - tree_a: PR
             tree_b: branch-3.0
     steps:

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -113,14 +113,6 @@ jobs:
             dir: branch-3.0,
             tgz: branch-3.0.tar.gz,
           }, {
-            name: openssl-3.2,
-            dir: branch-3.2,
-            tgz: branch-3.2.tar.gz,
-          }, {
-            name: openssl-3.3,
-            dir: branch-3.3,
-            tgz: branch-3.3.tar.gz,
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -199,11 +191,9 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-master, branch-3.5, branch-3.4, branch-3.3,
-                  branch-3.2, branch-3.0,
+        tree_a: [ branch-master, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
-        tree_b: [ branch-master, branch-3.5, branch-3.4, branch-3.3,
-                  branch-3.2, branch-3.0  ]
+        tree_b: [ branch-master, branch-3.5, branch-3.4, branch-3.0 ]
     steps:
       - name: early exit checks
         id: early_exit


### PR DESCRIPTION
Remove openssl-3.1, openssl-3.2 and openssl-3.3 from CI jobs

These branches are EOL, so there is no need to keep running CI jobs for them.