### PR TITLE
Remove QUIC_TSERVER: Move script_45 to script_49

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2567,51 +2567,8 @@ static const struct script_op script_44[] = {
 };
 
 /* 45. PING must generate ACK */
-static int force_ping(struct helper *h, struct helper_local *hl)
-{
-    QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(ACQUIRE_S());
-
-    h->scratch0 = ossl_quic_channel_get_diag_num_rx_ack(ch);
-
-    if (!TEST_true(ossl_quic_tserver_ping(ACQUIRE_S())))
-        return 0;
-
-    return 1;
-}
-
-static int wait_incoming_acks_increased(struct helper *h, struct helper_local *hl)
-{
-    QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(ACQUIRE_S());
-    uint16_t count;
-
-    count = ossl_quic_channel_get_diag_num_rx_ack(ch);
-
-    if (count == h->scratch0) {
-        h->check_spin_again = 1;
-        return 0;
-    }
-
-    return 1;
-}
-
 static const struct script_op script_45[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_BEGIN_REPEAT(2),
-
-    OP_CHECK(force_ping, 0),
-    OP_CHECK(wait_incoming_acks_increased, 0),
-
-    OP_END_REPEAT(),
-
-    OP_S_WRITE(a, "Strawberry", 10),
-    OP_C_READ_EXPECT(DEFAULT, "Strawberry", 10),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2673,20 +2673,7 @@ static const struct script_op script_46[] = {
 
 /* 47. Fault injection - ACK - malformed subsequent range */
 static const struct script_op script_47[] = {
-    OP_S_SET_INJECT_PLAIN(script_46_inject_plain),
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_SET_INJECT_WORD(2, 0),
-
-    OP_S_WRITE(a, "Strawberry", 10),
-
-    OP_C_EXPECT_CONN_CLOSE_INFO(OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2685,24 +2685,7 @@ static const struct script_op script_48[] = {
 
 /* 49. Fault injection - ACK - fictional PN */
 static const struct script_op script_49[] = {
-    OP_S_SET_INJECT_PLAIN(script_46_inject_plain),
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_SET_INJECT_WORD(4, 0),
-
-    OP_S_WRITE(a, "Strawberry", 10),
-    /*
-     * The injected ACK acknowledges a packet number we have not sent, which the
-     * peer is expected to treat as a PROTOCOL_VIOLATION, so the connection is
-     * closed rather than the stream data being delivered.
-     */
-    OP_C_EXPECT_CONN_CLOSE_INFO(OSSL_QUIC_ERR_PROTOCOL_VIOLATION, 0, 0),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2679,20 +2679,7 @@ static const struct script_op script_47[] = {
 
 /* 48. Fault injection - ACK - malformed subsequent range */
 static const struct script_op script_48[] = {
-    OP_S_SET_INJECT_PLAIN(script_46_inject_plain),
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_SET_INJECT_WORD(3, 0),
-
-    OP_S_WRITE(a, "Strawberry", 10),
-
-    OP_C_EXPECT_CONN_CLOSE_INFO(OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2667,20 +2667,7 @@ err:
 }
 
 static const struct script_op script_46[] = {
-    OP_S_SET_INJECT_PLAIN(script_46_inject_plain),
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_SET_INJECT_WORD(1, 0),
-
-    OP_S_WRITE(a, "Strawberry", 10),
-
-    OP_C_EXPECT_CONN_CLOSE_INFO(OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -1075,6 +1075,27 @@ err:
     return ok;
 }
 
+/* Inhibit ticking at the QUIC_ENGINE level */
+DEF_FUNC(hf_set_engine_tick_inhibit)
+{
+    int ok = 0;
+    uint64_t inhibit;
+    SSL *ssl;
+    QUIC_CHANNEL *ch;
+
+    F_POP(inhibit);
+    REQUIRE_SSL(ssl);
+
+    if (!TEST_ptr(ch = ossl_quic_conn_get_channel(ssl)))
+        goto err;
+
+    ossl_quic_engine_set_inhibit_tick(ossl_quic_channel_get0_engine(ch),
+        inhibit != 0);
+    ok = 1;
+err:
+    return ok;
+}
+
 /*
  * Skip fake time and wait for the assist thread to catch up. It waits on real
  * time internally, so wake it and spin until the event timeout is back in the
@@ -1770,6 +1791,20 @@ err:
     (OP_PUSH_PZ(#name),      \
         OP_PUSH_U64(1),      \
         OP_FUNC(hf_set_tick_active))
+
+/*
+ * Inhibits/uninhibits ticking of the QUIC_ENGINE that "name" belongs  (see
+ * see hf_set_engine_tick_inhibit).
+ */
+#define OP_ENGINE_TICK_DISABLE(name) \
+    (OP_SELECT_SSL(0, name),         \
+        OP_PUSH_U64(1),              \
+        OP_FUNC(hf_set_engine_tick_inhibit))
+
+#define OP_ENGINE_TICK_ENABLE(name) \
+    (OP_SELECT_SSL(0, name),        \
+        OP_PUSH_U64(0),             \
+        OP_FUNC(hf_set_engine_tick_inhibit))
 
 #define OP_SKIP_TIME_WAIT(name, ms) \
     (OP_SELECT_SSL(0, name),        \

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -2873,8 +2873,114 @@ DEF_SCRIPT(script_45, "PING must generate ACK")
     OP_READ_EXPECT(C, "Strawberry", 10);
 }
 
-DEF_SCRIPT(script_46, "place holder for multistrem script_46")
+static int inject_malformed_ack_plain(RADIX_FAULT *fault, QUIC_PKT_HDR *hdr,
+    unsigned char *buf, size_t len)
 {
+    int ok = 0;
+    WPACKET wpkt;
+    unsigned char frame_buf[16];
+    size_t written;
+    uint64_t type = 0, largest_acked = 0, first_range = 0, range_count = 0;
+    uint64_t agap = 0, alen = 0;
+    uint64_t ect0 = 0, ect1 = 0, ecnce = 0;
+
+    if (fault->word0 == 0)
+        return 1;
+
+    if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
+            sizeof(frame_buf), 0)))
+        return 0;
+
+    type = OSSL_QUIC_FRAME_TYPE_ACK_WITHOUT_ECN;
+
+    switch (fault->word0) {
+    case 1:
+        largest_acked = 100;
+        first_range = 101;
+        range_count = 0;
+        break;
+    case 2:
+        largest_acked = 100;
+        first_range = 80;
+        /* [20..100]; [0..18]  */
+        range_count = 1;
+        agap = 0;
+        alen = 19;
+        break;
+    case 3:
+        largest_acked = 100;
+        first_range = 80;
+        range_count = 1;
+        agap = 18;
+        alen = 1;
+        break;
+    case 4:
+        type = OSSL_QUIC_FRAME_TYPE_ACK_WITH_ECN;
+        largest_acked = 100;
+        first_range = 1;
+        range_count = 0;
+        break;
+    case 5:
+        type = OSSL_QUIC_FRAME_TYPE_ACK_WITH_ECN;
+        largest_acked = 0;
+        first_range = 0;
+        range_count = 0;
+        ect0 = 0;
+        ect1 = 50;
+        ecnce = 200;
+        break;
+    }
+
+    fault->word0 = 0;
+
+    if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, type))
+        || !TEST_true(WPACKET_quic_write_vlint(&wpkt, largest_acked))
+        || !TEST_true(WPACKET_quic_write_vlint(&wpkt, /*ack_delay=*/0))
+        || !TEST_true(WPACKET_quic_write_vlint(&wpkt, /*ack_range_count=*/range_count))
+        || !TEST_true(WPACKET_quic_write_vlint(&wpkt, /*first_ack_range=*/first_range)))
+        goto err;
+
+    if (range_count > 0)
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, /*range[0].gap=*/agap))
+            || !TEST_true(WPACKET_quic_write_vlint(&wpkt, /*range[0].len=*/alen)))
+            goto err;
+
+    if (type == OSSL_QUIC_FRAME_TYPE_ACK_WITH_ECN)
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, ect0))
+            || !TEST_true(WPACKET_quic_write_vlint(&wpkt, ect1))
+            || !TEST_true(WPACKET_quic_write_vlint(&wpkt, ecnce)))
+            goto err;
+
+    if (!TEST_true(WPACKET_get_total_written(&wpkt, &written))
+        || !radix_fault_prepend_frame(fault, frame_buf, written))
+        goto err;
+
+    ok = 1;
+err:
+    if (ok)
+        WPACKET_finish(&wpkt);
+    else
+        WPACKET_cleanup(&wpkt);
+    return ok;
+}
+
+/* 46. Fault injection - ACK - malformed initial range */
+DEF_SCRIPT(script_46, "Fault injection - ACK - malformed initial range")
+{
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_SET_INJECT_PLAIN(S, inject_malformed_ack_plain);
+
+    OP_WRITE(C, "apple", 5);
+    OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
+    OP_READ_EXPECT(Sa, "apple", 5);
+
+    OP_SET_INJECT_WORD(1, 0);
+
+    OP_WRITE(Sa, "Strawberry", 10);
+
+    OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }
 
 DEF_SCRIPT(script_47, "place holder for multistrem script_47")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -2983,8 +2983,22 @@ DEF_SCRIPT(script_46, "Fault injection - ACK - malformed initial range")
     OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }
 
