### PR TITLE
ocsp: Reject update times X509_cmp_time() cannot compare

### DIFF
--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -310,7 +310,7 @@ int OCSP_resp_find_status(OCSP_BASICRESP *bs, OCSP_CERTID *id, int *status,
 int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisupd,
     ASN1_GENERALIZEDTIME *nextupd, long nsec, long maxsec)
 {
-    int ret = 1;
+    int ret = 1, cmp;
     time_t t_now, t_tmp;
 
     time(&t_now);
@@ -320,16 +320,20 @@ int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisupd,
         ret = 0;
     } else {
         t_tmp = t_now + nsec;
-        if (X509_cmp_time(thisupd, &t_tmp) > 0) {
+        cmp = X509_cmp_time(thisupd, &t_tmp);
+        if (cmp == 0) {
+            ERR_raise(ERR_LIB_OCSP, OCSP_R_ERROR_IN_THISUPDATE_FIELD);
+            ret = 0;
+        } else if (cmp > 0) {
             ERR_raise(ERR_LIB_OCSP, OCSP_R_STATUS_NOT_YET_VALID);
             ret = 0;
         }
 
         /*
          * If maxsec specified check thisUpdate is not more than maxsec in
-         * the past
+         * the past. Skip this check if thisUpdate could not be compared above.
          */
-        if (maxsec >= 0) {
+        if (cmp != 0 && maxsec >= 0) {
             t_tmp = t_now - maxsec;
             if (X509_cmp_time(thisupd, &t_tmp) < 0) {
                 ERR_raise(ERR_LIB_OCSP, OCSP_R_STATUS_TOO_OLD);
@@ -347,7 +351,11 @@ int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisupd,
         ret = 0;
     } else {
         t_tmp = t_now - nsec;
-        if (X509_cmp_time(nextupd, &t_tmp) < 0) {
+        cmp = X509_cmp_time(nextupd, &t_tmp);
+        if (cmp == 0) {
+            ERR_raise(ERR_LIB_OCSP, OCSP_R_ERROR_IN_NEXTUPDATE_FIELD);
+            ret = 0;
+        } else if (cmp < 0) {
             ERR_raise(ERR_LIB_OCSP, OCSP_R_STATUS_EXPIRED);
             ret = 0;
         }

--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -11,12 +11,14 @@
 
 #include <openssl/opensslconf.h>
 #include <openssl/crypto.h>
+#include <openssl/err.h>
 #include <openssl/ocsp.h>
 #include <openssl/x509.h>
 #include <openssl/asn1.h>
 #include <openssl/pem.h>
 
 #include "testutil.h"
+#include "internal/nelem.h"
 
 static const char *certstr;
 static const char *privkeystr;
@@ -213,6 +215,57 @@ err:
     return ret;
 }
 
+static const struct {
+    const char *thisupd;
+    const char *nextupd;
+    long maxsec;
+    int reason;
+} invalid_update_tests[] = {
+    { "99991231235959+0100", NULL, 60,
+        OCSP_R_ERROR_IN_THISUPDATE_FIELD },
+    { "20000101000000Z", "20000102000000.5Z", -1,
+        OCSP_R_ERROR_IN_NEXTUPDATE_FIELD },
+    /* Canonical forms must keep their existing, specific reasons */
+    { "20000101000000Z", NULL, 60, OCSP_R_STATUS_TOO_OLD },
+    { "20000101000000Z", "20000102000000Z", -1,
+        OCSP_R_STATUS_EXPIRED },
+};
+
+static int test_invalid_update_time(int idx)
+{
+    ASN1_GENERALIZEDTIME *thisupd = NULL, *nextupd = NULL;
+    unsigned long errcode;
+    int ret = 0;
+
+    if (!TEST_ptr(thisupd = ASN1_GENERALIZEDTIME_new())
+        || !TEST_true(ASN1_GENERALIZEDTIME_set_string(
+            thisupd, invalid_update_tests[idx].thisupd)))
+        goto err;
+    if (invalid_update_tests[idx].nextupd != NULL
+        && (!TEST_ptr(nextupd = ASN1_GENERALIZEDTIME_new())
+            || !TEST_true(ASN1_GENERALIZEDTIME_set_string(
+                nextupd, invalid_update_tests[idx].nextupd))))
+        goto err;
+
+    ERR_clear_error();
+    if (!TEST_false(OCSP_check_validity(
+            thisupd, nextupd, 0, invalid_update_tests[idx].maxsec)))
+        goto err;
+    errcode = ERR_get_error();
+    if (!TEST_int_eq(ERR_GET_LIB(errcode), ERR_LIB_OCSP)
+        || !TEST_int_eq(ERR_GET_REASON(errcode),
+            invalid_update_tests[idx].reason)
+        || !TEST_ulong_eq(ERR_peek_error(), 0))
+        goto err;
+    ret = 1;
+
+err:
+    ERR_clear_error();
+    ASN1_GENERALIZEDTIME_free(thisupd);
+    ASN1_GENERALIZEDTIME_free(nextupd);
+    return ret;
+}
+
 #endif /* OPENSSL_NO_OCSP */
 
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
@@ -231,6 +284,8 @@ int setup_tests(void)
     ADD_TEST(test_resp_signer);
     ADD_ALL_TESTS(test_access_description, 3);
     ADD_TEST(test_ocsp_url_svcloc_new);
+    ADD_ALL_TESTS(test_invalid_update_time,
+        OSSL_NELEM(invalid_update_tests));
 #endif
     return 1;
 }


### PR DESCRIPTION
`OCSP_check_validity` was treating a zero return from `X509_cmp_time` as a successful comparison. For `GeneralizedTime` values with a numeric UTC offset or fractional seconds, zero means that the time could not be compared. This could let an invalid OCSP update time pass the freshness checks.

This change reports the appropriate field error when either `thisUpdate` or `nextUpdate` can't be compared. It also skips the optional maximum age check when the first `thisUpdate` comparison has already failed.

The tests cover both unsupported time forms, the `maxsec >= 0` path, and the existing stale and expired cases. The bytewise ordering check is left as it was because these unsupported encodings already cause the response to fail.

This PR is for the affected 3.x branches. Master and 4.0 already convert these times before checking freshness, following commit 4036f4b0e324.

The change is based on 3.6 and applies cleanly to 3.5, 3.4, and 3.0.

Fixes #32377

##### Checklist

- [x] tests are added or updated