### PR TITLE
DTLS 1.3 Support blocking mode on listeners and connections (pending #32239)

### DIFF
--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -289,6 +289,15 @@ generate and verify cookies based on the client's address, providing basic
 amplification attack protection without requiring application-specific
 callback implementations.
 
+A DTLS listener demultiplexes a single network socket to many connections, so it
+cannot allow one connection's read to block and thereby stall the others. Its
+network BIO is configured for nonblocking operation when it is set, and blocking
+behaviour is provided by waiting for readiness of that socket instead. A DTLS
+listener is blocking by default, and the connections it returns inherit that;
+use L<SSL_set_blocking_mode(3)> to change it. A listener whose BIO cannot provide
+a poll descriptor, such as one using a memory BIO, has nothing to wait on and is
+nonblocking whatever is requested.
+
 An example DTLS server using the listener API in single threaded mode which only
 accepts one connection at a time. A typical implementation would utilize L<SSL_poll(3)>
 and can accept multiple connections concurrently.

--- a/doc/man3/SSL_set_bio.pod
+++ b/doc/man3/SSL_set_bio.pod
@@ -101,6 +101,11 @@ BIO is subsequently set on the SSL object which can support blocking mode,
 blocking mode will not be automatically re-enabled. For more information, see
 L<SSL_set_blocking_mode(3)>.
 
+When B<ssl> is a DTLS listener object, the BIO is configured for nonblocking
+operation, since a listener demultiplexes one socket to many connections and so
+cannot allow a read for one of them to block. Blocking behaviour is provided by
+waiting for readiness of the socket instead; see L<SSL_set_blocking_mode(3)>.
+
 When B<ssl> is a DTLS listener object, these functions must not be called
 concurrently with any other operations on the listener or its connections.
 This includes L<SSL_accept_connection(3)>, L<SSL_poll(3)>,

--- a/doc/man3/SSL_set_blocking_mode.pod
+++ b/doc/man3/SSL_set_blocking_mode.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 SSL_set_blocking_mode, SSL_get_blocking_mode - configure blocking mode for a
-QUIC SSL object
+QUIC or DTLS listener SSL object
 
 =head1 SYNOPSIS
 
@@ -14,11 +14,14 @@ QUIC SSL object
 
 =head1 DESCRIPTION
 
-SSL_set_blocking_mode() can be used to enable or disable blocking mode on a QUIC
-connection SSL object. By default, blocking is enabled, unless the SSL object is
-configured to use an underlying read or write BIO which cannot provide a poll
-descriptor (see L<BIO_get_rpoll_descriptor(3)>), as blocking mode cannot be
-supported in this case.
+SSL_set_blocking_mode() can be used to enable or disable blocking mode on an SSL
+object which has a blocking mode of its own. For QUIC that means a connection,
+stream or listener SSL object. For DTLS it means a listener SSL object created
+with L<SSL_new_listener(3)>, or a connection SSL object returned from one by
+L<SSL_accept_connection(3)>. By default, blocking is enabled, unless the SSL
+object is configured to use an underlying read or write BIO which cannot provide
+a poll descriptor (see L<BIO_get_rpoll_descriptor(3)>), as blocking mode cannot
+be supported in this case.
 
 To enable blocking mode, call SSL_set_blocking_mode() with I<blocking> set to 1;
 to disable it, call SSL_set_blocking_mode() with I<blocking> set to 0.
@@ -30,10 +33,13 @@ until the requested operation can be performed. In nonblocking mode, these
 calls will fail if the requested operation cannot be performed immediately; see
 L<SSL_get_error(3)>.
 
-These functions are only applicable to QUIC connection SSL objects. Other kinds
-of SSL object, such as those for TLS, automatically function in blocking or
-nonblocking mode based on whether the underlying network read and write BIOs
-provided to the SSL object are themselves configured in nonblocking mode.
+Other kinds of SSL object, such as those for TLS or a DTLS object which did not
+come from a listener, automatically function in blocking or nonblocking mode
+based on whether the underlying network read and write BIOs provided to the SSL
+object are themselves configured in nonblocking mode, and so have no separate
+blocking mode to configure.
+
+=head2 QUIC connections
 
 Where a QUIC connection SSL object is used in nonblocking mode, an application
 is responsible for ensuring that the SSL object is ticked regularly; see
@@ -44,24 +50,45 @@ connection SSL object with a network BIO which cannot support blocking mode. To
 re-enable blocking mode in this case, an application must set a network BIO
 which can support blocking mode and explicitly call SSL_set_blocking_mode().
 
+=head2 DTLS listeners
+
+A DTLS listener demultiplexes a single network socket to many connections, so it
+cannot allow a read for one connection to block and thereby stall the others.
+Its network BIO is therefore configured for nonblocking operation when it is set,
+and blocking mode is provided by waiting for readiness of that socket instead,
+as it is for QUIC. This applies to L<SSL_accept_connection(3)> on the listener as
+well as to reads and writes on the connections it returns.
+
+A connection SSL object returned by L<SSL_accept_connection(3)> inherits the
+blocking mode of the listener it came from. Calling SSL_set_blocking_mode() on
+such a connection overrides that inheritance for that connection only, and there
+is no way to return it to inheriting afterwards. The blocking mode of a listener
+is normally configured once, before it is used.
+
+A DTLS listener whose network BIO cannot provide a poll descriptor, such as one
+using a memory BIO, has nothing to wait on and is therefore nonblocking
+whatever has been requested.
+
 =head1 RETURN VALUES
 
 SSL_set_blocking_mode() returns 1 on success and 0 on failure. The function
-fails if called on an SSL object which does not represent a QUIC connection,
-or if blocking mode cannot be used for the given connection.
+fails if called on an SSL object which has no blocking mode of its own, or if
+blocking mode was requested and cannot be used for the given object.
 
-SSL_get_blocking_mode() returns 1 if blocking is currently enabled. It returns
--1 if called on an unsupported SSL object.
+SSL_get_blocking_mode() returns 1 if blocking is currently enabled and 0 if it
+is not. It returns -1 if called on an SSL object which has no blocking mode of
+its own.
 
 =head1 SEE ALSO
 
-L<SSL_handle_events(3)>, L<SSL_poll(3)>, L<openssl-quic(7)>,
-L<openssl-quic-concurrency(7)>, L<ssl(7)>
+L<SSL_handle_events(3)>, L<SSL_poll(3)>, L<SSL_new_listener(3)>,
+L<openssl-quic(7)>, L<openssl-quic-concurrency(7)>, L<ssl(7)>
 
 =head1 HISTORY
 
 The SSL_set_blocking_mode() and SSL_get_blocking_mode() functions were added in
-OpenSSL 3.2.
+OpenSSL 3.2. Support for DTLS listeners and the connections created from them
+was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_set_blocking_mode.pod
+++ b/doc/man3/SSL_set_blocking_mode.pod
@@ -57,7 +57,9 @@ cannot allow a read for one connection to block and thereby stall the others.
 Its network BIO is therefore configured for nonblocking operation when it is set,
 and blocking mode is provided by waiting for readiness of that socket instead,
 as it is for QUIC. This applies to L<SSL_accept_connection(3)> on the listener as
-well as to reads and writes on the connections it returns.
+well as to reads and writes on the connections it returns. A write which the
+socket cannot accept is retried once it can be sent, where a nonblocking
+connection discards the datagram and reports that the write should be retried.
 
 A connection SSL object returned by L<SSL_accept_connection(3)> inherits the
 blocking mode of the listener it came from. Calling SSL_set_blocking_mode() on

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -2457,19 +2457,13 @@ SSL *ossl_dtls_accept_connection(SSL *ssl, uint64_t flags)
     }
 
     /*
-     * Loop calling ossl_dtls_tick() until a verified connection arrives or
-     * a fatal error occurs.
+     * Blocking path: tick to make whatever progress is possible now, and if
+     * that did not produce a connection, wait for readiness before ticking
+     * again.
      *
-     * This blocking accept path requires net_rbio to be a blocking BIO. With
-     * a blocking BIO each tick sleeps inside BIO_recvmmsg() until a datagram
-     * is received, so the loop waits efficiently and does not spin.
-     *
-     * If net_rbio were non-blocking, BIO_recvmmsg() would return a transient
-     * (non-fatal) error when no datagram is ready; ossl_dtls_tick() would then
-     * return >= 0 with the incoming queue still empty and this loop would busy
-     * spin. Callers that want non-blocking behaviour must use
-     * SSL_ACCEPT_CONNECTION_NO_BLOCK (handled above) instead of a non-blocking
-     * BIO on this path.
+     * The wait is what stops this from being a busy loop. The network BIO is
+     * non-blocking, so a tick which finds no datagram returns immediately;
+     * without waiting in between, this loop would spin.
      */
     for (;;) {
         if (ossl_dtls_tick(dl) < 0) {
@@ -2482,6 +2476,16 @@ SSL *ossl_dtls_accept_connection(SSL *ssl, uint64_t flags)
         conn = sk_SSL_shift(dl->incoming_connections);
         ossl_crypto_mutex_unlock(dl->mutex);
         if (conn != NULL)
+            break;
+
+        /*
+         * Nothing yet, so wait for the listener to become ready before ticking
+         * again. What that amounts to is decided by the poll translation for a
+         * listener: the network socket becoming readable, or another thread
+         * signalling the notifier because it produced readiness on our behalf.
+         */
+        if (!ossl_dtls_block_until_ready(ssl, SSL_POLL_EVENT_IC,
+                ossl_time_infinite()))
             break;
     }
 
@@ -2533,6 +2537,16 @@ void ossl_dtls_listener_set0_net_rbio(SSL *s, BIO *bio)
         return;
 
     dl = (DTLS_LISTENER *)s;
+
+    /*
+     * The listener demultiplexes one socket to many connections, so it can
+     * never afford to block inside a read: a read for one connection would
+     * stall every other, and the demux lock is held across it. Blocking
+     * behaviour is provided by waiting for readiness instead, so configure the
+     * BIO for non-blocking operation on the application's behalf, as QUIC does.
+     */
+    if (bio != NULL)
+        BIO_set_nbio(bio, 1); /* best effort autoconfig */
 
     ossl_crypto_mutex_lock(dl->mutex);
 
@@ -2600,6 +2614,10 @@ void ossl_dtls_listener_set0_net_wbio(SSL *s, BIO *bio)
         return;
 
     dl = (DTLS_LISTENER *)s;
+
+    /* See ossl_dtls_listener_set0_net_rbio() as to why. */
+    if (bio != NULL)
+        BIO_set_nbio(bio, 1); /* best effort autoconfig */
 
     old_wbio = dl->net_wbio;
 

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -565,7 +565,14 @@ int dtls1_handle_timeout(SSL_CONNECTION *s)
         dtls1_double_timeout(s);
 
     if (dtls1_check_timeout_num(s) < 0) {
-        /* SSLfatal() already called */
+        /*
+         * SSLfatal() already called, so the connection is finished. Stop the
+         * timer rather than returning with next_timeout left in the past:
+         * nothing will re-arm or clear it from here, so DTLSv1_get_timeout()
+         * would report "due now" for ever and spin any caller which waits on
+         * it.
+         */
+        dtls1_stop_timer(s);
         return -1;
     }
 

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -3088,20 +3088,26 @@ int ossl_dtls_set_blocking_mode(SSL *s, int blocking)
      * Any other DTLS object takes its behaviour from its own BIO in the
      * traditional way, so there is nothing here to configure.
      */
-    if (IS_DTLS_LISTENER(s)) {
-        ((DTLS_LISTENER *)s)->req_blocking_mode = mode;
-    } else if (sc != NULL && sc->d1 != NULL && sc->d1->listener != NULL) {
-        sc->d1->req_blocking_mode = mode;
-    } else {
+    if (!IS_DTLS_LISTENER(s)
+        && (sc == NULL || sc->d1 == NULL || sc->d1->listener == NULL)) {
         ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }
 
-    /* Refuse to claim blocking we cannot deliver, as QUIC does. */
+    /*
+     * Refuse to claim blocking we cannot deliver, as QUIC does. Checked before
+     * anything is written, so that a call which fails leaves the mode alone
+     * rather than reporting failure having already changed it.
+     */
     if (blocking && !ossl_dtls_can_support_blocking(s)) {
         ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
         return 0;
     }
+
+    if (IS_DTLS_LISTENER(s))
+        ((DTLS_LISTENER *)s)->req_blocking_mode = mode;
+    else
+        sc->d1->req_blocking_mode = mode;
 
     return 1;
 }

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -3181,6 +3181,44 @@ int ossl_dtls_conn_wait_for_datagram(SSL *s)
     }
 }
 
+/*
+ * Wait until the listener's socket can accept another datagram, for a
+ * connection which is in blocking mode.
+ *
+ * The socket is shared with every other connection and is always
+ * non-blocking, so a send which cannot be completed has nowhere to wait. For
+ * DTLS the record layer would otherwise discard the datagram - a reasonable
+ * default for an unreliable transport, but not what an application which asked
+ * for blocking writes expects.
+ *
+ * Only one wait is performed. The caller retries the send, and comes back here
+ * if it still cannot proceed, so a wakeup which turns out not to leave room in
+ * the socket buffer costs an extra attempt rather than a lost datagram.
+ *
+ * Returns 1 if the send should be retried, or 0 if the wait could not be
+ * performed or the listener has failed.
+ */
+int ossl_dtls_conn_wait_for_write(SSL *s)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+    DTLS_LISTENER *dl;
+    int fatal;
+
+    if (sc == NULL || sc->d1 == NULL || sc->d1->listener == NULL)
+        return 0;
+
+    dl = (DTLS_LISTENER *)sc->d1->listener;
+
+    ossl_crypto_mutex_lock(dl->mutex);
+    fatal = dl->fatal;
+    ossl_crypto_mutex_unlock(dl->mutex);
+    if (fatal)
+        return 0;
+
+    return ossl_dtls_block_until_ready(s, SSL_POLL_EVENT_W,
+        ossl_time_infinite());
+}
+
 void ossl_dtls_listener_enter_blocking_section(SSL *s)
 {
     DTLS_LISTENER *dl;

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -2522,7 +2522,7 @@ SSL *ossl_dtls_accept_connection(SSL *ssl, uint64_t flags)
          * signalling the notifier because it produced readiness on our behalf.
          */
         if (!ossl_dtls_block_until_ready(ssl, SSL_POLL_EVENT_IC,
-                ossl_time_infinite()))
+                ossl_time_infinite(), /*bound_by_event_timeout=*/1))
             break;
     }
 
@@ -3178,7 +3178,7 @@ int ossl_dtls_conn_wait_for_datagram(SSL *s)
          * time to retransmit.
          */
         if (!ossl_dtls_block_until_ready(s, SSL_POLL_EVENT_R,
-                ossl_time_infinite()))
+                ossl_time_infinite(), /*bound_by_event_timeout=*/1))
             return 0;
 
         if (!SSL_handle_events(s))
@@ -3209,6 +3209,19 @@ int ossl_dtls_conn_wait_for_datagram(SSL *s)
  * if it still cannot proceed, so a wakeup which turns out not to leave room in
  * the socket buffer costs an extra attempt rather than a lost datagram.
  *
