### PR TITLE
Drop dead own EC point formats fields and code

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -829,15 +829,6 @@ SSL *ossl_ssl_connection_new_int(SSL_CTX *ctx, SSL *user_ssl,
         goto err;
 
     s->session_ctx = ctx;
-    if (ctx->ext.ecpointformats != NULL) {
-        s->ext.ecpointformats = OPENSSL_memdup(ctx->ext.ecpointformats,
-            ctx->ext.ecpointformats_len);
-        if (s->ext.ecpointformats == NULL) {
-            s->ext.ecpointformats_len = 0;
-            goto err;
-        }
-        s->ext.ecpointformats_len = ctx->ext.ecpointformats_len;
-    }
     if (ctx->ext.supportedgroups != NULL) {
         size_t add = 0;
 
@@ -1483,7 +1474,6 @@ void ossl_ssl_connection_free(SSL *ssl)
 
     OPENSSL_free(s->ext.hostname);
     SSL_CTX_free(s->session_ctx);
-    OPENSSL_free(s->ext.ecpointformats);
     OPENSSL_free(s->ext.peer_ecpointformats);
     OPENSSL_free(s->ext.supportedgroups);
     OPENSSL_free(s->ext.keyshares);
@@ -4409,7 +4399,6 @@ void SSL_CTX_free(SSL_CTX *a)
     tls_engine_finish(a->client_cert_engine);
 #endif
 
-    OPENSSL_free(a->ext.ecpointformats);
     OPENSSL_free(a->ext.supportedgroups);
     OPENSSL_free(a->ext.keyshares);
     OPENSSL_free(a->ext.tuples);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1016,10 +1016,6 @@ struct ssl_ctx_st {
         /* RFC 4366 Maximum Fragment Length Negotiation */
         uint8_t max_fragment_len_mode;
 
-        /* EC extension values inherited by SSL structure */
-        size_t ecpointformats_len;
-        unsigned char *ecpointformats;
-
         size_t supportedgroups_len;
         uint16_t *supportedgroups;
 
@@ -1646,9 +1642,6 @@ struct ssl_connection_st {
         /* TLS 1.3 tickets requested by the application. */
         int extra_tickets_expected;
 
-        /* our list */
-        size_t ecpointformats_len;
-        unsigned char *ecpointformats;
         /* peer's list */
         size_t peer_ecpointformats_len;
         unsigned char *peer_ecpointformats;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1052,9 +1052,7 @@ static int final_ec_pt_formats(SSL_CONNECTION *s, unsigned int context,
      * suite, then if server returns an EC point formats lists extension it
      * must contain uncompressed.
      */
-    if (s->ext.ecpointformats != NULL
-        && s->ext.ecpointformats_len > 0
-        && s->ext.peer_ecpointformats != NULL
+    if (s->ext.peer_ecpointformats != NULL
         && s->ext.peer_ecpointformats_len > 0
         && ((alg_k & SSL_kECDHE) || (alg_a & SSL_aECDSA))) {
         /* we are using an ECC cipher */

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1808,13 +1808,8 @@ int tls1_check_group_id(SSL_CONNECTION *s, uint16_t group_id,
 void tls1_get_formatlist(SSL_CONNECTION *s, const unsigned char **pformats,
     size_t *num_formats)
 {
-    /*
-     * If we have a custom point format list use it otherwise use default
-     */
-    if (s->ext.ecpointformats) {
-        *pformats = s->ext.ecpointformats;
-        *num_formats = s->ext.ecpointformats_len;
-    } else if ((s->options & SSL_OP_LEGACY_EC_POINT_FORMATS) != 0) {
+    /* Advertise only uncompressed unless legacy formats are enabled */
+    if ((s->options & SSL_OP_LEGACY_EC_POINT_FORMATS) != 0) {
         *pformats = ecformats_all;
         /* For Suite B we don't support char2 fields */
         if (tls1_suiteb(s))


### PR DESCRIPTION
The SSL_CTX and SSL connection "ext.ecpointformats" fields were always NULL. The client-side `final_ec_pt_formats()` function will now actually reject invalid server point formats that omit `uncompressed`.

This is not an issue in master.
Similar PRs will be opened for 3.5 and 3.0/3.4 (separate because cherry-pick not clean).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
