### PR TITLE
.github/workflows: Add openssl-4.0 to CI and remove backport branches. (4.0)

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -131,6 +131,11 @@ jobs:
             tgz: branch-3.6.tar.gz,
             extra_config: "enable-lms",
           }, {
+            name: openssl-4.0,
+            dir: branch-4.0,
+            tgz: branch-4.0.tar.gz,
+            extra_config: "enable-lms enable-tls-deprecated-ec",
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,
@@ -200,12 +205,14 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-3.6, branch-3.5, branch-3.4, branch-3.0,
+        tree_a: [ branch-4.0, branch-3.6, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
           - tree_a: PR
             tree_b: branch-master
+          - tree_a: PR
+            tree_b: branch-4.0
           - tree_a: PR
             tree_b: branch-3.6
           - tree_a: PR


### PR DESCRIPTION
Add missing stable branch and remove backport branches.
