### PR TITLE
PSK: Fix ALPN handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,13 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Fixed a bug where a TLS 1.3 session ticket could retain a stale ALPN
+   protocol from an earlier connection after a resumption negotiated a
+   different protocol (or none), on both the server and the client,
+   which could otherwise affect a later 0-RTT decision.
+
+   *Daniel Kubec and Viktor Dukhovni*
+
  * Fixed TLS 1.3 clients to encrypt 0-RTT early data with the first offered
    PSK identity (RFC 9846 section 4.3.10) when a 0-RTT-capable resumption
    ticket has aged out and an external PSK is offered in its place. The early

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3226,6 +3226,34 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
     s->session->session_id_length = sess_len;
     s->session->not_resumable = 0;
 
+    /*
+     * Refresh the session's recollection of the negotiated ALPN protocol to
+     * match this connection, rather than leaving it as whatever the session
+     * (or the session it was duplicated from, on a resumption) previously
+     * carried. Without this, a connection that resumes a session but
+     * negotiates no ALPN (or a different one) leaves the stale protocol
+     * name in place, and a later 0-RTT attempt against this ticket can
+     * incorrectly trip the "inconsistent early data alpn" check -- or, if
+     * the client happens to offer that same stale protocol again by
+     * coincidence, incorrectly appear consistent. This mirrors, on the
+     * client, the server-side fix for issue #11197 in
+     * tls_construct_new_session_ticket().
+     */
+    OPENSSL_free(s->session->ext.alpn_selected);
+    if (s->s3.alpn_selected != NULL) {
+        s->session->ext.alpn_selected = OPENSSL_memdup(s->s3.alpn_selected,
+            s->s3.alpn_selected_len);
+        if (s->session->ext.alpn_selected == NULL) {
+            s->session->ext.alpn_selected_len = 0;
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
+            goto err;
+        }
+        s->session->ext.alpn_selected_len = s->s3.alpn_selected_len;
+    } else {
+        s->session->ext.alpn_selected = NULL;
+        s->session->ext.alpn_selected_len = 0;
+    }
+
     /* This is a standalone message in TLSv1.3, so there is no more to read */
     if (SSL_CONNECTION_IS_TLS13(s)) {
         const EVP_MD *md = ssl_handshake_md(s);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4596,6 +4596,18 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
                 goto err;
             }
             s->session->ext.alpn_selected_len = s->s3.alpn_selected_len;
+        } else {
+            /*
+             * No ALPN was negotiated on this handshake. If we resumed a
+             * session that had previously negotiated ALPN, the stale value
+             * must be cleared from the (copied) session before it is stored
+             * in the new ticket. Otherwise a subsequent 0-RTT attempt using
+             * that ticket would incorrectly assume an ALPN protocol had been
+             * negotiated. See tls_handle_alpn().
+             */
+            OPENSSL_free(s->session->ext.alpn_selected);
+            s->session->ext.alpn_selected = NULL;
+            s->session->ext.alpn_selected_len = 0;
         }
         s->session->ext.max_early_data = s->max_early_data;
     }

--- a/test/tls13tickettest.c
+++ b/test/tls13tickettest.c
@@ -62,6 +62,7 @@ struct stats {
     unsigned int sh_has_psk;
     unsigned int sh_has_supported_versions;
     unsigned int ee_has_early_data;
+    unsigned int ee_has_alpn;
 };
 
 struct tls13_endpoint {
@@ -196,9 +197,13 @@ static void parse_ee_exts(const unsigned char *buf, size_t len, struct stats *x)
         case TLSEXT_TYPE_early_data:
             x->ee_has_early_data = 1;
             break;
+        case TLSEXT_TYPE_application_layer_protocol_negotiation:
+            x->ee_has_alpn = 1;
+            break;
         }
     }
