### PR TITLE
 .github/workflows: add openssl-4.0 and openssl-3.6 to CI (3.0)

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -122,6 +122,14 @@ jobs:
             dir: branch-3.5,
             tgz: branch-3.5.tar.gz,
           }, {
+            name: openssl-3.6,
+            dir: branch-3.6,
+            tgz: branch-3.6.tar.gz,
+          }, {
+            name: openssl-4.0,
+            dir: branch-4.0,
+            tgz: branch-4.0.tar.gz,
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,
@@ -189,12 +197,16 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-3.5, branch-3.4, branch-3.0,
+        tree_a: [ branch-4.0, branch-3.6, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
           - tree_a: PR
             tree_b: branch-master
+          - tree_a: PR
+            tree_b: branch-4.0
+          - tree_a: PR
+            tree_b: branch-3.6
           - tree_a: PR
             tree_b: branch-3.5
           - tree_a: PR


### PR DESCRIPTION
Add missing stable branches.