-DEF_SCRIPT(script_47, "place holder for multistrem script_47")
+DEF_SCRIPT(script_47, "Fault injection - ACK - malformed subsequent range")
 {
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_SET_INJECT_PLAIN(S, inject_malformed_ack_plain);
+
+    OP_WRITE(C, "apple", 5);
+    OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
+    OP_READ_EXPECT(Sa, "apple", 5);
+
+    OP_SET_INJECT_WORD(2, 0);
+
+    OP_WRITE(Sa, "Strawberry", 10);
+
+    OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }
 
 DEF_SCRIPT(script_48, "place holder for multistrem script_48")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -2805,8 +2805,72 @@ DEF_SCRIPT(script_44, "Fault injection - PADDING")
     OP_READ_EXPECT(C, "Strawberry", 10);
 }
 
-DEF_SCRIPT(script_45, "place holder for multistrem script_45")
+static uint16_t script_45_ack_count;
+
+/* 45. PING must generate ACK */
+DEF_FUNC(force_ping_45)
 {
+    int ok = 0;
+    SSL *ssl;
+    QUIC_CHANNEL *ch;
+
+    REQUIRE_SSL(ssl);
+    ch = ossl_quic_conn_get_channel(ssl);
+    if (!TEST_ptr(ch))
+        goto err;
+
+    script_45_ack_count = ossl_quic_channel_get_diag_num_rx_ack(ch);
+
+    if (!TEST_true(ossl_quic_channel_ping(ch)))
+        goto err;
+
+    ok = 1;
+err:
+    return ok;
+}
+
+DEF_FUNC(wait_incoming_acks_increased_45)
+{
+    int ok = 0;
+    SSL *ssl;
+    QUIC_CHANNEL *ch;
+    uint16_t count;
+
+    REQUIRE_SSL(ssl);
+    ch = ossl_quic_conn_get_channel(ssl);
+    if (!TEST_ptr(ch))
+        goto err;
+
+    count = ossl_quic_channel_get_diag_num_rx_ack(ch);
+
+    if (count == script_45_ack_count)
+        F_SPIN_AGAIN();
+
+    ok = 1;
+err:
+    return ok;
+}
+
+DEF_SCRIPT(script_45, "PING must generate ACK")
+{
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_WRITE(C, "apple", 5);
+    OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
+    OP_READ_EXPECT(Sa, "apple", 5);
+
+    for (i = 0; i < 2; ++i) {
+        OP_SELECT_SSL(0, S);
+        OP_FUNC(force_ping_45);
+        OP_SELECT_SSL(0, S);
+        OP_FUNC(wait_incoming_acks_increased_45);
+    }
+
+    OP_WRITE(Sa, "Strawberry", 10);
+    OP_READ_EXPECT(C, "Strawberry", 10);
 }
 
 DEF_SCRIPT(script_46, "place holder for multistrem script_46")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -3001,8 +3001,22 @@ DEF_SCRIPT(script_47, "Fault injection - ACK - malformed subsequent range")
     OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }
 
