### PR TITLE
ci: fix race condition in parallel Perl 5.10 build

### DIFF
--- a/.github/workflows/perl-minimal-checker.yml
+++ b/.github/workflows/perl-minimal-checker.yml
@@ -41,7 +41,7 @@ jobs:
         tar xf perl-5.10.1.tar.bz2
         cd perl-5.10.1
         ./Configure -des -Dprefix=/tmp/perl -A ccflags='-Wno-incompatible-pointer-types' -A define:malloctype='void *' -A define:freetype='void' -Dlibs='-ldl -lm -lutil -lc'
-        make -j $(nproc) perl
+        make -j1 perl
         make install
         popd
     - name: Install Test::More 0.96


### PR DESCRIPTION
The `perl-minimal-checker` workflow builds Perl 5.10.1 using `make -j $(nproc) perl`. The Perl 5.10 makefile can run multiple `configpm` recipes concurrently. These recipes update `lib/Config.pm` and `lib/Config_heavy.pl`, so one process can read a partially written `lib/Config.pm` and fail with:

    lib/Config.pm did not return a true value at configpm line 1023.

Example occurrence: https://github.com/openssl/openssl/actions/runs/31485190055/job/93758841964?pr=32301

Build this old Perl release with `make -j1 perl` to serialize those recipes.
Only the Perl 5.10 build is serialized; the Test::More and OpenSSL builds continue to use all available CPUs.

Validation:

- Configured Perl 5.10.1 with the workflow's options, ran `make -j1 perl` followed by `make install`, and verified that the installed interpreter reports `v5.10.1`.