### PR TITLE
quic: charge anti-amplification credit per packet, not per datagram

### DIFF
--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -1462,7 +1462,6 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
     PACKET pkt;
     OSSL_ACKM_RX_PKT ackm_data;
     uint32_t enc_level;
-    size_t dgram_len = qpacket->datagram_len;
 
     if (ch == NULL)
         return 0;
@@ -1498,7 +1497,7 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
     if (enc_level == QUIC_ENC_LEVEL_HANDSHAKE)
         ossl_quic_tx_packetiser_set_validated(ch->txp);
     else
-        ossl_quic_tx_packetiser_add_unvalidated_credit(ch->txp, dgram_len);
+        ossl_quic_tx_packetiser_add_unvalidated_credit(ch->txp, qpacket->hdr->len);
 
     /* Now that special cases are out of the way, parse frames */
     if (!PACKET_buf_init(&pkt, qpacket->hdr->data, qpacket->hdr->len)


### PR DESCRIPTION
`ossl_quic_handle_frames()` runs once per received packet, but adds the full
datagram length to the connection's unvalidated (anti-amplification) send credit
on every call. Because each coalesced packet in a datagram carries that same
datagram length, a datagram of size D containing N coalesced Initial packets
grants `3*N*D` of pre-validation send credit instead of `3*D`, inflating the RFC
9000 s.8.1 amplification limit by the coalesced-packet count (bounded by
`QUIC_MAX_PKT_PER_URXE`).

The comment above the call already states the intent — "add the size of this
packet to the unvalidated credit" — so this charges `qpacket->hdr->len` (the size
of this packet) rather than the whole datagram. Summed across the coalesced
packets of a datagram, the credit now tracks that one datagram. It under-counts
by per-packet header/tag overhead, which is safe as it only tightens the limit.

`CLA: trivial`

Tested: `quic_multistream_test` and `quic_tserver_test` pass. There is no internal
unit test for the amplification limit to extend (it is exercised by the interop
harness), so no new test is included.