-DEF_SCRIPT(script_48, "place holder for multistrem script_48")
+DEF_SCRIPT(script_48, "Fault injection - ACK - malformed subsequent range")
 {
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_SET_INJECT_PLAIN(S, inject_malformed_ack_plain);
+
+    OP_WRITE(C, "apple", 5);
+    OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
+    OP_READ_EXPECT(Sa, "apple", 5);
+
+    OP_SET_INJECT_WORD(3, 0);
+
+    OP_WRITE(Sa, "Strawberry", 10);
+
+    OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }
 
 DEF_SCRIPT(script_49, "place holder for multistrem script_49")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -3019,8 +3019,26 @@ DEF_SCRIPT(script_48, "Fault injection - ACK - malformed subsequent range")
     OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }
 
-DEF_SCRIPT(script_49, "place holder for multistrem script_49")
+DEF_SCRIPT(script_49, "Fault injection - ACK - fictional PN")
 {
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_SET_INJECT_PLAIN(S, inject_malformed_ack_plain);
+
+    OP_WRITE(C, "apple", 5);
+    OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
+    OP_READ_EXPECT(Sa, "apple", 5);
+
+    OP_SET_INJECT_WORD(4, 0);
+
+    OP_WRITE(Sa, "Strawberry", 10);
+    /*
+     * The injected ACK acknowledges a packet number we have not sent, which the
+     * peer is expected to treat as a PROTOCOL_VIOLATION, so the connection is
+     * closed rather than the stream data being delivered.
+     */
+    OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_PROTOCOL_VIOLATION, 0, 0);
 }
 
 DEF_SCRIPT(script_50, "place holder for multistrem script_50")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -2976,9 +2976,10 @@ DEF_SCRIPT(script_46, "Fault injection - ACK - malformed initial range")
     OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
     OP_READ_EXPECT(Sa, "apple", 5);
 
