### PR TITLE
doc: drop OPENSSL_armcap(3) references in EVP_CIPHER-SM4 (3.4 doc-nits fix)

### DIFF
--- a/doc/man7/EVP_CIPHER-SM4.pod
+++ b/doc/man7/EVP_CIPHER-SM4.pod
@@ -43,8 +43,7 @@ SM4 implementations in OpenSSL may use secret-dependent table lookups and
 are not guaranteed to be constant-time. In particular, the portable C
 implementation uses S-box and T-table lookups and may be vulnerable to
 cache-timing side-channel attacks. Which code path is used depends on CPU
-capabilities; see L<OPENSSL_armcap(3)>, L<OPENSSL_ia32cap(3)> and
-L<OPENSSL_riscvcap(3)>.
+capabilities; see L<OPENSSL_ia32cap(3)> and L<OPENSSL_riscvcap(3)>.
 
 The SM4-XTS implementation allows streaming to be performed, but each
 L<EVP_EncryptUpdate(3)> or L<EVP_DecryptUpdate(3)> call requires each input
@@ -55,8 +54,8 @@ stealing (CTS) is used to fill the block.
 
 =head1 SEE ALSO
 
-L<OPENSSL_armcap(3)>, L<OPENSSL_ia32cap(3)>, L<OPENSSL_riscvcap(3)>,
-L<OSSL_PROVIDER-default(7)>, L<provider-cipher(7)>
+L<OPENSSL_ia32cap(3)>, L<OPENSSL_riscvcap(3)>, L<OSSL_PROVIDER-default(7)>,
+L<provider-cipher(7)>
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
The `check_docs` job (`make doc-nits`) on the openssl-3.4 branch fails with:

    doc/man7/EVP_CIPHER-SM4.pod:1: reference to non-existing OPENSSL_armcap(3)

`OPENSSL_armcap(3)` was referenced by d0aa08287c ("Document SM4
table-lookup side-channel risk"), but that man page only exists on
master, not on the 3.4 branch.

Remove the references, keeping the existing `OPENSSL_ia32cap(3)` and
`OPENSSL_riscvcap(3)` ones.

Verified locally: `make doc-nits` passes.

Note: the `external-test-pyca` failure seen in the same CI runs is
**not** addressed here — it fails identically on openssl-3.5, so it
needs separate cross-branch investigation.
