### PR TITLE
Remove openssl-3.1, openssl-3.2 and openssl-3.3 from CI jobs (3.0)

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -114,14 +114,6 @@ jobs:
             dir: branch-3.0,
             tgz: branch-3.0.tar.gz,
           }, {
-            name: openssl-3.2,
-            dir: branch-3.2,
-            tgz: branch-3.2.tar.gz,
-          }, {
-            name: openssl-3.3,
-            dir: branch-3.3,
-            tgz: branch-3.3.tar.gz,
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -197,7 +189,7 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-3.5, branch-3.4, branch-3.3, branch-3.2, branch-3.0,
+        tree_a: [ branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
@@ -207,10 +199,6 @@ jobs:
             tree_b: branch-3.5
           - tree_a: PR
             tree_b: branch-3.4
-          - tree_a: PR
-            tree_b: branch-3.3
-          - tree_a: PR
-            tree_b: branch-3.2
           - tree_a: PR
             tree_b: branch-3.0
     steps:


### PR DESCRIPTION
Remove openssl-3.1, openssl-3.2 and openssl-3.3 from CI jobs

These branches are EOL, so there is no need to keep running CI jobs for them.