+    OP_ENGINE_TICK_DISABLE(S);
     OP_SET_INJECT_WORD(1, 0);
-
     OP_WRITE(Sa, "Strawberry", 10);
+    OP_ENGINE_TICK_ENABLE(S);
 
     OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }
@@ -2994,9 +2995,10 @@ DEF_SCRIPT(script_47, "Fault injection - ACK - malformed subsequent range")
     OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
     OP_READ_EXPECT(Sa, "apple", 5);
 
+    OP_ENGINE_TICK_DISABLE(S);
     OP_SET_INJECT_WORD(2, 0);
-
     OP_WRITE(Sa, "Strawberry", 10);
+    OP_ENGINE_TICK_ENABLE(S);
 
     OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }
@@ -3012,9 +3014,10 @@ DEF_SCRIPT(script_48, "Fault injection - ACK - malformed subsequent range")
     OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
     OP_READ_EXPECT(Sa, "apple", 5);
 
+    OP_ENGINE_TICK_DISABLE(S);
     OP_SET_INJECT_WORD(3, 0);
-
     OP_WRITE(Sa, "Strawberry", 10);
+    OP_ENGINE_TICK_ENABLE(S);
 
     OP_EXPECT_CONN_CLOSE_INFO(C, OSSL_QUIC_ERR_FRAME_ENCODING_ERROR, 0, 0);
 }

--- a/test/recipes/70-test_quic_multistream.t
+++ b/test/recipes/70-test_quic_multistream.t
@@ -38,7 +38,11 @@ SKIP: {
     skip "not running CI tests", 1 unless $ENV{OSSL_RUN_CI_TESTS};
 
     subtest "check qlog output" => sub {
-        plan tests => 1;
+        plan tests => 2;
+        ok(run(test(["quic_radix_test",
+                     srctop_file("test", "certs", "servercert.pem"),
+                     srctop_file("test", "certs", "serverkey.pem")])),
+               "running quic_radix_test to contribute qlog output");
 
         ok(run(cmd([data_file("verify-qlog.py")], exe_shell => "python3")),
                "running qlog verification script");

--- a/test/recipes/70-test_quic_multistream.t
+++ b/test/recipes/70-test_quic_multistream.t
@@ -37,7 +37,7 @@ SKIP: {
     skip "no qlog", 1 if disabled('qlog');
     skip "not running CI tests", 1 unless $ENV{OSSL_RUN_CI_TESTS};
 
-    subtest "check qlog output" => sub {
+    subtest "generate and check qlog output" => sub {
         plan tests => 2;
         ok(run(test(["quic_radix_test",
                      srctop_file("test", "certs", "servercert.pem"),


### PR DESCRIPTION
Based off the changes in https://github.com/openssl/openssl/pull/32236, so will be blocked until that's merged

Fixes https://github.com/openssl/project/issues/1995

##### Checklist

- [x] tests are added or updated