### PR TITLE
Conform to RFC 9846 for the maximum legacy version field for tls 1.3

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2354,6 +2354,20 @@ int ssl_choose_client_version(SSL_CONNECTION *s, int version,
         return 0;
     }
 
+    /*-
+     * RFC 9846 section 4.2.3 requires a client receiving a TLS 1.3
+     * ServerHello whose legacy_version is not 0x0303 to abort the handshake
+     * with a protocol_version alert.  RFC 8446 placed no such requirement
+     * on the client.  The requirement on the server to send 0x0303 is not
+     * new -- it was already in RFC 8446 -- and OpenSSL servers comply, as
+     * do any others we know of.
+     */
+    if (s->version == TLS1_3_VERSION && version != TLS1_2_VERSION) {
+        s->version = origv;
+        SSLfatal(s, SSL_AD_PROTOCOL_VERSION, SSL_R_WRONG_SSL_VERSION);
+        return 0;
+    }
+
     switch (ssl->method->version) {
     default:
         if (s->version != ssl->method->version) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2264,6 +2264,19 @@ int ssl_choose_server_version(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello,
             if (s->ext.ech.success == 1 && best_vers != TLS1_3_VERSION)
                 return SSL_R_UNSUPPORTED_PROTOCOL;
 #endif
+            /*-
+             * RFC 9846 Section 4.2.2 requires a server selecting TLS
+             * 1.3 to abort the handshake with a protocol_version
+             * alert if the ClientHello carries a maximum
+             * legacy_version other than 0x0303.  RFC 8446 placed no
+             * such requirement on the server.  It is not possible
+             * with an OpenSSL client to send a TLS 1.3 client hello
+             * with any other value, even if TLS 1.3 is supported but
+             * not TLS 1.2.
+             */
+            if (best_vers == TLS1_3_VERSION && client_version != TLS1_2_VERSION)
+                return SSL_R_BAD_LEGACY_VERSION;
+
             if (s->hello_retry_request != SSL_HRR_NONE) {
                 /*
                  * This is after a HelloRetryRequest so we better check that we

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2274,6 +2274,9 @@ int ssl_choose_server_version(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello,
              * with any other value, even if TLS 1.3 is supported but
              * not TLS 1.2.
              */
+#if DTLS_MAX_VERSION_INTERNAL != DTLS1_2_VERSION
+#error Code needs update for DTLSv1.3
+#endif
             if (best_vers == TLS1_3_VERSION && client_version != TLS1_2_VERSION)
                 return SSL_R_BAD_LEGACY_VERSION;
 
@@ -2375,6 +2378,9 @@ int ssl_choose_client_version(SSL_CONNECTION *s, int version,
      * new -- it was already in RFC 8446 -- and OpenSSL servers comply, as
      * do any others we know of.
      */
+#if DTLS_MAX_VERSION_INTERNAL != DTLS1_2_VERSION
+#error Code needs update for DTLSv1.3
+#endif
     if (s->version == TLS1_3_VERSION && version != TLS1_2_VERSION) {
         s->version = origv;
         SSLfatal(s, SSL_AD_PROTOCOL_VERSION, SSL_R_WRONG_SSL_VERSION);

--- a/test/recipes/70-test_tls13legacyversion.t
+++ b/test/recipes/70-test_tls13legacyversion.t
@@ -1,0 +1,100 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
+use OpenSSL::Test::Utils;
+use TLSProxy::Proxy;
+use TLSProxy::Message;
+use Cwd qw(abs_path);
+
+my $test_name = "test_tls13legacyversion";
+setup($test_name);
+
+plan skip_all => "TLSProxy isn't usable on $^O"
+    if $^O =~ /^(VMS)$/;
+
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
+
+plan skip_all => "$test_name needs the sock feature enabled"
+    if disabled("sock");
+
+plan skip_all => "$test_name needs TLS1.3 enabled"
+    if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
+my $proxy = TLSProxy::Proxy->new(
+    undef,
+    cmdstr(app(["openssl"]), display => 1),
+    srctop_file("apps", "server.pem"),
+    (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE}),
+    have_IPv6()
+);
+
+#The legacy_version to write into the ServerHello, or undef to leave the
+#message alone.
+my $legacy_version;
+
+#Test 1: An unmodified handshake still succeeds
+$proxy->filter(\&legacy_version_filter);
+$legacy_version = undef;
+$proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+plan tests => 4;
+ok(TLSProxy::Message->success(), "Unmodified legacy_version");
+
+#Test 2: RFC 9846 section 4.2.3 - a TLS1.3 ServerHello carrying 0x0304 in
+#        legacy_version must be rejected with a protocol_version alert
+$proxy->clear();
+$legacy_version = TLSProxy::Record::VERS_TLS_1_3;
+$proxy->start();
+ok(is_protocol_version_client_alert(), "legacy_version of TLSv1.3");
+
+#Test 3: The same for a legacy_version below 0x0303
+$proxy->clear();
+$legacy_version = TLSProxy::Record::VERS_TLS_1_0;
+$proxy->start();
+ok(is_protocol_version_client_alert(), "legacy_version of TLSv1.0");
+
+#Test 4: A HelloRetryRequest is a TLS1.3 ServerHello, so the same applies.
+#        Force one by offering a group the server does not accept.
+$proxy->clear();
+if (disabled("ec")) {
+    $proxy->serverflags("-curves ffdhe3072");
+} else {
+    $proxy->serverflags("-curves P-384");
+}
+$legacy_version = TLSProxy::Record::VERS_TLS_1_3;
+$proxy->start();
+ok(is_protocol_version_client_alert(),
+   "legacy_version of TLSv1.3 in a HelloRetryRequest");
+
+#Validate that the handshake failed with a protocol_version alert sent by
+#the client
+sub is_protocol_version_client_alert
+{
+    return 0 unless TLSProxy::Message->fail();
+    my $alert = TLSProxy::Message->alert();
+    return 0 if !defined $alert || $alert->server();
+    return $alert->description() == TLSProxy::Message::AL_DESC_PROTOCOL_VERSION;
+}
+
+sub legacy_version_filter
+{
+    my $proxy = shift;
+
+    return if !defined $legacy_version;
+
+    foreach my $message (@{$proxy->message_list}) {
+        if ($message->mt == TLSProxy::Message::MT_SERVER_HELLO) {
+            $message->server_version($legacy_version);
+            $message->repack();
+        }
+    }
+}

--- a/test/recipes/70-test_tls13legacyversion.t
+++ b/test/recipes/70-test_tls13legacyversion.t
@@ -38,15 +38,17 @@ my $proxy = TLSProxy::Proxy->new(
     have_IPv6()
 );
 
-#The legacy_version to write into the ServerHello, or undef to leave the
-#message alone.
+#The legacy_version to write into a hello, or undef to leave the handshake
+#untouched.  $rewrite_client_hello picks which side gets rewritten: the
+#ClientHello when it is set, the ServerHello when it is not.
 my $legacy_version;
+my $rewrite_client_hello = 0;
 
 #Test 1: An unmodified handshake still succeeds
 $proxy->filter(\&legacy_version_filter);
 $legacy_version = undef;
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 4;
+plan tests => 6;
 ok(TLSProxy::Message->success(), "Unmodified legacy_version");
 
 #Test 2: RFC 9846 section 4.2.3 - a TLS1.3 ServerHello carrying 0x0304 in
@@ -75,25 +77,64 @@ $proxy->start();
 ok(is_protocol_version_client_alert(),
    "legacy_version of TLSv1.3 in a HelloRetryRequest");
 
+#Test 5: RFC 9846 section 4.2.2 - a server selecting TLS1.3 must reject a
+#        ClientHello carrying 0x0304 in legacy_version.  A modified
+#        ClientHello also breaks the handshake transcript, so check the
+#        alert rather than just the failure: the version check fires while
+#        the ClientHello is processed, long before any Finished message.
+$proxy->clear();
+$rewrite_client_hello = 1;
+$legacy_version = TLSProxy::Record::VERS_TLS_1_3;
+$proxy->start();
+ok(is_protocol_version_server_alert(),
+   "ClientHello legacy_version of TLSv1.3");
+
+#Test 6: The same for a ClientHello legacy_version below 0x0303
+$proxy->clear();
+$legacy_version = TLSProxy::Record::VERS_TLS_1_0;
+$proxy->start();
+ok(is_protocol_version_server_alert(),
+   "ClientHello legacy_version of TLSv1.0");
+
 #Validate that the handshake failed with a protocol_version alert sent by
 #the client
 sub is_protocol_version_client_alert
 {
+    return is_protocol_version_alert(0);
+}
+
+#The same, for an alert sent by the server
+sub is_protocol_version_server_alert
+{
+    return is_protocol_version_alert(1);
+}
+
+sub is_protocol_version_alert
+{
+    my $fromserver = shift;
+
     return 0 unless TLSProxy::Message->fail();
     my $alert = TLSProxy::Message->alert();
-    return 0 if !defined $alert || $alert->server();
+    return 0 if !defined $alert;
+    return 0 if ($alert->server() ? 1 : 0) != $fromserver;
     return $alert->description() == TLSProxy::Message::AL_DESC_PROTOCOL_VERSION;
 }
 
 sub legacy_version_filter
 {
     my $proxy = shift;
+    my $mt = $rewrite_client_hello ? TLSProxy::Message::MT_CLIENT_HELLO
+                                   : TLSProxy::Message::MT_SERVER_HELLO;
 
     return if !defined $legacy_version;
 
     foreach my $message (@{$proxy->message_list}) {
-        if ($message->mt == TLSProxy::Message::MT_SERVER_HELLO) {
-            $message->server_version($legacy_version);
+        if ($message->mt == $mt) {
+            if ($rewrite_client_hello) {
+                $message->client_version($legacy_version);
+            } else {
+                $message->server_version($legacy_version);
+            }
             $message->repack();
         }
     }


### PR DESCRIPTION
So this brings us into conformance with RFC 9846 only for our treatment of the maximum 
legacy version field. There are other things in there which probably require more thought that
we might want to do (such as forbidding TLS 1.0 and 1.1 completely) but I suspect not now. 

This sounds scary, but is not that. 

9846 newly requires the maximum legacy version to be 0x303 (TLS 1.2) and for the handshake
to be aborted at either end (client or server) if this is not the case in a *TLS 1.3* *hello message. 

We did not check this field at the client end, because all compliant servers already send 0x303 as
the maximum supported version, and have since RFC 8446 days, and even if TLS 1.2 was not among
the legacy versions that were supported. If this sounds strange, don't worry - by the time the server 
has seen the client's hello, decided the client will support 1.3 and it will do 1.3 (which it must do before
sending a server hello) this version completely does not matter. it's a nothingburger.   The OpenSSL
server has always behaved this way. This will likely only be changed by someone manipulating
things to check for spec compliance, or evil.  either way, the client check I believe is extremely
unlikely to affect anything real, so the spec conformance is cheap.

We also did not check the client hello at the server, and tolerated lower maximum versions. This was permitted
in RFC8446 but is not with RFC 9846 - however, to put this in context, it is not possible to have an
OpenSSL or LIbreSSL client (and many others) send a TLS 1.3 client hello without either supporting 
no legacy versions at all, or supporting TLS 1.2 as one of the legacy versions. - So an OpenSSL client
will never be affected by this check.  The only client likely affected by this check is 1) protocol compliance
checkers, or evil people attacking the handshake, or 2) A TLS stack that supports "holes" in it's supported
versions and somehow configures itself to support and send a TLS 1.3 client hello, and supports legacy
TLS versions, but *not* TLS 1.2, the latter is so vanishingly unlikely in any real configuration I believe 1) is
the more likely scenario by far. therefore again, spec conformance here is cheap, and should not affect
anyone. 

The net result is both the client and server may still be configured to support all tls versions, but if they
are configured to do tls 1.3, and any tls legacy versions, they must include tls 1.2 - they can't have a "hole"
(and I remind you such a configuration is impossible today in OpenSSL). To reiterate - this does not disallow
support for clients or servers being configured to support tls 1.0 and 1.1, with 1.2 and 1.3

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
