### PR TITLE
[3.6] ci: drop no-docs from the interop spec for pre-3.2 branches

### DIFF
--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -43,6 +43,11 @@ jobs:
           cd SPECS/ && source ${GITHUB_WORKSPACE}/VERSION.dat && \
           sed -i "s/^Version: .*\$/Version: $MAJOR.$MINOR.$PATCH/" openssl.spec && \
           sed -i 's/^Release: .*$/Release: dev/' openssl.spec
+          # The spec comes from the interop repo and always passes no-docs, which
+          # Configure only understands since 3.2.0. Drop it on older branches.
+          if [ "$MAJOR" -lt 3 ] || { [ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 2 ]; }; then
+            sed -i 's/[[:space:]]*no-docs\>//g' /build/SPECS/openssl.spec
+          fi
           yum-builddep -y /build/SPECS/openssl.spec # just for sure nothing is missing
           mkdir -p /build/SOURCES
           tar --transform "s/^__w\/openssl\/openssl/openssl-$MAJOR.$MINOR.$PATCH/" -czf /build/SOURCES/openssl-$MAJOR.$MINOR.$PATCH.tar.gz "$GITHUB_WORKSPACE"


### PR DESCRIPTION
The RPM spec comes from the interop repo and unconditionally passes no-docs, which Configure only understands since 3.2.0.  When the interop workflow is dispatched for an openssl-3.0 PR it checks out that tree, so Configure fails with "Unsupported options: no-docs".

Strip the option from the spec when VERSION.dat reports a version older than 3.2.

Fixes: https://github.com/openssl/openssl/actions/runs/31461178864/job/93684837491

Backport of https://github.com/openssl/openssl/pull/32296
