### PR TITLE
CI: specify RISC-V vector extension version in QEMU

### DIFF
--- a/.github/workflows/riscv-more-cross-compiles.yml
+++ b/.github/workflows/riscv-more-cross-compiles.yml
@@ -110,7 +110,7 @@ jobs:
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64,
             fips: no,
-            qemucpu: "rv64,v=true,vlen=128,zbb=true,zvbb=false,zvkb=false",
+            qemucpu: "rv64,v=true,vext_spec=v1.0,vlen=128,zbb=true,zvbb=false,zvkb=false",
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_v_zbb"
           }, {
@@ -123,7 +123,7 @@ jobs:
             # do not use zvkb flag for qemucpu as ubuntu-latest (24.04) uses QEMU 8.2.2
             # see https://lists.nongnu.org/archive/html/qemu-devel/2024-05/msg02231.html
             # Should be zvkg=true,zvbb=false,zvkb=false
-            qemucpu: "rv64,v=true,vlen=128,zvkg=true,zvbb=false",
+            qemucpu: "rv64,v=true,vext_spec=v1.0,vlen=128,zvkg=true,zvbb=false",
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_v_zvkg"
           }, {
@@ -136,7 +136,7 @@ jobs:
             # do not use zvkb flag for qemucpu as ubuntu-latest (24.04) uses QEMU 8.2.2
             # see https://lists.nongnu.org/archive/html/qemu-devel/2024-05/msg02231.html
             # Should be zvkb=true,zvbc=true,zvkg=false
-            qemucpu: "rv64,v=true,vlen=128,zvbb=true,zvbc=true,zvkg=false",
+            qemucpu: "rv64,v=true,vext_spec=v1.0,vlen=128,zvbb=true,zvbc=true,zvkg=false",
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_v_zvkb_zvbc"
           }, {
@@ -149,7 +149,7 @@ jobs:
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64,
             fips: no,
-            qemucpu: "rv64,v=true,vlen=128,zvkned=true,zvbb=false,zvkb=false,zvkg=false",
+            qemucpu: "rv64,v=true,vext_spec=v1.0,vlen=128,zvkned=true,zvbb=false,zvkb=false,zvkg=false",
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_v_zvkned"
           }, {
@@ -169,7 +169,7 @@ jobs:
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64,
             fips: no,
-            qemucpu: "rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zbkc=true,zbkx=true,zknd=true,zkne=true,zknh=true,zksed=true,zksh=true,zkr=true,zkt=true,v=true,vlen=128,zvbb=true,zvbc=true,zvkb=true,zvkg=true,zvkned=true,zvknha=true,zvknhb=true,zvksed=true,zvksh=true",
+            qemucpu: "rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zbkc=true,zbkx=true,zknd=true,zkne=true,zknh=true,zksed=true,zksh=true,zkr=true,zkt=true,v=true,vext_spec=v1.0,vlen=128,zvbb=true,zvbc=true,zvkb=true,zvkg=true,zvkned=true,zvknha=true,zvknhb=true,zvksed=true,zvksh=true",
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_zkr_zkt_v_zvbb_zvbc_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh"
           }, {
@@ -180,7 +180,7 @@ jobs:
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64,
             fips: no,
-            qemucpu: "rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zbkc=true,zbkx=true,zknd=true,zkne=true,zknh=true,zksed=true,zksh=true,zkr=true,zkt=true,v=true,vlen=256,zvbb=true,zvbc=true,zvkb=true,zvkg=true,zvkned=true,zvknha=true,zvknhb=true,zvksed=true,zvksh=true",
+            qemucpu: "rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zbkc=true,zbkx=true,zknd=true,zkne=true,zknh=true,zksed=true,zksh=true,zkr=true,zkt=true,v=true,vext_spec=v1.0,vlen=256,zvbb=true,zvbc=true,zvkb=true,zvkg=true,zvkned=true,zvknha=true,zvknhb=true,zvksed=true,zvksh=true",
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_zkr_zkt_v_zvbb_zvbc_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvl256"
           }, {
@@ -191,7 +191,7 @@ jobs:
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64,
             fips: no,
-            qemucpu: "rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zbkc=true,zbkx=true,zknd=true,zkne=true,zknh=true,zksed=true,zksh=true,zkr=true,zkt=true,v=true,vlen=512,zvbb=true,zvbc=true,zvkb=true,zvkg=true,zvkned=true,zvknha=true,zvknhb=true,zvksed=true,zvksh=true",
+            qemucpu: "rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zbkc=true,zbkx=true,zknd=true,zkne=true,zknh=true,zksed=true,zksh=true,zkr=true,zkt=true,v=true,vext_spec=v1.0,vlen=512,zvbb=true,zvbc=true,zvkb=true,zvkg=true,zvkned=true,zvknha=true,zvknhb=true,zvksed=true,zvksh=true",
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_zkr_zkt_v_zvbb_zvbc_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvl512"
           }, {
@@ -235,7 +235,7 @@ jobs:
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64,
             fips: no,
-            qemucpu: "rv64,v=true,vlen=128,zvkned=true",
+            qemucpu: "rv64,v=true,vext_spec=v1.0,vlen=128,zvkned=true",
             # No opensslcapsname: hwprobe is used for capability detection.
             opensslcaps: "rv64gc_v_zvkned_hwprobe",
             # V must be detected. ZVKNED is not reported by QEMU 8.2.2 (ubuntu-latest)


### PR DESCRIPTION
Fixes the RISC-V CI failures.

The RISC-V CI jobs were failing on the current `master`. As suggested by @ZenithalHourlyRate (https://github.com/openssl/openssl/issues/32229#issuecomment-5238457005), explicitly specifying the vector extension version

    vext_spec=v1.0

in the QEMU CPU configuration fixes the problem.

I verified that after this change the RISC-V CI completes successfully.

Fixes #32229

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
