### PR TITLE
.github/workflows: Add openssl-4.0 to CI and remove backport branches. (3.5)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,15 +19,6 @@ jobs:
       matrix:
         release: [
           {
-            branch: '4.0',
-            cppflags: ''
-          }, {
-            branch: '3.6',
-            cppflags: ''
-          }, {
-            branch: '3.5',
-            cppflags: 'CPPFLAGS=-ansi'
-          }, {
             branch: '3.4',
             cppflags: 'CPPFLAGS=-ansi'
           }, {

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -126,6 +126,10 @@ jobs:
             dir: branch-3.6,
             tgz: branch-3.6.tar.gz,
           }, {
+            name: openssl-4.0,
+            dir: branch-4.0,
+            tgz: branch-4.0.tar.gz,
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,
@@ -193,12 +197,14 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-3.6, branch-3.5, branch-3.4, branch-3.0,
+        tree_a: [ branch-4.0, branch-3.6, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
           - tree_a: PR
             tree_b: branch-master
+          - tree_a: PR
+            tree_b: branch-4.0
           - tree_a: PR
             tree_b: branch-3.6
           - tree_a: PR


### PR DESCRIPTION
Add missing stable branch and remove backport branches.
