### PR TITLE
test: keep QUIC RADIX diagnostics out of the TAP pipe

### DIFF
--- a/test/recipes/70-test_quic_radix.t
+++ b/test/recipes/70-test_quic_radix.t
@@ -1,13 +1,49 @@
 #! /usr/bin/env perl
-# Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
-use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test qw/:DEFAULT result_file srctop_file/;
 use OpenSSL::Test::Utils;
+
+sub diagnose_failure {
+    my ($log, $max_bytes) = @_;
+    my $fh;
+
+    diag("Full stderr: $log");
+    if (!open($fh, "<", $log)) {
+        diag("Could not open stderr log: $!");
+        return;
+    }
+
+    binmode($fh);
+    my $size = -s $fh;
+    if (!defined($size)) {
+        diag("Could not determine stderr log size: $!");
+        close($fh);
+        return;
+    }
+
+    my $offset = $size > $max_bytes ? $size - $max_bytes : 0;
+    if (!seek($fh, $offset, 0)) {
+        diag("Could not seek in stderr log: $!");
+        close($fh);
+        return;
+    }
+
+    # Do not start the diagnostic output with a truncated line.
+    scalar <$fh> if $offset > 0;
+
+    diag("Stderr tail (up to " . ($max_bytes / 1024) . " KiB):");
+    while (my $line = <$fh>) {
+        $line =~ s/\r?\n\z//;
+        diag($line);
+    }
+    close($fh);
+}
 
 setup("test_quic_radix");
 
@@ -16,6 +52,13 @@ plan skip_all => "QUIC protocol is not supported by this OpenSSL build"
 
 plan tests => 1;
 
-ok(run(test(["quic_radix_test",
-             srctop_file("test", "certs", "servercert.pem"),
-             srctop_file("test", "certs", "serverkey.pem")])));
+# Keep the test's multi-megabyte diagnostics out of the TAP pipe.
+my $redirect = $ENV{HARNESS_ACTIVE} && !$ENV{HARNESS_VERBOSE};
+my $stderr_log = result_file("quic_radix_test.log");
+my $result = run(test(["quic_radix_test",
+                       srctop_file("test", "certs", "servercert.pem"),
+                       srctop_file("test", "certs", "serverkey.pem")],
+                      $redirect ? (stderr => $stderr_log) : ()));
+
+diagnose_failure($stderr_log, 32 * 1024) if !$result && $redirect;
+ok($result, "running QUIC RADIX tests");


### PR DESCRIPTION
`quic_radix_test` emits several MiB of diagnostics to stderr even when it succeeds. In #32128 the process was observed blocked in `fwrite` while writing this output to its inherited stderr pipe. Its actual TAP stdout is only a few KiB.

As a targeted workaround, when the recipe runs under a non-verbose harness, redirect the test stderr to `quic_radix_test.log` in its result directory.
If the test fails, replay diagnostics from at most the final 32 KiB and report the full log path. This keeps failures diagnosable without sending the whole multi-megabyte log back through the pipe. CI jobs which don't archive test result directories retain only the bounded replay.

Verbose and direct recipe runs remain unchanged. This removes the observed writer-side backpressure point, but doesn't establish why the harness reader stopped making progress in the reported runs.

The change is deliberately local to the noisy QUIC RADIX recipe and doesn't alter `OpenSSL::Test::run` or general TAP harness behavior.

Related to #32128

##### Checklist
- [x] tests are added or updated