+ * The retransmission timer deliberately does not shorten this wait, unlike the
+ * one for a datagram above. There the wakeup is useful, because the wait can
+ * service the timer itself; here it cannot. Servicing it would mean
+ * retransmitting a flight from inside tls_retry_write_records(), which is
+ * part-way through sending one and holds write buffer state that a
+ * re-entrant do_dtls1_write() would clobber. Waking for a timer nothing then
+ * services would be worse than not waking: the timeout stays expired, and an
+ * expired timeout reads as a zero deadline, so every later wait would return
+ * at once and the caller's retry loop would spin without sleeping. Waiting for
+ * the socket alone is also what the send actually needs. Retransmission is not
+ * the right response to a flight which has not finished going out, and once it
+ * has, the state machine handles the timer as usual.
+ *
  * Returns 1 if the send should be retried, or 0 if the wait could not be
  * performed or the listener has failed.
  */
@@ -3230,7 +3243,7 @@ int ossl_dtls_conn_wait_for_write(SSL *s)
         return 0;
 
     return ossl_dtls_block_until_ready(s, SSL_POLL_EVENT_W,
-        ossl_time_infinite());
+        ossl_time_infinite(), /*bound_by_event_timeout=*/0);
 }
 
 void ossl_dtls_listener_enter_blocking_section(SSL *s)

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -1344,6 +1344,25 @@ err:
 }
 
 /*
+ * dtls_listener_signal_notifier - wake threads blocked on this listener.
+ *
+ * Readiness may be produced by the thread which pumps the demux while a
+ * different thread is blocked in poll() on the network socket. That socket
+ * will not necessarily become readable again from the blocked thread's point
+ * of view, so the notifier is used to wake it.
+ *
+ * The caller must hold dl->mutex.
+ */
+static void dtls_listener_signal_notifier(DTLS_LISTENER *dl)
+{
+    if (dl->have_notifier && dl->cur_blocking_waiters > 0
+        && !dl->signalled_notifier) {
+        ossl_rio_notifier_signal(&dl->notifier);
+        dl->signalled_notifier = 1;
+    }
+}
+
+/*
  * dtls_listener_packet_handler - callback for handling incoming datagrams.
  *
  * This callback is invoked by the demux for each received datagram. It routes
@@ -1450,10 +1469,7 @@ static void dtls_listener_packet_handler(DGRAM_URXE *urxe, void *arg)
     ossl_dtls_rx_inject_urxe(sc->d1->rx, urxe);
 
     /* Signal notifier if needed */
-    if (dl->have_notifier && dl->cur_blocking_waiters > 0 && !dl->signalled_notifier) {
-        ossl_rio_notifier_signal(&dl->notifier);
-        dl->signalled_notifier = 1;
-    }
+    dtls_listener_signal_notifier(dl);
 
     ossl_crypto_mutex_unlock(dl->mutex);
     return;
@@ -2308,6 +2324,14 @@ static int dtls_listener_drive_pending(DTLS_LISTENER *dl)
             }
         }
     }
