### PR TITLE
Revert ".github/workflows/ci-doc-changes.yml: pin mdl to 0.17.0"

### DIFF
--- a/.github/workflows/ci-doc-changes.yml
+++ b/.github/workflows/ci-doc-changes.yml
@@ -32,9 +32,7 @@ jobs:
       run: make help
     - name: make md-nits
       run: |
-          # mdl 0.18.0 is incompatible with the runner's uri 0.12.x.
-          # See https://github.com/markdownlint/markdownlint/issues/605
-          sudo gem install mdl -v 0.17.0
+          sudo gem install mdl
           make md-nits
 
   # out-of-source-and-install checks multiple things at the same time:


### PR DESCRIPTION
This reverts commit 1a3455e2ce39 ".github/workflows/ci-doc-changes.yml: pin mdl to 0.17.0":  mdl 0.18.1, that contains the fix[1] for the issue[2], is now in the gem repository[3], so the pin can be removed.

[1] https://github.com/markdownlint/markdownlint/pull/606
[2] https://github.com/markdownlint/markdownlint/issues/605
[3] https://rubygems.org/gems/mdl/versions/0.18.1