### PR TITLE
Consistently use ASN1_ITEM_rptr() for ASN1_ITEMs

### DIFF
--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -35,7 +35,7 @@ CMS_ContentInfo *d2i_CMS_ContentInfo(CMS_ContentInfo **a,
     const CMS_CTX *ctx = ossl_cms_get0_cmsctx(a == NULL ? NULL : *a);
 
     ci = (CMS_ContentInfo *)ASN1_item_d2i_ex((ASN1_VALUE **)a, in, len,
-        (CMS_ContentInfo_it()),
+        ASN1_ITEM_rptr(CMS_ContentInfo),
         ossl_cms_ctx_get0_libctx(ctx),
         ossl_cms_ctx_get0_propq(ctx));
     if (ci != NULL) {
@@ -48,7 +48,7 @@ CMS_ContentInfo *d2i_CMS_ContentInfo(CMS_ContentInfo **a,
 
 int i2d_CMS_ContentInfo(const CMS_ContentInfo *a, unsigned char **out)
 {
-    return ASN1_item_i2d((const ASN1_VALUE *)a, out, (CMS_ContentInfo_it()));
+    return ASN1_item_i2d((const ASN1_VALUE *)a, out, ASN1_ITEM_rptr(CMS_ContentInfo));
 }
 
 CMS_ContentInfo *CMS_ContentInfo_new_ex(OSSL_LIB_CTX *libctx, const char *propq)

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -73,7 +73,7 @@ PKCS7 *d2i_PKCS7(PKCS7 **a, const unsigned char **in, long len)
         propq = (*a)->ctx.propq;
     }
 
-    ret = (PKCS7 *)ASN1_item_d2i_ex((ASN1_VALUE **)a, in, len, (PKCS7_it()),
+    ret = (PKCS7 *)ASN1_item_d2i_ex((ASN1_VALUE **)a, in, len, ASN1_ITEM_rptr(PKCS7),
         libctx, propq);
     if (ret != NULL)
         ossl_pkcs7_resolve_libctx(ret);
@@ -82,7 +82,7 @@ PKCS7 *d2i_PKCS7(PKCS7 **a, const unsigned char **in, long len)
 
 int i2d_PKCS7(const PKCS7 *a, unsigned char **out)
 {
-    return ASN1_item_i2d((const ASN1_VALUE *)a, out, (PKCS7_it()));
+    return ASN1_item_i2d((const ASN1_VALUE *)a, out, ASN1_ITEM_rptr(PKCS7));
 }
 
 PKCS7 *PKCS7_new(void)

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -417,7 +417,7 @@ X509_CRL *X509_CRL_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509_CRL *crl = NULL;
 
-    crl = (X509_CRL *)ASN1_item_new((X509_CRL_it()));
+    crl = (X509_CRL *)ASN1_item_new(ASN1_ITEM_rptr(X509_CRL));
     if (!ossl_x509_crl_set0_libctx(crl, libctx, propq)) {
         X509_CRL_free(crl);
         crl = NULL;

--- a/crypto/x509/x_ietfatt.c
+++ b/crypto/x509/x_ietfatt.c
@@ -64,7 +64,7 @@ OSSL_IETF_ATTR_SYNTAX *d2i_OSSL_IETF_ATTR_SYNTAX(OSSL_IETF_ATTR_SYNTAX **a,
     int i;
 
     ias = (OSSL_IETF_ATTR_SYNTAX *)ASN1_item_d2i((ASN1_VALUE **)a, in, len,
-        OSSL_IETF_ATTR_SYNTAX_it());
+        ASN1_ITEM_rptr(OSSL_IETF_ATTR_SYNTAX));
     if (ias == NULL)
         return ias;
 
@@ -91,7 +91,7 @@ invalid_types:
 int i2d_OSSL_IETF_ATTR_SYNTAX(const OSSL_IETF_ATTR_SYNTAX *a,
     unsigned char **out)
 {
-    return ASN1_item_i2d((const ASN1_VALUE *)a, out, OSSL_IETF_ATTR_SYNTAX_it());
+    return ASN1_item_i2d((const ASN1_VALUE *)a, out, ASN1_ITEM_rptr(OSSL_IETF_ATTR_SYNTAX));
 }
 
 int OSSL_IETF_ATTR_SYNTAX_get_value_num(const OSSL_IETF_ATTR_SYNTAX *a)

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -280,7 +280,7 @@ X509_PUBKEY *X509_PUBKEY_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509_PUBKEY *pubkey = NULL;
 
-    pubkey = (X509_PUBKEY *)ASN1_item_new_ex(X509_PUBKEY_it(), libctx, propq);
+    pubkey = (X509_PUBKEY *)ASN1_item_new_ex(ASN1_ITEM_rptr(X509_PUBKEY), libctx, propq);
     if (!x509_pubkey_set0_libctx(pubkey, libctx, propq)) {
         X509_PUBKEY_free(pubkey);
         pubkey = NULL;

--- a/crypto/x509/x_req.c
+++ b/crypto/x509/x_req.c
@@ -158,7 +158,7 @@ X509_REQ *X509_REQ_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509_REQ *req = NULL;
 
-    req = (X509_REQ *)ASN1_item_new((X509_REQ_it()));
+    req = (X509_REQ *)ASN1_item_new(ASN1_ITEM_rptr(X509_REQ));
     if (!ossl_x509_req_set0_libctx(req, libctx, propq)) {
         X509_REQ_free(req);
         req = NULL;

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -156,7 +156,7 @@ X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509 *cert = NULL;
 
-    cert = (X509 *)ASN1_item_new_ex(X509_it(), libctx, propq);
+    cert = (X509 *)ASN1_item_new_ex(ASN1_ITEM_rptr(X509), libctx, propq);
     if (!ossl_x509_set0_libctx(cert, libctx, propq)) {
         X509_free(cert);
         cert = NULL;


### PR DESCRIPTION
Since #9285 this indirection is no longer really needed and perhaps
it is time to mop up the internal uses of ASN1_ITEM_rptr(). I just
wanted to point out that these are inconsistent with all the other
uses of ASN.1 items, of which there are tons.

PS: doc/man7/ossl-guide-migration.pod and doc/man3/X509_dup.pod
use FOO_it(), which I will leave to someone else to fix.