### PR TITLE
Skip the common test options in dtls_multithread_test

### DIFF
--- a/test/dtls_multithread_test.c
+++ b/test/dtls_multithread_test.c
@@ -444,8 +444,15 @@ err:
     return testresult;
 }
 
+OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
+
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
         || !TEST_ptr(privkey = test_get_argument(1)))
         return 0;


### PR DESCRIPTION
setup_tests() read its two positional arguments without first calling test_skip_common_options(), so the option cursor was never advanced from the test's point of view and test_get_argument(0) returned the option itself. Passing -test or -iter therefore left the certificate path set to the literal string "-test", and the run failed on that:

    error:80000002:system library:file_ctrl:No such file or directory:
        ...:calling fopen(-test, r)

The option was not being ignored: the framework parses it in process_shared_options() and the selected sub-test really does run. Only the positional arguments were shifted, which is what made the failure look unrelated to the option.

Also declare the usage string, so -help describes the two arguments the test needs rather than showing none.

Assisted-by: Claude Code:claude-opus-5
