### PR TITLE
Free connections before listeners in the radix test cleanup

### DIFF
--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -439,6 +439,22 @@ static int RADIX_PROCESS_join_all_threads(RADIX_PROCESS *rp, int *testresult)
     return ok;
 }
 
+/*
+ * Free every non-listener object's SSL before cleanup_one() frees any listener.
+ *
+ * A connection's assist thread reads from its network BIO, and for a dgram BIO
+ * pair (see hf_link_dgram_pair) that BIO belongs to the linked listener. Freeing
+ * the connection joins its assist thread (see ossl_quic_free), so doing so first
+ * ensures no assist thread is still reading when the listener BIOs are freed.
+ */
+static void cleanup_nonlistener(RADIX_OBJ *obj)
+{
+    if (obj->ssl != NULL && !SSL_is_listener(obj->ssl)) {
+        SSL_free(obj->ssl);
+        obj->ssl = NULL;
+    }
+}
+
 static void cleanup_one(RADIX_OBJ *obj)
 {
     obj->registered = 0;
@@ -459,6 +475,7 @@ static void RADIX_PROCESS_cleanup(RADIX_PROCESS *rp)
     sk_RADIX_THREAD_free(rp->threads);
     rp->threads = NULL;
 
+    lh_RADIX_OBJ_doall(rp->objs, cleanup_nonlistener);
     lh_RADIX_OBJ_doall(rp->objs, cleanup_one);
     lh_RADIX_OBJ_free(rp->objs);
     rp->objs = NULL;


### PR DESCRIPTION
A connection's assist thread reads from its network BIO, which for a dgram BIO pair belongs to the linked listener. Freeing a listener while the connection's assist thread is still running is a use-after-free. Freeing connections first joins their assist threads, so no thread is reading when the listener BIOs are freed.

<img width="386" height="240" alt="Flakiness" src="https://github.com/user-attachments/assets/3e66a7d1-c4ad-41d6-bbaf-ed11ae284bac" />


Fixes #32420
Maybe Fixes: https://github.com/openssl/project/issues/2051

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