+
+    /*
+     * A connection became acceptable. Any thread blocked waiting for one is
+     * polling the network socket, which will not necessarily become readable
+     * again on its behalf, so wake it explicitly.
+     */
+    if (result)
+        dtls_listener_signal_notifier(dl);
 
     /* Remove failed connections (after releasing refs so ref count is 1) */
     for (i = 0; i < sk_SSL_num(ctx.failed_conns); i++) {

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -338,6 +338,7 @@ int dtls1_clear(SSL *ssl)
         OSSL_TIME created_at = s->d1->created_at;
         unsigned int req_blocking_mode = s->d1->req_blocking_mode;
         unsigned int force_nonblocking = s->d1->force_nonblocking;
+        unsigned int being_driven = s->d1->being_driven;
 #endif
 
         mtu = s->d1->mtu;
@@ -374,6 +375,13 @@ int dtls1_clear(SSL *ssl)
          * there and stall the listener.
          */
         s->d1->force_nonblocking = force_nonblocking;
+        /*
+         * being_driven says the listener is driving this connection's
+         * handshake, and is what keeps a concurrent tick from collecting it a
+         * second time. Losing it would let two threads into the state machine
+         * for one connection.
+         */
+        s->d1->being_driven = being_driven;
         s->d1->created_at = created_at;
 #endif
 

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -337,6 +337,7 @@ int dtls1_clear(SSL *ssl)
         SSL *listener = s->d1->listener;
         OSSL_TIME created_at = s->d1->created_at;
         unsigned int req_blocking_mode = s->d1->req_blocking_mode;
+        unsigned int force_nonblocking = s->d1->force_nonblocking;
 #endif
 
         mtu = s->d1->mtu;
@@ -367,6 +368,12 @@ int dtls1_clear(SSL *ssl)
          * configured it, not of the handshake, so it survives a clear.
          */
         s->d1->req_blocking_mode = req_blocking_mode;
+        /*
+         * SSL_clear() can be called from inside the very SSL_accept() the
+         * listener is driving, so losing this would let the connection block
+         * there and stall the listener.
+         */
+        s->d1->force_nonblocking = force_nonblocking;
         s->d1->created_at = created_at;
 #endif
 
@@ -2195,7 +2202,14 @@ static void drive_single_connection(SSL *ssl, DTLS_LISTENER *dl,
     if (dl->require_hrr_cookie || dl->require_hvr_cookie)
         sc->s3.flags |= TLS1_FLAGS_STATELESS;
 
+    /*
+     * We are inside the listener's own tick, so this must not block: nothing
+     * else can make progress while it does, including whatever it would be
+     * waiting for.
+     */
+    sc->d1->force_nonblocking = 1;
     ret = SSL_accept(ssl);
+    sc->d1->force_nonblocking = 0;
 
     /*
      * Always clear the stateless flag after SSL_accept() completes.
@@ -3003,6 +3017,10 @@ static int ossl_dtls_desires_blocking(const SSL *s)
     const DTLS_LISTENER *dl = NULL;
 
     if (sc != NULL && sc->d1 != NULL) {
+        /* The listener is driving this connection; it must not block. */
+        if (sc->d1->force_nonblocking)
+            return 0;
+
         if (sc->d1->req_blocking_mode != DTLS_BLOCKING_MODE_INHERIT)
             return sc->d1->req_blocking_mode == DTLS_BLOCKING_MODE_BLOCKING;
 

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -336,6 +336,7 @@ int dtls1_clear(SSL *ssl)
         DTLS_RX *rx = s->d1->rx;
         SSL *listener = s->d1->listener;
         OSSL_TIME created_at = s->d1->created_at;
+        unsigned int req_blocking_mode = s->d1->req_blocking_mode;
 #endif
 
         mtu = s->d1->mtu;
@@ -361,6 +362,11 @@ int dtls1_clear(SSL *ssl)
 #ifndef OPENSSL_NO_DTLS
         s->d1->rx = rx;
         s->d1->listener = listener;
+        /*
+         * The blocking mode is a property of the connection as the application
+         * configured it, not of the handshake, so it survives a clear.
+         */
+        s->d1->req_blocking_mode = req_blocking_mode;
         s->d1->created_at = created_at;
 #endif
 
@@ -2433,6 +2439,15 @@ SSL *ossl_dtls_accept_connection(SSL *ssl, uint64_t flags)
     if (conn != NULL)
         goto end;
 
+    /*
+     * Wait only if the caller has not asked us not to and the listener is in
+     * blocking mode. Note that the check for a network BIO below is deliberately
+     * left ahead of this, so that asking to wait on a listener which has none
+     * remains an error rather than silently returning nothing.
+     */
+    if (!no_block && !ossl_dtls_blocking(ssl) && dl->net_rbio != NULL)
+        no_block = 1;
+
     if (no_block) {
         /*
          * Non-blocking: run one tick to drain any pending datagram, then
@@ -2969,6 +2984,119 @@ int ossl_dtls_set_value_uint(SSL *s, uint32_t class_, uint32_t id, uint64_t valu
 
     ossl_crypto_mutex_unlock(dl->mutex);
     return ret;
+}
+
+/*
+ * Resolve the requested blocking mode of a DTLS listener, or of a connection
+ * created from one, following the inheritance chain.
+ *
+ * A connection set to INHERIT follows its listener; a listener set to INHERIT
+ * is blocking, there being nothing further to inherit from. Blocking is
+ * therefore the default unless the application asks otherwise.
+ *
+ * Returns 1 if blocking is wanted, which says nothing about whether it can be
+ * provided - see ossl_dtls_can_support_blocking().
+ */
+static int ossl_dtls_desires_blocking(const SSL *s)
+{
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL_ONLY(s);
+    const DTLS_LISTENER *dl = NULL;
+
+    if (sc != NULL && sc->d1 != NULL) {
+        if (sc->d1->req_blocking_mode != DTLS_BLOCKING_MODE_INHERIT)
+            return sc->d1->req_blocking_mode == DTLS_BLOCKING_MODE_BLOCKING;
+
+        dl = (const DTLS_LISTENER *)sc->d1->listener;
+    } else if (IS_DTLS_LISTENER(s)) {
+        dl = (const DTLS_LISTENER *)s;
+    }
+
+    if (dl == NULL)
+        return 0;
+
+    return dl->req_blocking_mode != DTLS_BLOCKING_MODE_NONBLOCKING;
+}
+
+/*
+ * Report whether blocking mode can be provided for a DTLS listener or a
+ * connection created from one.
+ *
+ * Blocking is emulated by waiting for readiness of the listener's network
+ * socket, so it requires a BIO which can supply a poll descriptor to wait on.
+ * A memory BIO cannot, and such a listener is therefore non-blocking whatever
+ * was requested, as is the case for QUIC.
+ */
+static int ossl_dtls_can_support_blocking(const SSL *s)
+{
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL_ONLY(s);
+    const SSL *listener = NULL;
+    BIO_POLL_DESCRIPTOR desc;
+    BIO *rbio;
+
+    if (sc != NULL && sc->d1 != NULL)
+        listener = sc->d1->listener;
+    else if (IS_DTLS_LISTENER(s))
+        listener = s;
+
+    if (listener == NULL)
+        return 0;
+
+    rbio = SSL_get_rbio(listener);
+    if (rbio == NULL)
+        return 0;
+
+    return BIO_get_rpoll_descriptor(rbio, &desc) != 0
+        && desc.type == BIO_POLL_DESCRIPTOR_TYPE_SOCK_FD;
+}
+
+/*
+ * Report whether a call on this object should block, which is the case when
+ * blocking is both wanted and possible.
+ */
+int ossl_dtls_blocking(const SSL *s)
+{
+    return ossl_dtls_desires_blocking(s) && ossl_dtls_can_support_blocking(s);
+}
+
+int ossl_dtls_set_blocking_mode(SSL *s, int blocking)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+    unsigned int mode = (blocking != 0)
+        ? DTLS_BLOCKING_MODE_BLOCKING
+        : DTLS_BLOCKING_MODE_NONBLOCKING;
+
+    /*
+     * Only a listener, or a connection created from one, has a blocking mode.
+     * Any other DTLS object takes its behaviour from its own BIO in the
+     * traditional way, so there is nothing here to configure.
+     */
+    if (IS_DTLS_LISTENER(s)) {
+        ((DTLS_LISTENER *)s)->req_blocking_mode = mode;
+    } else if (sc != NULL && sc->d1 != NULL && sc->d1->listener != NULL) {
+        sc->d1->req_blocking_mode = mode;
+    } else {
+        ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT);
+        return 0;
+    }
+
+    /* Refuse to claim blocking we cannot deliver, as QUIC does. */
+    if (blocking && !ossl_dtls_can_support_blocking(s)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
+        return 0;
+    }
+
+    return 1;
+}
+
+int ossl_dtls_get_blocking_mode(const SSL *s)
+{
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL_ONLY(s);
+
+    if (!IS_DTLS_LISTENER(s)
+        && (sc == NULL || sc->d1 == NULL || sc->d1->listener == NULL))
+        return -1;
+
+    return ossl_dtls_blocking(s);
 }
 
 void ossl_dtls_listener_enter_blocking_section(SSL *s)

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -3048,6 +3048,18 @@ int ossl_dtls_conn_poll_events(SSL *s, uint64_t events, int do_tick,
         ossl_dtls_tick(dl);
     }
 
+    /*
+     * Handle events for the connection itself, which for DTLS means servicing
+     * the retransmission timer. The caller may have blocked until that timer
+     * expired, so if nothing retransmits here then nothing will, and the
+     * deadline would be recomputed as "now" on every subsequent wait.
+     *
+     * A failure here leaves the connection in a fatal error state, which the
+     * SSL_POLL_EVENT_EC check below reports.
+     */
+    if (do_tick)
+        SSL_handle_events(s);
+
     if ((events & SSL_POLL_EVENT_R) != 0) {
         if (SSL_has_pending(s) || SSL_pending(s) > 0) {
             result |= SSL_POLL_EVENT_R;

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -3117,6 +3117,70 @@ int ossl_dtls_get_blocking_mode(const SSL *s)
     return ossl_dtls_blocking(s);
 }
 
+/*
+ * Wait until a datagram has been demultiplexed to this connection's receive
+ * queue, for a connection which is in blocking mode.
+ *
+ * This is what makes a blocking read on a listener based connection block. Such
+ * a connection has no BIO of its own to block in: it reads from a queue which
+ * the listener fills, so the wait has to happen here instead.
+ *
+ * A wakeup does not mean the datagram was ours - the listener's socket is
+ * shared, and another connection may be the one with data - so this loops until
+ * something actually lands in our queue. Events are handled after each wait
+ * because nothing else will do it while we are in here, and the retransmission
+ * timer needs servicing if it is what woke us.
+ *
+ * A datagram which is already waiting costs nothing: the wait pumps the
+ * listener's demux while translating the poll, and returns without sleeping if
+ * anything has been queued for us by then.
+ *
+ * Returns 1 if a datagram is now queued for this connection, or 0 if the wait
+ * could not be performed or the listener has failed.
+ */
+int ossl_dtls_conn_wait_for_datagram(SSL *s)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+    DTLS_LISTENER *dl;
+    int empty;
+
+    if (sc == NULL || sc->d1 == NULL || sc->d1->rx == NULL
+        || sc->d1->listener == NULL)
+        return 0;
+
+    dl = (DTLS_LISTENER *)sc->d1->listener;
+
+    for (;;) {
+        ossl_crypto_mutex_lock(dl->mutex);
+        if (dl->fatal) {
+            ossl_crypto_mutex_unlock(dl->mutex);
+            return 0;
+        }
+        ossl_crypto_mutex_unlock(dl->mutex);
+
+        /*
+         * An infinite deadline here is bounded by the connection's own event
+         * timeout, which the poll translation folds in, so this still wakes in
+         * time to retransmit.
+         */
+        if (!ossl_dtls_block_until_ready(s, SSL_POLL_EVENT_R,
+                ossl_time_infinite()))
+            return 0;
+
+        if (!SSL_handle_events(s))
+            return 0;
+
+        ossl_dgram_demux_pump(sc->d1->rx->demux);
+
+        ossl_crypto_mutex_lock(sc->d1->rx->mutex);
+        empty = ossl_list_urxe_is_empty(&sc->d1->rx->urxe_pending);
+        ossl_crypto_mutex_unlock(sc->d1->rx->mutex);
+
+        if (!empty)
+            return 1;
+    }
+}
+
 void ossl_dtls_listener_enter_blocking_section(SSL *s)
 {
     DTLS_LISTENER *dl;

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -394,6 +394,7 @@ struct ossl_record_layer_st {
     OSSL_FUNC_rlayer_padding_fn *padding;
     OSSL_FUNC_rlayer_get_urxe_packet_fn *get_urxe_packet;
     OSSL_FUNC_rlayer_release_urxe_packet_fn *release_urxe_packet;
+    OSSL_FUNC_rlayer_block_for_write_fn *block_for_write;
 
     size_t max_pipelines;
 

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1334,6 +1334,9 @@ int tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
             case OSSL_FUNC_RLAYER_RELEASE_URXE_PACKET:
                 rl->release_urxe_packet = OSSL_FUNC_rlayer_release_urxe_packet(fns);
                 break;
+            case OSSL_FUNC_RLAYER_BLOCK_FOR_WRITE:
+                rl->block_for_write = OSSL_FUNC_rlayer_block_for_write(fns);
+                break;
             default:
                 /* Just ignore anything we don't understand */
                 break;
@@ -1966,6 +1969,22 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl)
                      */
                     if (BIO_err_is_non_fatal(err)) {
                         ERR_pop_to_mark();
+
+                        /*
+                         * A connection in blocking mode waits for the socket to
+                         * become writable and sends again, rather than reporting
+                         * a retry. Nothing has been consumed, so the next time
+                         * round the loop repeats this same send.
+                         *
+                         * Only listener based connections install this callback.
+                         * Anything else either has a socket of its own to block
+                         * in or is genuinely non-blocking, and keeps the
+                         * behaviour below.
+                         */
+                        if (rl->block_for_write != NULL
+                            && rl->block_for_write(rl->cbarg))
+                            continue;
+
                         ret = OSSL_RECORD_RETURN_RETRY;
                         i = 0;
                         tmpwrit = 0;

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1213,6 +1213,18 @@ static void rlayer_dtls_release_urxe_packet(void *cbarg, void *packet_handle)
     if (s != NULL && s->d1 != NULL && s->d1->rx != NULL && urxe != NULL)
         ossl_dtls_rx_release_urxe(s->d1->rx, urxe);
 }
+
+static OSSL_FUNC_rlayer_block_for_write_fn rlayer_dtls_block_for_write;
+static int rlayer_dtls_block_for_write(void *cbarg)
+{
+    SSL_CONNECTION *s = cbarg;
+
+    if (s == NULL || s->d1 == NULL || s->d1->listener == NULL
+        || !ossl_dtls_blocking(SSL_CONNECTION_GET_SSL(s)))
+        return 0;
+
+    return ossl_dtls_conn_wait_for_write(SSL_CONNECTION_GET_SSL(s));
+}
 #endif
 
 static const OSSL_DISPATCH rlayer_dispatch[] = {
@@ -1223,6 +1235,7 @@ static const OSSL_DISPATCH rlayer_dispatch[] = {
 #if !defined(OPENSSL_NO_DTLS) && !defined(OPENSSL_NO_SOCK)
     { OSSL_FUNC_RLAYER_GET_URXE_PACKET, (void (*)(void))rlayer_dtls_get_urxe_packet },
     { OSSL_FUNC_RLAYER_RELEASE_URXE_PACKET, (void (*)(void))rlayer_dtls_release_urxe_packet },
+    { OSSL_FUNC_RLAYER_BLOCK_FOR_WRITE, (void (*)(void))rlayer_dtls_block_for_write },
 #endif
     OSSL_DISPATCH_END
 };

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1182,6 +1182,19 @@ static int rlayer_dtls_get_urxe_packet(void *cbarg, unsigned char **data,
         urxe = ossl_dtls_read_datagram(s->d1->rx);
     }
 
+    /*
+     * Still nothing. In blocking mode this is where the caller waits: the
+     * connection has no BIO of its own to block in, so returning here would
+     * report SSL_ERROR_WANT_READ instead of blocking. Waiting inside this
+     * callback keeps that out of the record layer and the state machine, which
+     * see only a read which took a while, exactly as a blocking BIO would give
+     * them.
+     */
+    if (urxe == NULL && s->d1->listener != NULL
+        && ossl_dtls_blocking(SSL_CONNECTION_GET_SSL(s))
+        && ossl_dtls_conn_wait_for_datagram(SSL_CONNECTION_GET_SSL(s)))
+        urxe = ossl_dtls_read_datagram(s->d1->rx);
+
     if (urxe == NULL)
         return 0;
 

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -211,4 +211,16 @@ OSSL_CORE_MAKE_FUNC(int, rlayer_get_urxe_packet, (void *cbarg, unsigned char **d
 #define OSSL_FUNC_RLAYER_RELEASE_URXE_PACKET 6
 OSSL_CORE_MAKE_FUNC(void, rlayer_release_urxe_packet, (void *cbarg, void *packet_handle))
 
+/*
+ * Callback for listener-based connections to wait until their shared socket can
+ * accept a datagram, for a connection which is in blocking mode. Such a
+ * connection cannot block in the socket itself, because the socket is shared
+ * with every other connection and is always non-blocking.
+ *
+ * Returns 1 if the send should be attempted again, or 0 to report the write as
+ * needing a retry in the usual way.
+ */
+#define OSSL_FUNC_RLAYER_BLOCK_FOR_WRITE 7
+OSSL_CORE_MAKE_FUNC(int, rlayer_block_for_write, (void *cbarg))
+
 #endif /* !defined(OSSL_SSL_RECORD_RECORD_H) */

--- a/ssl/rio/poll_builder.c
+++ b/ssl/rio/poll_builder.c
@@ -135,9 +135,39 @@ int ossl_rio_poll_builder_add_fd(RIO_POLL_BUILDER *rpb, int fd,
 #endif
 }
 
+/* Returns 1 if no file descriptors have been added to the poll builder. */
+static int rio_poll_builder_is_empty(const RIO_POLL_BUILDER *rpb)
+{
+#if RIO_POLL_METHOD == RIO_POLL_METHOD_SELECT
+    return rpb->hwm_fd < 0;
+#elif RIO_POLL_METHOD == RIO_POLL_METHOD_POLL
+    return rpb->pfd_num == 0;
+#else
+    return 1;
+#endif
+}
+
 int ossl_rio_poll_builder_poll(RIO_POLL_BUILDER *rpb, OSSL_TIME deadline)
 {
     int rc;
+
+    /*
+     * Waiting with no file descriptors is legitimate: a DTLS connection whose
+     * BIO cannot provide a poll descriptor has no readiness to wait for, but
+     * still has a retransmission deadline to wake for. Handle that here rather
+     * than leaving it to the OS, because poll() treats an empty descriptor set
+     * as a plain sleep whereas Windows' select() rejects it outright.
+     *
+     * With no descriptors and no deadline nothing could ever wake us, so that
+     * is a caller error rather than an indefinite sleep.
+     */
+    if (rio_poll_builder_is_empty(rpb)) {
+        if (ossl_time_is_infinite(deadline))
+            return 0;
+
+        OSSL_sleep(ossl_time2ms(ossl_time_subtract(deadline, ossl_time_now())));
+        return 1;
+    }
 
 #if RIO_POLL_METHOD == RIO_POLL_METHOD_SELECT
     do {

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -446,6 +446,7 @@ static int poll_translate(SSL_POLL_ITEM *items,
     RIO_POLL_BUILDER *rpb,
     OSSL_TIME *p_earliest_wakeup_deadline,
     int *abort_blocking,
+    int bound_by_event_timeout,
     size_t *p_result_count)
 {
     int ok = 1;
@@ -516,15 +517,22 @@ static int poll_translate(SSL_POLL_ITEM *items,
                      * Bound the wait by the DTLS retransmission timer,
                      * otherwise a poll with no timeout sleeps straight through
                      * the point at which we should be retransmitting.
+                     *
+                     * Unless the caller has told us not to. A waiter which
+                     * cannot service the timer must not be woken by it: it
+                     * would find the timeout still expired on the next wait,
+                     * which reads as a zero deadline, and spin.
                      */
-                    if (!SSL_get_event_timeout(ssl, &timeout, &is_infinite))
-                        FAIL_ITEM(i++); /* need to clean up this item too */
+                    if (bound_by_event_timeout) {
+                        if (!SSL_get_event_timeout(ssl, &timeout, &is_infinite))
+                            FAIL_ITEM(i++); /* need to clean up this item too */
 
-                    if (!is_infinite)
-                        earliest_wakeup_deadline
-                            = ossl_time_min(earliest_wakeup_deadline,
-                                ossl_time_add(ossl_time_now(),
-                                    ossl_time_from_timeval(timeout)));
+                        if (!is_infinite)
+                            earliest_wakeup_deadline
+                                = ossl_time_min(earliest_wakeup_deadline,
+                                    ossl_time_add(ossl_time_now(),
+                                        ossl_time_from_timeval(timeout)));
+                    }
 
                 } else {
                     ERR_raise_data(ERR_LIB_SSL, SSL_R_POLL_REQUEST_NOT_SUPPORTED,
@@ -574,6 +582,7 @@ static int poll_block(SSL_POLL_ITEM *items,
     size_t num_items,
     size_t stride,
     OSSL_TIME user_deadline,
+    int bound_by_event_timeout,
     size_t *p_result_count)
 {
     int ok = 0, abort_blocking = 0;
@@ -610,6 +619,7 @@ static int poll_block(SSL_POLL_ITEM *items,
     if (!poll_translate(items, num_items, stride, &wctx, &rpb,
             &earliest_wakeup_deadline,
             &abort_blocking,
+            bound_by_event_timeout,
             p_result_count))
         goto out;
 
@@ -648,9 +658,16 @@ out:
  * becoming readable says nothing about which connection the datagram is for -
  * so the caller must re-test its own condition and wait again if needed.
  *
+ * bound_by_event_timeout says whether the connection's own event timeout, which
+ * for DTLS is the retransmission timer, should shorten the wait. Pass 1 unless
+ * the caller is unable to service that timer when it fires: waking for a
+ * timeout nothing then handles leaves it expired, and an expired timeout reads
+ * as a zero deadline, so every later wait returns at once.
+ *
  * Returns 1 if the wait completed and 0 on error.
  */
-int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline)
+int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline,
+    int bound_by_event_timeout)
 {
     SSL_POLL_ITEM item;
     size_t result_count = 0;
@@ -660,7 +677,8 @@ int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline)
     item.events = events;
     item.revents = 0;
 
-    return poll_block(&item, 1, sizeof(item), deadline, &result_count);
+    return poll_block(&item, 1, sizeof(item), deadline, bound_by_event_timeout,
+        &result_count);
 }
 #endif /* OPENSSL_NO_DTLS */
 #endif
@@ -816,7 +834,8 @@ int SSL_poll(SSL_POLL_ITEM *items,
          */
         do_tick = 1;
 #if !defined(OPENSSL_NO_QUIC) || !defined(OPENSSL_NO_DTLS)
-        if (!poll_block(items, num_items, stride, deadline, &result_count)) {
+        if (!poll_block(items, num_items, stride, deadline,
+                /*bound_by_event_timeout=*/1, &result_count)) {
             ok = 0;
             goto out;
         }

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -169,10 +169,14 @@ static void postpoll_translation_cleanup_ssl_quic(SSL *ssl,
 #ifndef OPENSSL_NO_DTLS
 static int poll_translate_ssl_dtls_listener(SSL *ssl,
     RIO_POLL_BUILDER *rpb,
-    uint64_t events)
+    uint64_t events,
+    int *abort_blocking)
 {
     BIO *rbio;
     BIO_POLL_DESCRIPTOR desc;
+    DTLS_LISTENER *dl = (DTLS_LISTENER *)ssl;
+    uint64_t revents = 0;
+    int nfd;
 
     rbio = SSL_get_rbio(ssl);
     if (rbio == NULL)
@@ -187,6 +191,41 @@ static int poll_translate_ssl_dtls_listener(SSL *ssl,
 
     if (!ossl_rio_poll_builder_add_fd(rpb, desc.value.fd, /*r=*/1, /*w=*/0))
         return 0;
+
+    /*
+     * Add the notifier FD for the DTLS listener (if multi-threaded mode is
+     * enabled). Another thread may queue an incoming connection for us, or
+     * demux data to one of our connections, without the underlying network
+     * socket ever becoming readable from our perspective.
+     */
+    if (dl->have_notifier) {
+        nfd = ossl_rio_notifier_as_fd(&dl->notifier);
+        if (nfd != -1) {
+            if (!ossl_rio_poll_builder_add_fd(rpb, nfd, /*r=*/1, /*w=*/0))
+                return 0;
+
+            /* Tell the listener we need to receive notifications. */
+            ossl_dtls_listener_enter_blocking_section(ssl);
+
+            /*
+             * Only after the above call returns is it guaranteed that any
+             * readiness events will cause the notifier to become readable.
+             * Therefore it is possible the listener became ready after the
+             * readout which decided we needed to block. Re-check now.
+             */
+            if (!ossl_dtls_listener_poll_events(ssl, events, /*do_tick=*/0,
+                    &revents)) {
+                ossl_dtls_listener_leave_blocking_section(ssl);
+                return 0;
+            }
+
+            if (revents != 0) {
+                ossl_dtls_listener_leave_blocking_section(ssl);
+                *abort_blocking = 1;
+                return 1;
+            }
+        }
+    }
 
     return 1;
 }
@@ -310,6 +349,15 @@ static int poll_translate_ssl_dtls_conn(SSL *ssl,
     return 1;
 }
 
+static void postpoll_translation_cleanup_ssl_dtls_listener(SSL *ssl)
+{
+    DTLS_LISTENER *dl = (DTLS_LISTENER *)ssl;
+
+    /* Need to mirror the enter blocking section call */
+    if (dl->have_notifier && ossl_rio_notifier_as_fd(&dl->notifier) != -1)
+        ossl_dtls_listener_leave_blocking_section(ssl);
+}
+
 static void postpoll_translation_cleanup_ssl_dtls_conn(SSL *ssl, uint64_t events)
 {
     SSL_CONNECTION *sc;
@@ -366,7 +414,7 @@ static void postpoll_translation_cleanup(SSL_POLL_ITEM *items,
 
 #ifndef OPENSSL_NO_DTLS
             case SSL_TYPE_DTLS_LISTENER:
-                /* Listeners don't enter blocking sections */
+                postpoll_translation_cleanup_ssl_dtls_listener(ssl);
                 break;
             case SSL_TYPE_SSL_CONNECTION:
                 if (SSL_is_dtls(ssl))
@@ -440,8 +488,13 @@ static int poll_translate(SSL_POLL_ITEM *items,
 
 #ifndef OPENSSL_NO_DTLS
             case SSL_TYPE_DTLS_LISTENER:
-                if (!poll_translate_ssl_dtls_listener(ssl, rpb, item->events))
+                if (!poll_translate_ssl_dtls_listener(ssl, rpb, item->events,
+                        abort_blocking))
                     FAIL_ITEM(i);
+
+                if (*abort_blocking)
+                    goto out;
+
                 break;
             case SSL_TYPE_SSL_CONNECTION:
                 if (SSL_is_dtls(ssl)) {

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -189,6 +189,13 @@ static int poll_translate_ssl_dtls_listener(SSL *ssl,
         return 0;
     }
 
+    /*
+     * Watch the socket for readability whatever was asked for. Every event a
+     * listener reports is ultimately driven by a datagram arriving, both an
+     * incoming connection and data pending on the listener itself, so there is
+     * no event for which this is the wrong thing to wait on. events is
+     * therefore only consulted for the readiness re-check below.
+     */
     if (!ossl_rio_poll_builder_add_fd(rpb, desc.value.fd, /*r=*/1, /*w=*/0))
         return 0;
 
@@ -625,6 +632,37 @@ out:
 #endif
     return ok;
 }
+
+#ifndef OPENSSL_NO_DTLS
+/*
+ * Wait until the given DTLS listener or listener-based connection may have
+ * become ready for one of the given events, or until the deadline expires.
+ *
+ * This is the wait that libssl itself performs when a DTLS object is used in
+ * blocking mode. It is the same wait SSL_poll() performs, and reuses it, so a
+ * blocking call is woken by the same means an application polling the object
+ * would be: readiness of the listener's socket, or the listener's notifier if
+ * another thread produces readiness without the socket becoming readable here.
+ *
+ * No readout is performed. A spurious wakeup is always possible - the socket
+ * becoming readable says nothing about which connection the datagram is for -
+ * so the caller must re-test its own condition and wait again if needed.
+ *
+ * Returns 1 if the wait completed and 0 on error.
+ */
+int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline)
+{
+    SSL_POLL_ITEM item;
+    size_t result_count = 0;
+
+    item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+    item.desc.value.ssl = ssl;
+    item.events = events;
+    item.revents = 0;
+
+    return poll_block(&item, 1, sizeof(item), deadline, &result_count);
+}
+#endif /* OPENSSL_NO_DTLS */
 #endif
 
 static int poll_readout(SSL_POLL_ITEM *items,

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -446,7 +446,7 @@ static int poll_translate(SSL_POLL_ITEM *items,
     size_t result_count = 0;
     SSL *ssl;
     OSSL_TIME earliest_wakeup_deadline = ossl_time_infinite();
-#ifndef OPENSSL_NO_QUIC
+#if !defined(OPENSSL_NO_QUIC) || !defined(OPENSSL_NO_DTLS)
     struct timeval timeout;
     int is_infinite = 0;
 #endif
@@ -504,6 +504,20 @@ static int poll_translate(SSL_POLL_ITEM *items,
 
                     if (*abort_blocking)
                         goto out;
+
+                    /*
+                     * Bound the wait by the DTLS retransmission timer,
+                     * otherwise a poll with no timeout sleeps straight through
+                     * the point at which we should be retransmitting.
+                     */
+                    if (!SSL_get_event_timeout(ssl, &timeout, &is_infinite))
+                        FAIL_ITEM(i++); /* need to clean up this item too */
+
+                    if (!is_infinite)
+                        earliest_wakeup_deadline
+                            = ossl_time_min(earliest_wakeup_deadline,
+                                ossl_time_add(ossl_time_now(),
+                                    ossl_time_from_timeval(timeout)));
 
                 } else {
                     ERR_raise_data(ERR_LIB_SSL, SSL_R_POLL_REQUEST_NOT_SUPPORTED,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -651,6 +651,8 @@ int ossl_ssl_connection_reset(SSL *s)
         SSL *saved_listener = NULL;
         OSSL_TIME saved_created_at = ossl_time_zero();
         unsigned int saved_req_blocking_mode = DTLS_BLOCKING_MODE_INHERIT;
+        unsigned int saved_force_nonblocking = 0;
+        unsigned int saved_being_driven = 0;
         int is_dtls_listener_conn = 0;
 
         if (SSL_CONNECTION_IS_DTLS(sc) && sc->d1 != NULL
@@ -661,6 +663,8 @@ int ossl_ssl_connection_reset(SSL *s)
             saved_listener = sc->d1->listener;
             saved_created_at = sc->d1->created_at;
             saved_req_blocking_mode = sc->d1->req_blocking_mode;
+            saved_force_nonblocking = sc->d1->force_nonblocking;
+            saved_being_driven = sc->d1->being_driven;
             /*
              * Prevent dtls1_free from freeing rx and releasing the listener
              * reference - we'll restore them after ssl_init.
@@ -694,6 +698,14 @@ int ossl_ssl_connection_reset(SSL *s)
              * connection, not handshake state, so it survives a clear.
              */
             sc->d1->req_blocking_mode = saved_req_blocking_mode;
+            /*
+             * Both of these say something about the call this SSL_clear() may
+             * be nested inside: that the listener is driving the handshake and
+             * that it must not block while doing so. dtls1_clear() carries them
+             * over for the same reason.
+             */
+            sc->d1->force_nonblocking = saved_force_nonblocking;
+            sc->d1->being_driven = saved_being_driven;
         }
 #endif
     } else {

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -650,6 +650,7 @@ int ossl_ssl_connection_reset(SSL *s)
         DTLS_RX *saved_rx = NULL;
         SSL *saved_listener = NULL;
         OSSL_TIME saved_created_at = ossl_time_zero();
+        unsigned int saved_req_blocking_mode = DTLS_BLOCKING_MODE_INHERIT;
         int is_dtls_listener_conn = 0;
 
         if (SSL_CONNECTION_IS_DTLS(sc) && sc->d1 != NULL
@@ -659,6 +660,7 @@ int ossl_ssl_connection_reset(SSL *s)
             saved_rx = sc->d1->rx;
             saved_listener = sc->d1->listener;
             saved_created_at = sc->d1->created_at;
+            saved_req_blocking_mode = sc->d1->req_blocking_mode;
             /*
              * Prevent dtls1_free from freeing rx and releasing the listener
              * reference - we'll restore them after ssl_init.
@@ -687,6 +689,11 @@ int ossl_ssl_connection_reset(SSL *s)
             sc->d1->rx = saved_rx;
             sc->d1->listener = saved_listener;
             sc->d1->created_at = saved_created_at;
+            /*
+             * The blocking mode is how the application configured this
+             * connection, not handshake state, so it survives a clear.
+             */
+            sc->d1->req_blocking_mode = saved_req_blocking_mode;
         }
 #endif
     } else {
@@ -7971,25 +7978,31 @@ int SSL_net_write_desired(SSL *s)
 int SSL_set_blocking_mode(SSL *s, int blocking)
 {
 #ifndef OPENSSL_NO_QUIC
-    if (!IS_QUIC(s))
-        return 0;
-
-    return ossl_quic_conn_set_blocking_mode(s, blocking);
-#else
-    return 0;
+    if (IS_QUIC(s))
+        return ossl_quic_conn_set_blocking_mode(s, blocking);
 #endif
+
+#if !defined(OPENSSL_NO_DTLS) && !defined(OPENSSL_NO_SOCK)
+    if (IS_DTLS(s))
+        return ossl_dtls_set_blocking_mode(s, blocking);
+#endif
+
+    return 0;
 }
 
 int SSL_get_blocking_mode(SSL *s)
 {
 #ifndef OPENSSL_NO_QUIC
-    if (!IS_QUIC(s))
-        return -1;
-
-    return ossl_quic_conn_get_blocking_mode(s);
-#else
-    return -1;
+    if (IS_QUIC(s))
+        return ossl_quic_conn_get_blocking_mode(s);
 #endif
+
+#if !defined(OPENSSL_NO_DTLS) && !defined(OPENSSL_NO_SOCK)
+    if (IS_DTLS(s))
+        return ossl_dtls_get_blocking_mode(s);
+#endif
+
+    return -1;
 }
 
 int SSL_set1_initial_peer_addr(SSL *s, const BIO_ADDR *peer_addr)

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -3070,6 +3070,7 @@ int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline);
 int ossl_dtls_blocking(const SSL *s);
 int ossl_dtls_set_blocking_mode(SSL *s, int blocking);
 int ossl_dtls_get_blocking_mode(const SSL *s);
+int ossl_dtls_conn_wait_for_datagram(SSL *s);
 int ossl_dtls_tick(DTLS_LISTENER *dl);
 
 /* DTLS Listener internal cookie callbacks */

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2222,11 +2222,30 @@ typedef struct dtls1_state_st {
      * the listener mutex.
      */
     unsigned int being_driven : 1;
+
+    /*
+     * Blocking mode requested for this connection, as a DTLS_BLOCKING_MODE.
+     * Defaults to inheriting from the listener it came from.
+     */
+    unsigned int req_blocking_mode : 2;
 #endif
 
 } DTLS1_STATE;
 
 #if !defined(OPENSSL_NO_DTLS) && !defined(OPENSSL_NO_SOCK)
+/*
+ * Blocking mode of a DTLS listener or of a connection created from one.
+ *
+ * A connection set to INHERIT follows its listener, and a listener set to
+ * INHERIT means blocking, so blocking is the default throughout unless an
+ * application asks otherwise. This mirrors QUIC_BLOCKING_MODE.
+ */
+enum {
+    DTLS_BLOCKING_MODE_INHERIT,
+    DTLS_BLOCKING_MODE_NONBLOCKING,
+    DTLS_BLOCKING_MODE_BLOCKING
+};
+
 /*
  * Define stack of SSL for DTLS listener incoming connections.
  */
@@ -2356,6 +2375,13 @@ typedef struct dtls_listener_st {
      * Count of threads currently blocked waiting in poll().
      */
     size_t cur_blocking_waiters;
+
+    /*
+     * Blocking mode requested for this listener, as a DTLS_BLOCKING_MODE.
+     * INHERIT here means blocking, there being nothing further to inherit
+     * from.
+     */
+    unsigned int req_blocking_mode : 2;
 } DTLS_LISTENER;
 
 #endif /* !OPENSSL_NO_DTLS && !OPENSSL_NO_SOCK */
@@ -3033,6 +3059,9 @@ int ossl_dtls_conn_poll_events(SSL *s, uint64_t events, int do_tick,
 void ossl_dtls_listener_enter_blocking_section(SSL *s);
 void ossl_dtls_listener_leave_blocking_section(SSL *s);
 int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline);
+int ossl_dtls_blocking(const SSL *s);
+int ossl_dtls_set_blocking_mode(SSL *s, int blocking);
+int ossl_dtls_get_blocking_mode(const SSL *s);
 int ossl_dtls_tick(DTLS_LISTENER *dl);
 
 /* DTLS Listener internal cookie callbacks */

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -3066,7 +3066,8 @@ int ossl_dtls_conn_poll_events(SSL *s, uint64_t events, int do_tick,
     uint64_t *revents);
 void ossl_dtls_listener_enter_blocking_section(SSL *s);
 void ossl_dtls_listener_leave_blocking_section(SSL *s);
-int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline);
+int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline,
+    int bound_by_event_timeout);
 int ossl_dtls_blocking(const SSL *s);
 int ossl_dtls_set_blocking_mode(SSL *s, int blocking);
 int ossl_dtls_get_blocking_mode(const SSL *s);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -3032,6 +3032,7 @@ int ossl_dtls_conn_poll_events(SSL *s, uint64_t events, int do_tick,
     uint64_t *revents);
 void ossl_dtls_listener_enter_blocking_section(SSL *s);
 void ossl_dtls_listener_leave_blocking_section(SSL *s);
+int ossl_dtls_block_until_ready(SSL *ssl, uint64_t events, OSSL_TIME deadline);
 int ossl_dtls_tick(DTLS_LISTENER *dl);
 
 /* DTLS Listener internal cookie callbacks */

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -3071,6 +3071,7 @@ int ossl_dtls_blocking(const SSL *s);
 int ossl_dtls_set_blocking_mode(SSL *s, int blocking);
 int ossl_dtls_get_blocking_mode(const SSL *s);
 int ossl_dtls_conn_wait_for_datagram(SSL *s);
+int ossl_dtls_conn_wait_for_write(SSL *s);
 int ossl_dtls_tick(DTLS_LISTENER *dl);
 
 /* DTLS Listener internal cookie callbacks */

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2228,6 +2228,14 @@ typedef struct dtls1_state_st {
      * Defaults to inheriting from the listener it came from.
      */
     unsigned int req_blocking_mode : 2;
+
+    /*
+     * Set while the listener itself is driving this connection's handshake, to
+     * stop it blocking. The listener drives pending connections from inside its
+     * own tick, so a connection which blocked there would stop the listener
+     * making any further progress, including the progress being waited for.
+     */
+    unsigned int force_nonblocking : 1;
 #endif
 
 } DTLS1_STATE;

--- a/test/dtls_multithread_test.c
+++ b/test/dtls_multithread_test.c
@@ -355,6 +355,16 @@ static int test_dtls_multithread(void)
     if (!TEST_true(create_listener(sctx, &listener, &server_addr, &server_fd)))
         goto err;
 
+    /*
+     * do_handshake() below drives both ends from this thread, so the server
+     * side must not block: a blocking read would wait for a client which only
+     * this thread can advance. Connections accepted from the listener inherit
+     * this. The worker threads which follow use SSL_poll() and expect
+     * SSL_ERROR_WANT_READ, so they need it too.
+     */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 0)))
+        goto err;
+
     for (i = 0; i < NUM_CLIENTS; i++) {
         if (!TEST_true(create_client(cctx, server_addr, &clients[i], &client_fds[i])))
             goto err;
@@ -503,6 +513,13 @@ static int test_dtls_blocking_accept(void)
     if (!TEST_true(create_listener(sctx, &listener, &server_addr, &server_fd)))
         goto err;
 
+    /*
+     * This test needs the blocking accept, so ask for it rather than relying
+     * on the default.
+     */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 1)))
+        goto err;
+
     /* Block a thread in accept before any client exists. */
     accept_args.listener = listener;
     accept_args.thread = ossl_crypto_thread_native_start(blocking_accept_thread,
@@ -554,6 +571,203 @@ err:
     return testresult;
 }
 
+/*
+ * How long the client waits, in milliseconds, after its handshake completes
+ * before sending anything. The server thread has to still be inside its
+ * blocking read when the write finally happens, or the test proves nothing.
+ *
+ * A machine slow enough to get there late does not make the test fail: the read
+ * then finds the datagram already queued and returns it, which is a pass with
+ * nothing demonstrated. Only the absence of blocking turns it into a failure.
+ */
+#define BLOCKING_READ_QUIET_MS 250
+
+/*
+ * Per-thread state for the blocking read
+ */
+struct read_thread_args {
+    SSL *listener;
+    SSL *conn; /* connection the accept returned */
+    CRYPTO_THREAD *thread;
+    char buf[256];
+    size_t readbytes;
+    int nonblocking_handshake; /* handshake without blocking mode */
+    int result; /* 1 = success, 0 = failure */
+};
+
+/*
+ * Helper: complete the handshake with the connection in non-blocking mode,
+ * driving the listener by hand, so that the blocking read which follows is the
+ * only thing relying on the emulation.
+ */
+static int nonblocking_handshake(struct read_thread_args *ta)
+{
+    int i, ret = -1, err;
+
+    if (!TEST_true(SSL_set_blocking_mode(ta->conn, 0)))
+        return 0;
+
+    for (i = 0; i < 200; i++) {
+        ret = SSL_accept(ta->conn);
+        if (ret == 1)
+            break;
+        err = SSL_get_error(ta->conn, ret);
+        if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+            TEST_error("SSL_accept failed (err %d)", err);
+            return 0;
+        }
+        /* Nothing else will service the listener while we are in here. */
+        if (!TEST_true(SSL_handle_events(ta->listener)))
+            return 0;
+        OSSL_sleep(10);
+    }
+
+    if (!TEST_int_eq(ret, 1))
+        return 0;
+
+    return TEST_true(SSL_set_blocking_mode(ta->conn, 1));
+}
+
+/*
+ * Thread function: accept a connection, complete its handshake and read from
+ * it, so that the thread never has to handle WANT_READ.
+ */
+static unsigned int blocking_read_thread(void *arg)
+{
+    struct read_thread_args *ta = (struct read_thread_args *)arg;
+
+    ta->conn = SSL_accept_connection(ta->listener, 0);
+    if (!TEST_ptr(ta->conn))
+        return 0;
+
+    /*
+     * A listener-created connection has no BIO of its own to block in - it
+     * reads from a queue the listener demultiplexes into - so without the
+     * emulation these calls return immediately with WANT_READ instead of
+     * waiting.
+     */
+    if (ta->nonblocking_handshake) {
+        if (!nonblocking_handshake(ta))
+            return 0;
+    } else if (!TEST_int_gt(SSL_accept(ta->conn), 0)) {
+        return 0;
+    }
+
+    if (!TEST_true(SSL_read_ex(ta->conn, ta->buf, sizeof(ta->buf) - 1,
+            &ta->readbytes)))
+        return 0;
+
+    ta->result = 1;
+    return 0;
+}
+
+/*
+ * Test that a blocking listener connection waits for a datagram rather than
+ * reporting WANT_READ.
+ *
+ * The client stays silent for BLOCKING_READ_QUIET_MS after its own handshake
+ * completes, so by the time it writes, the server thread is already parked in
+ * SSL_read_ex() with nothing to return. A non-blocking connection reports
+ * WANT_READ immediately, so the absence of the emulation shows up as a failed
+ * assertion rather than as a hang.
+ *
+ * idx 0 blocks in the handshake as well as in the read. idx 1 handshakes in
+ * non-blocking mode and only then switches the connection to blocking, which
+ * leaves the read as the sole assertion the emulation has to satisfy - without
+ * it, idx 0 fails at SSL_accept() and never reaches the read, so on its own it
+ * would not tell us the read path works.
+ *
+ * Only the client is driven from this thread: the accepting thread ticks the
+ * listener itself, which is what lets a blocked connection make progress at
+ * all.
+ */
+static int test_dtls_blocking_read(int idx)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *listener = NULL, *client = NULL;
+    struct read_thread_args read_args;
+    BIO_ADDR *server_addr = NULL;
+    int server_fd = -1, client_fd = -1;
+    int testresult = 0;
+    size_t written;
+    int i, ret = -1, err;
+
+    memset(&read_args, 0, sizeof(read_args));
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), 0, 0, &sctx, &cctx, cert, privkey)))
+        goto err;
+
+    if (!TEST_true(create_listener(sctx, &listener, &server_addr, &server_fd)))
+        goto err;
+
+    /* Blocking is the default, but this test depends on it, so be explicit. */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 1)))
+        goto err;
+
+    read_args.listener = listener;
+    read_args.nonblocking_handshake = idx;
+    read_args.thread = ossl_crypto_thread_native_start(blocking_read_thread,
+        &read_args, 1);
+    if (!TEST_ptr(read_args.thread))
+        goto err;
+
+    if (!TEST_true(create_client(cctx, server_addr, &client, &client_fd)))
+        goto err;
+
+    /* Drive the client's handshake to completion. */
+    SSL_set_connect_state(client);
+    for (i = 0; i < 200; i++) {
+        ret = SSL_connect(client);
+        if (ret == 1)
+            break;
+        err = SSL_get_error(client, ret);
+        if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+            TEST_error("SSL_connect failed (err %d)", err);
+            goto err;
+        }
+        OSSL_sleep(10);
+    }
+    if (!TEST_int_eq(ret, 1))
+        goto err;
+
+    /* Let the server thread reach its read and find nothing there. */
+    OSSL_sleep(BLOCKING_READ_QUIET_MS);
+
+    if (!TEST_true(SSL_write_ex(client, CLIENT_TO_SERVER_MSG,
+            strlen(CLIENT_TO_SERVER_MSG), &written)))
+        goto err;
+
+    ossl_crypto_thread_native_join(read_args.thread, NULL);
+    ossl_crypto_thread_native_clean(read_args.thread);
+    read_args.thread = NULL;
+
+    if (!TEST_int_eq(read_args.result, 1))
+        goto err;
+
+    read_args.buf[read_args.readbytes] = '\0';
+    if (!TEST_str_eq(read_args.buf, CLIENT_TO_SERVER_MSG))
+        goto err;
+
+    testresult = 1;
+err:
+    if (read_args.thread != NULL) {
+        ossl_crypto_thread_native_join(read_args.thread, NULL);
+        ossl_crypto_thread_native_clean(read_args.thread);
+    }
+    SSL_free(read_args.conn);
+    SSL_free(client);
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    if (client_fd >= 0)
+        BIO_closesocket(client_fd);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 int setup_tests(void)
 {
     if (!TEST_ptr(cert = test_get_argument(0))
@@ -562,5 +776,6 @@ int setup_tests(void)
 
     ADD_TEST(test_dtls_multithread);
     ADD_TEST(test_dtls_blocking_accept);
+    ADD_ALL_TESTS(test_dtls_blocking_read, 2);
     return 1;
 }

--- a/test/dtls_multithread_test.c
+++ b/test/dtls_multithread_test.c
@@ -444,6 +444,116 @@ err:
     return testresult;
 }
 
+/*
+ * Per-thread state for the blocking accept
+ */
+struct accept_thread_args {
+    SSL *listener;
+    SSL *conn; /* connection the accept returned */
+    CRYPTO_THREAD *thread;
+    int result; /* 1 = success, 0 = failure */
+};
+
+/*
+ * Thread function: block in SSL_accept_connection() until a connection turns
+ * up. This is the accept path which ticks the listener itself, so no other
+ * thread needs to drive it.
+ */
+static unsigned int blocking_accept_thread(void *arg)
+{
+    struct accept_thread_args *ta = (struct accept_thread_args *)arg;
+
+    ta->conn = SSL_accept_connection(ta->listener, 0);
+    ta->result = (ta->conn != NULL);
+    return 1;
+}
+
+/*
+ * Test that a blocking SSL_accept_connection() waits for a connection and
+ * returns it.
+ *
+ * The listener demultiplexes one socket to many connections, so it cannot
+ * block inside a read: doing so would stall every other connection, and the
+ * demux lock is held across it. Blocking accept therefore has to wait for
+ * readiness rather than for a datagram, which is what this exercises - a
+ * client is only created once the accepting thread is already in the call.
+ *
+ * Note that this cannot distinguish waiting from spinning: the accept returns
+ * the connection either way, and the difference is CPU consumed rather than
+ * anything observable through the API. It is a test that the blocking path
+ * works at all, which was previously only covered for the failure case of
+ * having no BIO set.
+ */
+static int test_dtls_blocking_accept(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *listener = NULL, *client = NULL;
+    struct accept_thread_args accept_args;
+    BIO_ADDR *server_addr = NULL;
+    int server_fd = -1, client_fd = -1;
+    int testresult = 0;
+    int i, ret, err;
+
+    memset(&accept_args, 0, sizeof(accept_args));
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), 0, 0, &sctx, &cctx, cert, privkey)))
+        goto err;
+
+    if (!TEST_true(create_listener(sctx, &listener, &server_addr, &server_fd)))
+        goto err;
+
+    /* Block a thread in accept before any client exists. */
+    accept_args.listener = listener;
+    accept_args.thread = ossl_crypto_thread_native_start(blocking_accept_thread,
+        &accept_args, 1);
+    if (!TEST_ptr(accept_args.thread))
+        goto err;
+
+    if (!TEST_true(create_client(cctx, server_addr, &client, &client_fd)))
+        goto err;
+
+    /*
+     * Drive the client's side of the cookie exchange. The accepting thread
+     * ticks the listener, so this only has to keep the client moving.
+     */
+    SSL_set_connect_state(client);
+    for (i = 0; i < 200 && accept_args.result == 0; i++) {
+        ret = SSL_connect(client);
+        err = SSL_get_error(client, ret);
+        if (ret <= 0 && err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+            TEST_error("SSL_connect failed (err %d)", err);
+            goto err;
+        }
+        OSSL_sleep(10);
+    }
+
+    ossl_crypto_thread_native_join(accept_args.thread, NULL);
+    ossl_crypto_thread_native_clean(accept_args.thread);
+    accept_args.thread = NULL;
+
+    if (!TEST_int_eq(accept_args.result, 1) || !TEST_ptr(accept_args.conn))
+        goto err;
+
+    testresult = 1;
+err:
+    if (accept_args.thread != NULL) {
+        ossl_crypto_thread_native_join(accept_args.thread, NULL);
+        ossl_crypto_thread_native_clean(accept_args.thread);
+    }
+    SSL_free(accept_args.conn);
+    SSL_free(client);
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    if (client_fd >= 0)
+        BIO_closesocket(client_fd);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 int setup_tests(void)
 {
     if (!TEST_ptr(cert = test_get_argument(0))
@@ -451,5 +561,6 @@ int setup_tests(void)
         return 0;
 
     ADD_TEST(test_dtls_multithread);
+    ADD_TEST(test_dtls_blocking_accept);
     return 1;
 }

--- a/test/dtls_multithread_test.c
+++ b/test/dtls_multithread_test.c
@@ -713,14 +713,20 @@ static int test_dtls_blocking_read(int idx)
     if (!TEST_true(SSL_set_blocking_mode(listener, 1)))
         goto err;
 
+    /*
+     * As in test_dtls_blocking_accept, create the client's socket before the
+     * thread which will park in the blocking accept, because nothing can
+     * release that thread except a connection arriving. Nothing is sent until
+     * SSL_connect() below, so the accept still waits.
+     */
+    if (!TEST_true(create_client(cctx, server_addr, &client, &client_fd)))
+        goto err;
+
     read_args.listener = listener;
     read_args.nonblocking_handshake = idx;
     read_args.thread = ossl_crypto_thread_native_start(blocking_read_thread,
         &read_args, 1);
     if (!TEST_ptr(read_args.thread))
-        goto err;
-
-    if (!TEST_true(create_client(cctx, server_addr, &client, &client_fd)))
         goto err;
 
     /* Drive the client's handshake to completion. */

--- a/test/dtls_multithread_test.c
+++ b/test/dtls_multithread_test.c
@@ -520,14 +520,22 @@ static int test_dtls_blocking_accept(void)
     if (!TEST_true(SSL_set_blocking_mode(listener, 1)))
         goto err;
 
-    /* Block a thread in accept before any client exists. */
+    /*
+     * Create the client's socket first, but do not connect with it yet. There
+     * is no way to cancel a blocking SSL_accept_connection(), so a thread
+     * parked in one is released only by a connection arriving - which means
+     * nothing between starting the thread and the exchange completing may bail
+     * out, or the join below would wait for ever. Anything which can fail is
+     * therefore done up front. The accept still has to wait, since no datagram
+     * is sent until SSL_connect() below.
+     */
+    if (!TEST_true(create_client(cctx, server_addr, &client, &client_fd)))
+        goto err;
+
     accept_args.listener = listener;
     accept_args.thread = ossl_crypto_thread_native_start(blocking_accept_thread,
         &accept_args, 1);
     if (!TEST_ptr(accept_args.thread))
-        goto err;
-
-    if (!TEST_true(create_client(cctx, server_addr, &client, &client_fd)))
         goto err;
 
     /*

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5632,6 +5632,202 @@ end:
     return testresult;
 }
 
+/*
+ * State for the filter BIO below.
+ */
+struct failing_send_data {
+    int fails_remaining; /* sends still to be rejected */
+    int sends; /* sends attempted through the filter */
+};
+
+static long failing_send_ctrl(BIO *bio, int cmd, long num, void *ptr)
+{
+    BIO *next = BIO_next(bio);
+
+    if (next == NULL)
+        return 0;
+
+    if (cmd == BIO_CTRL_DUP)
+        return 0L;
+
+    /*
+     * Everything else, the poll descriptors in particular, has to reach the
+     * socket underneath: the blocking write waits on the descriptor this
+     * returns.
+     */
+    return BIO_ctrl(next, cmd, num, ptr);
+}
+
+static int failing_send_sendmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
+    size_t num_msg, uint64_t flags, size_t *msgs_processed)
+{
+    struct failing_send_data *data = BIO_get_data(bio);
+    BIO *next = BIO_next(bio);
+
+    if (data == NULL || next == NULL)
+        return 0;
+
+    data->sends++;
+
+    if (data->fails_remaining > 0) {
+        data->fails_remaining--;
+        *msgs_processed = 0;
+        /*
+         * BIO_err_is_non_fatal() accepts this, so the record layer treats the
+         * send as one to be attempted again rather than as an error.
+         */
+        ERR_raise(ERR_LIB_BIO, BIO_R_NON_FATAL);
+        return 0;
+    }
+
+    return BIO_sendmmsg(next, msg, stride, num_msg, flags, msgs_processed);
+}
+
+/* Choose a sufficiently large type likely to be unused for this custom BIO */
+#define BIO_TYPE_FAILING_SEND_FILTER (0x83 | BIO_TYPE_FILTER)
+
+static BIO_METHOD *method_failing_send = NULL;
+
+/* Note: Not thread safe! */
+static const BIO_METHOD *bio_f_failing_send_filter(void)
+{
+    if (method_failing_send == NULL) {
+        method_failing_send = BIO_meth_new(BIO_TYPE_FAILING_SEND_FILTER,
+            "Failing datagram send filter");
+        if (method_failing_send == NULL
+            || !BIO_meth_set_ctrl(method_failing_send, failing_send_ctrl)
+            || !BIO_meth_set_sendmmsg(method_failing_send,
+                failing_send_sendmmsg))
+            return NULL;
+    }
+    return method_failing_send;
+}
+
+/*
+ * Test that a write on a blocking listener connection waits for the socket and
+ * sends again, rather than reporting that it needs to be retried.
+ *
+ * A datagram which cannot be sent is normally dropped, which is reasonable for
+ * an unreliable transport but is not what an application asking for blocking
+ * writes expects: it gets no data sent and a WANT_WRITE it did not ask to have
+ * to handle. The listener's socket is shared and always non-blocking, so there
+ * is nothing for such a write to block in by itself.
+ *
+ * A loopback socket's send buffer does not fill, so a filter BIO supplies the
+ * transient failure instead. Only one send is rejected: the retry then goes
+ * through, and the client is read to confirm the datagram was really sent
+ * rather than merely reported as sent.
+ *
+ * The handshake runs with the listener non-blocking, so this test drives both
+ * ends from the one thread as the others here do, and only the connection is
+ * switched to blocking, for the write.
+ */
+static int test_dtls_blocking_write(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *listener = NULL, *clientssl = NULL, *serverssl = NULL;
+    BIO_ADDR *server_addr = NULL;
+    BIO *sockbio = NULL, *filter = NULL;
+    struct failing_send_data data;
+    int server_fd = -1, client_fd = -1;
+    int testresult = 0;
+    char buf[256];
+    size_t written = 0, readbytes = 0;
+    int i, ret = -1;
+
+    memset(&data, 0, sizeof(data));
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_VERSION, 0, &sctx, &cctx, cert,
+            privkey)))
+        goto end;
+
+    if (!TEST_true(create_dtls_listener(sctx, SSL_LISTENER_FLAG_SINGLE_THREAD,
+            &listener, &server_addr, &server_fd)))
+        goto end;
+
+    /*
+     * Insert the filter in front of the listener's socket for writes only,
+     * leaving reads to reach the socket directly. The listener holds a
+     * reference for each direction, so the filter chain needs one of its own.
+     */
+    if (!TEST_ptr(sockbio = SSL_get_wbio(listener))
+        || !TEST_ptr(filter = BIO_new(bio_f_failing_send_filter())))
+        goto end;
+
+    BIO_set_data(filter, &data);
+    BIO_set_init(filter, 1);
+
+    if (!TEST_true(BIO_up_ref(sockbio))) {
+        BIO_free(filter);
+        goto end;
+    }
+
+    BIO_push(filter, sockbio);
+    SSL_set0_wbio(listener, filter); /* the listener owns the chain now */
+    filter = NULL;
+
+    if (!TEST_true(create_dtls_client_for_addr(cctx, server_addr, &clientssl,
+            &client_fd)))
+        goto end;
+
+    if (!drive_until_connection_queued(listener, clientssl)
+        || !TEST_ptr(serverssl = SSL_accept_connection(listener,
+                         SSL_ACCEPT_CONNECTION_NO_BLOCK)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /*
+     * Everything up to here, including any post-handshake traffic, has gone
+     * through the filter untouched. Reject the next send only.
+     */
+    if (!TEST_true(SSL_set_blocking_mode(serverssl, 1))
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 1))
+        goto end;
+
+    data.fails_remaining = 1;
+
+    if (!TEST_true(SSL_write_ex(serverssl, "msg", 3, &written))
+        || !TEST_size_t_eq(written, 3))
+        goto end;
+
+    /* The send really was rejected, and was retried rather than reported. */
+    if (!TEST_int_eq(data.fails_remaining, 0))
+        goto end;
+
+    /* The datagram reached the client, so nothing was dropped on the way. */
+    for (i = 0; i < 20; i++) {
+        ret = SSL_read_ex(clientssl, buf, sizeof(buf), &readbytes);
+        if (ret == 1)
+            break;
+        if (!TEST_int_eq(SSL_get_error(clientssl, ret), SSL_ERROR_WANT_READ))
+            goto end;
+        OSSL_sleep(10);
+    }
+
+    if (!TEST_int_eq(ret, 1)
+        || !TEST_mem_eq(buf, readbytes, "msg", 3))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    if (client_fd >= 0)
+        BIO_closesocket(client_fd);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    BIO_meth_free(method_failing_send);
+    method_failing_send = NULL;
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
@@ -5716,6 +5912,7 @@ int setup_tests(void)
     /* Blocking mode tests */
     ADD_TEST(test_dtls_blocking_mode);
     ADD_TEST(test_dtls_accept_wait_requires_mode_and_flag);
+    ADD_TEST(test_dtls_blocking_write);
 
     /* SSL object ownership tests (run with ASAN to detect leaks/double-frees) */
     ADD_TEST(test_ssl_ownership_pending_conn_leak);

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5168,6 +5168,81 @@ static unsigned int short_timer_cb(SSL *s, unsigned int timer_us)
 }
 
 /*
+ * Force a retransmission timeout short enough that it is always already
+ * expired, so the timeout can be driven repeatedly without waiting. Anything
+ * at or below 15ms is treated as expired by dtls1_get_timeout().
+ */
+static unsigned int tiny_timer_cb(SSL *s, unsigned int timer_us)
+{
+    return 1000; /* 1ms */
+}
+
+/*
+ * Test that the DTLS retransmission timer is stopped once the connection gives
+ * up retransmitting.
+ *
+ * dtls1_handle_timeout() fails the connection after DTLS1_TMO_ALERT_COUNT
+ * unanswered retransmissions. It must not leave the timer armed in the past
+ * when it does: nothing will re-arm or clear it afterwards, so every later
+ * query reports the timeout as due immediately, and any caller which waits on
+ * it spins instead of sleeping - whether that is an application using
+ * DTLSv1_get_timeout() with select(), or SSL_poll() bounding its own wait.
+ */
+static int test_dtls_timer_stopped_when_retransmits_exhausted(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    struct timeval timer_left;
+    int is_infinite = 0;
+    int retc, rets;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_VERSION, 0, &sctx, &cctx, cert,
+            privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    DTLS_set_timer_cb(serverssl, tiny_timer_cb);
+
+    retc = SSL_connect(clientssl);
+    if (!TEST_int_le(retc, 0)
+        || !TEST_int_eq(SSL_get_error(clientssl, retc), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /*
+     * With a timeout this short the server's timer is expired on every read
+     * attempt, so the accept retransmits until the budget runs out and fails
+     * the connection by itself. The client is never fed, so nothing is ever
+     * acknowledged.
+     *
+     * The retransmissions happen in dtls1_read_bytes(), which calls
+     * dtls1_handle_timeout() and, when it reports that it retransmitted, goes
+     * back to its start label to try the read again.
+     */
+    rets = SSL_accept(serverssl);
+    if (!TEST_int_le(rets, 0)
+        || !TEST_int_eq(SSL_get_error(serverssl, rets), SSL_ERROR_SSL))
+        goto end;
+
+    /* The timer must not have been left armed in the past. */
+    if (!TEST_true(SSL_get_event_timeout(serverssl, &timer_left, &is_infinite))
+        || !TEST_true(is_infinite))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
  * Test that a blocking SSL_poll() on a DTLS connection honours the
  * retransmission timer.
  *
@@ -5381,6 +5456,7 @@ int setup_tests(void)
     ADD_TEST(test_dtls_poll_listener_enters_blocking_section);
 #endif
     ADD_TEST(test_dtls_poll_conn_honours_retransmit_timer);
+    ADD_TEST(test_dtls_timer_stopped_when_retransmits_exhausted);
 
     return 1;
 }

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5347,6 +5347,252 @@ end:
     return testresult;
 }
 
+/*
+ * Drive a client's ClientHello, and any cookie exchange, at the listener until
+ * a connection is sitting on its accept queue, without accepting it.
+ *
+ * Returns 1 on success, 0 on failure.
+ */
+static int drive_until_connection_queued(SSL *listener, SSL *clientssl)
+{
+    SSL_POLL_ITEM poll_item;
+    struct timeval poll_timeout;
+    size_t poll_result = 0;
+    int abortctr, retc, err_code;
+
+    poll_item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+    poll_item.desc.value.ssl = listener;
+    poll_timeout.tv_sec = 0;
+    poll_timeout.tv_usec = 0;
+
+    SSL_set_connect_state(clientssl);
+
+    for (abortctr = 0; abortctr < 100; abortctr++) {
+        retc = SSL_connect(clientssl);
+        err_code = SSL_get_error(clientssl, retc);
+        if (retc <= 0
+            && err_code != SSL_ERROR_WANT_READ
+            && err_code != SSL_ERROR_WANT_WRITE) {
+            TEST_error("SSL_connect failed (err %d)", err_code);
+            return 0;
+        }
+
+        /* A zero timeout, so this ticks the listener without ever waiting. */
+        poll_item.events = SSL_POLL_EVENT_IC;
+        poll_item.revents = 0;
+
+        if (!TEST_true(SSL_poll(&poll_item, 1, sizeof(poll_item), &poll_timeout,
+                0, &poll_result)))
+            return 0;
+
+        if ((poll_item.revents & SSL_POLL_EVENT_IC) != 0)
+            return 1;
+    }
+
+    TEST_error("cookie exchange loop did not converge");
+    return 0;
+}
+
+/*
+ * Test the blocking mode of a DTLS listener and of the connections it creates.
+ *
+ * Blocking is the default, as it is for QUIC: a listener which was never
+ * configured is blocking, and a connection follows its listener unless it was
+ * given a setting of its own.
+ *
+ * Blocking is emulated by waiting for readiness of the listener's socket, so it
+ * needs a BIO which can supply a poll descriptor to wait on. Where there is
+ * none the object is non-blocking whatever was asked for, and asking for
+ * blocking fails rather than claiming something which cannot be delivered.
+ */
+static int test_dtls_blocking_mode(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *listener = NULL, *clientssl = NULL, *serverssl = NULL;
+    SSL *memlistener = NULL, *memclient = NULL, *plainssl = NULL;
+    BIO_ADDR *server_addr = NULL, *client_addr = NULL;
+    int server_fd = -1, client_fd = -1;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_VERSION, 0, &sctx, &cctx, cert,
+            privkey)))
+        goto end;
+
+    /* A socket BIO supplies a poll descriptor, so blocking is available. */
+    if (!TEST_true(create_dtls_listener(sctx,
+            SSL_LISTENER_FLAG_REQUIRE_HVR | SSL_LISTENER_FLAG_REQUIRE_HRR
+                | SSL_LISTENER_FLAG_SINGLE_THREAD,
+            &listener, &server_addr, &server_fd)))
+        goto end;
+
+    /* Blocking by default, having never been configured. */
+    if (!TEST_int_eq(SSL_get_blocking_mode(listener), 1))
+        goto end;
+
+    /* Get a connection object accepted from the listener to examine. */
+    if (!TEST_true(create_dtls_client_for_addr(cctx, server_addr, &clientssl,
+            &client_fd)))
+        goto end;
+
+    if (!drive_until_connection_queued(listener, clientssl)
+        || !TEST_ptr(serverssl = SSL_accept_connection(listener,
+                         SSL_ACCEPT_CONNECTION_NO_BLOCK)))
+        goto end;
+
+    /* It inherits the listener's mode. */
+
+    if (!TEST_int_eq(SSL_get_blocking_mode(serverssl), 1))
+        goto end;
+
+    /* Setting the listener non-blocking is inherited by the connection. */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 0))
+        || !TEST_int_eq(SSL_get_blocking_mode(listener), 0)
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0))
+        goto end;
+
+    /* A setting on the connection overrides what it would inherit. */
+    if (!TEST_true(SSL_set_blocking_mode(serverssl, 1))
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 1)
+        || !TEST_int_eq(SSL_get_blocking_mode(listener), 0))
+        goto end;
+
+    /*
+     * A connection's own setting survives SSL_clear(). The mode is a property
+     * of the connection as the application configured it, not of the handshake,
+     * and dtls1_clear() memsets d1 and restores only selected fields.
+     *
+     * The listener and the connection must disagree for this to prove anything:
+     * were the connection's setting lost it would fall back to inheriting, and
+     * that is only visible if the listener says something different.
+     */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 1))
+        || !TEST_true(SSL_set_blocking_mode(serverssl, 0))
+        || !TEST_int_eq(SSL_get_blocking_mode(listener), 1)
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0))
+        goto end;
+
+    if (!TEST_true(SSL_clear(serverssl))
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0))
+        goto end;
+
+    /*
+     * Clear again. SSL_clear() resets the method to the default one, so the
+     * first call above went through the ssl_deinit/ssl_init path that
+     * reallocates d1 while this one goes through dtls1_clear(). Both discard
+     * d1, so both have to be covered.
+     */
+    if (!TEST_true(SSL_clear(serverssl))
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0))
+        goto end;
+
+    /* And back the other way round. */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 1))
+        || !TEST_true(SSL_set_blocking_mode(serverssl, 0))
+        || !TEST_int_eq(SSL_get_blocking_mode(listener), 1)
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0))
+        goto end;
+
+    /*
+     * A listener on BIOs which cannot supply a poll descriptor reports
+     * non-blocking however it was configured, and asking for blocking fails.
+     */
+    if (!TEST_true(create_dtls_listener_and_client_mem(sctx, cctx,
+            SSL_LISTENER_FLAG_SINGLE_THREAD, &memlistener, &memclient,
+            &client_addr)))
+        goto end;
+
+    if (!TEST_int_eq(SSL_get_blocking_mode(memlistener), 0))
+        goto end;
+
+    ERR_clear_error();
+    if (!TEST_false(SSL_set_blocking_mode(memlistener, 1))
+        || !TEST_int_eq((int)ERR_GET_REASON(ERR_peek_error()), ERR_R_UNSUPPORTED))
+        goto end;
+    ERR_clear_error();
+
+    /* Asking for non-blocking is fine, that being what it already is. */
+    if (!TEST_true(SSL_set_blocking_mode(memlistener, 0))
+        || !TEST_int_eq(SSL_get_blocking_mode(memlistener), 0))
+        goto end;
+
+    /*
+     * A DTLS object which did not come from a listener has no blocking mode:
+     * it takes its behaviour from its own BIO in the traditional way.
+     */
+    if (!TEST_ptr(plainssl = SSL_new(cctx)))
+        goto end;
+
+    if (!TEST_int_eq(SSL_get_blocking_mode(plainssl), -1)
+        || !TEST_false(SSL_set_blocking_mode(plainssl, 1))
+        || !TEST_false(SSL_set_blocking_mode(plainssl, 0)))
+        goto end;
+
+    testresult = 1;
+end:
+    ERR_clear_error();
+    SSL_free(plainssl);
+    SSL_free(memclient);
+    SSL_free(memlistener);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_free(listener);
+    BIO_ADDR_free(client_addr);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    if (client_fd >= 0)
+        BIO_closesocket(client_fd);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
+ * Test when SSL_accept_connection() waits and when it does not.
+ *
+ * It waits only if the caller did not pass SSL_ACCEPT_CONNECTION_NO_BLOCK and
+ * the listener is in blocking mode, which is the same rule QUIC applies. So
+ * either of the two saying not to wait is enough, and this checks both of those
+ * cases: no client exists, so anything which did wait would never return.
+ */
+static int test_dtls_accept_wait_requires_mode_and_flag(void)
+{
+    SSL_CTX *sctx = NULL;
+    SSL *listener = NULL;
+    BIO_ADDR *server_addr = NULL;
+    int server_fd = -1;
+    int testresult = 0;
+
+    if (!TEST_ptr(sctx = SSL_CTX_new(DTLS_server_method())))
+        goto end;
+
+    if (!TEST_true(create_dtls_listener(sctx, SSL_LISTENER_FLAG_SINGLE_THREAD,
+            &listener, &server_addr, &server_fd)))
+        goto end;
+
+    /* Non-blocking mode, and no flag: the mode alone stops it waiting. */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 0))
+        || !TEST_ptr_null(SSL_accept_connection(listener, 0)))
+        goto end;
+
+    /* Blocking mode, but the flag overrides it. */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 1))
+        || !TEST_int_eq(SSL_get_blocking_mode(listener), 1)
+        || !TEST_ptr_null(SSL_accept_connection(listener,
+            SSL_ACCEPT_CONNECTION_NO_BLOCK)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
@@ -5427,6 +5673,10 @@ int setup_tests(void)
     /* Pending timeout tests */
     ADD_TEST(test_dtls_listener_pending_timeout_basic);
     ADD_TEST(test_dtls_listener_pending_timeout_invalid);
+
+    /* Blocking mode tests */
+    ADD_TEST(test_dtls_blocking_mode);
+    ADD_TEST(test_dtls_accept_wait_requires_mode_and_flag);
 
     /* SSL object ownership tests (run with ASAN to detect leaks/double-frees) */
     ADD_TEST(test_ssl_ownership_pending_conn_leak);

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5633,6 +5633,70 @@ end:
 }
 
 /*
+ * Test that a rejected SSL_set_blocking_mode() leaves the mode alone.
+ *
+ * Whether blocking can be supported depends on the listener's BIO, so a
+ * request can be refused now and be perfectly deliverable later. The refusal
+ * must therefore not record the mode it refused to set: the effect only becomes
+ * visible once a BIO which can supply a poll descriptor is in place, at which
+ * point the listener would be found blocking on the strength of a call which
+ * failed.
+ */
+static int test_dtls_blocking_mode_failed_set_is_inert(void)
+{
+    SSL_CTX *sctx = NULL;
+    SSL *listener = NULL;
+    BIO_ADDR *server_addr = NULL;
+    BIO *rbio = NULL;
+    int server_fd = -1;
+    int testresult = 0;
+
+    if (!TEST_ptr(sctx = SSL_CTX_new(DTLS_server_method())))
+        goto end;
+
+    if (!TEST_true(create_dtls_listener(sctx, SSL_LISTENER_FLAG_SINGLE_THREAD,
+            &listener, &server_addr, &server_fd)))
+        goto end;
+
+    /* Ask for non-blocking explicitly, so the default cannot mask a change. */
+    if (!TEST_true(SSL_set_blocking_mode(listener, 0))
+        || !TEST_int_eq(SSL_get_blocking_mode(listener), 0))
+        goto end;
+
+    /* Keep the BIO, then take it away so blocking cannot be supported. */
+    if (!TEST_ptr(rbio = SSL_get_rbio(listener))
+        || !TEST_true(BIO_up_ref(rbio)))
+        goto end;
+
+    SSL_set0_rbio(listener, NULL);
+
+    ERR_clear_error();
+    if (!TEST_false(SSL_set_blocking_mode(listener, 1))
+        || !TEST_int_eq((int)ERR_GET_REASON(ERR_peek_error()),
+            ERR_R_UNSUPPORTED)) {
+        BIO_free(rbio);
+        goto end;
+    }
+    ERR_clear_error();
+
+    /* Give the BIO back, which makes blocking supportable once more. */
+    SSL_set0_rbio(listener, rbio);
+
+    /* The refused request must not have taken effect. */
+    if (!TEST_int_eq(SSL_get_blocking_mode(listener), 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
+/*
  * State for the filter BIO below.
  */
 struct failing_send_data {
@@ -5911,6 +5975,7 @@ int setup_tests(void)
 
     /* Blocking mode tests */
     ADD_TEST(test_dtls_blocking_mode);
+    ADD_TEST(test_dtls_blocking_mode_failed_set_is_inert);
     ADD_TEST(test_dtls_accept_wait_requires_mode_and_flag);
     ADD_TEST(test_dtls_blocking_write);
 

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -28,6 +28,7 @@
 #include "internal/time.h"
 #include "internal/sockets.h"
 #include "internal/dgram_demux.h"
+#include "internal/ssl_unwrap.h"
 #include "helpers/ssltestlib.h"
 #include "testutil.h"
 #include "../ssl/ssl_local.h"
@@ -5443,6 +5444,7 @@ static int test_dtls_blocking_mode(void)
     SSL *listener = NULL, *clientssl = NULL, *serverssl = NULL;
     SSL *memlistener = NULL, *memclient = NULL, *plainssl = NULL;
     BIO_ADDR *server_addr = NULL, *client_addr = NULL;
+    SSL_CONNECTION *sc;
     int server_fd = -1, client_fd = -1;
     int testresult = 0;
 
@@ -5511,8 +5513,25 @@ static int test_dtls_blocking_mode(void)
         || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0))
         goto end;
 
+    /*
+     * being_driven has to survive a clear as well, for a different reason: it
+     * records that the listener is driving this connection's handshake, and is
+     * what stops a concurrent tick collecting the same connection a second
+     * time. The listener can reach SSL_clear() from inside the very
+     * SSL_accept() it is driving, so losing it there would admit a second
+     * thread to the state machine for this connection.
+     *
+     * It has to be set by hand, being held only for the duration of a call
+     * inside the listener's tick, which is not observable from out here.
+     */
+    if (!TEST_ptr(sc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl)))
+        goto end;
+    sc->d1->being_driven = 1;
+
     if (!TEST_true(SSL_clear(serverssl))
-        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0))
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0)
+        || !TEST_ptr(sc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl))
+        || !TEST_int_eq(sc->d1->being_driven, 1))
         goto end;
 
     /*
@@ -5522,8 +5541,12 @@ static int test_dtls_blocking_mode(void)
      * d1, so both have to be covered.
      */
     if (!TEST_true(SSL_clear(serverssl))
-        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0))
+        || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 0)
+        || !TEST_ptr(sc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl))
+        || !TEST_int_eq(sc->d1->being_driven, 1))
         goto end;
