### PR TITLE
Deal with riscv64 qemu-user stderr noise

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -129,6 +129,10 @@ jobs:
             fips: no
           }, {
             arch: riscv64-linux-gnu,
+            # Pin the vector spec version, otherwise qemu-user emits a
+            # "vector version is not specified" warning on stderr at every
+            # process start, which upsets tests that parse or check stderr.
+            qemucpu: "rv64,v=true,vext_spec=v1.0",
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64,
             fips: no


### PR DESCRIPTION
When the RISCV vector extensions version is not explicitly specified, qemu issues warnings to stderr when running each program.  This broke some CI jobs.

Pin the version to the (current) "v1.0" default.

##### Checklist
- [x] tests are added or updated
