### PR TITLE
`.github/workflows/prov-compat-label.yml`: remove support for SSLv3

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  opts: enable-rc5 enable-md2 enable-ssl3 enable-weak-ssl-ciphers enable-zlib
+  opts: enable-rc5 enable-md2 enable-weak-ssl-ciphers enable-zlib
 
 jobs:
   fips-releases:


### PR DESCRIPTION
This is a partial backport of 60c15b2aff15 "Remove support for SSLv3" that includes only changes to .github/workflows/prov-compat-label.yml.

Original-Commit: 60c15b2aff15 "Remove support for SSLv3"
Original-PR: https://github.com/openssl/openssl/pull/29338