### PR TITLE
ci: remove enable-ssl3 from prov-compat-label tests

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  opts: enable-rc5 enable-md2 enable-ssl3 enable-weak-ssl-ciphers enable-zlib
+  opts: enable-rc5 enable-md2 enable-weak-ssl-ciphers enable-zlib
 
 jobs:
   fips-releases:


### PR DESCRIPTION
This is a partial backport of patch
60c15b2aff ("Remove support for SSLv3") to fix CI run.

It should fix the issue with extended tests and "Unsupported options: enable-ssl3".
