### PR TITLE
fuzz/provider.c: check evp##_up_ref return value in collect_##evp

### DIFF
--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -32,8 +32,11 @@
     {                                                                    \
         STACK_OF(evp) *obj_stack = stack;                                \
                                                                          \
-        if (sk_##evp##_push(obj_stack, obj) > 0)                         \
-            evp##_up_ref(obj);                                           \
+        if (!evp##_up_ref(obj))                                          \
+            return;                                                      \
+                                                                         \
+        if (sk_##evp##_push(obj_stack, obj) <= 0)                        \
+            evp##_free(obj);                                             \
     }                                                                    \
     static void init_##name(OSSL_LIB_CTX *libctx)                        \
     {                                                                    \


### PR DESCRIPTION
Coverity has reported an unchecked result of an evp##_up_ref call that is checked elsewhere.  Rewrite the collect routine to try to do the up_ref first, and then call free if push doesn't succeed.

Resolves: https://scan5.scan.coverity.com/#/project-view/65248/10222?selectedIssue=1695451
Resolves: https://scan5.scan.coverity.com/#/project-view/65248/10222?selectedIssue=1695454
Fixes: f3b988dc2951 "Add provider fuzzer"

Reviewed-by: Nikola Pajkovsky <nikolap@openssl.org>
Reviewed-by: Paul Dale <paul.dale@oracle.com>
MergeDate: Thu Jul  2 07:26:22 2026
(Merged from https://github.com/openssl/openssl/pull/31792)

(cherry picked from commit 862844ddf9f844863b309db47765615940b09cc8)