+
+    sc->d1->being_driven = 0;
 
     /* And back the other way round. */
     if (!TEST_true(SSL_set_blocking_mode(listener, 1))

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -740,9 +740,10 @@ err:
 }
 
 /*
- * Test SSL_accept_connection with no net_bio and NO_BLOCK flag.
- * When there is no BIO set and the caller requests non-blocking behaviour,
- * the function must return NULL immediately without raising an error.
+ * Test SSL_accept_connection with no net_bio and the
+ * SSL_ACCEPT_CONNECTION_NO_BLOCK flag, so that the caller is not asking to
+ * wait. The function must return NULL immediately without raising an error,
+ * the absence of a BIO being indistinguishable from having nothing queued.
  */
 static int test_dtls_accept_connection_no_bio_no_block(void)
 {
@@ -784,9 +785,10 @@ err:
 }
 
 /*
- * Test SSL_accept_connection with no net_bio and blocking mode (no NO_BLOCK).
- * When there is no BIO and the caller wants to block, the function must return
- * NULL and raise SSL_R_BIO_NOT_SET.
+ * Test SSL_accept_connection with no net_bio and without the
+ * SSL_ACCEPT_CONNECTION_NO_BLOCK flag, so that the caller is asking to wait.
+ * When there is no BIO the function must return NULL and raise
+ * SSL_R_BIO_NOT_SET rather than waiting, since nothing could ever arrive.
  */
 static int test_dtls_accept_connection_no_bio_block(void)
 {

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -27,6 +27,7 @@
 #include <openssl/conf.h>
 #include "internal/time.h"
 #include "internal/sockets.h"
+#include "internal/dgram_demux.h"
 #include "helpers/ssltestlib.h"
 #include "testutil.h"
 #include "../ssl/ssl_local.h"
@@ -4841,6 +4842,185 @@ static int test_new_pending_cb_alternate(void)
     return run_new_pending_cb_scenario(100, 1, 2, 1, 2, 0);
 }
 
