### PR TITLE
Fix bugs found by OSSL_STORE fuzzer 

### DIFF
--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -231,6 +231,7 @@ OSSL_DECODER_INSTANCE *
 ossl_decoder_instance_new_forprov(OSSL_DECODER *decoder, void *provctx,
     const char *input_structure)
 {
+    OSSL_DECODER_INSTANCE *decoder_inst = NULL;
     void *decoderctx;
 
     if (!ossl_assert(decoder != NULL)) {
@@ -251,7 +252,10 @@ ossl_decoder_instance_new_forprov(OSSL_DECODER *decoder, void *provctx,
             return 0;
         }
     }
-    return ossl_decoder_instance_new(decoder, decoderctx);
+    decoder_inst = ossl_decoder_instance_new(decoder, decoderctx);
+    if (decoder_inst == NULL)
+        decoder->freectx(decoderctx);
+    return decoder_inst;
 }
 
 OSSL_DECODER_INSTANCE *ossl_decoder_instance_new(OSSL_DECODER *decoder,

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -1091,6 +1091,7 @@ OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bp, const char *scheme,
         } else if (!loader_set_params(fetched_loader, loader_ctx,
                        params, propq)) {
             (void)fetched_loader->p_close(loader_ctx);
+            loader_ctx = NULL;
             OSSL_STORE_LOADER_free(fetched_loader);
             fetched_loader = NULL;
         }
@@ -1099,20 +1100,16 @@ OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bp, const char *scheme,
     }
 
     if (loader_ctx == NULL) {
-        ERR_clear_last_mark();
-        return NULL;
+        goto err;
     }
 
     if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL) {
-        ERR_clear_last_mark();
-        return NULL;
+        goto err;
     }
 
     if (ui_method != NULL
         && !ossl_pw_set_ui_method(&ctx->pwdata, ui_method, ui_data)) {
-        ERR_clear_last_mark();
-        OPENSSL_free(ctx);
-        return NULL;
+        goto err;
     }
 
     ctx->fetched_loader = fetched_loader;
@@ -1129,4 +1126,28 @@ OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bp, const char *scheme,
     ERR_pop_to_mark();
 
     return ctx;
+
+err:
+    ERR_clear_last_mark();
+    if (loader_ctx != NULL) {
+        /*
+         * Temporary structure so OSSL_STORE_close() can work even when
+         * |ctx| couldn't be allocated or initialized properly.
+         */
+        OSSL_STORE_CTX tmpctx = {
+            NULL,
+        };
+
+        tmpctx.fetched_loader = fetched_loader;
+        tmpctx.loader = loader;
+        tmpctx.loader_ctx = loader_ctx;
+
+        /* We return NULL regardless of an error while closing. */
+        (void)ossl_store_close_it(&tmpctx);
+        fetched_loader = NULL;
+    }
+
+    OSSL_STORE_LOADER_free(fetched_loader);
+    OPENSSL_free(ctx);
+    return NULL;
 }

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -308,6 +308,12 @@ static EVP_PKEY *try_key_value(struct extracted_param_data_st *data,
     decoderctx = OSSL_DECODER_CTX_new_for_pkey(&pk, data->input_type, data->data_structure,
         data->data_type, selection, libctx,
         propq);
+
+    if (decoderctx == NULL) {
+        *harderr = 1;
+        return NULL;
+    }
+
     (void)OSSL_DECODER_CTX_set_passphrase_cb(decoderctx, cb, cbarg);
 
     /* No error if this couldn't be decoded */

--- a/test/ossl_store_test.c
+++ b/test/ossl_store_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,6 +11,8 @@
 #include <limits.h>
 #include <openssl/store.h>
 #include <openssl/ui.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
 #include "testutil.h"
 
 #ifndef PATH_MAX
@@ -249,6 +251,55 @@ static int test_store_attach_unregistered_scheme(void)
     return ret;
 }
 
+static int test_store_attach_load_mfail(void)
+{
+    const unsigned char input[] = { 0x30, 0x00 };
+    BIO *bio = NULL;
+    OSSL_STORE_CTX *store_ctx = NULL;
+    OSSL_STORE_INFO *info = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(bio = BIO_new_mem_buf(input, sizeof(input))))
+        goto err;
+
+    MFAIL_start();
+    store_ctx = OSSL_STORE_attach(bio, "file",
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    if (store_ctx != NULL)
+        info = OSSL_STORE_load(store_ctx);
+    MFAIL_end();
+
+    ret = 1;
+
+err:
+    OSSL_STORE_INFO_free(info);
+    OSSL_STORE_close(store_ctx);
+    BIO_free(bio);
+    return ret;
+}
+
+static int test_store_attach_invalid_params(void)
+{
+    const unsigned char input[] = { 0 };
+    char invalid_expect[] = "invalid";
+    OSSL_PARAM params[] = {
+        OSSL_PARAM_construct_utf8_string(OSSL_STORE_PARAM_EXPECT, invalid_expect, 0),
+        OSSL_PARAM_END
+    };
+    BIO *bio = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(bio = BIO_new_mem_buf(input, sizeof(input))))
+        goto err;
+
+    ret = TEST_ptr_null(OSSL_STORE_attach(bio, "file",
+        NULL, NULL, NULL, NULL, params, NULL, NULL));
+
+err:
+    BIO_free(bio);
+    return ret;
+}
+
 static int test_store_delete_null_uri(void)
 {
     /* Passing NULL uri must return 0, not crash */
@@ -310,6 +361,8 @@ int setup_tests(void)
 #endif
     ADD_TEST(test_store_search_by_key_fingerprint_fail);
     ADD_TEST(test_store_delete_null_uri);
+    ADD_MFAIL_NO_CHECK_TEST(test_store_attach_load_mfail);
+    ADD_TEST(test_store_attach_invalid_params);
     ADD_ALL_TESTS(test_store_get_params, 3);
     if (sm2file != NULL)
         ADD_TEST(test_store_attach_unregistered_scheme);


### PR DESCRIPTION
Fixed: 
1. NULL dereference in try_key_value() when OSSL_DECODER_CTX_new_for_pkey() fails.
2. Memory leak in ossl_decoder_instance_new_forprov() when ossl_decoder_instance_new() fails.
3. OSSL_STORE_attach() memory leaks and dangling pointer return on MFAIL paths.

Added regression tests.
Found by : store fuzzer.
- [ ] documentation is added or updated
- [x] tests are added or updated
