### PR TITLE
Build current-stable qemu for the hppa cross job

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -222,6 +222,38 @@ jobs:
       if: matrix.platform.tests != 'none'
       run: sudo apt-get -yq --allow-unauthenticated --allow-downgrades --allow-remove-essential --allow-change-held-packages install qemu-user
 
+    # Ubuntu 24.04 pins qemu-user at 8.2.2. Pre-9.2 qemu has a number of known
+    # serious bugs with hppa emulation, and the hppa job appears to hit an
+    # intermittent SIGILL under it (empty log, no guest signal - i.e. qemu
+    # itself, not the test). Build a current-stable qemu for the hppa job and
+    # point binfmt at it.
+    - name: use current-stable qemu for hppa
+      if: contains(matrix.platform.arch, 'hppa') && matrix.platform.tests != 'none'
+      env:
+        QEMU_TAG: v11.1.0
+      run: |
+        sudo apt-get -yq install ninja-build pkg-config libglib2.0-dev \
+          flex bison python3-venv python3-pip
+        git clone --depth 1 -b "$QEMU_TAG" \
+          https://gitlab.com/qemu-project/qemu.git /tmp/qemu
+        mkdir /tmp/qemu/build
+        cd /tmp/qemu/build
+        ../configure --target-list=hppa-linux-user --static \
+          --disable-docs --disable-tools --disable-plugins
+        ninja qemu-hppa
+        # binfmt on this runner is managed by systemd-binfmt (no
+        # update-binfmts). Overwrite the registered interpreter binary in
+        # place and refresh the registration so any 'F' flag re-opens it.
+        newq=/tmp/qemu/build/qemu-hppa
+        sudo cp "$newq" /usr/bin/qemu-hppa
+        entry=$(ls /proc/sys/fs/binfmt_misc/ | grep -i hppa | head -1)
+        interp=$(sed -n 's/^interpreter //p' "/proc/sys/fs/binfmt_misc/$entry")
+        echo "binfmt entry=$entry interpreter=$interp"
+        [ -n "$interp" ] && sudo cp "$newq" "$interp"
+        sudo systemctl restart systemd-binfmt 2>/dev/null || true
+        cat "/proc/sys/fs/binfmt_misc/$entry"
+        "${interp:-/usr/bin/qemu-hppa}" --version | head -1
+
     - name: Set QEMU environment
       if: matrix.platform.qemucpu != ''
       run: echo "QEMU_CPU=${{ matrix.platform.qemucpu }}" >> $GITHUB_ENV

--- a/.github/workflows/make-test
+++ b/.github/workflows/make-test
@@ -43,28 +43,29 @@ for test_name in quic_multistream; do
     fi
 done
 
-# Collect any core dumps together with the matching test binary, so the core is
+# Collect any core dumps together with the crashing binary, so the core is
 # usable with gdb without a rebuild. Cores land in two places: host cores in
 # /tmp/cores via core_pattern (core.<exe>.<pid>), and qemu-user guest cores
-# written next to the test in its run directory (qemu_<exe>_<pid>.core). Sweep
-# the tree for both and pair each with test/<exe> where possible. Only a
-# failing run produces any. Linux only for now.
+# written next to the test in its run directory (qemu_<exe>_<...>.core). For
+# each core, take the executable path the core records for itself (its execfn)
+# and copy that binary alongside; this matches any crashing program without
+# parsing core file names. Only a failing run produces any. Linux only for now.
 if [ "$(uname)" = Linux ]; then
     {
-        find /tmp/cores . \
-            \( -type d \( -name .git -o -name artifacts \) -prune \) -o \
-            \( -type f \( -name 'core' -o -name 'core.*' -o -name '*.core' \) \
-               -print0 \) 2>/dev/null |
-        while IFS= read -r -d '' core; do
-            base=$(basename "$core")
-            case "$base" in
-                qemu_*.core) exe=${base#qemu_}; exe=${exe%.core}; exe=${exe%_*} ;;
-                core.*)      exe=${base#core.}; exe=${exe%.*} ;;
-                *.core)      exe=${base%.core}; exe=${exe%_*} ;;
-                *)           exe= ;;
-            esac
-            [ -n "$exe" ] && [ -f "test/$exe" ] &&
-                cp "test/$exe" "$OSSL_CI_ARTIFACTS_PATH/" 2>/dev/null || true
+        { ls /tmp/cores/* 2>/dev/null || true
+          find . -name 'qemu_*.core' -type f 2>/dev/null || true; } |
+        while IFS= read -r core; do
+            [ -f "$core" ] || continue
+            # execfn is recorded relative to the test's working directory
+            # (e.g. ../../test/quic_radix_test); strip leading ../ so it
+            # resolves from the build root.
+            exe=$(file -b "$core" 2>/dev/null |
+                  sed -n "s/.*execfn: '\([^']*\)'.*/\1/p" |
+                  sed 's#^\(\.\./\)*##')
+            # Only pull in binaries from the build tree (relative execfn), not
+            # system executables such as /usr/bin/perl.
+            [ -n "$exe" ] && [ "${exe#/}" = "$exe" ] && [ -f "$exe" ] &&
+                cp "$exe" "$OSSL_CI_ARTIFACTS_PATH/" 2>/dev/null || true
             cp "$core" "$OSSL_CI_ARTIFACTS_PATH/" 2>/dev/null || true
         done
     } || true

