### PR TITLE
Reject DSA parameters where N exceeds 512

### DIFF
--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -84,6 +84,13 @@ static int ffc_validate_LN(size_t L, size_t N, int type, int verify)
             L, N);
 #endif
     } else if (type == FFC_PARAM_TYPE_DSA) {
+        if (N > 512) {
+#ifndef OPENSSL_NO_DSA
+            ERR_raise_data(ERR_LIB_DSA, DSA_R_BAD_FFC_PARAMETERS,
+                "N is %zu, but the maximum supported N is 512", N);
+#endif
+            return 0;
+        }
         if (L >= 3072 && N >= 256)
             return 128;
         if (L >= 2048 && N >= 224)


### PR DESCRIPTION
Update the FFC parameter validation to explicitly reject DSA configurations where the N parameter is greater than 256. Previously, the logic accepted any N >= 256 if L >= 3072. This change enforces the maximum supported limit for N and raises an error to prevent the use of invalid or unsupported parameter combinations.

This is needed because generate_q_fips186_4() allocates a `md` buffer that is at most `EVP_MAX_MD_SIZE` long (64 bytes). If N is greater than 256 then the qsize parameter passed in input to generate_q_fips186_4() will be greater than 64 causing internal operations on the buffer to overflow.

This was found by Red Hat with AISLE, but deemed not a security issue because there is no reasonable way to cause an attacket to set the qbits values directly, if this ever happen it is just misuse of an API by an application.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
