### PR TITLE
Bugfix in the file BIO - avoiding false negatives based on previous errno

### DIFF
--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -182,6 +182,9 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
     FILE **fpp;
     char p[4];
     int st;
+#if defined(OPENSSL_SYS_WINDOWS)
+    int oldErr;
+#endif
 
     switch (cmd) {
     case BIO_C_FILE_SEEK:
@@ -198,6 +201,10 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
          * so we map the 0:non-0 return value here to 0:1 with a
          * double negation
          */
+#if defined(OPENSSL_SYS_WINDOWS)
+        oldErr = errno;
+        errno = 0;
+#endif
         if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             ret = !!(long)UP_feof(fp);
         else
@@ -211,6 +218,8 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
          */
         if (ret == 0 && errno == EINVAL)
             ret = -EINVAL;
+        else if (errno == 0)
+            errno = oldErr;
 #endif
         break;
     case BIO_C_FILE_TELL:


### PR DESCRIPTION
On Windows, BIO_eof() analyses errno after calling foef(). It worked incorrectly if feof() finished successfully but errno was set by a previous operation, so we should zero errno before calling feof().

This patch is based on @Rydier's idea.

Fixes #32179

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
