### PR TITLE
Zeroize ML-KEM "implicit reject" flag

### DIFF
--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -1560,6 +1560,7 @@ static int decap(uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
         secret[i] = constant_time_select_8(mask, Kr[i], failure_key[i]);
     ret = 1;
 end:
+    mask = 0;
     OPENSSL_cleanse(buf, DECAP_BUFFER_SZ);
     return ret;
 }


### PR DESCRIPTION
As required by FIPS 203 Section 6.3, the "implicit reject" flag shall be destroyed prior to ML-KEM.Decaps_internal terminating.