### PR TITLE
apps: fix password source lines being split into unintended passwords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,15 @@ OpenSSL 4.1
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Fixed handling of password sources read from `file:`, `fd:`, and `stdin` at
+   the 1023-byte line-length boundary. A maximum-length password followed by a
+   newline is now consumed as one complete line, so when the same source is used
+   for both `-passin` and `-passout`, the next line is used for the output
+   password as documented. Longer password lines are now rejected rather than
+   being silently truncated or split into another password.
+
+   *Mounir Idrassi*
+
  * Fixed a bug where a TLS 1.3 session ticket could retain a stale ALPN
    protocol from an earlier connection after a resumption negotiated a
    different protocol (or none), on both the server and the client,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -219,7 +219,7 @@ int app_passwd(const char *arg1, const char *arg2, char **pass1, char **pass2)
 static char *app_get_pass(const char *arg, int keepbio)
 {
     static BIO *pwdbio = NULL;
-    char *tmp, tpass[APP_PASS_LEN];
+    char *tmp, tpass[APP_PASS_LEN + 1];
     int i;
 
     /* PASS_SOURCE_SIZE_MAX = max number of chars before ':' in below strings */
@@ -290,19 +290,30 @@ static char *app_get_pass(const char *arg, int keepbio)
             return NULL;
         }
     }
-    i = BIO_gets(pwdbio, tpass, APP_PASS_LEN);
+    i = BIO_gets(pwdbio, tpass, sizeof(tpass));
+    if (i <= 0) {
+        BIO_puts(bio_err, "Error reading password from BIO\n");
+        goto err;
+    }
+    tmp = strchr(tpass, '\n');
+    if (tmp != NULL) {
+        *tmp = '\0';
+    } else if (i == APP_PASS_LEN) {
+        BIO_printf(bio_err,
+            "Password is too long (maximum %d bytes)\n",
+            APP_PASS_LEN - 1);
+        goto err;
+    }
     if (keepbio != 1) {
         BIO_free_all(pwdbio);
         pwdbio = NULL;
     }
-    if (i <= 0) {
-        BIO_puts(bio_err, "Error reading password from BIO\n");
-        return NULL;
-    }
-    tmp = strchr(tpass, '\n');
-    if (tmp != NULL)
-        *tmp = 0;
     return OPENSSL_strdup(tpass);
+
+err:
+    BIO_free_all(pwdbio);
+    pwdbio = NULL;
+    return NULL;
 }
 
 char *app_conf_try_string(const CONF *conf, const char *group, const char *name)

--- a/test/recipes/15-test_pkey.t
+++ b/test/recipes/15-test_pkey.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_pkey");
 
-plan tests => 9;
+plan tests => 10;
 
 my @app = ('openssl', 'pkey');
 
@@ -42,6 +42,51 @@ subtest "=== pkey typical en-/decryption (using AES256-CBC) ===" => sub {
        "decrypt key");
     is(compare_text($in_key, $decrypted_key), 0,
        "Same file contents after encrypting and decrypting in separate files");
+};
+
+subtest "=== pkey password file line boundaries ===" => sub {
+    plan tests => 6;
+
+    my $password_file = 'passwords.txt';
+    my $encrypted_key = 'boundary-encrypted-key.pem';
+    my $eof_encrypted_key = 'eof-boundary-encrypted-key.pem';
+    my $too_long_key = 'too-long-encrypted-key.pem';
+    my $output_password = 'output-password';
+    my $password_source = "file:$password_file";
+    my $max_password = 'A' x 1023;
+    my $fh;
+
+    open $fh, '>', $password_file or die "Cannot open $password_file: $!";
+    print $fh $max_password, "\n$output_password\n";
+    close $fh or die "Cannot close $password_file: $!";
+
+    ok(run(app([@app, '-aes256', '-in', $in_key, '-out', $encrypted_key,
+                '-passin', $password_source, '-passout', $password_source])),
+       "read a maximum-length input password followed by an output password");
+    ok(run(app([@app, '-in', $encrypted_key,
+                '-passin', "pass:$output_password", '-noout'])),
+       "the second line is used as the output password");
+    ok(!run(app([@app, '-in', $encrypted_key, '-passin', 'pass:', '-noout'])),
+       "the line separator is not used as an empty output password");
+
+    open $fh, '>', $password_file or die "Cannot open $password_file: $!";
+    print $fh $max_password;
+    close $fh or die "Cannot close $password_file: $!";
+
+    ok(run(app([@app, '-aes256', '-in', $in_key,
+                '-out', $eof_encrypted_key, '-passout', $password_source])),
+       "read a maximum-length password ending at EOF");
+    ok(run(app([@app, '-in', $eof_encrypted_key,
+                '-passin', "pass:$max_password", '-noout'])),
+       "the complete maximum-length password is used at EOF");
+
+    open $fh, '>', $password_file or die "Cannot open $password_file: $!";
+    print $fh 'A' x 1024, "\n$output_password\n";
+    close $fh or die "Cannot close $password_file: $!";
+
+    ok(!run(app([@app, '-aes256', '-in', $in_key, '-out', $too_long_key,
+                 '-passin', $password_source, '-passout', $password_source])),
+       "reject an overlong password instead of treating its tail as another password");
 };
 
 subtest "=== pkey handling of identical input and output files (using 3DES) and -traditional ===" => sub {


### PR DESCRIPTION
While looking into #32307, I found a separate bug in the shared password source parser.

`app_get_pass` misparses password sources containing multiple lines at the `APP_PASS_LEN` boundary.

`BIO_gets` reads at most 1023 bytes. Because of this, when the first password is exactly 1023 bytes and is followed by a newline:

- the newline remains unread
- if the same source supplies two passwords, the newline is read as an empty second password
- the intended second line is ignored

When the first line exceeds 1023 bytes, it is split and its remaining bytes are instead interpreted as the second password.

This can silently cause output material to be encrypted with an empty or otherwise unintended password rather than the second password supplied by the user.

Fix the parser by reading one additional byte when the buffer boundary is reached:

- consume the newline following a valid password at the maximum supported length
- accept EOF when such a password has no terminating newline
- reject an overlong line rather than splitting it into multiple passwords

Regression tests cover both a first password of exactly 1023 bytes and an overlong password source. On the unpatched code, they demonstrate that the intended second password is ignored, that an empty password is selected at the exact boundary, and that an overlong first line is accepted and split.

## Validation

- `make test TESTS=test_pkey VF=1`
- `make test TESTS='test_pkey test_pkcs8 test_req test_rsa test_pkcs12' VF=1`
- manual validation with a shared `stdin` password source
- full `make test`: 386 files and 4,571 tests passed

##### Checklist

- [x] tests are added or updated
