### PR TITLE
[3.5] `.clang-format`: update `TypenameMacros` and `ForEachMacros`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,6 +16,15 @@ PointerAlignment: Right
 # of a comment block to protect comments as
 # per STYLE.md
 CommentPragmas:  '(^ IWYU pragma:|^\*$|^-$)'
+ForEachMacros:
+  - "OSSL_LIST_FOREACH"
+  - "OSSL_LIST_FOREACH_FROM"
+  - "OSSL_LIST_FOREACH_REV"
+  - "OSSL_LIST_FOREACH_REV_FROM"
+  - "OSSL_LIST_FOREACH_DELSAFE"
+  - "OSSL_LIST_FOREACH_DELSAFE_FROM"
+  - "OSSL_LIST_FOREACH_REV_DELSAFE"
+  - "OSSL_LIST_FOREACH_REV_DELSAFE_FROM"
 # OpenSSL uses typedefs extensively. Tell clang-format about them.
 TypeNames:
   - "ACCESS_DESCRIPTION"

--- a/.clang-format
+++ b/.clang-format
@@ -1130,7 +1130,12 @@ TypeNames:
   - "HASH_LONG"
   - "MD32_REG_T"
 # OpenSSL uses macros extensively. Tell clang-format about them.
-TypenameMacros: ['LHASH_OF', 'STACK_OF']
+TypenameMacros:
+  - "LHASH_OF"
+  - "OSSL_LIST"
+  - "PRIORITY_QUEUE_OF"
+  - "SPARSE_ARRAY_OF"
+  - "STACK_OF"
 StatementMacros:
   - "BLOCK_CIPHER_aead"
   - "BLOCK_CIPHER_generic"

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -64,7 +64,7 @@ typedef struct {
 
 struct ossl_method_store_st {
     OSSL_LIB_CTX *ctx;
-    SPARSE_ARRAY_OF(ALGORITHM) * algs;
+    SPARSE_ARRAY_OF(ALGORITHM) *algs;
     /*
      * Lock to protect the |algs| array from concurrent writing, when
      * individual implementations or queries are inserted.  This is used

--- a/include/crypto/sparse_array.h
+++ b/include/crypto/sparse_array.h
@@ -20,52 +20,52 @@ extern "C" {
 
 #define SPARSE_ARRAY_OF(type) struct sparse_array_st_##type
 
-#define DEFINE_SPARSE_ARRAY_OF_INTERNAL(type, ctype)                                                               \
-    SPARSE_ARRAY_OF(type);                                                                                         \
-    static ossl_unused ossl_inline SPARSE_ARRAY_OF(type) * ossl_sa_##type##_new(void)                              \
-    {                                                                                                              \
-        return (SPARSE_ARRAY_OF(type) *)ossl_sa_new();                                                             \
-    }                                                                                                              \
-    static ossl_unused ossl_inline void                                                                            \
-    ossl_sa_##type##_free(SPARSE_ARRAY_OF(type) * sa)                                                              \
-    {                                                                                                              \
-        ossl_sa_free((OPENSSL_SA *)sa);                                                                            \
-    }                                                                                                              \
-    static ossl_unused ossl_inline void                                                                            \
-    ossl_sa_##type##_free_leaves(SPARSE_ARRAY_OF(type) * sa)                                                       \
-    {                                                                                                              \
-        ossl_sa_free_leaves((OPENSSL_SA *)sa);                                                                     \
-    }                                                                                                              \
-    static ossl_unused ossl_inline size_t                                                                          \
-    ossl_sa_##type##_num(const SPARSE_ARRAY_OF(type) * sa)                                                         \
-    {                                                                                                              \
-        return ossl_sa_num((OPENSSL_SA *)sa);                                                                      \
-    }                                                                                                              \
-    static ossl_unused ossl_inline void                                                                            \
-    ossl_sa_##type##_doall(const SPARSE_ARRAY_OF(type) * sa,                                                       \
-        void (*leaf)(ossl_uintmax_t, type *))                                                                      \
-    {                                                                                                              \
-        ossl_sa_doall((OPENSSL_SA *)sa,                                                                            \
-            (void (*)(ossl_uintmax_t, void *))leaf);                                                               \
-    }                                                                                                              \
-    static ossl_unused ossl_inline void                                                                            \
-    ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) * sa,                                                   \
-        void (*leaf)(ossl_uintmax_t, type *, void *),                                                              \
-        void *arg)                                                                                                 \
-    {                                                                                                              \
-        ossl_sa_doall_arg((OPENSSL_SA *)sa,                                                                        \
-            (void (*)(ossl_uintmax_t, void *, void *))leaf, arg);                                                  \
-    }                                                                                                              \
-    static ossl_unused ossl_inline ctype *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) * sa, ossl_uintmax_t n) \
-    {                                                                                                              \
-        return (type *)ossl_sa_get((OPENSSL_SA *)sa, n);                                                           \
-    }                                                                                                              \
-    static ossl_unused ossl_inline int                                                                             \
-    ossl_sa_##type##_set(SPARSE_ARRAY_OF(type) * sa,                                                               \
-        ossl_uintmax_t n, ctype *val)                                                                              \
-    {                                                                                                              \
-        return ossl_sa_set((OPENSSL_SA *)sa, n, (void *)val);                                                      \
-    }                                                                                                              \
+#define DEFINE_SPARSE_ARRAY_OF_INTERNAL(type, ctype)                                                              \
+    SPARSE_ARRAY_OF(type);                                                                                        \
+    static ossl_unused ossl_inline SPARSE_ARRAY_OF(type) *ossl_sa_##type##_new(void)                              \
+    {                                                                                                             \
+        return (SPARSE_ARRAY_OF(type) *)ossl_sa_new();                                                            \
+    }                                                                                                             \
+    static ossl_unused ossl_inline void                                                                           \
+    ossl_sa_##type##_free(SPARSE_ARRAY_OF(type) *sa)                                                              \
+    {                                                                                                             \
+        ossl_sa_free((OPENSSL_SA *)sa);                                                                           \
+    }                                                                                                             \
+    static ossl_unused ossl_inline void                                                                           \
+    ossl_sa_##type##_free_leaves(SPARSE_ARRAY_OF(type) *sa)                                                       \
+    {                                                                                                             \
+        ossl_sa_free_leaves((OPENSSL_SA *)sa);                                                                    \
+    }                                                                                                             \
+    static ossl_unused ossl_inline size_t                                                                         \
+    ossl_sa_##type##_num(const SPARSE_ARRAY_OF(type) *sa)                                                         \
+    {                                                                                                             \
+        return ossl_sa_num((OPENSSL_SA *)sa);                                                                     \
+    }                                                                                                             \
+    static ossl_unused ossl_inline void                                                                           \
+    ossl_sa_##type##_doall(const SPARSE_ARRAY_OF(type) *sa,                                                       \
+        void (*leaf)(ossl_uintmax_t, type *))                                                                     \
+    {                                                                                                             \
+        ossl_sa_doall((OPENSSL_SA *)sa,                                                                           \
+            (void (*)(ossl_uintmax_t, void *))leaf);                                                              \
+    }                                                                                                             \
+    static ossl_unused ossl_inline void                                                                           \
+    ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) *sa,                                                   \
+        void (*leaf)(ossl_uintmax_t, type *, void *),                                                             \
+        void *arg)                                                                                                \
+    {                                                                                                             \
+        ossl_sa_doall_arg((OPENSSL_SA *)sa,                                                                       \
+            (void (*)(ossl_uintmax_t, void *, void *))leaf, arg);                                                 \
+    }                                                                                                             \
+    static ossl_unused ossl_inline ctype *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) *sa, ossl_uintmax_t n) \
+    {                                                                                                             \
+        return (type *)ossl_sa_get((OPENSSL_SA *)sa, n);                                                          \
+    }                                                                                                             \
+    static ossl_unused ossl_inline int                                                                            \
+    ossl_sa_##type##_set(SPARSE_ARRAY_OF(type) *sa,                                                               \
+        ossl_uintmax_t n, ctype *val)                                                                             \
+    {                                                                                                             \
+        return ossl_sa_set((OPENSSL_SA *)sa, n, (void *)val);                                                     \
+    }                                                                                                             \
     SPARSE_ARRAY_OF(type)
 
 #define DEFINE_SPARSE_ARRAY_OF(type) \

--- a/include/internal/list.h
+++ b/include/internal/list.h
@@ -25,28 +25,28 @@
         (p) != NULL;                          \
         (p) = ossl_list_##name##_next(p))
 #define OSSL_LIST_FOREACH(p, name, l) \
-    OSSL_LIST_FOREACH_FROM(p, name, ossl_list_##name##_head(l))
+    OSSL_LIST_FOREACH_FROM (p, name, ossl_list_##name##_head(l))
 
 #define OSSL_LIST_FOREACH_REV_FROM(p, name, init) \
     for ((p) = (init);                            \
         (p) != NULL;                              \
         (p) = ossl_list_##name##_prev(p))
 #define OSSL_LIST_FOREACH_REV(p, name, l) \
-    OSSL_LIST_FOREACH_FROM(p, name, ossl_list_##name##_tail(l))
+    OSSL_LIST_FOREACH_FROM (p, name, ossl_list_##name##_tail(l))
 
 #define OSSL_LIST_FOREACH_DELSAFE_FROM(p, pn, name, init)        \
     for ((p) = (init);                                           \
         (p) != NULL && (((pn) = ossl_list_##name##_next(p)), 1); \
         (p) = (pn))
 #define OSSL_LIST_FOREACH_DELSAFE(p, pn, name, l) \
-    OSSL_LIST_FOREACH_DELSAFE_FROM(p, pn, name, ossl_list_##name##_head(l))
+    OSSL_LIST_FOREACH_DELSAFE_FROM (p, pn, name, ossl_list_##name##_head(l))
 
 #define OSSL_LIST_FOREACH_REV_DELSAFE_FROM(p, pn, name, init)    \
     for ((p) = (init);                                           \
         (p) != NULL && (((pn) = ossl_list_##name##_prev(p)), 1); \
         (p) = (pn))
 #define OSSL_LIST_FOREACH_REV_DELSAFE(p, pn, name, l) \
-    OSSL_LIST_FOREACH_REV_DELSAFE_FROM(p, pn, name, ossl_list_##name##_tail(l))
+    OSSL_LIST_FOREACH_REV_DELSAFE_FROM (p, pn, name, ossl_list_##name##_tail(l))
 
 /* Define a list structure */
 #define OSSL_LIST(name) OSSL_LIST_##name
@@ -67,7 +67,7 @@
 
 #define DEFINE_LIST_OF_IMPL(name, type)                                                       \
     static ossl_unused ossl_inline void                                                       \
-    ossl_list_##name##_init(OSSL_LIST(name) * list)                                           \
+    ossl_list_##name##_init(OSSL_LIST(name) *list)                                            \
     {                                                                                         \
         memset(list, 0, sizeof(*list));                                                       \
     }                                                                                         \
@@ -78,24 +78,24 @@
             sizeof(elem->ossl_list_##name));                                                  \
     }                                                                                         \
     static ossl_unused ossl_inline int                                                        \
-    ossl_list_##name##_is_empty(const OSSL_LIST(name) * list)                                 \
+    ossl_list_##name##_is_empty(const OSSL_LIST(name) *list)                                  \
     {                                                                                         \
         return list->num_elems == 0;                                                          \
     }                                                                                         \
     static ossl_unused ossl_inline size_t                                                     \
-    ossl_list_##name##_num(const OSSL_LIST(name) * list)                                      \
+    ossl_list_##name##_num(const OSSL_LIST(name) *list)                                       \
     {                                                                                         \
         return list->num_elems;                                                               \
     }                                                                                         \
     static ossl_unused ossl_inline type *                                                     \
-    ossl_list_##name##_head(const OSSL_LIST(name) * list)                                     \
+    ossl_list_##name##_head(const OSSL_LIST(name) *list)                                      \
     {                                                                                         \
         assert(list->alpha == NULL                                                            \
             || list->alpha->ossl_list_##name.list == list);                                   \
         return list->alpha;                                                                   \
     }                                                                                         \
     static ossl_unused ossl_inline type *                                                     \
-    ossl_list_##name##_tail(const OSSL_LIST(name) * list)                                     \
+    ossl_list_##name##_tail(const OSSL_LIST(name) *list)                                      \
     {                                                                                         \
         assert(list->omega == NULL                                                            \
             || list->omega->ossl_list_##name.list == list);                                   \
@@ -120,7 +120,7 @@
         return elem->ossl_list_##name.prev;                                                   \
     }                                                                                         \
     static ossl_unused ossl_inline void                                                       \
-    ossl_list_##name##_remove(OSSL_LIST(name) * list, type * elem)                            \
+    ossl_list_##name##_remove(OSSL_LIST(name) *list, type *elem)                              \
     {                                                                                         \
         assert(elem->ossl_list_##name.list == list);                                          \
         OSSL_LIST_DBG(elem->ossl_list_##name.list = NULL)                                     \
@@ -137,7 +137,7 @@
             sizeof(elem->ossl_list_##name));                                                  \
     }                                                                                         \
     static ossl_unused ossl_inline void                                                       \
-    ossl_list_##name##_insert_head(OSSL_LIST(name) * list, type * elem)                       \
+    ossl_list_##name##_insert_head(OSSL_LIST(name) *list, type *elem)                         \
     {                                                                                         \
         assert(elem->ossl_list_##name.list == NULL);                                          \
         OSSL_LIST_DBG(elem->ossl_list_##name.list = list)                                     \
@@ -151,7 +151,7 @@
         list->num_elems++;                                                                    \
     }                                                                                         \
     static ossl_unused ossl_inline void                                                       \
-    ossl_list_##name##_insert_tail(OSSL_LIST(name) * list, type * elem)                       \
+    ossl_list_##name##_insert_tail(OSSL_LIST(name) *list, type *elem)                         \
     {                                                                                         \
         assert(elem->ossl_list_##name.list == NULL);                                          \
         OSSL_LIST_DBG(elem->ossl_list_##name.list = list)                                     \
@@ -165,8 +165,8 @@
         list->num_elems++;                                                                    \
     }                                                                                         \
     static ossl_unused ossl_inline void                                                       \
-    ossl_list_##name##_insert_before(OSSL_LIST(name) * list, type * e,                        \
-        type * elem)                                                                          \
+    ossl_list_##name##_insert_before(OSSL_LIST(name) *list, type *e,                          \
+        type *elem)                                                                           \
     {                                                                                         \
         assert(elem->ossl_list_##name.list == NULL);                                          \
         OSSL_LIST_DBG(elem->ossl_list_##name.list = list)                                     \
@@ -180,8 +180,8 @@
         list->num_elems++;                                                                    \
     }                                                                                         \
     static ossl_unused ossl_inline void                                                       \
-    ossl_list_##name##_insert_after(OSSL_LIST(name) * list, type * e,                         \
-        type * elem)                                                                          \
+    ossl_list_##name##_insert_after(OSSL_LIST(name) *list, type *e,                           \
+        type *elem)                                                                           \
     {                                                                                         \
         assert(elem->ossl_list_##name.list == NULL);                                          \
         OSSL_LIST_DBG(elem->ossl_list_##name.list = list)                                     \
@@ -195,7 +195,7 @@
         list->num_elems++;                                                                    \
     }                                                                                         \
     static ossl_unused ossl_inline void                                                       \
-    ossl_list_##name##_join(OSSL_LIST(name) * lh, OSSL_LIST(name) * lt)                       \
+    ossl_list_##name##_join(OSSL_LIST(name) *lh, OSSL_LIST(name) *lt)                         \
     {                                                                                         \
         OSSL_LIST_DBG(type * _p); /* local variable '_p' when debug */                        \
         if (lt == NULL || lh == NULL || lt->num_elems == 0 || lh == lt)                       \

--- a/include/internal/priority_queue.h
+++ b/include/internal/priority_queue.h
@@ -16,56 +16,56 @@
 
 #define PRIORITY_QUEUE_OF(type) OSSL_PRIORITY_QUEUE_##type
 
-#define DEFINE_PRIORITY_QUEUE_OF_INTERNAL(type, ctype)                                                                              \
-    typedef struct ossl_priority_queue_st_##type PRIORITY_QUEUE_OF(type);                                                           \
-    static ossl_unused ossl_inline PRIORITY_QUEUE_OF(type) * ossl_pqueue_##type##_new(int (*compare)(const ctype *, const ctype *)) \
-    {                                                                                                                               \
-        return (PRIORITY_QUEUE_OF(type) *)ossl_pqueue_new(                                                                          \
-            (int (*)(const void *, const void *))compare);                                                                          \
-    }                                                                                                                               \
-    static ossl_unused ossl_inline void                                                                                             \
-    ossl_pqueue_##type##_free(PRIORITY_QUEUE_OF(type) * pq)                                                                         \
-    {                                                                                                                               \
-        ossl_pqueue_free((OSSL_PQUEUE *)pq);                                                                                        \
-    }                                                                                                                               \
-    static ossl_unused ossl_inline void                                                                                             \
-    ossl_pqueue_##type##_pop_free(PRIORITY_QUEUE_OF(type) * pq,                                                                     \
-        void (*freefunc)(ctype *))                                                                                                  \
-    {                                                                                                                               \
-        ossl_pqueue_pop_free((OSSL_PQUEUE *)pq, (void (*)(void *))freefunc);                                                        \
-    }                                                                                                                               \
-    static ossl_unused ossl_inline int                                                                                              \
-    ossl_pqueue_##type##_reserve(PRIORITY_QUEUE_OF(type) * pq, size_t n)                                                            \
-    {                                                                                                                               \
-        return ossl_pqueue_reserve((OSSL_PQUEUE *)pq, n);                                                                           \
-    }                                                                                                                               \
-    static ossl_unused ossl_inline size_t                                                                                           \
-    ossl_pqueue_##type##_num(const PRIORITY_QUEUE_OF(type) * pq)                                                                    \
-    {                                                                                                                               \
-        return ossl_pqueue_num((OSSL_PQUEUE *)pq);                                                                                  \
-    }                                                                                                                               \
-    static ossl_unused ossl_inline int                                                                                              \
-    ossl_pqueue_##type##_push(PRIORITY_QUEUE_OF(type) * pq,                                                                         \
-        ctype * data, size_t *elem)                                                                                                 \
-    {                                                                                                                               \
-        return ossl_pqueue_push((OSSL_PQUEUE *)pq, (void *)data, elem);                                                             \
-    }                                                                                                                               \
-    static ossl_unused ossl_inline ctype *                                                                                          \
-    ossl_pqueue_##type##_peek(const PRIORITY_QUEUE_OF(type) * pq)                                                                   \
-    {                                                                                                                               \
-        return (type *)ossl_pqueue_peek((OSSL_PQUEUE *)pq);                                                                         \
-    }                                                                                                                               \
-    static ossl_unused ossl_inline ctype *                                                                                          \
-    ossl_pqueue_##type##_pop(PRIORITY_QUEUE_OF(type) * pq)                                                                          \
-    {                                                                                                                               \
-        return (type *)ossl_pqueue_pop((OSSL_PQUEUE *)pq);                                                                          \
-    }                                                                                                                               \
-    static ossl_unused ossl_inline ctype *                                                                                          \
-    ossl_pqueue_##type##_remove(PRIORITY_QUEUE_OF(type) * pq,                                                                       \
-        size_t elem)                                                                                                                \
-    {                                                                                                                               \
-        return (type *)ossl_pqueue_remove((OSSL_PQUEUE *)pq, elem);                                                                 \
-    }                                                                                                                               \
+#define DEFINE_PRIORITY_QUEUE_OF_INTERNAL(type, ctype)                                                                             \
+    typedef struct ossl_priority_queue_st_##type PRIORITY_QUEUE_OF(type);                                                          \
+    static ossl_unused ossl_inline PRIORITY_QUEUE_OF(type) *ossl_pqueue_##type##_new(int (*compare)(const ctype *, const ctype *)) \
+    {                                                                                                                              \
+        return (PRIORITY_QUEUE_OF(type) *)ossl_pqueue_new(                                                                         \
+            (int (*)(const void *, const void *))compare);                                                                         \
+    }                                                                                                                              \
+    static ossl_unused ossl_inline void                                                                                            \
+    ossl_pqueue_##type##_free(PRIORITY_QUEUE_OF(type) *pq)                                                                         \
+    {                                                                                                                              \
+        ossl_pqueue_free((OSSL_PQUEUE *)pq);                                                                                       \
+    }                                                                                                                              \
+    static ossl_unused ossl_inline void                                                                                            \
+    ossl_pqueue_##type##_pop_free(PRIORITY_QUEUE_OF(type) *pq,                                                                     \
+        void (*freefunc)(ctype *))                                                                                                 \
+    {                                                                                                                              \
+        ossl_pqueue_pop_free((OSSL_PQUEUE *)pq, (void (*)(void *))freefunc);                                                       \
+    }                                                                                                                              \
+    static ossl_unused ossl_inline int                                                                                             \
+    ossl_pqueue_##type##_reserve(PRIORITY_QUEUE_OF(type) *pq, size_t n)                                                            \
+    {                                                                                                                              \
+        return ossl_pqueue_reserve((OSSL_PQUEUE *)pq, n);                                                                          \
+    }                                                                                                                              \
+    static ossl_unused ossl_inline size_t                                                                                          \
+    ossl_pqueue_##type##_num(const PRIORITY_QUEUE_OF(type) *pq)                                                                    \
+    {                                                                                                                              \
+        return ossl_pqueue_num((OSSL_PQUEUE *)pq);                                                                                 \
+    }                                                                                                                              \
+    static ossl_unused ossl_inline int                                                                                             \
+    ossl_pqueue_##type##_push(PRIORITY_QUEUE_OF(type) *pq,                                                                         \
+        ctype *data, size_t *elem)                                                                                                 \
+    {                                                                                                                              \
+        return ossl_pqueue_push((OSSL_PQUEUE *)pq, (void *)data, elem);                                                            \
+    }                                                                                                                              \
+    static ossl_unused ossl_inline ctype *                                                                                         \
+    ossl_pqueue_##type##_peek(const PRIORITY_QUEUE_OF(type) *pq)                                                                   \
+    {                                                                                                                              \
+        return (type *)ossl_pqueue_peek((OSSL_PQUEUE *)pq);                                                                        \
+    }                                                                                                                              \
+    static ossl_unused ossl_inline ctype *                                                                                         \
+    ossl_pqueue_##type##_pop(PRIORITY_QUEUE_OF(type) *pq)                                                                          \
+    {                                                                                                                              \
+        return (type *)ossl_pqueue_pop((OSSL_PQUEUE *)pq);                                                                         \
+    }                                                                                                                              \
+    static ossl_unused ossl_inline ctype *                                                                                         \
+    ossl_pqueue_##type##_remove(PRIORITY_QUEUE_OF(type) *pq,                                                                       \
+        size_t elem)                                                                                                               \
+    {                                                                                                                              \
+        return (type *)ossl_pqueue_remove((OSSL_PQUEUE *)pq, elem);                                                                \
+    }                                                                                                                              \
     struct ossl_priority_queue_st_##type
 
 #define DEFINE_PRIORITY_QUEUE_OF(type) \

--- a/ssl/quic/quic_engine.c
+++ b/ssl/quic/quic_engine.c
@@ -136,8 +136,8 @@ void ossl_quic_engine_update_poll_descriptors(QUIC_ENGINE *qeng, int force)
      * the engine level in future when we can have multiple ports. This is not
      * important currently as the port list has a single entry.
      */
-    OSSL_LIST_FOREACH(port, port, &qeng->port_list)
-    ossl_quic_port_update_poll_descriptors(port, force);
+    OSSL_LIST_FOREACH (port, port, &qeng->port_list)
+        ossl_quic_port_update_poll_descriptors(port, force);
 }
 
 /*
@@ -185,8 +185,7 @@ static void qeng_tick(QUIC_TICK_RESULT *res, void *arg, uint32_t flags)
         return;
 
     /* Iterate through all ports and service them. */
-    OSSL_LIST_FOREACH(port, port, &qeng->port_list)
-    {
+    OSSL_LIST_FOREACH (port, port, &qeng->port_list) {
         QUIC_TICK_RESULT subr = { 0 };
 
         ossl_quic_port_subtick(port, &subr, flags);

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -439,8 +439,8 @@ int ossl_quic_port_set_net_wbio(QUIC_PORT *port, BIO *net_wbio)
     if (!port_update_poll_desc(port, net_wbio, /*for_write=*/1))
         return 0;
 
-    OSSL_LIST_FOREACH(ch, ch, &port->channel_list)
-    ossl_qtx_set_bio(ch->qtx, net_wbio);
+    OSSL_LIST_FOREACH (ch, ch, &port->channel_list)
+        ossl_qtx_set_bio(ch->qtx, net_wbio);
 
     port->net_wbio = net_wbio;
     port_update_addressing_mode(port);
@@ -678,8 +678,7 @@ void ossl_quic_port_subtick(QUIC_PORT *port, QUIC_TICK_RESULT *res,
             port_rx_pre(port);
 
         /* Iterate through all channels and service them. */
-        OSSL_LIST_FOREACH(ch, ch, &port->channel_list)
-        {
+        OSSL_LIST_FOREACH (ch, ch, &port->channel_list) {
             QUIC_TICK_RESULT subr = { 0 };
 
             ossl_quic_channel_subtick(ch, &subr, flags);
@@ -1756,9 +1755,9 @@ void ossl_quic_port_raise_net_error(QUIC_PORT *port,
     if (triggering_ch != NULL)
         ossl_quic_channel_raise_net_error(triggering_ch);
 
-    OSSL_LIST_FOREACH(ch, ch, &port->channel_list)
-    if (ch != triggering_ch)
-        ossl_quic_channel_raise_net_error(ch);
+    OSSL_LIST_FOREACH (ch, ch, &port->channel_list)
+        if (ch != triggering_ch)
+            ossl_quic_channel_raise_net_error(ch);
 }
 
 void ossl_quic_port_restore_err_state(const QUIC_PORT *port)

--- a/ssl/quic/quic_rcidm.c
+++ b/ssl/quic/quic_rcidm.c
@@ -191,7 +191,7 @@ struct quic_rcidm_st {
     uint64_t retire_prior_to;
 
     /* (SORT BY seq_num ASC) -> (RCID *) */
-    PRIORITY_QUEUE_OF(RCID) * rcids;
+    PRIORITY_QUEUE_OF(RCID) *rcids;
 
     /*
      * Current RCID object we are using. This may differ from the first item in
@@ -311,8 +311,8 @@ void ossl_quic_rcidm_free(QUIC_RCIDM *rcidm)
     while ((rcid = ossl_pqueue_RCID_pop(rcidm->rcids)) != NULL)
         OPENSSL_free(rcid);
 
-    OSSL_LIST_FOREACH_DELSAFE(rcid, rnext, retiring, &rcidm->retiring_list)
-    OPENSSL_free(rcid);
+    OSSL_LIST_FOREACH_DELSAFE (rcid, rnext, retiring, &rcidm->retiring_list)
+        OPENSSL_free(rcid);
 
     ossl_pqueue_RCID_free(rcidm->rcids);
     OPENSSL_free(rcidm);

--- a/ssl/quic/quic_reactor_wait_ctx.c
+++ b/ssl/quic/quic_reactor_wait_ctx.c
@@ -45,9 +45,9 @@ int ossl_quic_reactor_wait_ctx_enter(QUIC_REACTOR_WAIT_CTX *ctx,
 {
     QUIC_REACTOR_WAIT_SLOT *slot;
 
-    OSSL_LIST_FOREACH(slot, quic_reactor_wait_slot, &ctx->slots)
-    if (slot->rtor == rtor)
-        break;
+    OSSL_LIST_FOREACH (slot, quic_reactor_wait_slot, &ctx->slots)
+        if (slot->rtor == rtor)
+            break;
 
     if (slot == NULL) {
         if ((slot = OPENSSL_zalloc(sizeof(QUIC_REACTOR_WAIT_SLOT))) == NULL)
@@ -66,9 +66,9 @@ void ossl_quic_reactor_wait_ctx_leave(QUIC_REACTOR_WAIT_CTX *ctx,
 {
     QUIC_REACTOR_WAIT_SLOT *slot;
 
-    OSSL_LIST_FOREACH(slot, quic_reactor_wait_slot, &ctx->slots)
-    if (slot->rtor == rtor)
-        break;
+    OSSL_LIST_FOREACH (slot, quic_reactor_wait_slot, &ctx->slots)
+        if (slot->rtor == rtor)
+            break;
 
     assert(slot != NULL);
     slot_deactivate(slot);
@@ -78,8 +78,7 @@ void ossl_quic_reactor_wait_ctx_cleanup(QUIC_REACTOR_WAIT_CTX *ctx)
 {
     QUIC_REACTOR_WAIT_SLOT *slot, *nslot;
 
-    OSSL_LIST_FOREACH_DELSAFE(slot, nslot, quic_reactor_wait_slot, &ctx->slots)
-    {
+    OSSL_LIST_FOREACH_DELSAFE (slot, nslot, quic_reactor_wait_slot, &ctx->slots) {
         assert(slot->blocking_count == 0);
         OPENSSL_free(slot);
     }

--- a/test/quic_cc_test.c
+++ b/test/quic_cc_test.c
@@ -99,7 +99,7 @@ struct net_sim {
     uint64_t latency; /* ms */
 
     uint64_t spare_capacity;
-    PRIORITY_QUEUE_OF(NET_PKT) * pkts;
+    PRIORITY_QUEUE_OF(NET_PKT) *pkts;
 
     uint64_t total_acked, total_lost; /* bytes */
 };

--- a/test/sparse_array_test.c
+++ b/test/sparse_array_test.c
@@ -36,7 +36,7 @@ static int test_sparse_array(void)
         { INT_MAX, "m" }, { 6666666, "d" }, { (ossl_uintmax_t)-1, "H" },
         { 99, "e" }
     };
-    SPARSE_ARRAY_OF(char) * sa;
+    SPARSE_ARRAY_OF(char) *sa;
     size_t i, j;
     int res = 0;
 
@@ -101,7 +101,7 @@ struct index_cases_st {
 };
 
 struct doall_st {
-    SPARSE_ARRAY_OF(char) * sa;
+    SPARSE_ARRAY_OF(char) *sa;
     size_t num_cases;
     const struct index_cases_st *cases;
     int res;


### PR DESCRIPTION
For some inconceivable reason, `OSSL_LIST`, `PRIORITY_QUEUE_OF`, `SPARSE_ARRAY_OF`, and  `OSSL_LIST_FOREACH*` macros haven't been included in clang-format config in commit 9a6040a50a94 "Add a WebKit clang-format file", which led to incorrect (and at times misleading) formatting of the code that uses them.  Rescind that omission and re-format the affected files.

This is a backport of [1] to the `openssl-3.5` branch.

[1] https://github.com/openssl/openssl/pull/32304

Fixes: 9a6040a50a94 "Add a WebKit clang-format file"