### PR TITLE
Drop dead own EC point formats fields and code (3.5)

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -828,15 +828,6 @@ SSL *ossl_ssl_connection_new_int(SSL_CTX *ctx, SSL *user_ssl,
         goto err;
 
     s->session_ctx = ctx;
-    if (ctx->ext.ecpointformats != NULL) {
-        s->ext.ecpointformats = OPENSSL_memdup(ctx->ext.ecpointformats,
-            ctx->ext.ecpointformats_len);
-        if (s->ext.ecpointformats == NULL) {
-            s->ext.ecpointformats_len = 0;
-            goto err;
-        }
-        s->ext.ecpointformats_len = ctx->ext.ecpointformats_len;
-    }
     if (ctx->ext.supportedgroups != NULL) {
         size_t add = 0;
 
@@ -1482,7 +1473,6 @@ void ossl_ssl_connection_free(SSL *ssl)
 
     OPENSSL_free(s->ext.hostname);
     SSL_CTX_free(s->session_ctx);
-    OPENSSL_free(s->ext.ecpointformats);
     OPENSSL_free(s->ext.peer_ecpointformats);
     OPENSSL_free(s->ext.supportedgroups);
     OPENSSL_free(s->ext.keyshares);
@@ -4402,7 +4392,6 @@ void SSL_CTX_free(SSL_CTX *a)
     tls_engine_finish(a->client_cert_engine);
 #endif
 
-    OPENSSL_free(a->ext.ecpointformats);
     OPENSSL_free(a->ext.supportedgroups);
     OPENSSL_free(a->ext.keyshares);
     OPENSSL_free(a->ext.tuples);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1016,10 +1016,6 @@ struct ssl_ctx_st {
         /* RFC 4366 Maximum Fragment Length Negotiation */
         uint8_t max_fragment_len_mode;
 
-        /* EC extension values inherited by SSL structure */
-        size_t ecpointformats_len;
-        unsigned char *ecpointformats;
-
         size_t supportedgroups_len;
         uint16_t *supportedgroups;
 
@@ -1645,9 +1641,6 @@ struct ssl_connection_st {
         /* TLS 1.3 tickets requested by the application. */
         int extra_tickets_expected;
 
-        /* our list */
-        size_t ecpointformats_len;
-        unsigned char *ecpointformats;
         /* peer's list */
         size_t peer_ecpointformats_len;
         unsigned char *peer_ecpointformats;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1051,9 +1051,7 @@ static int final_ec_pt_formats(SSL_CONNECTION *s, unsigned int context,
      * suite, then if server returns an EC point formats lists extension it
      * must contain uncompressed.
      */
-    if (s->ext.ecpointformats != NULL
-        && s->ext.ecpointformats_len > 0
-        && s->ext.peer_ecpointformats != NULL
+    if (s->ext.peer_ecpointformats != NULL
         && s->ext.peer_ecpointformats_len > 0
         && ((alg_k & SSL_kECDHE) || (alg_a & SSL_aECDSA))) {
         /* we are using an ECC cipher */

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1801,20 +1801,13 @@ int tls1_check_group_id(SSL_CONNECTION *s, uint16_t group_id,
 void tls1_get_formatlist(SSL_CONNECTION *s, const unsigned char **pformats,
     size_t *num_formats)
 {
-    /*
-     * If we have a custom point format list use it otherwise use default
-     */
-    if (s->ext.ecpointformats) {
-        *pformats = s->ext.ecpointformats;
-        *num_formats = s->ext.ecpointformats_len;
-    } else {
-        *pformats = ecformats_default;
-        /* For Suite B we don't support char2 fields */
-        if (tls1_suiteb(s))
-            *num_formats = sizeof(ecformats_default) - 1;
-        else
-            *num_formats = sizeof(ecformats_default);
-    }
+    /* Use default */
+    *pformats = ecformats_default;
+    /* For Suite B we don't support char2 fields */
+    if (tls1_suiteb(s))
+        *num_formats = sizeof(ecformats_default) - 1;
+    else
+        *num_formats = sizeof(ecformats_default);
 }
 
 /* Return group id of a key */


### PR DESCRIPTION
The SSL_CTX and SSL connection "ext.ecpointformats" fields were always NULL. The client-side final_ec_pt_formats() function will now reject invalid server point formats that omit uncompressed.

3.5 variant of #32332