+/*
+ * The test below needs a listener with a notifier, which only exists
+ * when the listener is created without SSL_LISTENER_FLAG_SINGLE_THREAD. In a
+ * no-threads build that listener cannot be created at all, because the
+ * condition variable it needs is unavailable.
+ */
+#if defined(OPENSSL_THREADS)
+/*
+ * Test that queueing a connection for accept signals the listener's notifier.
+ *
+ * A thread waiting in SSL_poll() for SSL_POLL_EVENT_IC is blocked on the
+ * listener's network socket and on its notifier. Where another thread does the
+ * demuxing, that socket does not necessarily become readable on the waiter's
+ * behalf, so the notifier is what has to wake it.
+ *
+ * Most of the time the bug this covers is masked. Every connection reaching
+ * the accept queue got there because a datagram was demuxed into its receive
+ * queue, and the packet handler has always signalled on that injection, so the
+ * waiter is woken, ticks the listener itself during its readout, and finds the
+ * connection. What is not covered by that is the window in which the injection
+ * and the queue push straddle a waiter registering, because signalling is
+ * conditional on there being a waiter at the time.
+ *
+ * The numbered steps below are that window - the interleaving of two threads
+ * which the fix exists to handle. They are not what this test does, and are
+ * given only so that what it does assert makes sense; see the end of this
+ * comment for how it is actually checked.
+ *
+ *   1. Accept thread A polls the listener for SSL_POLL_EVENT_IC. Its readout
+ *      ticks the listener, finds nothing, and it decides to block. It is not
+ *      a registered waiter yet.
+ *   2. Worker thread B polls one of its own connections, which also ticks the
+ *      listener. The pump reads a client's final ClientHello and injects it
+ *      into that pending connection's queue. There are no waiters, so nothing
+ *      is signalled.
+ *   3. A enters the blocking section. Its re-check runs without ticking, so it
+ *      sees only the accept queue, which is still empty, and it blocks.
+ *   4. B's tick reaches dtls_listener_drive_pending(), which completes the
+ *      connection against the buffered ClientHello and pushes it onto the
+ *      accept queue.
+ *
+ * Without a signal at step 4, A sleeps on with a validated connection sitting
+ * ready, until some unrelated datagram makes the socket readable again. B
+ * consumed the only one in flight, and the client is now waiting on the
+ * server, so on a quiet listener that is until the client retransmits.
+ *
+ * That interleaving cannot be forced from outside the library, so rather than
+ * reproducing the steps above, this drives their essential part by hand and on
+ * one thread: pumping the demux directly performs step 2, the signal it raises
+ * is then cleared, and the tick which follows can only signal by way of step 4.
+ * Asserting that it did is therefore asserting that a queue push signals.
+ *
+ * signalled_notifier is protected by the listener mutex in the library, which
+ * has to assume concurrent access. This test is single threaded throughout, so
+ * it reads the field directly without holding the mutex.
+ */
+static int test_dtls_notifier_signalled_on_accept_queue_push(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *listener = NULL, *clientssl = NULL;
+    BIO_ADDR *server_addr = NULL;
+    DTLS_LISTENER *dl;
+    SSL_POLL_ITEM poll_item;
+    struct timeval poll_timeout;
+    size_t poll_result = 0;
+    int server_fd = -1, client_fd = -1;
+    int in_blocking_section = 0;
+    int abortctr, retc, err_code;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_VERSION, 0, &sctx, &cctx, cert,
+            privkey)))
+        goto end;
+
+    /*
+     * Multi-threaded mode (no SSL_LISTENER_FLAG_SINGLE_THREAD) so that the
+     * listener has a notifier at all.
+     */
+    if (!TEST_true(create_dtls_listener(sctx,
+            SSL_LISTENER_FLAG_REQUIRE_HVR | SSL_LISTENER_FLAG_REQUIRE_HRR,
+            &listener, &server_addr, &server_fd)))
+        goto end;
+
+    dl = (DTLS_LISTENER *)listener;
+    if (!TEST_true(dl->have_notifier))
+        goto end;
+
+    if (!TEST_true(create_dtls_client_for_addr(cctx, server_addr, &clientssl,
+            &client_fd)))
+        goto end;
+
+    /* Pose as a thread waiting for readiness, so signalling is enabled. */
+    ossl_dtls_listener_enter_blocking_section(listener);
+    in_blocking_section = 1;
+
+    /*
+     * Drive the cookie exchange, splitting each round into its two halves so
+     * that the two signalling opportunities can be told apart:
+     *
+     *   - demuxing a datagram to a connection's receive queue, which the
+     *     packet handler has always signalled, and
+     *   - completing a connection and pushing it onto the accept queue.
+     *
+     * Pumping the demux directly performs only the first. The signal it
+     * raises is then cleared, so when the listener is next ticked the pump
+     * finds nothing new and only the accept queue push can signal.
+     *
+     * There is no public API for that split: SSL_poll() and
+     * SSL_accept_connection() both tick the listener, which does the two
+     * together.
+     */
+    poll_item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+    poll_item.desc.value.ssl = listener;
+    poll_timeout.tv_sec = 0;
+    poll_timeout.tv_usec = 0;
+
+    SSL_set_connect_state(clientssl);
+    for (abortctr = 0; abortctr < 100; abortctr++) {
+        retc = SSL_connect(clientssl);
+        err_code = SSL_get_error(clientssl, retc);
+        if (retc <= 0
+            && err_code != SSL_ERROR_WANT_READ
+            && err_code != SSL_ERROR_WANT_WRITE) {
+            TEST_error("SSL_connect failed (err %d)", err_code);
+            goto end;
+        }
+
+        ossl_dgram_demux_pump(dl->demux);
+
+        ossl_dtls_listener_leave_blocking_section(listener);
+        in_blocking_section = 0;
+        if (!TEST_int_eq(dl->signalled_notifier, 0))
+            goto end;
+        ossl_dtls_listener_enter_blocking_section(listener);
+        in_blocking_section = 1;
+
+        /*
+         * A zero timeout, so this ticks the listener and reads out the result
+         * without ever blocking, and therefore without itself entering a
+         * blocking section and clearing the signal we are watching for.
+         */
+        poll_item.events = SSL_POLL_EVENT_IC;
+        poll_item.revents = 0;
+
+        if (!TEST_true(SSL_poll(&poll_item, 1, sizeof(poll_item), &poll_timeout,
+                0, &poll_result)))
+            goto end;
+
+        if ((poll_item.revents & SSL_POLL_EVENT_IC) != 0)
+            break;
+    }
+
+    if (!TEST_size_t_gt(SSL_get_accept_connection_queue_len(listener), 0))
+        goto end;
+
+    /* The accept queue push must have woken any waiter. */
+    if (!TEST_int_eq(dl->signalled_notifier, 1))
+        goto end;
+
+    testresult = 1;
+end:
+    if (in_blocking_section)
+        ossl_dtls_listener_leave_blocking_section(listener);
+    SSL_free(clientssl);
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    if (client_fd >= 0)
+        BIO_closesocket(client_fd);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+#endif /* OPENSSL_THREADS */
+
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
@@ -4946,5 +5126,11 @@ int setup_tests(void)
     ADD_TEST(test_new_pending_cb_blocked_by_cap);
     ADD_TEST(test_new_pending_cb_all_denied_under_cap);
     ADD_TEST(test_new_pending_cb_alternate);
