### PR TITLE
Add option to scrub BIGNUM's memory when BN_CTX_end is called.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -334,6 +334,10 @@ OpenSSL Releases
 
    *Dimitri John Ledkov*
 
+ * The API functions `BN_CTX_start_ex` has been added to libcrypto.
+
+   *Wolfgang Beck*
+
 OpenSSL 4.0
 -----------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@ OpenSSL 4.1
 
   * Fixed verification of DSA certificates signed with SHA-384 or SHA-512.
 
+  * API call `BN_CTX_start_ex` has been added.
+
 OpenSSL 4.0
 -----------
 

--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -37,23 +37,30 @@ typedef struct bignum_pool {
 static void BN_POOL_init(BN_POOL *);
 static void BN_POOL_finish(BN_POOL *);
 static BIGNUM *BN_POOL_get(BN_POOL *, int);
-static void BN_POOL_release(BN_POOL *, unsigned int);
+static void BN_POOL_release(BN_POOL *, unsigned int, unsigned int);
 
 /************/
 /* BN_STACK */
 /************/
 
 /* A wrapper to manage the "stack frames" */
+typedef struct bignum_ctx_frame {
+    /* The number of temporaries in use when the frame was opened */
+    unsigned int used;
+    /* Frame-scoped behavior flags */
+    unsigned int flags;
+} BN_CTX_FRAME;
+
 typedef struct bignum_ctx_stack {
-    /* Array of indexes into the bignum stack */
-    unsigned int *indexes;
+    /* Array of frame records into the bignum stack */
+    BN_CTX_FRAME *indexes;
     /* Number of stack frames, and the size of the allocated array */
     unsigned int depth, size;
 } BN_STACK;
 static void BN_STACK_init(BN_STACK *);
 static void BN_STACK_finish(BN_STACK *);
-static int BN_STACK_push(BN_STACK *, unsigned int);
-static unsigned int BN_STACK_pop(BN_STACK *);
+static int BN_STACK_push(BN_STACK *, unsigned int, unsigned int);
+static BN_CTX_FRAME BN_STACK_pop(BN_STACK *);
 
 /**********/
 /* BN_CTX */
@@ -71,7 +78,7 @@ struct bignum_ctx {
     int err_stack;
     /* Block "gets" until an "end" (compatibility behaviour) */
     int too_many;
-    /* Flags. */
+    /* Flags applied to bignums obtained from the pool. */
     int flags;
     /* The library context */
     OSSL_LIB_CTX *libctx;
@@ -97,7 +104,7 @@ static void ctxdbg(BIO *channel, const char *text, BN_CTX *ctx)
     bnidx = 0;
     BIO_printf(channel, "   %16s : ", "");
     while (fpidx < stack->depth) {
-        while (bnidx++ < stack->indexes[fpidx])
+        while (bnidx++ < stack->indexes[fpidx].used)
             BIO_printf(channel, "    ");
         BIO_printf(channel, "^^^ ");
         bnidx++;
@@ -184,16 +191,27 @@ void BN_CTX_free(BN_CTX *ctx)
 
 void BN_CTX_start(BN_CTX *ctx)
 {
+    (void)BN_CTX_start_ex(ctx, 0);
+}
+
+int BN_CTX_start_ex(BN_CTX *ctx, unsigned int flags)
+{
     CTXDBG("ENTER BN_CTX_start()", ctx);
     /* If we're already overflowing ... */
-    if (ctx->err_stack || ctx->too_many)
+    if (ctx->err_stack || ctx->too_many) {
         ctx->err_stack++;
+        CTXDBG("LEAVE BN_CTX_start()", ctx);
+        return 0;
+    }
     /* (Try to) get a new frame pointer */
-    else if (!BN_STACK_push(&ctx->stack, ctx->used)) {
+    if (!BN_STACK_push(&ctx->stack, ctx->used, flags)) {
         ERR_raise(ERR_LIB_BN, BN_R_TOO_MANY_TEMPORARY_VARIABLES);
         ctx->err_stack++;
+        CTXDBG("LEAVE BN_CTX_start()", ctx);
+        return 0;
     }
     CTXDBG("LEAVE BN_CTX_start()", ctx);
+    return 1;
 }
 
 void BN_CTX_end(BN_CTX *ctx)
@@ -204,10 +222,11 @@ void BN_CTX_end(BN_CTX *ctx)
     if (ctx->err_stack)
         ctx->err_stack--;
     else {
-        unsigned int fp = BN_STACK_pop(&ctx->stack);
+        BN_CTX_FRAME frame = BN_STACK_pop(&ctx->stack);
+        unsigned int fp = frame.used;
         /* Does this stack frame have anything to release? */
         if (fp < ctx->used)
-            BN_POOL_release(&ctx->pool, ctx->used - fp);
+            BN_POOL_release(&ctx->pool, ctx->used - fp, frame.flags);
         ctx->used = fp;
         /* Unjam "too_many" in case "get" had failed */
         ctx->too_many = 0;
@@ -263,12 +282,12 @@ static void BN_STACK_finish(BN_STACK *st)
     st->indexes = NULL;
 }
 
-static int BN_STACK_push(BN_STACK *st, unsigned int idx)
+static int BN_STACK_push(BN_STACK *st, unsigned int idx, unsigned int flags)
 {
     if (st->depth == st->size) {
         /* Need to expand */
         unsigned int newsize = st->size ? (st->size * 3 / 2) : BN_CTX_START_FRAMES;
-        unsigned int *newitems;
+        BN_CTX_FRAME *newitems;
 
         if ((newitems = OPENSSL_malloc_array(newsize, sizeof(*newitems))) == NULL)
             return 0;
@@ -278,11 +297,13 @@ static int BN_STACK_push(BN_STACK *st, unsigned int idx)
         st->indexes = newitems;
         st->size = newsize;
     }
-    st->indexes[(st->depth)++] = idx;
+    st->indexes[st->depth].used = idx;
+    st->indexes[st->depth].flags = flags;
+    st->depth++;
     return 1;
 }
 
-static unsigned int BN_STACK_pop(BN_STACK *st)
+static BN_CTX_FRAME BN_STACK_pop(BN_STACK *st)
 {
     return st->indexes[--(st->depth)];
 }
@@ -351,13 +372,18 @@ static BIGNUM *BN_POOL_get(BN_POOL *p, int flag)
     return p->current->vals + ((p->used++) % BN_CTX_POOL_SIZE);
 }
 
-static void BN_POOL_release(BN_POOL *p, unsigned int num)
+static void BN_POOL_release(BN_POOL *p, unsigned int num, unsigned int flags)
 {
     unsigned int offset = (p->used - 1) % BN_CTX_POOL_SIZE;
 
     p->used -= num;
     while (num--) {
         bn_check_top(p->current->vals + offset);
+        BIGNUM *bn = p->current->vals + offset;
+
+        if ((flags & BN_CTX_START_FLAG_SCRUB_ON_END) != 0)
+            BN_clear(bn);
+        bn_check_top(bn);
         if (offset == 0) {
             offset = BN_CTX_POOL_SIZE - 1;
             p->current = p->current->prev;

--- a/doc/man3/BN_CTX_start.pod
+++ b/doc/man3/BN_CTX_start.pod
@@ -2,13 +2,15 @@
 
 =head1 NAME
 
-BN_CTX_start, BN_CTX_get, BN_CTX_end - use temporary BIGNUM variables
+BN_CTX_start, BN_CTX_start_ex, BN_CTX_get, BN_CTX_end - use temporary BIGNUM variables
 
 =head1 SYNOPSIS
 
  #include <openssl/bn.h>
 
  void BN_CTX_start(BN_CTX *ctx);
+
+ void BN_CTX_start_ex(BN_CTX *ctx, unsigned int flags);
 
  BIGNUM *BN_CTX_get(BN_CTX *ctx);
 
@@ -21,10 +23,14 @@ a B<BN_CTX> (which can been created by using L<BN_CTX_new(3)>)
 in order to save the overhead of repeatedly creating and
 freeing B<BIGNUM>s in functions that are called from inside a loop.
 
-A function must call BN_CTX_start() first. Then, BN_CTX_get() may be
-called repeatedly to obtain temporary B<BIGNUM>s. All BN_CTX_get()
-calls must be made before calling any other functions that use the
-B<ctx> as an argument.
+A function must call BN_CTX_start() or BN_CTX_start_ex() first.
+BN_CTX_start_ex() provides an additional flag parameter which can be
+BN_CTX_START_FLAG_SCRUB_ON_END to overwrite the internal memory of the
+BN value when BN_CTX_end is called.
+
+Then, BN_CTX_get() may be called repeatedly to obtain temporary B<BIGNUM>s.
+All BN_CTX_get() calls must be made before calling any other functions
+that use the B<ctx> as an argument.
 
 Finally, BN_CTX_end() must be called before returning from the function.
 If B<ctx> is NULL, nothing is done.
@@ -34,6 +40,8 @@ BN_CTX_get() become invalid.
 =head1 RETURN VALUES
 
 BN_CTX_start() and BN_CTX_end() return no values.
+
+BN_CTX_start_ex() returns 1 in success , otherwise 0.
 
 BN_CTX_get() returns a pointer to the B<BIGNUM>, or B<NULL> on error.
 Once BN_CTX_get() has failed, the subsequent calls will return B<NULL>
@@ -45,6 +53,10 @@ can be obtained by L<ERR_get_error(3)>.
 =head1 SEE ALSO
 
 L<BN_CTX_new(3)>
+
+=head1 HISTORY
+
+The BN_CTX_new_ex() function was added in OpenSSL 4.1.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -197,6 +197,8 @@ int BN_is_odd(const BIGNUM *a);
 
 void BN_zero_ex(BIGNUM *a);
 
+#define BN_CTX_START_FLAG_SCRUB_ON_END 0x0001u
+
 #if OPENSSL_API_LEVEL > 908
 #define BN_zero(a) BN_zero_ex(a)
 #else
@@ -210,6 +212,7 @@ BN_CTX *BN_CTX_new(void);
 BN_CTX *BN_CTX_secure_new_ex(OSSL_LIB_CTX *ctx);
 BN_CTX *BN_CTX_secure_new(void);
 void BN_CTX_free(BN_CTX *c);
+int BN_CTX_start_ex(BN_CTX *ctx, unsigned int flags);
 void BN_CTX_start(BN_CTX *ctx);
 BIGNUM *BN_CTX_get(BN_CTX *ctx);
 void BN_CTX_end(BN_CTX *ctx);

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -19,6 +19,7 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include "../crypto/bn/bn_local.h"
 #include "internal/nelem.h"
 #include "internal/numbers.h"
 #include "testutil.h"
@@ -2911,6 +2912,57 @@ err:
     return st;
 }
 
+static int test_ctx_scrub_on_end_flag(void)
+{
+    BN_CTX *nctx = NULL;
+    BIGNUM *pbn = NULL;
+    int ok = 0;
+    int bnstartcnt = 0;
+    BN_ULONG bnval = 0x11111111UL;
+    struct bignum_st *bignumstr = NULL;
+
+    if (!TEST_ptr(nctx = BN_CTX_new()))
+        goto err;
+
+    /* Create bignum without being scrubed and released it.
+     * Check if value persist in memory.
+     */
+    BN_CTX_start(nctx);
+    bnstartcnt++;
+    if (!TEST_ptr(pbn = BN_CTX_get(nctx))
+        || !TEST_true(BN_set_word(pbn, bnval)))
+        goto err;
+    BN_CTX_end(nctx);
+    bnstartcnt--;
+    bignumstr = (struct bignum_st *)pbn;
+    if (memcmp(&bignumstr->d, &bnval, sizeof(BN_ULONG)) == 0)
+        goto err;
+
+    /* Create a to be scrubed bignum and release it.
+     * Check if value persist in memory.
+     */
+    bnval = 0x22222222UL;
+    if (!TEST_true(BN_CTX_start_ex(nctx, BN_CTX_START_FLAG_SCRUB_ON_END)))
+        goto err;
+    bnstartcnt++;
+    if (!TEST_ptr(pbn = BN_CTX_get(nctx))
+        || !TEST_true(BN_set_word(pbn, bnval)))
+        goto err;
+    BN_CTX_end(nctx);
+    bnstartcnt--;
+    bignumstr = (struct bignum_st *)pbn;
+    bnval = 0x00000000UL;
+    if (memcmp(&bignumstr->d, &bnval, sizeof(BN_ULONG)) == 0)
+        goto err;
+
+    ok = 1;
+err:
+    for (; bnstartcnt > 0; bnstartcnt--)
+        BN_CTX_end(nctx);
+    BN_CTX_free(nctx);
+    return ok;
+}
+
 static int test_coprime(void)
 {
     BIGNUM *a = NULL, *b = NULL;
@@ -3505,6 +3557,7 @@ int setup_tests(void)
         ADD_ALL_TESTS(test_smallsafeprime, 16);
         ADD_TEST(test_swap);
         ADD_TEST(test_ctx_consttime_flag);
+        ADD_TEST(test_ctx_scrub_on_end_flag);
 #ifndef OPENSSL_NO_EC2M
         ADD_TEST(test_gf2m_add);
         ADD_TEST(test_gf2m_mod);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5728,3 +5728,4 @@ ASN1_STRING_set1_data                   ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set1_string                 ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_get_length                  ?	4_1_0	EXIST::FUNCTION:
 CMS_add_standard_smimecap_ex            ?	4_1_0	EXIST::FUNCTION:CMS
+BN_CTX_start_ex                         ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This PR addresses discussion of https://github.com/openssl/openssl/issues/32018.
BN_CTX pool doesn't scrub a BIGNUM's backing memory on release (BN_CTX_end/BN_POOL_release).
A new BN_CTX_start_ex API was introduces to mark a new BN to be cleared when BN_CTX_end ist called.

- Enhance BN_CTX_start documentation to add description of new  BN_CTX_start_ex API.
- Enhance bntest to test clearing BN memory on BN_CTX_end.
