### PR TITLE
Test EVP_PKEY_get_size for zero return

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -8920,7 +8920,7 @@ static int test_rsasve_degenerate_ciphertext(int idx)
         goto err;
 
     ctlen = secretlen = (size_t)EVP_PKEY_get_size(rsakey);
-    if (!TEST_int_gt(ctlen, 0))
+    if (!TEST_size_t_gt(ctlen, 0))
         goto err;
     if (!TEST_ptr(ct = OPENSSL_zalloc(ctlen))
         || !TEST_ptr(secret = OPENSSL_malloc(secretlen)))

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -8920,6 +8920,8 @@ static int test_rsasve_degenerate_ciphertext(int idx)
         goto err;
 
     ctlen = secretlen = (size_t)EVP_PKEY_get_size(rsakey);
+    if (!TEST_int_gt(ctlen, 0))
+        goto err;
     if (!TEST_ptr(ct = OPENSSL_zalloc(ctlen))
         || !TEST_ptr(secret = OPENSSL_malloc(secretlen)))
         goto err;


### PR DESCRIPTION
The test_rsasve_degenerate_ciphertext calls EVP_PKEY_get_size and uses that returned value as an array index (offset by -1), but fails to check if the returned size is greater than zero (which can be returned in an error case), leading to an array index underflow.

Ensure that the returned value is greater than zero

Fixes https://scan5.scan.coverity.com/#/project-view/60762/10222?selectedIssue=1699973


