### PR TITLE
Fix residual tlsmac double-free in cipher dupctx implementations

### DIFF
--- a/providers/implementations/ciphers/cipher_aria.c
+++ b/providers/implementations/ciphers/cipher_aria.c
@@ -36,6 +36,10 @@ static void *aria_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     in->base.hw->copyctx(&ret->base, &in->base);
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_blowfish.c
+++ b/providers/implementations/ciphers/cipher_blowfish.c
@@ -44,6 +44,10 @@ static void *blowfish_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     *ret = *in;
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_camellia.c
+++ b/providers/implementations/ciphers/cipher_camellia.c
@@ -42,6 +42,10 @@ static void *camellia_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     in->base.hw->copyctx(&ret->base, &in->base);
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_cast5.c
+++ b/providers/implementations/ciphers/cipher_cast5.c
@@ -45,6 +45,10 @@ static void *cast5_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     *ret = *in;
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -56,6 +56,10 @@ static void *des_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     in->base.hw->copyctx(&ret->base, &in->base);
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_idea.c
+++ b/providers/implementations/ciphers/cipher_idea.c
@@ -43,6 +43,10 @@ static void *idea_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     *ret = *in;
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_rc2.c
+++ b/providers/implementations/ciphers/cipher_rc2.c
@@ -53,6 +53,10 @@ static void *rc2_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     *ret = *in;
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_rc4.c
+++ b/providers/implementations/ciphers/cipher_rc4.c
@@ -46,6 +46,10 @@ static void *rc4_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     *ret = *in;
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_rc5.c
+++ b/providers/implementations/ciphers/cipher_rc5.c
@@ -50,6 +50,10 @@ static void *rc5_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     *ret = *in;
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_seed.c
+++ b/providers/implementations/ciphers/cipher_seed.c
@@ -42,6 +42,10 @@ static void *seed_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     *ret = *in;
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_sm4.c
+++ b/providers/implementations/ciphers/cipher_sm4.c
@@ -36,6 +36,10 @@ static void *sm4_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     in->base.hw->copyctx(&ret->base, &in->base);
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/providers/implementations/ciphers/cipher_tdes_common.c
+++ b/providers/implementations/ciphers/cipher_tdes_common.c
@@ -49,6 +49,10 @@ void *ossl_tdes_dupctx(void *ctx)
         return NULL;
     OSSL_FIPS_IND_COPY(ret, in)
     in->base.hw->copyctx(&ret->base, &in->base);
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
 
     return ret;
 }

--- a/test/cipher_dupctx_test.c
+++ b/test/cipher_dupctx_test.c
@@ -35,7 +35,11 @@ static int test_dupctx_tlsmac(int idx)
 {
     static const char *cipher_names[] = {
         "AES-128-CBC",
-        "AES-256-CBC"
+        "AES-256-CBC",
+        "ARIA-128-CBC",
+        "CAMELLIA-128-CBC",
+        "SM4-CBC",
+        "DES-EDE3-CBC"
     };
     const char *name = cipher_names[idx];
     EVP_CIPHER_CTX *ctx = NULL, *dupctx = NULL;
@@ -73,7 +77,8 @@ static int test_dupctx_tlsmac(int idx)
     /*
      * Perform a decrypt update with enough data to trigger tlsmac
      * allocation. Buffer needs at least: block_size + mac_size + 1.
-     * For AES-CBC: 16 + 20 + 1 = 37 minimum. Use 64 for safety.
+     * For a 16-byte block cipher: 16 + 20 + 1 = 37 minimum. Use 64 so
+     * this also covers the tested 8-byte block cipher.
      * Last byte is padding length (0 = 1 byte of padding).
      */
     memset(buf, 0, sizeof(buf));
@@ -113,6 +118,6 @@ err:
 
 int setup_tests(void)
 {
-    ADD_ALL_TESTS(test_dupctx_tlsmac, 2);
+    ADD_ALL_TESTS(test_dupctx_tlsmac, 6);
     return 1;
 }


### PR DESCRIPTION
Several provider cipher dupctx implementations shallow-copy the generic cipher context, including its heap-owned tlsmac buffer. If a TLS CBC decrypt context is copied after an update, freeing both contexts can therefore free the same buffer twice.

Use `ossl_cipher_generic_dupctx_tlsmac()` in every remaining cipher dupctx implementation and add regression coverage for ARIA, Camellia, SM4 and 3DES alongside AES.

Tests:

* `test_cipher_dupctx` under ASan/UBSan
* `test_evp`
* default and legacy provider builds