### PR TITLE
Fix TLS 1.3 client alerts after early data (regression)

### DIFF
--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -411,7 +411,7 @@ static int tls13_add_record_padding(OSSL_RECORD_LAYER *rl,
     size_t taglen = rl->taglen;
 
     /* Nothing to be done in the case of a plaintext alert */
-    if (rl->allow_plain_alerts && thistempl->type != SSL3_RT_ALERT)
+    if (rl->allow_plain_alerts && thistempl->type == SSL3_RT_ALERT)
         return 1;
 
     if (!WPACKET_put_bytes_u8(thispkt, thistempl->type)) {

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -878,6 +878,10 @@ int tls13_change_cipher_state(SSL_CONNECTION *s, int which)
         goto err;
     }
 
+    if ((which & SSL3_CC_WRITE) != 0
+        && !s->server && label == client_early_traffic)
+        s->rlayer.wrlmethod->set_plain_alerts(s->rlayer.wrl, 1);
+
     ret = 1;
 err:
     if ((which & SSL3_CC_EARLY) != 0) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4582,6 +4582,60 @@ static int setupearly_data_test(SSL_CTX **cctx, SSL_CTX **sctx, SSL **clientssl,
     return 1;
 }
 
+#if !defined(OSSL_NO_USABLE_TLS1_3)
+/*
+ * Test that a client fatal alert generated after writing early data, but
+ * before receiving a ServerHello, is sent in plaintext. The server cannot be
+ * assumed to have selected TLSv1.3 or accepted the PSK at this point.
+ */
+static int test_early_data_plaintext_alert(void)
+{
+    static const unsigned char unexpected_certificate[] = {
+        SSL3_RT_HANDSHAKE, 0x03, 0x03, 0x00, 0x04,
+        SSL3_MT_CERTIFICATE, 0x00, 0x00, 0x00
+    };
+    static const unsigned char expected_alert[] = {
+        SSL3_RT_ALERT, 0x03, 0x03, 0x00, 0x02,
+        SSL3_AL_FATAL, SSL_AD_UNEXPECTED_MESSAGE
+    };
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    BIO *wbio;
+    unsigned char alert[sizeof(expected_alert) + 1];
+    size_t written, readbytes;
+    int testresult = 0;
+
+    if (!TEST_true(setupearly_data_test(&cctx, &sctx, &clientssl,
+            &serverssl, NULL, 2, SHA384_DIGEST_LENGTH, 0))
+        || !TEST_true(SSL_write_early_data(clientssl, MSG1, strlen(MSG1),
+            &written))
+        || !TEST_size_t_eq(written, strlen(MSG1))
+        || !TEST_ptr(wbio = SSL_get_wbio(clientssl))
+        || !TEST_int_eq(BIO_reset(wbio), 1)
+        || !TEST_true(BIO_write_ex(SSL_get_rbio(clientssl),
+            unexpected_certificate, sizeof(unexpected_certificate),
+            &written))
+        || !TEST_size_t_eq(written, sizeof(unexpected_certificate))
+        || !TEST_int_le(SSL_connect(clientssl), 0)
+        || !TEST_true(BIO_read_ex(wbio, alert, sizeof(alert), &readbytes))
+        || !TEST_mem_eq(alert, readbytes, expected_alert,
+            sizeof(expected_alert)))
+        goto end;
+
+    testresult = 1;
+end:
+    ERR_clear_error();
+    SSL_SESSION_free(clientpsk);
+    SSL_SESSION_free(serverpsk);
+    clientpsk = serverpsk = NULL;
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+#endif
+
 static int check_early_data_timeout(OSSL_TIME timer)
 {
     int res = 0;
@@ -17076,6 +17130,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_early_data_psk_with_all_ciphers, 14);
     ADD_ALL_TESTS(test_early_data_not_expected, 6);
 #if !defined(OSSL_NO_USABLE_TLS1_3)
+    ADD_TEST(test_early_data_plaintext_alert);
     ADD_TEST(test_early_data_psk_cipher_mismatch);
 #endif
 #endif /* !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3) */


### PR DESCRIPTION
When a TLS 1.3 client installs its early-data write keys, plaintext alerts are enabled on the existing write record layer before that layer is replaced. The setting is consequently lost, causing fatal alerts raised before receipt of a valid ServerHello to be encrypted with the early-data keys.

The peer can't be assumed to support TLS 1.3, accept the PSK, or possess the early-data keys at this point, so it may be unable to process such an alert.

Enable plaintext alerts on the newly installed client early-data write layer while retaining the existing setting on the old layer for errors encountered during record-layer replacement.

Also correct the inverted condition in `tls13_add_record_padding`. When plaintext alerts are enabled, only alert records should omit the TLS 1.3 inner content type; ordinary early application data must retain it.

Add a regression test that writes early data, injects an unexpected handshake message before ServerHello, and verifies the exact plaintext fatal alert on the wire.

Tests:

- `make test TESTS='test_sslapi test_tls13secrets' HARNESS_JOBS=1`

### Regression Status / Backport
This is a regression from the record-layer refactor merged in PR #19343 and affects OpenSSL 3.2 and later. It should be backported to the currently supported affected branches: openssl-4.0, openssl-3.6, openssl-3.5, and openssl-3.4. The 3.0 branch predates the regression and is not affected. This change restores the plaintext-alert behavior originally introduced by PR #6887.

The commit applies cleanly in three-way checks against today’s tips of all four branches

##### Checklist

- [x] tests are added or updated