### PR TITLE
Fix VS2013 build of QUIC API tests

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -3867,12 +3867,12 @@ static int test_pending_limit(void)
     if (!TEST_true(ok)) {
         TEST_info("%s call to SSL_set_generic_request_uint"
                   "(SSL_VALUE_QUIC_MAX_PENDING_CONNS failed",
-            __func__);
+            OPENSSL_FUNC);
         goto end;
     }
 
     if (!TEST_true(SSL_listen(serverssl_listener))) {
-        TEST_info("%s SSL_listen() failed", __func__);
+        TEST_info("%s SSL_listen() failed", OPENSSL_FUNC);
         goto end;
     }
 


### PR DESCRIPTION
The pending-connections-limit test in `test/quicapitest.c` uses the C99 `__func__` predefined identifier. Visual Studio 2013 doesn't provide `__func__` in C mode, so both `VC-WIN32` and `VC-WIN64A` builds currently fail while compiling this test.

Use OpenSSL's `OPENSSL_FUNC` compatibility macro instead. This maps to the compiler supported equivalent and is already used elsewhere in the test suite. The change affects diagnostic text only.

### Testing

Tested with Visual Studio 2013 Update 5 (cl 18.00.40629):

- `VC-WIN64A`: full `nmake /S` build succeeds; `openssl version -a` succeeds; `nmake /S run_tests TESTS=test_quicapi` passes.
- `VC-WIN32`: full `nmake /S` build succeeds; `openssl version -a` succeeds; `nmake /S run_tests TESTS=test_quicapi` passes.

##### Checklist

- [x] tests are added or updated