### PR TITLE
ktls: include <sys/socket.h> on the Linux path

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -240,6 +240,7 @@ static ossl_inline int ktls_sendfile(int s, int fd, off_t off, size_t size,
 #endif
 #endif
 
+#include <sys/socket.h>
 #include <sys/sendfile.h>
 #include <netinet/tcp.h>
 #include <linux/socket.h>


### PR DESCRIPTION
The Linux branch of ktls.h uses struct msghdr, struct cmsghdr, struct iovec, the CMSG_* macros, sendmsg() and recvmsg(), but includes neither <sys/socket.h> nor <sys/uio.h>. Nothing requires <netinet/tcp.h> to declare those.

Include <sys/socket.h> explicitly, as the FreeBSD branch of this same header already does. On glibc this is a no-op, and it improves portability for other libcs.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
