### PR TITLE
Add CMS_verify() fuzzer

### DIFF
--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -32,7 +32,7 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   ENDIF
 
   IF[{- !$disabled{"cms"} -}]
-    PROGRAMS{noinst}=cms
+    PROGRAMS{noinst}=cms cms_verify
   ENDIF
 
   IF[{- !$disabled{"ct"} -}]
@@ -86,6 +86,10 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   SOURCE[cms]=cms.c driver.c
   INCLUDE[cms]=../include {- $ex_inc -}
   DEPEND[cms]=../libcrypto {- $ex_lib -}
+
+  SOURCE[cms_verify]=cms_verify.c driver.c
+  INCLUDE[cms_verify]=../include {- $ex_inc -}
+  DEPEND[cms_verify]=../libcrypto {- $ex_lib -}
 
   SOURCE[pkcs12]=pkcs12.c driver.c
   INCLUDE[pkcs12]=../include {- $ex_inc -}
@@ -218,7 +222,7 @@ IF[{- !$disabled{tests} -}]
   ENDIF
 
   IF[{- !$disabled{"cms"} -}]
-    PROGRAMS{noinst}=cms-test
+    PROGRAMS{noinst}=cms-test cms_verify-test
   ENDIF
 
   IF[{- !$disabled{"ct"} -}]
@@ -285,6 +289,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[cms-test]=cms.c $FUZZTESTSRC
   INCLUDE[cms-test]=../include ../test/mfail
   DEPEND[cms-test]=../libcrypto.a
+
+  SOURCE[cms_verify-test]=cms_verify.c $FUZZTESTSRC
+  INCLUDE[cms_verify-test]=../include ../test/mfail
+  DEPEND[cms_verify-test]=../libcrypto.a
 
   SOURCE[pkcs12-test]=pkcs12.c $FUZZTESTSRC
   INCLUDE[pkcs12-test]=../include ../test/mfail

--- a/fuzz/cms_verify.c
+++ b/fuzz/cms_verify.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+#include <limits.h>
+#include <openssl/bio.h>
+#include <openssl/cms.h>
+#include <openssl/err.h>
+#include "fuzzer.h"
+
+int FuzzerInitialize(int *argc, char ***argv)
+{
+    return 1;
+}
+
+int FuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+    BIO *indata = NULL;
+    BIO *out = NULL;
+    CMS_ContentInfo *cms = NULL;
+    const unsigned char *in;
+    size_t consumed;
+    size_t remaining;
+
+    if (len > LONG_MAX)
+        return 0;
+
+    in = buf;
+    cms = d2i_CMS_ContentInfo(NULL, &in, (long)len);
+    if (cms == NULL)
+        goto err;
+
+    consumed = (size_t)(in - buf);
+    remaining = len - consumed;
+    if (remaining > INT_MAX)
+        goto err;
+
+    if (consumed < len) {
+        indata = BIO_new_mem_buf(in, (int)remaining);
+        if (indata == NULL)
+            goto err;
+    }
+
+    out = BIO_new(BIO_s_null());
+    if (out == NULL)
+        goto err;
+
+    CMS_verify(cms, NULL, NULL, indata, out,
+        CMS_NO_SIGNER_CERT_VERIFY);
+
+err:
+    BIO_free(out);
+    CMS_ContentInfo_free(cms);
+    BIO_free(indata);
+    ERR_clear_error();
+    return 0;
+}
+
+void FuzzerCleanup(void)
+{
+}

--- a/test/recipes/99-test_fuzz_cms_verify.t
+++ b/test/recipes/99-test_fuzz_cms_verify.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+my $fuzzer = "cms_verify";
+setup("test_fuzz_${fuzzer}");
+
+plan skip_all => "This test requires cms support"
+    if disabled("cms");
+
+plan tests => 2; # one more due to below require_ok(...)
+
+require_ok(srctop_file('test','recipes','fuzz.pl'));
+
+fuzz_ok($fuzzer);


### PR DESCRIPTION
Add CMS_verify() fuzzer with CMS_NO_SIGNER_CERT_VERIFY
flag to exercise signature verification without requiring
trusted certificate store.

Motivated by : [CVE-2026-45447](https://openssl-library.org/news/vulnerabilities/index.html#:~:text=FIPS%20module%20boundary.-,CVE%2D2026%2D45447,-Severity) which affects PKCS7_verify(),
and add coverage for similar CMS_verify().

Corpora : https://github.com/openssl/fuzz-corpora/pull/36