### PR TITLE
[3.5] Backport #32060 (drbg fips conf identity fix) and #32346 (conf identity test fix)- #32355

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -674,7 +674,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
     EVP_RAND_CTX *ctx;
     OSSL_PARAM params[9], *p = params;
     const OSSL_PARAM *settables;
-    const char *prov_name;
     char *name, *cipher;
     int use_df = 1;
 
@@ -686,7 +685,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
         ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_FETCH_DRBG);
         return NULL;
     }
-    prov_name = ossl_provider_name(EVP_RAND_get0_provider(rand));
     ctx = EVP_RAND_CTX_new(rand, parent);
     EVP_RAND_free(rand);
     if (ctx == NULL) {
@@ -704,9 +702,6 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
         && OSSL_PARAM_locate_const(settables, OSSL_DRBG_PARAM_DIGEST))
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_DIGEST,
             dgbl->rng_digest, 0);
-    if (prov_name != NULL)
-        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_PROV_PARAM_CORE_PROV_NAME,
-            (char *)prov_name, 0);
     if (dgbl->rng_propq != NULL)
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_PROPERTIES,
             dgbl->rng_propq, 0);

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -725,7 +725,6 @@ static int drbg_ctr_set_ctx_params_locked(void *vctx, const OSSL_PARAM params[])
     PROV_DRBG *ctx = (PROV_DRBG *)vctx;
     PROV_DRBG_CTR *ctr = (PROV_DRBG_CTR *)ctx->data;
     OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
-    OSSL_PROVIDER *prov = NULL;
     const OSSL_PARAM *p;
     char *ecb;
     const char *propquery = NULL;
@@ -743,19 +742,14 @@ static int drbg_ctr_set_ctx_params_locked(void *vctx, const OSSL_PARAM params[])
         != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        propquery = (const char *)p->data;
     }
 
-    if ((p = OSSL_PARAM_locate_const(params,
-             OSSL_PROV_PARAM_CORE_PROV_NAME))
-        != NULL) {
-        if (p->data_type != OSSL_PARAM_UTF8_STRING)
-            return 0;
-        if ((prov = ossl_provider_find(libctx,
-                 (const char *)p->data, 1))
-            == NULL)
-            return 0;
-    }
+#ifndef FIPS_MODULE
+    propquery = "provider=default";
+    if (p != NULL
+        && p->data_type == OSSL_PARAM_UTF8_STRING)
+        propquery = (const char *)p->data;
+#endif
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_DRBG_PARAM_CIPHER)) != NULL) {
         const char *base = (const char *)p->data;
@@ -764,50 +758,33 @@ static int drbg_ctr_set_ctx_params_locked(void *vctx, const OSSL_PARAM params[])
 
         if (p->data_type != OSSL_PARAM_UTF8_STRING
             || p->data_size < ctr_str_len) {
-            ossl_provider_free(prov);
             return 0;
         }
         if (OPENSSL_strcasecmp("CTR", base + p->data_size - ctr_str_len) != 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_REQUIRE_CTR_MODE_CIPHER);
-            ossl_provider_free(prov);
             return 0;
         }
         if ((ecb = OPENSSL_strndup(base, p->data_size)) == NULL) {
-            ossl_provider_free(prov);
             return 0;
         }
         strcpy(ecb + p->data_size - ecb_str_len, "ECB");
         EVP_CIPHER_free(ctr->cipher_ecb);
         EVP_CIPHER_free(ctr->cipher_ctr);
+        ctr->cipher_ctr = NULL;
+        ctr->cipher_ecb = NULL;
         /*
          * Try to fetch algorithms from our own provider code, fallback
          * to generic fetch only if that fails
          */
-        (void)ERR_set_mark();
-        ctr->cipher_ctr = evp_cipher_fetch_from_prov(prov, base, NULL);
-        if (ctr->cipher_ctr == NULL) {
-            (void)ERR_pop_to_mark();
-            ctr->cipher_ctr = EVP_CIPHER_fetch(libctx, base, propquery);
-        } else {
-            (void)ERR_clear_last_mark();
-        }
-        (void)ERR_set_mark();
-        ctr->cipher_ecb = evp_cipher_fetch_from_prov(prov, ecb, NULL);
-        if (ctr->cipher_ecb == NULL) {
-            (void)ERR_pop_to_mark();
-            ctr->cipher_ecb = EVP_CIPHER_fetch(libctx, ecb, propquery);
-        } else {
-            (void)ERR_clear_last_mark();
-        }
+        ctr->cipher_ctr = EVP_CIPHER_fetch(libctx, base, propquery);
+        ctr->cipher_ecb = EVP_CIPHER_fetch(libctx, ecb, propquery);
         OPENSSL_free(ecb);
         if (ctr->cipher_ctr == NULL || ctr->cipher_ecb == NULL) {
             ERR_raise(ERR_LIB_PROV, PROV_R_UNABLE_TO_FIND_CIPHERS);
-            ossl_provider_free(prov);
             return 0;
         }
         cipher_init = 1;
     }
