### PR TITLE
Fix build break on evp_mac_fetch_from_prov

### DIFF
--- a/providers/implementations/rands/drbg_hmac.c.in
+++ b/providers/implementations/rands/drbg_hmac.c.in
@@ -484,7 +484,7 @@ static int drbg_fetch_algs_from_prov(const struct drbg_set_ctx_params_st *p,
     EVP_MAC_CTX_free(*macctx);
     *macctx = NULL;
 
-    mac = evp_mac_fetch_from_prov(prov, (const char *)p->mac->data, NULL);
+    mac = EVP_MAC_fetch(libctx, p->mac->data, propquery);
     if (mac) {
         *macctx = EVP_MAC_CTX_new(mac);
         /* The context holds on to the MAC */


### PR DESCRIPTION
Recent backport applied cleanly to 3.6, but 3.6 includes an extra call to evp_mac_fetch_from_prov, which uses a no longer in existance parameter.

Fix that up.

