### PR TITLE
Use an int for the return value of i2a_ASN1_OBJECT

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -2497,11 +2497,12 @@ static int old_entry_print(const ASN1_OBJECT *obj, const ASN1_STRING *str)
 {
     char buf[25], *pbuf;
     const char *p;
+    int i;
     size_t j;
 
-    j = i2a_ASN1_OBJECT(bio_err, obj);
+    i = i2a_ASN1_OBJECT(bio_err, obj);
     pbuf = buf;
-    for (j = 22 - j; j > 0; j--)
+    for (i = 22 - i; i > 0; i--)
         *(pbuf++) = ' ';
     *(pbuf++) = ':';
     *(pbuf++) = '\0';


### PR DESCRIPTION
And as a result in this loop. I changed this to a size_t which was needed where the variable was used later on and missed this case at the start.

While harmless, coverity notices. so let's do it right

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
