### PR TITLE
ssl: add ECDHE fallback for missing supported_groups

### DIFF
--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -159,6 +159,12 @@ The cipher string B<@SECLEVEL>=I<n> can be used at any point to set the security
 level to I<n>, which should be a number between zero and five, inclusive.
 See L<SSL_CTX_set_security_level(3)> for a description of what each level means.
 
+The cipher string B<@DEFAULT_EC>=I<group> configures the named group to use for
+ephemeral ECDH key exchange when a TLS 1.2 or earlier client does not send a
+Supported Groups extension. The group must also be enabled in the server's
+supported groups list and allowed by the configured security policy. This
+setting does not change group selection for clients that send the extension.
+
 The cipher list can be prefixed with the B<DEFAULT> keyword, which enables
 the default cipher list as defined below.  Unlike cipher strings,
 this prefix may not be combined with other strings using B<+> character.

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -125,6 +125,7 @@ CERT *ssl_cert_dup(CERT *cert)
 
     ret->dh_tmp_cb = cert->dh_tmp_cb;
     ret->dh_tmp_auto = cert->dh_tmp_auto;
+    ret->default_ecdh_group = cert->default_ecdh_group;
 
     for (i = 0; i < ret->ssl_pkey_num; i++) {
         CERT_PKEY *cpk = cert->pkeys + i;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -22,6 +22,7 @@
 #include <openssl/conf.h>
 #include <openssl/trace.h>
 #include "internal/nelem.h"
+#include "internal/tlsgroups.h"
 #include "ssl_local.h"
 #include "internal/thread_once.h"
 #include "internal/cryptlib.h"
@@ -923,7 +924,7 @@ static int ssl_cipher_strength_sort(CIPHER_ORDER **head_p,
 static int ssl_cipher_process_rulestr(const char *rule_str,
     CIPHER_ORDER **head_p,
     CIPHER_ORDER **tail_p,
-    const SSL_CIPHER **ca_list, CERT *c)
+    const SSL_CIPHER **ca_list, SSL_CTX *ctx, CERT *c)
 {
     uint32_t alg_mkey, alg_auth, alg_enc, alg_mac, algo_strength;
     int min_tls;
@@ -1149,6 +1150,30 @@ static int ssl_cipher_process_rulestr(const char *rule_str,
                 } else {
                     c->sec_level = level;
                     ok = 1;
+                }
+            } else if (buflen > (int)(sizeof("DEFAULT_EC=") - 1)
+                && CHECK_AND_SKIP_CASE_PREFIX(buf, "DEFAULT_EC=")) {
+                char group_name[65];
+                size_t group_name_len =
+                    (size_t)buflen - (sizeof("DEFAULT_EC=") - 1);
+                uint16_t group_id;
+
+                if (group_name_len >= sizeof(group_name)) {
+                    ERR_raise(ERR_LIB_SSL, SSL_R_INVALID_COMMAND);
+                } else {
+                    memcpy(group_name, buf, group_name_len);
+                    group_name[group_name_len] = '\0';
+                    group_id = tls1_group_name2id(ctx, group_name);
+                    /*
+                     * Only pure ECDHE groups are useful as a fallback for
+                     * the legacy "client omitted supported_groups" case.
+                     */
+                    if (group_id == 0 || !is_ecdhe_group(group_id)) {
+                        ERR_raise(ERR_LIB_SSL, SSL_R_INVALID_COMMAND);
+                    } else {
+                        c->default_ecdh_group = group_id;
+                        ok = 1;
+                    }
                 }
             } else {
                 ERR_raise(ERR_LIB_SSL, SSL_R_INVALID_COMMAND);
@@ -1552,14 +1577,14 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(SSL_CTX *ctx,
     rule_p = rule_str;
     if (HAS_CASE_PREFIX(rule_str, "DEFAULT")) {
         ok = ssl_cipher_process_rulestr(OSSL_default_cipher_list(),
-            &head, &tail, ca_list, c);
+            &head, &tail, ca_list, ctx, c);
         rule_p += 7;
         if (*rule_p == ':')
             rule_p++;
     }
 
     if (ok && (rule_p[0] != '\0'))
-        ok = ssl_cipher_process_rulestr(rule_p, &head, &tail, ca_list, c);
+        ok = ssl_cipher_process_rulestr(rule_p, &head, &tail, ca_list, ctx, c);
 
     OPENSSL_free(ca_list); /* Not needed anymore */
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2157,6 +2157,7 @@ typedef struct cert_st {
     EVP_PKEY *dh_tmp;
     DH *(*dh_tmp_cb)(SSL *ssl, int is_export, int keysize);
     int dh_tmp_auto;
+    uint16_t default_ecdh_group;
     /* Flags related to certificates */
     uint32_t cert_flags;
     CERT_PKEY *pkeys;
@@ -2783,6 +2784,7 @@ SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n);
 
 __owur const TLS_GROUP_INFO *tls1_group_id_lookup(SSL_CTX *ctx, uint16_t curve_id);
 __owur const char *tls1_group_id2name(SSL_CTX *ctx, uint16_t group_id);
+__owur uint16_t tls1_group_name2id(SSL_CTX *ctx, const char *name);
 __owur int tls1_group_id2nid(uint16_t group_id, int include_unknown);
 __owur uint16_t tls1_nid2group_id(int nid);
 __owur int tls1_check_group_id(SSL_CONNECTION *s, uint16_t group_id,

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -721,7 +721,7 @@ int ssl_load_sigalgs(SSL_CTX *ctx)
     return 1;
 }
 
-static uint16_t tls1_group_name2id(SSL_CTX *ctx, const char *name)
+uint16_t tls1_group_name2id(SSL_CTX *ctx, const char *name)
 {
     size_t i;
 
@@ -1011,6 +1011,33 @@ end:
     return ret;
 }
 
+static uint16_t tls1_get_default_ecdh_group(SSL_CONNECTION *s)
+{
+    const TLS_GROUP_INFO *inf;
+    uint16_t group_id = s->cert->default_ecdh_group;
+    int minversion, maxversion;
+
+    if (group_id == 0 || !is_ecdhe_group(group_id)
+        || !tls1_check_group_id(s, group_id, 1)
+        || !tls_group_allowed(s, group_id, SSL_SECOP_CURVE_SHARED))
+        return 0;
+
+    inf = tls1_group_id_lookup(SSL_CONNECTION_GET_CTX(s), group_id);
+    if (!ossl_assert(inf != NULL))
+        return 0;
+
+    minversion = SSL_CONNECTION_IS_DTLS(s) ? inf->mindtls : inf->mintls;
+    maxversion = SSL_CONNECTION_IS_DTLS(s) ? inf->maxdtls : inf->maxtls;
+    if (maxversion == -1
+        || (minversion != 0
+            && ssl_version_cmp(s, s->version, minversion) < 0)
+        || (maxversion != 0
+            && ssl_version_cmp(s, s->version, maxversion) > 0))
+        return 0;
+
+    return group_id;
+}
+
 /*-
  * For nmatch >= 0, return the id of the |nmatch|th shared group or 0
  * if there is no match.
@@ -1029,6 +1056,7 @@ uint16_t tls1_shared_group(SSL_CONNECTION *s, int nmatch, int groups)
 {
     const uint16_t *pref, *supp;
     size_t num_pref, num_supp, i;
+    size_t num_peer_groups;
     int k;
     SSL_CTX *ctx = SSL_CONNECTION_GET_CTX(s);
 
@@ -1098,7 +1126,36 @@ uint16_t tls1_shared_group(SSL_CONNECTION *s, int nmatch, int groups)
     }
     if (nmatch == TLS1_GROUPS_RETURN_NUMBER)
         return k;
-    /* Out of range (nmatch > k). */
+
+    /*
+     * No shared group was found.  RFC 4492 / 8422 section 5.1.2 permit the
+     * server to pick any curve when the client omitted the supported_groups
+     * extension entirely (as opposed to sending a list that simply shares
+     * nothing with us).  Honour an explicitly configured fallback only in
+     * that case, only for non-FFDHE searches, and only for the "first /
+     * temporary-key" lookups.  Default behaviour (no configuration) stays
+     * unchanged.
+     *
+     * Note: nmatch was rewritten from TLS1_GROUPS_RETURN_TMP_ID to 0 above,
+     * so we only need to test nmatch == 0 here.  The original caller that
+     * asked for TMP_ID still receives the fallback group.
+     */
+    if (k == 0
+        && nmatch == 0
+        && groups != TLS1_GROUPS_FFDHE_GROUPS) {
+        const uint16_t *peer_groups;
+
+        tls1_get_peer_groups(s, &peer_groups, &num_peer_groups);
+        /* groups_len == 0 always means the extension was absent */
+        if (num_peer_groups == 0) {
+            uint16_t def = tls1_get_default_ecdh_group(s);
+
+            if (def != 0)
+                return def;
+        }
+    }
+
+    /* Out of range (nmatch > k) or no usable default configured. */
     return 0;
 }
 
@@ -2032,9 +2089,10 @@ int tls1_check_ffdhe_tmp_key(SSL_CONNECTION *s, unsigned long cid)
  */
 int tls1_check_ec_tmp_key(SSL_CONNECTION *s, unsigned long cid)
 {
-    /* If not Suite B just need a shared group */
-    if (!tls1_suiteb(s))
+    /* If not Suite B just need a shared (or configured fallback) group */
+    if (!tls1_suiteb(s)) {
         return tls1_shared_group(s, 0, TLS1_GROUPS_NON_FFDHE_GROUPS) != 0;
+    }
     /*
      * If Suite B, AES128 MUST use P-256 and AES256 MUST use P-384, no other
      * curves permitted.

--- a/test/recipes/70-test_sslextension.t
+++ b/test/recipes/70-test_sslextension.t
@@ -85,6 +85,46 @@ sub extension_filter
     }
 }
 
+# Remove the supported_groups extension from ClientHello. After observing the
+# ServerHello, discard that flight. Forwarding it would make the client and
+# server transcripts differ, so the subsequent Finished MAC check would fail.
+sub remove_supported_groups
+{
+    my $proxy = shift;
+
+    if ($proxy->flight == 0) {
+        foreach my $message (@{$proxy->message_list}) {
+            next if $message->mt != TLSProxy::Message::MT_CLIENT_HELLO;
+            delete ${$message->extension_data}{TLSProxy::Message::EXT_SUPPORTED_GROUPS};
+            $message->process_extensions();
+            $message->repack();
+        }
+        return;
+    }
+
+    # Do not forward ServerHello. TLSProxy has no success() setter; keeping the
+    # record would make the client send a Finished based on its original,
+    # unmodified ClientHello and cause s_server to exit with an error. Abort
+    # the proxy after observing this intentional partial handshake.
+    if ($proxy->flight >= 1 && server_sent_hello($proxy)) {
+        @{$proxy->record_list} = grep {
+            $_->flight != $proxy->flight
+        } @{$proxy->record_list};
+        $proxy->abort(1);
+        $proxy->filter(undef);
+    }
+}
+
+sub server_sent_hello
+{
+    my $proxy = shift;
+
+    foreach my $message (@{$proxy->message_list}) {
+        return 1 if $message->mt == TLSProxy::Message::MT_SERVER_HELLO;
+    }
+    return 0;
+}
+
 sub inject_duplicate_extension
 {
   my ($proxy, $message_type) = @_;
@@ -198,7 +238,7 @@ sub inject_cryptopro_extension
 
 # Test 1-2: Sending a duplicate extension should fail.
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 9;
+plan tests => 11;
 ok($fatal_alert, "Duplicate ClientHello extension");
 
 SKIP: {
@@ -237,6 +277,35 @@ SKIP: {
     $proxy->clientflags("-no_tls1_3");
     $proxy->start();
     ok(TLSProxy::Message->success(), "Cryptopro extension in ClientHello");
+}
+
+SKIP: {
+    skip "TLS <= 1.2 disabled or EC disabled", 2
+        if $no_below_tls13 || disabled("ec");
+
+    # Without the setting the server must still reject the handshake.
+    $proxy->clear();
+    $proxy->filter(\&remove_supported_groups);
+    $proxy->clientflags("-tls1_2");
+    $proxy->serverflags("-tls1_2");
+    $proxy->cipherc("ECDHE-RSA-AES128-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA256");
+    $proxy->start();
+    ok(!server_sent_hello($proxy),
+       "Server rejects ECDHE without supported_groups when no default is set");
+
+    # Mutating ClientHello on the wire breaks the Finished MAC, so check that
+    # the server accepted it by observing its ServerHello. The filter discards
+    # that ServerHello, preventing the client from sending a mismatched Finished.
+    $proxy->clear();
+    $proxy->filter(\&remove_supported_groups);
+    $proxy->clientflags("-tls1_2");
+    $proxy->serverflags("-tls1_2");
+    $proxy->cipherc("ECDHE-RSA-AES128-SHA256");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA256:\@DEFAULT_EC=P-256");
+    $proxy->start();
+    ok(server_sent_hello($proxy),
+        "Server uses configured default ECDHE group without supported_groups");
 }
 
 SKIP: {

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -182,6 +182,7 @@ sub init
         serverpid => 0,
         clientpid => 0,
         clientexit => 0,
+        abort => 0,
         execute => $execute,
         cert => $cert,
         debug => $debug,
@@ -221,6 +222,7 @@ sub clearClient
     $self->{sessionfile} = undef;
     $self->{clientpid} = 0;
     $self->{clientexit} = 0;
+    $self->{abort} = 0;
     $is_tls13 = 0;
     $ciphersuite = undef;
 
@@ -521,7 +523,7 @@ sub clientstart
     my $ctr = 0;
     local $SIG{PIPE} = "IGNORE";
     $self->{saw_session_ticket} = undef;
-    while($fdset->count && $ctr < 10) {
+    while($fdset->count && $ctr < 10 && !$self->abort) {
         if (defined($self->{sessionfile})) {
             # s_client got -ign_eof and won't be exiting voluntarily, so we
             # look for data *and* session ticket...
@@ -595,7 +597,8 @@ sub clientstart
         print "Waiting for s_server process to close: $pid...\n";
         # it's done already, just collect the exit code [and reap]...
         waitpid($pid, 0);
-        die "exit code $? from s_server process\n" if $? != 0;
+        die "exit code $? from s_server process\n"
+            if $? != 0 && !$self->abort;
     } else {
         # It's a bit counter-intuitive spot to make next connection to
         # the s_server. Rationale is that established connection works
@@ -814,6 +817,14 @@ sub serverconnects
         $self->{serverconnects} = shift;
     }
     return $self->{serverconnects};
+}
+sub abort
+{
+    my $self = shift;
+    if (@_) {
+        $self->{abort} = shift;
+    }
+    return $self->{abort};
 }
 # This is a bit ugly because the caller is responsible for keeping the records
 # in sync with the updated message list; simply updating the message list isn't


### PR DESCRIPTION
## Summary

Add `@DEFAULT_EC=<group>` cipher-string command. For TLS 1.2 and earlier ECDHE handshakes where client omits supported_groups, use this configured ECDHE group when it is enabled, protocol-valid, and allowed by security policy.

Existing group selection remains unchanged when client sends supported_groups. Invalid or non-ECDHE group names are rejected.

## Changes

- Parse and store `@DEFAULT_EC=<group>`.
- Select configured fallback only for absent `supported_groups`.
- Reject unknown and non-ECDHE groups.
- Document command in `openssl-ciphers(1)`.
- Add TLSProxy coverage for fallback and default rejection behavior.
- Add controlled TLSProxy abort for intentional partial-handshake tests.

Fixes: #22732 


##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