+    /* Blocking SSL_poll() wakeup tests */
+#if defined(OPENSSL_THREADS)
+    ADD_TEST(test_dtls_notifier_signalled_on_accept_queue_push);
+#endif
+
+
     return 1;
 }

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5851,14 +5851,21 @@ static int test_dtls_blocking_write(void)
         || !TEST_int_eq(SSL_get_blocking_mode(serverssl), 1))
         goto end;
 
+    data.sends = 0;
     data.fails_remaining = 1;
 
     if (!TEST_true(SSL_write_ex(serverssl, "msg", 3, &written))
         || !TEST_size_t_eq(written, 3))
         goto end;
 
-    /* The send really was rejected, and was retried rather than reported. */
-    if (!TEST_int_eq(data.fails_remaining, 0))
+    /*
+     * The send really was rejected, and was retried rather than reported: the
+     * count proves a second attempt was made, which is the whole behaviour
+     * under test. Without it, a write which never reached the filter at all
+     * would look the same as one which was retried.
+     */
+    if (!TEST_int_eq(data.fails_remaining, 0)
+        || !TEST_int_ge(data.sends, 2))
         goto end;
 
     /* The datagram reached the client, so nothing was dropped on the way. */

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -4843,7 +4843,7 @@ static int test_new_pending_cb_alternate(void)
 }
 
 /*
- * The test below needs a listener with a notifier, which only exists
+ * The two tests below need a listener with a notifier, which only exists
  * when the listener is created without SSL_LISTENER_FLAG_SINGLE_THREAD. In a
  * no-threads build that listener cannot be created at all, because the
  * condition variable it needs is unavailable.
@@ -5018,6 +5018,144 @@ end:
     return testresult;
 }
 
+/*
+ * Test that a blocking SSL_poll() on a listener enters a blocking section.
+ *
+ * Unless it does, three things follow: the notifier is not in the poll set, so
+ * it cannot wake this thread; cur_blocking_waiters is never incremented, and
+ * since signalling is conditional on there being a waiter, no other thread
+ * even attempts to signal; and there is no re-check after registering, so
+ * readiness arising between the readout and the wait is lost.
+ *
+ * Polling the socket alone is not enough, though not because a wakeup can be
+ * missed outright. poll() reports whatever is currently sitting in the socket
+ * buffer and returns immediately if there is any, so a thread cannot miss a
+ * datagram just by being outside poll() when it arrives. What it can miss is a
+ * datagram another thread has already taken. With several threads polling the
+ * one shared socket that happens constantly: an arriving datagram wakes all of
+ * them, only one gets it, and the rest find nothing. Any of them can be the
+ * one that takes it, because SSL_read() on a connection pumps the demux and
+ * SSL_poll() on a connection ticks the whole listener.
+ *
+ *   1. Accept thread A polls the listener for SSL_POLL_EVENT_IC. Its readout
+ *      ticks the listener, finds nothing, and it decides to block.
+ *   2. A client's final ClientHello lands on the shared socket.
+ *   3. Worker thread B, polling one of its own connections, ticks the listener
+ *      and is the one that takes the datagram. Its tick completes the pending
+ *      connection and pushes it onto the accept queue. Signalling is attempted,
+ *      but A never registered as a waiter, so nothing is signalled.
+ *   4. A reaches its poll, watching the socket alone. B drained it, so it is
+ *      empty, and A sleeps with a validated connection sitting on the accept
+ *      queue.
+ *
+ * A's readout, back at step 1, would have found that connection had it run
+ * after step 3 rather than before it. Registering as a waiter and re-checking
+ * is what removes the dependency on that ordering.
+ *
+ * Note that the signal added for the step 3 queue push is itself conditional on
+ * a registered waiter, so it does nothing for a thread polling the listener
+ * until that thread registers. The two fixes are complementary.
+ *
+ * None of that has a public observable, and this deliberately does not time
+ * the wait. Instead it relies on the last waiter out of a blocking section
+ * draining a raised notifier signal: raise one beforehand, poll briefly with
+ * nothing ready, and check afterwards. Drained means a blocking section was
+ * entered and left, since only a leave drains it and only an enter can be left;
+ * still standing means neither happened.
+ *
+ * signalled_notifier is protected by the listener mutex in the library, which
+ * has to assume concurrent access. This test is single threaded throughout, so
+ * it reads and writes the field directly without holding the mutex.
+ *
+ * Note what this does not cover. That the notifier is in the poll set, and so
+ * can actually deliver a wakeup, is not checked: with a signal raised the poll
+ * returns at once if the notifier is being watched and sleeps out its timeout
+ * if it is not, and only timing separates those. A longer timeout would not
+ * help, because the first iteration's leave drains the notifier and the next
+ * one sleeps out the remainder either way. The re-check after registering is
+ * not covered either, since readiness arriving between the readout and the
+ * registration cannot be produced from a single thread.
+ */
+static int test_dtls_poll_listener_enters_blocking_section(void)
+{
+    SSL_CTX *sctx = NULL;
+    SSL *listener = NULL;
+    BIO_ADDR *server_addr = NULL;
+    DTLS_LISTENER *dl;
+    SSL_POLL_ITEM poll_item;
+    struct timeval poll_timeout;
+    size_t poll_result = 0;
+    int server_fd = -1, nfd = -1;
+    int testresult = 0;
+
+    if (!TEST_ptr(sctx = SSL_CTX_new(DTLS_server_method())))
+        goto end;
+
+    if (!TEST_true(create_dtls_listener(sctx, 0, &listener, &server_addr,
+            &server_fd)))
+        goto end;
+
+    dl = (DTLS_LISTENER *)listener;
+    if (!TEST_true(dl->have_notifier))
+        goto end;
+
+    /*
+     * Raise the notifier as another thread reporting readiness would, which
+     * means both writing to the notifier and recording that it is raised, as
+     * dtls_listener_signal_notifier() does.
+     */
+    if (!TEST_true(ossl_rio_notifier_signal(&dl->notifier)))
+        goto end;
+    dl->signalled_notifier = 1;
+
+    nfd = ossl_rio_notifier_as_fd(&dl->notifier);
+    if (!TEST_int_ge(nfd, 0)
+        || !TEST_int_gt(BIO_socket_ready(nfd, /*for_read=*/1), 0))
+        goto end;
+
+    /*
+     * Poll with a short timeout. No client exists, so nothing is ever ready
+     * and SSL_poll() must block, which is what drives the translation that
+     * enters the blocking section.
+     */
+    poll_item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+    poll_item.desc.value.ssl = listener;
+    poll_item.events = SSL_POLL_EVENT_IC;
+    poll_item.revents = 0;
+    poll_timeout.tv_sec = 0;
+    poll_timeout.tv_usec = 100000;
+
+    if (!TEST_true(SSL_poll(&poll_item, 1, sizeof(poll_item), &poll_timeout, 0,
+            &poll_result)))
+        goto end;
+
+    if (!TEST_size_t_eq(poll_result, 0))
+        goto end;
+
+    /*
+     * Leaving the blocking section must have drained the notifier. Check the
+     * notifier itself and not only the flag recording its state, since it is
+     * the notifier being readable that would spuriously wake a later waiter.
+     */
+    if (!TEST_int_eq(BIO_socket_ready(nfd, /*for_read=*/1), 0))
+        goto end;
+
+    if (!TEST_int_eq(dl->signalled_notifier, 0))
+        goto end;
+
+    if (!TEST_size_t_eq(dl->cur_blocking_waiters, 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(listener);
+    BIO_ADDR_free(server_addr);
+    if (server_fd >= 0)
+        BIO_closesocket(server_fd);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
 #endif /* OPENSSL_THREADS */
 
 
@@ -5129,6 +5267,7 @@ int setup_tests(void)
     /* Blocking SSL_poll() wakeup tests */
 #if defined(OPENSSL_THREADS)
     ADD_TEST(test_dtls_notifier_signalled_on_accept_queue_push);
+    ADD_TEST(test_dtls_poll_listener_enters_blocking_section);
 #endif
 
 

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -114,7 +114,7 @@ static int dtls_read_with_retry(SSL *ssl, void *buf, size_t bufsize,
  * Returns 1 on success, 0 on failure.
  * On success, caller is responsible for cleanup using the returned pointers/fds.
  */
-static int create_dtls_listener(SSL_CTX *sctx, uint64_t listener_flags,
+static int create_dtls_listener_unconfigured(SSL_CTX *sctx, uint64_t listener_flags,
     SSL **listener, BIO_ADDR **server_addr, int *server_fd)
 {
     BIO *listener_bio = NULL;
@@ -180,6 +180,38 @@ err:
         *server_fd = -1;
     }
     return ret;
+}
+
+/*
+ * As create_dtls_listener_unconfigured(), but also opts out of blocking mode.
+ *
+ * These tests drive both ends of a handshake from a single thread, so the server
+ * side must not block: a blocking read would wait for a client which only this
+ * thread can advance. A listener is blocking by default, so opt out here rather
+ * than in each test, and note that connections accepted from it inherit this.
+ *
+ * A test which needs to observe the default, or to exercise blocking mode, should
+ * use create_dtls_listener_unconfigured() and configure what it needs.
+ */
+static int create_dtls_listener(SSL_CTX *sctx, uint64_t listener_flags,
+    SSL **listener, BIO_ADDR **server_addr, int *server_fd)
+{
+    if (!create_dtls_listener_unconfigured(sctx, listener_flags, listener,
+            server_addr, server_fd))
+        return 0;
+
+    if (!TEST_true(SSL_set_blocking_mode(*listener, 0))) {
+        SSL_free(*listener);
+        BIO_ADDR_free(*server_addr);
+        if (*server_fd >= 0)
+            BIO_closesocket(*server_fd);
+        *listener = NULL;
+        *server_addr = NULL;
+        *server_fd = -1;
+        return 0;
+    }
+
+    return 1;
 }
 
 /*
@@ -5419,8 +5451,15 @@ static int test_dtls_blocking_mode(void)
             privkey)))
         goto end;
 
-    /* A socket BIO supplies a poll descriptor, so blocking is available. */
-    if (!TEST_true(create_dtls_listener(sctx,
+    /*
+     * create_dtls_listener() turns blocking mode off on behalf of the single
+     * threaded tests, so it cannot be used here: this test has to see the mode
+     * a listener has when the application has never set it. Hence the
+     * unconfigured variant.
+     *
+     * A socket BIO supplies a poll descriptor, so blocking is available.
+     */
+    if (!TEST_true(create_dtls_listener_unconfigured(sctx,
             SSL_LISTENER_FLAG_REQUIRE_HVR | SSL_LISTENER_FLAG_REQUIRE_HRR
                 | SSL_LISTENER_FLAG_SINGLE_THREAD,
             &listener, &server_addr, &server_fd)))

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5158,6 +5158,117 @@ end:
 
 #endif /* OPENSSL_THREADS */
 
+static unsigned int short_timer_cb_count;
+
+/* Force a short retransmission timeout and count how often it is consulted. */
+static unsigned int short_timer_cb(SSL *s, unsigned int timer_us)
+{
+    ++short_timer_cb_count;
+    return 50000; /* 50ms */
+}
+
+/*
+ * Test that a blocking SSL_poll() on a DTLS connection honours the
+ * retransmission timer.
+ *
+ * SSL_poll() bounds its wait by the per-object event timeout so that timer
+ * driven work is not delayed. For a DTLS connection that timeout is the
+ * handshake retransmission timer: if it is ignored, a poll with a long user
+ * timeout sleeps straight through the point at which the flight should have
+ * been resent, and if the peer had lost that flight neither side progresses.
+ *
+ * This does not time the wait. The retransmission timeout is forced down to
+ * 50ms and the poll is given much longer, so a correct implementation must
+ * wake and retransmit at least once before the poll deadline; an
+ * implementation which ignores the timer retransmits not at all.
+ */
+static int test_dtls_poll_conn_honours_retransmit_timer(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_POLL_ITEM poll_item;
+    struct timeval poll_timeout, timer_left;
+    size_t poll_result = 0;
+    int is_infinite = 0;
+    int retc, rets, err_code;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_VERSION, 0, &sctx, &cctx, cert,
+            privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    /*
+     * Install the short timeout before the server sends anything, so that it
+     * is picked up when the retransmission timer is first started rather than
+     * only on a later expiry.
+     */
+    DTLS_set_timer_cb(serverssl, short_timer_cb);
+
+    /*
+     * Drive just far enough for the server to send its first flight and start
+     * its retransmission timer. The client is then left alone, so the flight
+     * stays unacknowledged for the duration of the poll.
+     */
+    retc = SSL_connect(clientssl);
+    if (!TEST_int_le(retc, 0)
+        || !TEST_int_eq(SSL_get_error(clientssl, retc), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /*
+     * The server consumes the ClientHello, sends its flight and then waits for
+     * the client, so this does not complete the handshake.
+     */
+    rets = SSL_accept(serverssl);
+    if (!TEST_int_le(rets, 0))
+        goto end;
+
+    err_code = SSL_get_error(serverssl, rets);
+    if (!TEST_true(err_code == SSL_ERROR_WANT_READ
+            || err_code == SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    /*
+     * Assert the precondition through the same call SSL_poll() uses to compute
+     * its deadline: a running timer is reported as a finite timeout.
+     */
+    if (!TEST_true(SSL_get_event_timeout(serverssl, &timer_left, &is_infinite))
+        || !TEST_false(is_infinite))
+        goto end;
+
+    short_timer_cb_count = 0;
+
+    /*
+     * Nothing will arrive for this connection during the poll, so it runs to
+     * its deadline. Along the way the retransmission timer must expire and be
+     * serviced, which re-arms the timer via the callback.
+     */
+    poll_item.desc.type = BIO_POLL_DESCRIPTOR_TYPE_SSL;
+    poll_item.desc.value.ssl = serverssl;
+    poll_item.events = SSL_POLL_EVENT_R;
+    poll_item.revents = 0;
+    poll_timeout.tv_sec = 0;
+    poll_timeout.tv_usec = 500000;
+
+    if (!TEST_true(SSL_poll(&poll_item, 1, sizeof(poll_item), &poll_timeout, 0,
+            &poll_result)))
+        goto end;
+
+    if (!TEST_size_t_gt(short_timer_cb_count, 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
 
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
@@ -5269,7 +5380,7 @@ int setup_tests(void)
     ADD_TEST(test_dtls_notifier_signalled_on_accept_queue_push);
     ADD_TEST(test_dtls_poll_listener_enters_blocking_section);
 #endif
-
+    ADD_TEST(test_dtls_poll_conn_honours_retransmit_timer);
 
     return 1;
 }


### PR DESCRIPTION
Brings DTLS listener blocking mode into line with QUIC.

`SSL_set_blocking_mode()` previously failed on every DTLS object. It now works
on a DTLS listener and on the connections accepted from it, which inherit the
listener's mode unless given one of their own. As for QUIC, the default is
blocking, the listener's network BIO is forced non-blocking, and blocking is
emulated by waiting for readiness — a listener demultiplexes one socket to many
connections, so it cannot let one of them block in a read and stall the rest.

`SSL_accept_connection()`, reads and writes on listener connections all block.
A listener connection has no BIO of its own to block in, so reads wait in the
record layer where a blocking BIO would have, and writes wait for the shared
socket and send again rather than discarding the datagram.

A listener whose BIO provides no poll descriptor, such as a memory BIO, has
nothing to wait on and stays non-blocking whatever is requested.

**Based on #32239, whose 5 commits it includes.** Reviewers should ignore the
first 5 commits and start at "DTLS 1.3 Wait rather than spin in the blocking
accept path". I will rebase once #32239 has landed.