-    TEST_info("ee extensions: early_data=%d", x->ee_has_early_data);
+    TEST_info("ee extensions: early_data=%d alpn=%d",
+        x->ee_has_early_data, x->ee_has_alpn);
 }
 
 static void msg_cb(int write_p, int version, int content_type,
@@ -369,6 +374,120 @@ static int enable_shared_psk(SSL *cssl, SSL *sssl)
     SSL_set_psk_use_session_callback(cssl, shared_psk_use_cb);
     SSL_set_psk_find_session_callback(sssl, ext_psk_find_cb);
     return 1;
+}
+
+/*
+ * The server offers a single protocol via server_alpn and selects it when the
+ * client advertises it. The client advertises a protocol using the
+ * length-prefixed wire form expected by SSL_set_alpn_protos().
+ */
+static const char *server_alpn = NULL;
+
+static int alpn_select_cb(SSL *ssl, const unsigned char **out,
+    unsigned char *outlen, const unsigned char *in,
+    unsigned int inlen, void *arg)
+{
+    unsigned int protlen = 0;
+    const unsigned char *prot;
+
+    if (server_alpn == NULL)
+        return SSL_TLSEXT_ERR_NOACK;
+
+    for (prot = in; prot < in + inlen; prot += protlen) {
+        protlen = *prot++;
+        if (in + inlen < prot + protlen)
+            return SSL_TLSEXT_ERR_NOACK;
+        if (protlen == strlen(server_alpn)
+            && memcmp(prot, server_alpn, protlen) == 0) {
+            *out = prot;
+            *outlen = protlen;
+            return SSL_TLSEXT_ERR_OK;
+        }
+    }
+    return SSL_TLSEXT_ERR_NOACK;
+}
+
+static int alpn_server_enable(SSL_CTX *ctx, const char *proto)
+{
+    server_alpn = proto;
+    SSL_CTX_set_alpn_select_cb(ctx, alpn_select_cb, NULL);
+    return 1;
+}
+
+/* Change which protocol the server selects for the next handshake. */
+static int alpn_server_select(const char *proto)
+{
+    server_alpn = proto;
+    return 1;
+}
+
+/* Append protocol proto (length-prefixed) to the wire buffer at *n. */
+static int alpn_wire_add(unsigned char *wire, size_t cap, unsigned int *n,
+    const char *proto)
+{
+    unsigned int plen = (unsigned int)strlen(proto);
+
+    if (plen == 0 || plen > 255 || *n + 1 + plen > cap)
+        return 0;
+    wire[(*n)++] = (unsigned char)plen;
+    memcpy(wire + *n, proto, plen);
+    *n += plen;
+    return 1;
+}
+
+static int alpn_client_offer(SSL *ssl, const char *proto)
+{
+    unsigned char wire[256];
+    unsigned int n = 0;
+
+    if (!alpn_wire_add(wire, sizeof(wire), &n, proto))
+        return 0;
+    /* SSL_set_alpn_protos() returns 0 on success. */
+    return SSL_set_alpn_protos(ssl, wire, n) == 0;
+}
+
+static int alpn_client_offer2(SSL *ssl, const char *p1, const char *p2)
+{
+    unsigned char wire[256];
+    unsigned int n = 0;
+
+    if (!alpn_wire_add(wire, sizeof(wire), &n, p1)
+        || !alpn_wire_add(wire, sizeof(wire), &n, p2))
+        return 0;
+    /* SSL_set_alpn_protos() returns 0 on success. */
+    return SSL_set_alpn_protos(ssl, wire, n) == 0;
+}
+
+/* Returns 1 if the connection negotiated exactly the given ALPN protocol. */
+static int alpn_conn_selected_is(SSL *ssl, const char *proto)
+{
+    const unsigned char *alpn = NULL;
+    unsigned int alpnlen = 0;
+
+    SSL_get0_alpn_selected(ssl, &alpn, &alpnlen);
+    return alpn != NULL
+        && alpnlen == strlen(proto)
+        && memcmp(alpn, proto, alpnlen) == 0;
+}
+
+/* Returns 1 if the connection negotiated no ALPN protocol. */
+static int alpn_conn_selected_none(SSL *ssl)
+{
+    const unsigned char *alpn = NULL;
+    unsigned int alpnlen = 0;
+
+    SSL_get0_alpn_selected(ssl, &alpn, &alpnlen);
+    return alpn == NULL && alpnlen == 0;
+}
+
+/* Returns 1 if the session stores no ALPN protocol. */
+static int alpn_sess_selected_none(SSL *ssl)
+{
+    const unsigned char *alpn = NULL;
+    size_t alpnlen = 0;
+
+    SSL_SESSION_get0_alpn_selected(SSL_get_session(ssl), &alpn, &alpnlen);
+    return alpn == NULL && alpnlen == 0;
 }
 
 /*
@@ -848,6 +967,280 @@ static int test_tls13_ticket_early_data_accepted(void)
     return test;
 }
 
+/*
+ * TLS 1.3 stale ALPN cleared from a resumption ticket
+ *
+ * A session that negotiated ALPN is resumed on a connection that negotiates no
+ * ALPN at all (the client advertises none). The NewSessionTicket issued for the
+ * resumed session must not retain the ALPN protocol from the original session;
+ * otherwise a later 0-RTT attempt using that ticket would incorrectly assume
+ * that protocol had been negotiated.
+ *
+ * Regression test for GitHub issue #11197: tls_construct_new_session_ticket()
+ * copied s->s3.alpn_selected into the session only when an ALPN protocol was
+ * negotiated, but failed to clear s->session->ext.alpn_selected when it wasn't.
+ *
+ * A third connection then resumes the now-ALPN-cleared ticket and negotiates
+ * "goodalpn" again -- the same, non-empty protocol as the original session,
+ * coincidentally. Since the ticket being resumed carries no ALPN, 0-RTT must
+ * still be rejected: the client's SSL_write_early_data() appears to succeed
+ * (the data is sent before the server's response is known), but a post hoc
+ * SSL_get_early_data_status() check confirms the server never accepted it.
+ *
+ * A fourth connection resumes that same ALPN-cleared ticket a second time --
+ * anti-replay is disabled for this test, so reusing it twice is not itself a
+ * reason for rejection -- but this time advertises no ALPN, consistent with
+ * what the ticket actually recorded. 0-RTT must now be accepted. Without this
+ * case, the rejection asserted for connection 3 would be unfalsifiable: it
+ * would look identical if early data were simply never being accepted here
+ * for any reason at all.
+ *
+ * The fourth connection resumes from an independent SSL_SESSION_dup() copy
+ * of the ticket (taken before connection 3 uses the original), rather than
+ * the original SSL_SESSION object itself: completing a handshake from a
+ * resumed session marks that SSL_SESSION object not-resumable on the client
+ * side as a single-use safeguard, independent of (and in addition to) the
+ * server's SSL_OP_NO_ANTI_REPLAY setting. Resuming the literal object a
+ * second time would therefore quietly fall back to a full, non-PSK
+ * handshake instead of testing the intended 0-RTT path.
+ */
+static int test_tls13_ticket_alpn_cleared(void)
+{
+    const unsigned char m[] = "message";
+    unsigned char buf[256];
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed2 = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed3 = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL, *sess2b = NULL;
+    size_t w = 0, r = 0;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(SSL_CTX_set_max_early_data(s, SSL3_RT_MAX_PLAIN_LENGTH))
+        && TEST_true(SSL_CTX_set_options(s, SSL_OP_NO_ANTI_REPLAY) != 0)
+        && TEST_true(alpn_server_enable(s, "goodalpn"))
+        /*
+         * Connection 1: the client advertises "goodalpn", the server selects
+         * it, and the negotiated protocol is stored in the session.
+         */
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(alpn_client_offer(initial.c.ssl, "goodalpn"))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(alpn_conn_selected_is(initial.s.ssl, "goodalpn"))
+        && TEST_true(alpn_conn_selected_is(initial.c.ssl, "goodalpn"))
+        && TEST_uint_eq(initial.c.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.s.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.c.stats.tickets, 2)
+        && TEST_uint_eq(initial.s.stats.tickets, 2)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(initial.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(initial.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(initial.s.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(initial.c.stats.ee_has_alpn, 1)
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        /*
+         * Connection 2: resume the session, but the client advertises no ALPN
+         * this time so nothing is negotiated. The server issues a fresh
+         * NewSessionTicket for the resumed session; its stored ALPN must be
+         * cleared rather than inheriting "goodalpn" from the original session.
+         */
+        && TEST_true(tls_channel_init(c, s, &resumed))
+        && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+        && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(SSL_session_reused(resumed.c.ssl))
+        && TEST_uint_eq(resumed.c.stats.nst_msgs, 1)
+        && TEST_uint_eq(resumed.s.stats.nst_msgs, 1)
+        && TEST_uint_eq(resumed.c.stats.tickets, 1)
+        && TEST_uint_eq(resumed.s.stats.tickets, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk, 1)
+        && TEST_uint_eq(resumed.c.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(resumed.s.stats.ch_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ch_has_psk_kex_modes, 1)
+        && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.s.stats.ee_has_alpn, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_alpn, 0)
+        /* No ALPN was negotiated on the resumption handshake ... */
+        && TEST_true(alpn_conn_selected_none(resumed.s.ssl))
+        && TEST_true(alpn_conn_selected_none(resumed.c.ssl))
+        /* ... so the session written into the new ticket must carry none. */
+        && TEST_true(alpn_sess_selected_none(resumed.s.ssl))
+        && TEST_true(tls_shutdown(&resumed))
+        && TEST_ptr(sess2 = SSL_get1_session(resumed.c.ssl))
+        /*
+         * Connection 3 is about to resume sess2 and, since 0-RTT is attempted
+         * on it, the client will mark sess2 not-resumable once that attempt
+         * completes (this happens on any full handshake completed from a
+         * resumed session, independent of the server's anti-replay setting --
+         * it is a client-side single-use restriction on the SSL_SESSION
+         * object itself). Take an independent copy now, while sess2 is still
+         * untouched, so connection 4 below has its own unconsumed ticket to
+         * resume from.
+         */
+        && TEST_ptr(sess2b = SSL_SESSION_dup(sess2))
+        /*
+         * Connection 3: resume the ALPN-cleared ticket from connection 2, but
+         * this time negotiate "goodalpn" again -- the same protocol as the
+         * original session, purely by coincidence. The ticket being resumed
+         * has no ALPN of its own, so 0-RTT must be rejected regardless of
+         * this match.
+         */
+        && TEST_true(tls_channel_init(c, s, &resumed2))
+        && TEST_true(alpn_client_offer(resumed2.c.ssl, "goodalpn"))
+        && TEST_true(SSL_set_session(resumed2.c.ssl, sess2))
+        && TEST_true(SSL_write_early_data(resumed2.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        /* The server skips the early data: nothing is delivered to the app. */
+        && TEST_int_eq(SSL_read_early_data(resumed2.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_FINISH)
+        && TEST_size_t_eq(r, 0)
+        && TEST_true(create_ssl_connection(resumed2.s.ssl, resumed2.c.ssl, 0))
+        && TEST_true(SSL_session_reused(resumed2.c.ssl))
+        && TEST_true(alpn_conn_selected_is(resumed2.s.ssl, "goodalpn"))
+        && TEST_true(alpn_conn_selected_is(resumed2.c.ssl, "goodalpn"))
+        && TEST_uint_eq(resumed2.s.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(resumed2.c.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(resumed2.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed2.c.stats.ee_has_early_data, 0)
+        /* Post hoc: the write appeared to succeed, but nothing was accepted. */
+        && TEST_int_eq(SSL_get_early_data_status(resumed2.c.ssl),
+            SSL_EARLY_DATA_REJECTED)
+        && TEST_true(tls_shutdown(&resumed2))
+        /*
+         * Connection 4: resume the same ticket from connection 2 again, via
+         * the untouched copy (sess2b) taken before connection 3 consumed
+         * sess2 -- anti-replay is off, so a second use of that ticket is not
+         * itself rejected -- but this time advertise no ALPN, matching what
+         * the ticket recorded. 0-RTT must be accepted, proving connection 3
+         * was rejected for the ALPN mismatch specifically, not because early
+         * data never works.
+         */
+        && TEST_true(tls_channel_init(c, s, &resumed3))
+        && TEST_true(SSL_set_session(resumed3.c.ssl, sess2b))
+        && TEST_true(SSL_write_early_data(resumed3.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        && TEST_int_eq(SSL_read_early_data(resumed3.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_SUCCESS)
+        && TEST_mem_eq(buf, r, m, sizeof(m))
+        && TEST_int_gt(SSL_connect(resumed3.c.ssl), 0)
+        && TEST_int_eq(SSL_read_early_data(resumed3.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_FINISH)
+        && TEST_size_t_eq(r, 0)
+        && TEST_int_eq(SSL_get_early_data_status(resumed3.s.ssl), SSL_EARLY_DATA_ACCEPTED)
+        && TEST_true(create_ssl_connection(resumed3.s.ssl, resumed3.c.ssl, 0))
+        && TEST_int_eq(SSL_get_early_data_status(resumed3.c.ssl), SSL_EARLY_DATA_ACCEPTED)
+        && TEST_true(SSL_session_reused(resumed3.c.ssl))
+        && TEST_true(alpn_conn_selected_none(resumed3.s.ssl))
+        && TEST_true(alpn_conn_selected_none(resumed3.c.ssl))
+        && TEST_uint_eq(resumed3.s.stats.ee_has_alpn, 0)
+        && TEST_uint_eq(resumed3.c.stats.ee_has_alpn, 0);
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    SSL_SESSION_free(sess2b);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    tls_channel_fini(&resumed2);
+    tls_channel_fini(&resumed3);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    server_alpn = NULL;
+    return test;
+}
+
+/*
+ * TLS 1.3 ALPN mismatch 0-RTT rejection
+ *
+ * The session negotiated ALPN "goodalpn". On resumption the client still offers
+ * "goodalpn" (so it is willing to send early data) alongside "otheralpn", and
+ * the server selects "otheralpn" instead. Because the ALPN selected for the
+ * resumption handshake differs from the one associated with the ticket, the
+ * server must reject 0-RTT while still completing the (resumed) handshake.
+ *
+ * RFC 9846 4.3.10: In order to accept early data, the server MUST have accepted
+ * a PSK cipher suite and selected the first key offered in the client's
+ * "pre_shared_key" extension. In addition, it MUST verify that the following
+ * values are the same as those associated with the selected PSK: TLS version
+ * number, selected cipher suite, and selected ALPN (RFC 7301) protocol, if any.
+ */
+static int test_tls13_ticket_alpn_mismatch_reject_early_data(void)
+{
+    const unsigned char m[] = "message";
+    unsigned char buf[256];
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL;
+    size_t w = 0, r = 0;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(SSL_CTX_set_max_early_data(s, SSL3_RT_MAX_PLAIN_LENGTH))
+        && TEST_true(SSL_CTX_set_options(s, SSL_OP_NO_ANTI_REPLAY) != 0)
+        && TEST_true(alpn_server_enable(s, "goodalpn"))
+        /* Connection 1: negotiate ALPN "goodalpn" and store it in the ticket. */
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(alpn_client_offer(initial.c.ssl, "goodalpn"))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, 0))
+        && TEST_true(alpn_conn_selected_is(initial.s.ssl, "goodalpn"))
+        && TEST_true(alpn_conn_selected_is(initial.c.ssl, "goodalpn"))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_uint_eq(initial.c.stats.nst_msgs, 2)
+        && TEST_uint_eq(initial.s.stats.nst_msgs, 2)
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        /*
+         * Connection 2: attempt 0-RTT. The client offers "goodalpn" (matching
+         * the ticket, so it is willing to send early data) plus "otheralpn";
+         * the server selects "otheralpn", which mismatches the ticket's ALPN.
+         */
+        && TEST_true(tls_channel_init(c, s, &resumed))
+        && TEST_true(alpn_client_offer2(resumed.c.ssl, "goodalpn", "otheralpn"))
+        && TEST_true(alpn_server_select("otheralpn"))
+        && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+        && TEST_true(SSL_write_early_data(resumed.c.ssl, m, sizeof(m), &w))
+        && TEST_size_t_eq(w, sizeof(m))
+        /* The server skips the early data: nothing is delivered to the app. */
+        && TEST_int_eq(SSL_read_early_data(resumed.s.ssl, buf, sizeof(buf), &r),
+            SSL_READ_EARLY_DATA_FINISH)
+        && TEST_size_t_eq(r, 0)
+        && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, 0))
+        && TEST_int_eq(SSL_get_early_data_status(resumed.c.ssl),
+            SSL_EARLY_DATA_REJECTED)
+        /* PSK resumption still succeeds, only 0-RTT is refused. */
+        && TEST_true(SSL_session_reused(resumed.c.ssl))
+        && TEST_true(alpn_conn_selected_is(resumed.s.ssl, "otheralpn"))
+        && TEST_true(alpn_conn_selected_is(resumed.c.ssl, "otheralpn"))
+        /* ALPN was negotiated, but the server did not accept early_data. */
+        && TEST_uint_eq(resumed.s.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(resumed.c.stats.ee_has_alpn, 1)
+        && TEST_uint_eq(resumed.s.stats.ee_has_early_data, 0)
+        && TEST_uint_eq(resumed.c.stats.ee_has_early_data, 0);
+
+    SSL_SESSION_free(sess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    server_alpn = NULL;
+    return test;
+}
+
 enum endpoint_state {
     ENDPOINT_WRITE_EARLY_DATA,
     ENDPOINT_READ_EARLY_DATA,
@@ -1317,6 +1710,8 @@ int setup_tests(void)
     ADD_TEST(test_tls13_ticket_resumed_set_num_tickets_zero);
     ADD_TEST(test_tls13_ticket_disable_server);
     ADD_TEST(test_tls13_ticket_no_decrypt);
+    ADD_TEST(test_tls13_ticket_alpn_cleared);
+    ADD_TEST(test_tls13_ticket_alpn_mismatch_reject_early_data);
     ADD_TEST(test_tls13_ticket_early_data_accepted);
     ADD_TEST(test_tls13_ticket_client_age_mismatch_reject_early_data_retry);
     ADD_TEST(test_tls13_ticket_client_age_mismatch_reject_early_data_outer);


### PR DESCRIPTION
Prevent acceptance of 0-RTT data when the negotiated ALPN protocol differs from the one associated with the session used for early data, and complete an abbreviated handshake without processing early data.

Clear stale ALPN in client-side session on ticket receipt, tls_process_new_session_ticket() (client) never updated s->session->ext.alpn_selected when installing a new ticket, so a session that had negotiated ALPN on an earlier connection kept reporting that protocol even after a later resumption negotiated a different one, or none at all.

Assisted-by: Claude:claude-opus-4-8

Fixes #11197

##### Checklist
- [x] tests are added or updated
