### PR TITLE
doc: correct pkcs12 passin and passout descriptions

### DIFF
--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -104,14 +104,19 @@ Print out a usage message.
 
 =item B<-passin> I<arg>
 
-The password source for the input, and for encrypting any private keys that
-are output.
+The password source for input files. With B<-export>, it is used to decrypt
+the input private key. Otherwise, it is the password for the input PKCS#12
+file.
 For more information about the format of B<arg>
 see L<openssl-passphrase-options(1)>.
 
 =item B<-passout> I<arg>
 
-The password source for output files.
+The password source for output files. With B<-export>, it is the password for
+the output PKCS#12 file. Otherwise, it is used to encrypt any private keys that
+are output.
+For more information about the format of B<arg>
+see L<openssl-passphrase-options(1)>.
 
 =item B<-password> I<arg>
 


### PR DESCRIPTION
The descriptions of `-passin` and `-passout` conflated their input and output roles and incorrectly attributed output private key encryption to `-passin`.

Clarify their behavior:

- during export, `-passin` decrypts the input private key and `-passout` protects the output PKCS#12 file
- during import, `-passin` unlocks the input PKCS#12 file and `-passout` encrypts private keys written to output

Also link `-passout` to the shared passphrase options documentation.

Fixes #32307

## Validation

```sh
make -s doc-nits
```

##### Checklist

- [x] documentation is added or updated