### PR TITLE
Add core dumps and matching binary to CI artifacts on linux

### DIFF
--- a/.github/workflows/make-test
+++ b/.github/workflows/make-test
@@ -17,6 +17,18 @@ fi
 mkdir -p "$OSSL_CI_ARTIFACTS_PATH"
 export OSSL_CI_ARTIFACTS_PATH="$(cd "$OSSL_CI_ARTIFACTS_PATH"; pwd)"
 
+# Enable core dumps so a crashing test leaves a core with every thread's stack
+# for diagnosis. Only a failing run produces one; green runs dump nothing.
+# Linux only for now; best effort - a runner that disallows this just won't
+# dump.
+if [ "$(uname)" = Linux ]; then
+    ulimit -c unlimited 2>/dev/null || true
+    if command -v sudo >/dev/null 2>&1; then
+        sudo mkdir -p /tmp/cores && sudo chmod 1777 /tmp/cores || true
+        echo '/tmp/cores/core.%e.%p' | sudo tee /proc/sys/kernel/core_pattern >/dev/null 2>&1 || true
+    fi
+fi
+
 # Run the tests. This might fail, but we need to capture artifacts anyway.
 set +e
 make test HARNESS_JOBS=${HARNESS_JOBS:-4} LHASH_WORKERS=${LHASH_WORKERS:-16} "$@"
@@ -30,6 +42,18 @@ for test_name in quic_multistream; do
         mv "test-runs/test_${test_name}" "$OSSL_CI_ARTIFACTS_PATH/"
     fi
 done
+
+# Collect any core dumps together with the matching test binary, so the core is
+# usable with gdb without a rebuild. The executable name is the %e field of the
+# core file name. Only a failing run produces any. Linux only for now.
+if [ "$(uname)" = Linux ]; then
+    for core in /tmp/cores/core.*; do
+        [ -f "$core" ] || continue
+        exe=$(basename "$core"); exe=${exe#core.}; exe=${exe%.*}
+        [ -f "test/$exe" ] && cp "test/$exe" "$OSSL_CI_ARTIFACTS_PATH/" || true
+        mv "$core" "$OSSL_CI_ARTIFACTS_PATH/" || true
+    done
+fi
 
 # Log the artifact tree.
 echo "::group::List of artifact files generated"


### PR DESCRIPTION
If we manage to have a test crash, let's get the core and binary in the artifacts

So for linux, we attempt to set the core pattern to drop the core file in /tmp. 

At the end of a failing run, if we have one, we try to grab the corresponding binary, 
and put both the core, and the binary, into the build artifacts. 

I mostly want this for https://github.com/openssl/openssl/pull/32424 but it has other uses.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
