### PR TITLE
test_pending_limit(): Use OPENSSL_FUNC instead of __func__

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -3867,12 +3867,12 @@ static int test_pending_limit(void)
     if (!TEST_true(ok)) {
         TEST_info("%s call to SSL_set_generic_request_uint"
                   "(SSL_VALUE_QUIC_MAX_PENDING_CONNS failed",
-            __func__);
+            OPENSSL_FUNC);
         goto end;
     }
 
     if (!TEST_true(SSL_listen(serverssl_listener))) {
-        TEST_info("%s SSL_listen() failed", __func__);
+        TEST_info("%s SSL_listen() failed", OPENSSL_FUNC);
         goto end;
     }
 


### PR DESCRIPTION
This is needed on 3.5 as that supports -ansi builds.

There is no point in having newer branches out of sync in this code, so this is submitted against master.
