### PR TITLE
Fix test failure with no-deprecated: skip DES symbols from duplicate check

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -187,6 +187,12 @@ foreach (sort keys %stlibname) {
     }
 }
 my @duplicates = sort grep { $symbols{$_} > 1 } keys %symbols;
+# When deprecated-3.0 is disabled, some deprecated symbols (e.g. DES)
+# are intentionally duplicated between libcrypto and liblegacy.
+# Skip them from the duplicate check.
+if (disabled('deprecated-3.0')) {
+    @duplicates = sort grep { $_ !~ /^DES_/ } @duplicates;
+}
 if (@duplicates) {
     note "Duplicates:";
     note join('\n', @duplicates);


### PR DESCRIPTION
When OpenSSL is configured with `no-deprecated --api=3.0`, the DES symbols are intentionally compiled into both `libcrypto.a` and `liblegacy.a` (see `crypto/des/build.info`). The `01-test_symbol_presence.t` test's static library duplicate symbol check incorrectly flags these as duplicates.

This fix skips `DES_*` symbols from the duplicate check when `deprecated-3.0` is disabled, since the duplication is intentional.

Closes #32409