--- a/.github/workflows/make-test
+++ b/.github/workflows/make-test
@@ -44,15 +44,30 @@ for test_name in quic_multistream; do
 done
 
 # Collect any core dumps together with the matching test binary, so the core is
-# usable with gdb without a rebuild. The executable name is the %e field of the
-# core file name. Only a failing run produces any. Linux only for now.
+# usable with gdb without a rebuild. Cores land in two places: host cores in
+# /tmp/cores via core_pattern (core.<exe>.<pid>), and qemu-user guest cores
+# written next to the test in its run directory (qemu_<exe>_<pid>.core). Sweep
+# the tree for both and pair each with test/<exe> where possible. Only a
+# failing run produces any. Linux only for now.
 if [ "$(uname)" = Linux ]; then
-    for core in /tmp/cores/core.*; do
-        [ -f "$core" ] || continue
-        exe=$(basename "$core"); exe=${exe#core.}; exe=${exe%.*}
-        [ -f "test/$exe" ] && cp "test/$exe" "$OSSL_CI_ARTIFACTS_PATH/" || true
-        mv "$core" "$OSSL_CI_ARTIFACTS_PATH/" || true
-    done
+    {
+        find /tmp/cores . \
+            \( -type d \( -name .git -o -name artifacts \) -prune \) -o \
+            \( -type f \( -name 'core' -o -name 'core.*' -o -name '*.core' \) \
+               -print0 \) 2>/dev/null |
+        while IFS= read -r -d '' core; do
+            base=$(basename "$core")
+            case "$base" in
+                qemu_*.core) exe=${base#qemu_}; exe=${exe%.core}; exe=${exe%_*} ;;
+                core.*)      exe=${base#core.}; exe=${exe%.*} ;;
+                *.core)      exe=${base%.core}; exe=${exe%_*} ;;
+                *)           exe= ;;
+            esac
+            [ -n "$exe" ] && [ -f "test/$exe" ] &&
+                cp "test/$exe" "$OSSL_CI_ARTIFACTS_PATH/" 2>/dev/null || true
+            cp "$core" "$OSSL_CI_ARTIFACTS_PATH/" 2>/dev/null || true
+        done
+    } || true
 fi
 
 # Log the artifact tree.

--- a/.github/workflows/make-test
+++ b/.github/workflows/make-test
@@ -17,6 +17,18 @@ fi
 mkdir -p "$OSSL_CI_ARTIFACTS_PATH"
 export OSSL_CI_ARTIFACTS_PATH="$(cd "$OSSL_CI_ARTIFACTS_PATH"; pwd)"
 
+# Enable core dumps so a crashing test leaves a core with every thread's stack
+# for diagnosis. Only a failing run produces one; green runs dump nothing.
+# Linux only for now; best effort - a runner that disallows this just won't
+# dump.
+if [ "$(uname)" = Linux ]; then
+    ulimit -c unlimited 2>/dev/null || true
+    if command -v sudo >/dev/null 2>&1; then
+        sudo mkdir -p /tmp/cores && sudo chmod 1777 /tmp/cores || true
+        echo '/tmp/cores/core.%e.%p' | sudo tee /proc/sys/kernel/core_pattern >/dev/null 2>&1 || true
+    fi
+fi
+
 # Run the tests. This might fail, but we need to capture artifacts anyway.
 set +e
 make test HARNESS_JOBS=${HARNESS_JOBS:-4} LHASH_WORKERS=${LHASH_WORKERS:-16} "$@"
@@ -30,6 +42,18 @@ for test_name in quic_multistream; do
         mv "test-runs/test_${test_name}" "$OSSL_CI_ARTIFACTS_PATH/"
     fi
 done
+
+# Collect any core dumps together with the matching test binary, so the core is
+# usable with gdb without a rebuild. The executable name is the %e field of the
+# core file name. Only a failing run produces any. Linux only for now.
+if [ "$(uname)" = Linux ]; then
+    for core in /tmp/cores/core.*; do
+        [ -f "$core" ] || continue
+        exe=$(basename "$core"); exe=${exe#core.}; exe=${exe%.*}
+        [ -f "test/$exe" ] && cp "test/$exe" "$OSSL_CI_ARTIFACTS_PATH/" || true
+        mv "$core" "$OSSL_CI_ARTIFACTS_PATH/" || true
+    done
+fi
 
 # Log the artifact tree.
 echo "::group::List of artifact files generated"


### PR DESCRIPTION
Ubuntu 24.04 pins qemu-user at 8.2.2, which has serious hppa emulation bugs; the hppa job appears to hit an intermittent SIGILL under it. Build qemu v11.1.0 for that job instead.

Note that this working once does not prove anything, the exit 132 failures with an empty log (which makes it appear like this could be QEMU's fault and matches a few of their fixed issues prior to 9.2) merely make this a strong possibility.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
