### PR TITLE
Fix RSA SHA-512 truncated digest signature mappings

### DIFF
--- a/crypto/objects/obj_xref.h
+++ b/crypto/objects/obj_xref.h
@@ -91,6 +91,8 @@ static const nid_triple sigoid_srt[] = {
     {NID_RSA_SHA3_256, NID_sha3_256, NID_rsaEncryption},
     {NID_RSA_SHA3_384, NID_sha3_384, NID_rsaEncryption},
     {NID_RSA_SHA3_512, NID_sha3_512, NID_rsaEncryption},
+    {NID_sha512_224WithRSAEncryption, NID_sha512_224, NID_rsaEncryption},
+    {NID_sha512_256WithRSAEncryption, NID_sha512_256, NID_rsaEncryption},
     {NID_SM2_with_SM3, NID_sm3, NID_sm2},
     {NID_ML_DSA_44, NID_undef, NID_ML_DSA_44},
     {NID_ML_DSA_65, NID_undef, NID_ML_DSA_65},
@@ -151,6 +153,8 @@ static const nid_triple *const sigoid_srt_xref[] = {
     &sigoid_srt[28],
     &sigoid_srt[40],
     &sigoid_srt[41],
+    &sigoid_srt[54],
+    &sigoid_srt[55],
     &sigoid_srt[50],
     &sigoid_srt[46],
     &sigoid_srt[51],
@@ -159,7 +163,7 @@ static const nid_triple *const sigoid_srt_xref[] = {
     &sigoid_srt[48],
     &sigoid_srt[53],
     &sigoid_srt[49],
-    &sigoid_srt[54],
+    &sigoid_srt[56],
 };
 /* clang-format on */
 

--- a/crypto/objects/obj_xref.txt
+++ b/crypto/objects/obj_xref.txt
@@ -11,6 +11,8 @@ sha256WithRSAEncryption sha256	rsaEncryption
 sha384WithRSAEncryption	sha384	rsaEncryption
 sha512WithRSAEncryption	sha512	rsaEncryption
 sha224WithRSAEncryption	sha224	rsaEncryption
+sha512_224WithRSAEncryption sha512_224 rsaEncryption
+sha512_256WithRSAEncryption sha512_256 rsaEncryption
 mdc2WithRSA		mdc2	rsaEncryption
 ripemd160WithRSA	ripemd160 rsaEncryption
 RSA_SHA3_224		sha3_224 rsaEncryption

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 132;
+plan tests => 133;
 
 require_ok(srctop_file('test', 'recipes', 'tconversion.pl'));
 
@@ -144,6 +144,28 @@ subtest "generating certificate requests with RSA" => sub {
                     "-config", srctop_file("test", "test.cnf"),
                     "-verify", "-in", "testreq_withattrs_der.pem", "-noout"])),
            "Verifying signature on request from a key with extra attributes - PEM");
+    }
+};
+
+subtest "RSA requests with truncated SHA-512 digests" => sub {
+    plan tests => 2;
+
+    SKIP: {
+        skip "RSA is not supported by this OpenSSL build", 2
+            if disabled("rsa");
+
+        foreach my $digest ("sha512-224", "sha512-256") {
+            my $request = "testreq-rsa-$digest.pem";
+
+            ok(run(app(["openssl", "req",
+                        "-config", srctop_file("test", "test.cnf"),
+                        "-new", "-out", $request,
+                        "-key", srctop_file("test", "testrsa.pem"),
+                        "-$digest"]))
+               && run(app(["openssl", "req", "-verify",
+                           "-in", $request, "-noout"])),
+               "Generating and verifying request with RSA and $digest");
+        }
     }
 };
 


### PR DESCRIPTION
OpenSSL can create CSRs and certificates with RSA PKCS#1 v1.5 signatures using SHA-512/224 or SHA-512/256, but it can't verify their signatures afterward.

The signing path obtains the complete `AlgorithmIdentifier` from the provider. Verification takes another route through `OBJ_find_sigid_algs`. Since the two signature OIDs were missing from the object cross reference table, verification stopped with an unknown signature algorithm error before checking the signature itself.

This adds the missing mappings for `sha512_224WithRSAEncryption` and `sha512_256WithRSAEncryption`, then regenerates `crypto/objects/obj_xref.h`.

The regression test is small. It generates and verifies one RSA CSR for each digest, covering the lookup that previously failed.

Tests run:

- `make test`
- `make test TESTS=test_req`
- `make test TESTS=test_verify`
- `make test TESTS=test_algorithmid`

Fixes #32252

##### Checklist

- [x] tests are added or updated