### PR TITLE
test: fix FIPS identity DRBG coverage

### DIFF
--- a/test/fipsidentity.cnf
+++ b/test/fipsidentity.cnf
@@ -7,6 +7,7 @@ config_diagnostics = 1
 
 [openssl_init]
 providers = provider_sect
+random = random_sect
 
 [provider_sect]
 default = default_sect
@@ -17,3 +18,6 @@ activate = yes
 
 [fips_sect]
 identity = fips-identity
+
+[random_sect]
+properties = fips=yes

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -31,7 +31,7 @@ plan tests => 13;
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
 my $fipsconf = srctop_file("test", "fips-and-base.cnf");
 my $defaultconf = srctop_file("test", "default.cnf");
-my $identityconf = srctop_file("test" ,"fips-identity.cnf");
+my $identityconf = srctop_file("test" ,"fipsidentity.cnf");
 my $tbs_data = $fipsmodule;
 my $bogus_data = $fipsconf;
 


### PR DESCRIPTION
While checking the test added by #32060, I noticed that it refers to `test/fips-identity.cnf`, while the file added by the same change is `test/fipsidentity.cnf`.

This is easy to miss because the missing configuration file doesn't make the OpenSSL commands fail. They continue with the default provider, so both RSA commands succeed and the test passes for the wrong reason.

Fixing the file name alone is not enough. The configuration loads both the default and renamed FIPS providers, and the application DRBG still comes from the default provider.

This patch keeps the existing two checks and changes only what is needed to make them exercise the affected path:

1. It uses the correct configuration file.
2. It sets `properties = fips=yes` in the random configuration. This makes the RSA key generation use a DRBG from the renamed FIPS provider.

With these changes the test fails in `rand_new_drbg` on the code before #32060 and passes with #32060 applied.

I tested the complete `test_cli_fips` recipe in a build configured with `enable-fips --strict-warnings`:

    make test TESTS=test_cli_fips HARNESS_VERBOSE=yes

The test passes, including both checks in the identity subtest.

##### Checklist
- [x] tests are added or updated