### PR TITLE
Ignore SSL_set_read_ahead() for KTLS-enabled objects

### DIFF
--- a/doc/man3/SSL_CTX_set_read_ahead.pod
+++ b/doc/man3/SSL_CTX_set_read_ahead.pod
@@ -37,6 +37,9 @@ SSL_CTX_get_default_read_ahead() is identical to SSL_CTX_get_read_ahead().
 These functions cannot be used with QUIC SSL objects. SSL_set_read_ahead()
 has no effect if called on a QUIC SSL object.
 
+SSL_set_read_ahead() has no effect if called on a KTLS-enabled object where
+reading ahead is always on.
+
 =head1 NOTES
 
 These functions have no impact when used with DTLS. The return values for

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1896,6 +1896,11 @@ void SSL_set_read_ahead(SSL *s, int yes)
     if (sc == NULL)
         return;
 
+#ifndef OPENSSL_NO_KTLS
+    if (sc->rlayer.rrlmethod == &ossl_ktls_record_method)
+        return;
+#endif
+
     RECORD_LAYER_set_read_ahead(&sc->rlayer, yes);
 
     *opts++ = OSSL_PARAM_construct_int(OSSL_LIBSSL_RECORD_LAYER_PARAM_READ_AHEAD,


### PR DESCRIPTION
Unsetting the read_ahead option for KTLS-enabled objects results in an unexpected state (SSL_R_RECORD_LAYER_FAILURE) during subsequent SSL_read() calls, at least on FreeBSD 15.1 with in-tree OpenSSL 3.5.6 7 Apr 2026 (Library: OpenSSL 3.5.6 7 Apr 2026).

Therefore, SSL_set_read_ahead() should be ignored for such objects, as read_ahead is always enabled within ktls_new_record_layer().

https://github.com/openssl/openssl/blob/b05a190fe598cc1deb6d6e314ab8d1c4dd2d4436/ssl/record/methods/ktls_meth.c#L432-L438

OpenSSL 3.0 does not seem to have this issue. The following may be the source of the difference.

3.0
https://github.com/openssl/openssl/blob/e1eee6f6f7b70b3445602c0c93459c9130426c5c/ssl/record/rec_layer_s3.c#L276-L289

3.5
https://github.com/openssl/openssl/blob/b05a190fe598cc1deb6d6e314ab8d1c4dd2d4436/ssl/record/methods/tls_common.c#L382-L391

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
