### PR TITLE
ocsp: Report expired nextUpdate with the correct reason

### DIFF
--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -347,7 +347,7 @@ int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisupd,
         }
         /* Check nextUpdate is not more than nsec in the past */
         if (next_time < t_now - nsec) {
-            ERR_raise(ERR_LIB_OCSP, OCSP_R_STATUS_NOT_YET_VALID);
+            ERR_raise(ERR_LIB_OCSP, OCSP_R_STATUS_EXPIRED);
             goto err;
         }
         /* Also don't allow nextUpdate to precede thisUpdate */


### PR DESCRIPTION
`OCSP_check_validity` already rejects an OCSP response when `nextUpdate` is too old, but master and 4.0 put `OCSP_R_STATUS_NOT_YET_VALID` on the error queue.

This changes the reason to `OCSP_R_STATUS_EXPIRED`, which is what the 3.x code reports. The return value and the certificate verification result don't change.

I tested this with a `--strict-warnings` build, the OCSP test recipe, and the small reproducer attached to #32399. The same source change applies to the openssl-4.0 branch.

Fixes #32399

CLA: trivial