-    ossl_provider_free(prov);
 
     if (cipher_init && !drbg_ctr_init(ctx))
         return 0;

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -526,13 +526,6 @@ static int drbg_fetch_digest_from_prov(const OSSL_PARAM params[],
     if (digest == NULL)
         return 0;
 
-    if ((p = OSSL_PARAM_locate_const(params,
-             OSSL_PROV_PARAM_CORE_PROV_NAME))
-        == NULL)
-        return 0;
-    if (p->data_type != OSSL_PARAM_UTF8_STRING)
-        return 0;
-
     p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_DIGEST);
     if (p == NULL) {
         ret = 1;

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -508,12 +508,20 @@ static const OSSL_PARAM *drbg_hash_gettable_ctx_params(ossl_unused void *vctx,
 
 static int drbg_fetch_digest_from_prov(const OSSL_PARAM params[],
     OSSL_LIB_CTX *libctx,
-    EVP_MD **digest)
+    EVP_MD **digest,
+    const char *propq)
 {
-    OSSL_PROVIDER *prov = NULL;
     const OSSL_PARAM *p;
     EVP_MD *md = NULL;
     int ret = 0;
+    const char *propquery = NULL;
+
+#ifndef FIPS_MODULE
+    if (propq == NULL)
+        propquery = "provider=default";
+    else
+        propquery = propq;
+#endif
 
     if (digest == NULL)
         return 0;
@@ -523,8 +531,6 @@ static int drbg_fetch_digest_from_prov(const OSSL_PARAM params[],
         == NULL)
         return 0;
     if (p->data_type != OSSL_PARAM_UTF8_STRING)
-        return 0;
-    if ((prov = ossl_provider_find(libctx, (const char *)p->data, 1)) == NULL)
         return 0;
 
     p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_DIGEST);
@@ -536,15 +542,13 @@ static int drbg_fetch_digest_from_prov(const OSSL_PARAM params[],
     if (p->data_type != OSSL_PARAM_UTF8_STRING)
         goto done;
 
-    md = evp_digest_fetch_from_prov(prov, (const char *)p->data, NULL);
+    md = EVP_MD_fetch(libctx, p->data, propquery);
     if (md) {
         EVP_MD_free(*digest);
         *digest = md;
         ret = 1;
     }
-
 done:
-    ossl_provider_free(prov);
     return ret;
 }
 
@@ -556,15 +560,24 @@ static int drbg_hash_set_ctx_params_locked(void *vctx, const OSSL_PARAM params[]
     EVP_MD *prov_md = NULL;
     const EVP_MD *md;
     int md_size;
+    const OSSL_PARAM *p;
 
     if (!OSSL_FIPS_IND_SET_CTX_PARAM(ctx, OSSL_FIPS_IND_SETTABLE0, params,
             OSSL_DRBG_PARAM_FIPS_DIGEST_CHECK))
         return 0;
 
     /* try to fetch digest from provider */
+    p = OSSL_PARAM_locate_const(params, OSSL_DRBG_PARAM_PROPERTIES);
     (void)ERR_set_mark();
-    if (!drbg_fetch_digest_from_prov(params, libctx, &prov_md)) {
+    if (!drbg_fetch_digest_from_prov(params, libctx, &prov_md,
+            (p != NULL && p->data_type == OSSL_PARAM_UTF8_STRING) ? p->data : NULL)) {
         (void)ERR_pop_to_mark();
+        /*
+         * Its possible for drbg_fetch_digest_from_prov to return 0 after having set prov_md
+         * so we need to ensure we free it here
+         */
+        EVP_MD_free(prov_md);
+
         /* fall back to full implementation search */
         if (!ossl_prov_digest_load_from_params(&hash->digest, params, libctx))
             return 0;

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -412,9 +412,8 @@ static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(ossl_unused void *vctx,
 static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
     OSSL_LIB_CTX *libctx,
     EVP_MAC_CTX **macctx,
-    EVP_MD **digest)
+    EVP_MD **digest, const char *propq)
 {
-    OSSL_PROVIDER *prov = NULL;
     const OSSL_PARAM *p;
     const char *digest_name = NULL;
     const char *hmac_name = NULL;
@@ -422,6 +421,14 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
     EVP_MAC *mac = NULL;
     OSSL_PARAM mac_params[2], *mp = mac_params;
     int ret = 0;
+    const char *propquery = NULL;
+
+#ifndef FIPS_MODULE
+    if (propq == NULL)
+        propquery = "provider=default";
+    else
+        propquery = propq;
+#endif
 
     if (macctx == NULL || digest == NULL)
         return 0;
@@ -432,8 +439,6 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
         return 0;
     if (p->data_type != OSSL_PARAM_UTF8_STRING)
         return 0;
-    if ((prov = ossl_provider_find(libctx, (const char *)p->data, 1)) == NULL)
-        return 0;
 
     p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_DIGEST);
     if (p) {
@@ -441,7 +446,7 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
             ERR_raise(ERR_LIB_PROV, PROV_R_VALUE_ERROR);
             goto done;
         }
-        md = evp_digest_fetch_from_prov(prov, digest_name, NULL);
+        md = EVP_MD_fetch(libctx, p->data, propquery);
         if (md) {
             EVP_MD_free(*digest);
             *digest = md;
@@ -467,7 +472,7 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
     EVP_MAC_CTX_free(*macctx);
     *macctx = NULL;
 
-    mac = evp_mac_fetch_from_prov(prov, hmac_name, NULL);
+    mac = EVP_MAC_fetch(libctx, p->data, propquery);
     if (mac) {
         *macctx = EVP_MAC_CTX_new(mac);
         /* The context holds on to the MAC */
@@ -484,7 +489,6 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
     }
 
 done:
-    ossl_provider_free(prov);
     return ret;
 }
 
@@ -496,15 +500,23 @@ static int drbg_hmac_set_ctx_params_locked(void *vctx, const OSSL_PARAM params[]
     EVP_MD *prov_md = NULL;
     const EVP_MD *md;
     int md_size;
+    const OSSL_PARAM *p;
 
     if (!OSSL_FIPS_IND_SET_CTX_PARAM(ctx, OSSL_FIPS_IND_SETTABLE0, params,
             OSSL_DRBG_PARAM_FIPS_DIGEST_CHECK))
         return 0;
 
     /* try to fetch mac and digest from provider */
+    p = OSSL_PARAM_locate_const(params, OSSL_DRBG_PARAM_PROPERTIES);
     (void)ERR_set_mark();
-    if (!drbg_fetch_algs_from_prov(params, libctx, &hmac->ctx, &prov_md)) {
+    if (!drbg_fetch_algs_from_prov(params, libctx, &hmac->ctx, &prov_md,
+            (p != NULL && p->data_type == OSSL_PARAM_UTF8_STRING) ? p->data : NULL)) {
         (void)ERR_pop_to_mark();
+        /*
+         * Its possible for drbg_fetch_algs_from_prov to return 0 and set prov_md here
+         * so we need to free prov_md to be leak free
+         */
+        EVP_MD_free(prov_md);
         /* fall back to full implementation search */
         if (!ossl_prov_digest_load_from_params(&hmac->digest, params, libctx))
             return 0;

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -419,7 +419,7 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
     const char *hmac_name = NULL;
     EVP_MD *md = NULL;
     EVP_MAC *mac = NULL;
-    OSSL_PARAM mac_params[2], *mp = mac_params;
+    OSSL_PARAM mac_params[3], *mp = mac_params;
     int ret = 0;
     const char *propquery = NULL;
 
@@ -471,6 +471,8 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
         /* The context holds on to the MAC */
         EVP_MAC_free(mac);
         *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, (char *)digest_name, 0);
+        if (propquery)
+            *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_PROPERTIES, (char *)propquery, 0);
         *mp = OSSL_PARAM_construct_end();
         if (!EVP_MAC_CTX_set_params(*macctx, mac_params)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_MAC);

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -433,13 +433,6 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
     if (macctx == NULL || digest == NULL)
         return 0;
 
-    if ((p = OSSL_PARAM_locate_const(params,
-             OSSL_PROV_PARAM_CORE_PROV_NAME))
-        == NULL)
-        return 0;
-    if (p->data_type != OSSL_PARAM_UTF8_STRING)
-        return 0;
-
     p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_DIGEST);
     if (p) {
         if (!OSSL_PARAM_get_utf8_string_ptr(p, &digest_name)) {
@@ -472,7 +465,7 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
     EVP_MAC_CTX_free(*macctx);
     *macctx = NULL;
 
-    mac = EVP_MAC_fetch(libctx, p->data, propquery);
+    mac = EVP_MAC_fetch(libctx, hmac_name, propquery);
     if (mac) {
         *macctx = EVP_MAC_CTX_new(mac);
         /* The context holds on to the MAC */

--- a/test/fipsidentity.cnf
+++ b/test/fipsidentity.cnf
@@ -1,0 +1,19 @@
+openssl_conf = openssl_init
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+.include fipsmodule.cnf
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+fips = fips_sect
+
+[default_sect]
+activate = yes
+
+[fips_sect]
+identity = fips-identity

--- a/test/fipsidentity.cnf
+++ b/test/fipsidentity.cnf
@@ -7,6 +7,7 @@ config_diagnostics = 1
 
 [openssl_init]
 providers = provider_sect
+random = random_sect
 
 [provider_sect]
 default = default_sect
@@ -17,3 +18,6 @@ activate = yes
 
 [fips_sect]
 identity = fips-identity
+
+[random_sect]
+properties = fips=yes

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -26,11 +26,12 @@ use platform;
 my $no_check = disabled("fips") || disabled('fips-securitychecks');
 plan skip_all => "Test only supported in a fips build with security checks"
     if $no_check;
-plan tests => 12;
+plan tests => 13;
 
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
 my $fipsconf = srctop_file("test", "fips-and-base.cnf");
 my $defaultconf = srctop_file("test", "default.cnf");
+my $identityconf = srctop_file("test" ,"fips-identity.cnf");
 my $tbs_data = $fipsmodule;
 my $bogus_data = $fipsconf;
 
@@ -279,6 +280,43 @@ SKIP: {
 
         tsignverify($testtext_prefix, $fips_key, $fips_pub_key, $nonfips_key,
                     $nonfips_pub_key);
+    };
+}
+
+SKIP: {
+    skip "FIPS RSA tests because of no rsa in this build", 1
+        if disabled("rsa");
+
+    subtest RSA_identity => sub {
+        my $testtext_prefix = 'RSA';
+        my $fips_key = $testtext_prefix.'.fips.priv.pem';
+        my $fips_pub_key = $testtext_prefix.'.fips.pub.pem';
+        my $nonfips_key = $testtext_prefix.'.nonfips.priv.pem';
+        my $nonfips_pub_key = $testtext_prefix.'.nonfips.pub.pem';
+        my $testtext = '';
+
+        plan tests => 2;
+
+        my $destfips = bldtop_file("test-runs", "test_cli_fips", platform->dso("fips-identity"));
+        copy($fipsmodule, $destfips) or die("Couldn't copy file");
+        $ENV{OPENSSL_CONF} = $identityconf;
+        my $oldmodules = $ENV{OPENSSL_MODULES};
+        $ENV{OPENSSL_MODULES} = bldtop_dir("test-runs", "test_cli_fips");
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with a non-FIPS algorithm with the default provider';
+        print "Running genpkey";
+        ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA',
+                    '-pkeyopt', 'rsa_keygen_bits:512',
+                    '-out', $nonfips_key])),
+           $testtext);
+
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with a FIPS algorithm';
+        ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA',
+                    '-pkeyopt', 'rsa_keygen_bits:2048',
+                    '-out', $fips_key])),
+           $testtext);
+        $ENV{OPENSSL_MODULES} = $oldmodules;
     };
 }
 

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -31,7 +31,7 @@ plan tests => 13;
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
 my $fipsconf = srctop_file("test", "fips-and-base.cnf");
 my $defaultconf = srctop_file("test", "default.cnf");
-my $identityconf = srctop_file("test" ,"fips-identity.cnf");
+my $identityconf = srctop_file("test" ,"fipsidentity.cnf");
 my $tbs_data = $fipsmodule;
 my $bogus_data = $fipsconf;
 


### PR DESCRIPTION
Backport https://github.com/openssl/openssl/pull/32060 and https://github.com/openssl/openssl/issues/32346 to 3.5 stable branch

