### PR TITLE
Backport #32256 openssl 4.0 to 3.0

### DIFF
--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -286,13 +286,19 @@ int ossl_ccm_stream_final(void *vctx, unsigned char *out, size_t *outl,
     size_t outsize)
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
-    int i;
+    unsigned char dummy_in = 0, dummy_out = 0;
 
     if (!ossl_prov_is_running())
         return 0;
 
-    i = ccm_cipher_internal(ctx, out, outl, NULL, 0);
-    if (i <= 0)
+    /*
+     * Encryption sets tag_set after processing the payload, while successful
+     * decryption clears iv_set. Use those transitions to avoid processing an
+     * operation twice.
+     */
+    if (!ctx->key_set
+        || (ctx->iv_set && (!ctx->enc || !ctx->tag_set)
+            && ccm_cipher_internal(ctx, &dummy_out, outl, &dummy_in, 0) <= 0))
         return 0;
 
     *outl = 0;
@@ -306,6 +312,9 @@ int ossl_ccm_cipher(void *vctx, unsigned char *out, size_t *outl, size_t outsize
 
     if (!ossl_prov_is_running())
         return 0;
+
+    if (in == NULL)
+        return ossl_ccm_stream_final(vctx, out, outl, outsize);
 
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -7019,6 +7019,189 @@ end:
     return ok;
 }
 
+static const AEAD_ONESHOT_CFG ccm_empty_final_cfgs[] = {
+    { "AES-128-CCM", 16, 12, 16, 1 },
+    { "AES-192-CCM", 24, 12, 16, 1 },
+    { "AES-256-CCM", 32, 12, 16, 1 },
+    { "ARIA-128-CCM", 16, 12, 16, 1 },
+    { "ARIA-192-CCM", 24, 12, 16, 1 },
+    { "ARIA-256-CCM", 32, 12, 16, 1 },
+    { "SM4-CCM", 16, 12, 16, 1 }
+};
+
+/*
+ * Finalize CCM after declaring an empty payload and supplying AAD, without a
+ * payload Update. Return one for authentication success, zero for an
+ * authentication failure, and minus one for any other failure.
+ */
+static int ccm_empty_final_op(const AEAD_ONESHOT_CFG *cfg, int enc,
+    int oneshot_final, const unsigned char *key, const unsigned char *iv,
+    const unsigned char *aad, size_t aad_len, unsigned char *tag,
+    const char **why)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *cipher = NULL;
+    unsigned char out[1] = { 0 };
+    int outl = 0, rv;
+    int ret = -1;
+
+    *why = NULL;
+
+    if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, cfg->name, testpropq))) {
+        *why = "CIPHER_FETCH";
+        goto end;
+    }
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())) {
+        *why = "CTX_NEW";
+        goto end;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, cipher, NULL, NULL, NULL, enc))) {
+        *why = "INIT_CIPHER";
+        goto end;
+    }
+    if (!TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN,
+                         (int)cfg->ivlen, NULL),
+            0)) {
+        *why = "SET_IVLEN";
+        goto end;
+    }
+    if (!TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG,
+                         (int)cfg->taglen, enc ? NULL : tag),
+            0)) {
+        *why = "SET_TAG";
+        goto end;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, key, iv, enc))) {
+        *why = "INIT_KEY_IV";
+        goto end;
+    }
+    if (!TEST_true(EVP_CipherUpdate(ctx, NULL, &outl, NULL, 0))) {
+        *why = "LENGTH";
+        goto end;
+    }
+    if (!TEST_true(EVP_CipherUpdate(ctx, NULL, &outl, aad, (int)aad_len))) {
+        *why = "AAD";
+        goto end;
+    }
+
+    if (oneshot_final) {
+        rv = EVP_Cipher(ctx, out, NULL, 0);
+        ret = rv >= 0;
+        if (ret && rv != 0) {
+            *why = "ONESHOT_FINAL_LENGTH";
+            ret = -1;
+            goto end;
+        }
+    } else {
+        ret = EVP_CipherFinal_ex(ctx, out, &outl) > 0;
+        if (ret && outl != 0) {
+            *why = "STREAM_FINAL_LENGTH";
+            ret = -1;
+            goto end;
+        }
+    }
+
+    if (ret && enc
+        && !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG,
+                            (int)cfg->taglen, tag),
+            0)) {
+        *why = "GET_TAG";
+        ret = -1;
+    }
+
+end:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    return ret;
+}
+
+static int test_ccm_empty_final(int idx)
+{
+    static const unsigned char fixed_key[32] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
+    };
+    static const unsigned char fixed_iv[12] = {
+        0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5,
+        0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab
+    };
+    static const unsigned char fixed_aad[] = "CCM empty-payload Final regression";
+    const AEAD_ONESHOT_CFG *cfg = &ccm_empty_final_cfgs[idx];
+    EVP_CIPHER *probe = NULL;
+    unsigned char tag_stream[16], tag_oneshot[16], bad_tag[16];
+    const char *why = NULL;
+    int rv, ok = 0;
+
+    ERR_set_mark();
+    probe = EVP_CIPHER_fetch(testctx, cfg->name, testpropq);
+    ERR_pop_to_mark();
+    if (probe == NULL) {
+        TEST_info("skipping, '%s' is not available", cfg->name);
+        return 1;
+    }
+    EVP_CIPHER_free(probe);
+
+    memset(tag_stream, 0, sizeof(tag_stream));
+    rv = ccm_empty_final_op(cfg, 1, 0, fixed_key, fixed_iv, fixed_aad,
+        sizeof(fixed_aad) - 1, tag_stream, &why);
+    if (!TEST_int_eq(rv, 1)) {
+        TEST_error("%s: streaming encryption failed at %s",
+            cfg->name, why ? why : "FINAL");
+        goto end;
+    }
+
+    memset(tag_oneshot, 0, sizeof(tag_oneshot));
+    rv = ccm_empty_final_op(cfg, 1, 1, fixed_key, fixed_iv, fixed_aad,
+        sizeof(fixed_aad) - 1, tag_oneshot, &why);
+    if (!TEST_int_eq(rv, 1)) {
+        TEST_error("%s: one-shot encryption failed at %s",
+            cfg->name, why ? why : "FINAL");
+        goto end;
+    }
+    if (!TEST_mem_eq(tag_stream, cfg->taglen, tag_oneshot, cfg->taglen)) {
+        TEST_error("%s: streaming and one-shot tags differ", cfg->name);
+        goto end;
+    }
+
+    rv = ccm_empty_final_op(cfg, 0, 0, fixed_key, fixed_iv, fixed_aad,
+        sizeof(fixed_aad) - 1, tag_stream, &why);
+    if (!TEST_int_eq(rv, 1)) {
+        TEST_error("%s: streaming verification failed at %s",
+            cfg->name, why ? why : "FINAL");
+        goto end;
+    }
+    rv = ccm_empty_final_op(cfg, 0, 1, fixed_key, fixed_iv, fixed_aad,
+        sizeof(fixed_aad) - 1, tag_stream, &why);
+    if (!TEST_int_eq(rv, 1)) {
+        TEST_error("%s: one-shot verification failed at %s",
+            cfg->name, why ? why : "FINAL");
+        goto end;
+    }
+
+    memcpy(bad_tag, tag_stream, cfg->taglen);
+    bad_tag[0] ^= 1;
+    rv = ccm_empty_final_op(cfg, 0, 0, fixed_key, fixed_iv, fixed_aad,
+        sizeof(fixed_aad) - 1, bad_tag, &why);
+    if (!TEST_int_eq(rv, 0)) {
+        TEST_error("%s: streaming Final accepted an invalid tag", cfg->name);
+        goto end;
+    }
+    ERR_clear_error();
+    rv = ccm_empty_final_op(cfg, 0, 1, fixed_key, fixed_iv, fixed_aad,
+        sizeof(fixed_aad) - 1, bad_tag, &why);
+    if (!TEST_int_eq(rv, 0)) {
+        TEST_error("%s: one-shot Final accepted an invalid tag", cfg->name);
+        goto end;
+    }
+    ERR_clear_error();
+
+    ok = 1;
+end:
+    return ok;
+}
+
 #ifndef OPENSSL_NO_DES
 static int test_EVP_CIPHER_get_type_des_ede3(void)
 {
@@ -8064,6 +8247,7 @@ int setup_tests(void)
 #endif
 
     ADD_ALL_TESTS(test_aead_oneshot_roundtrip, 2 * OSSL_NELEM(aead_oneshot_cfgs));
+    ADD_ALL_TESTS(test_ccm_empty_final, OSSL_NELEM(ccm_empty_final_cfgs));
 
     /* Test cases for CVE-2026-45446 */
     ADD_TEST(test_aes_gcm_siv_empty_data);


### PR DESCRIPTION
Fixes #32253

This backports #32256 (commit 493a46c61983195c2b49bfde75ffba0321e5e69d) to openssl-4.0, openssl-3.6, openssl-3.5, openssl-3.4, and openssl-3.0 with a stable branch test adaptation and dedicated regression coverage.

The 3.0 branch is affected. In its pre-fix provider CCM path, `ossl_ccm_stream_final` calls `ccm_cipher_internal` with `in == NULL` and `out != NULL`. This takes the early `finish` path without invoking the CCM authentication operation. If an empty message declares a zero payload length and then omits the payload Update, encryption therefore does not generate a tag, and decryption can return success without verifying the supplied tag.

The master regression test is not directly applicable because the newer generic zero-length AEAD test it uses is absent from these branches. This PR instead adds equivalent coverage using their common `evp_extra_test` infrastructure. For every available built-in CCM cipher (AES-128/192/256-CCM, ARIA-128/192/256-CCM, and SM4-CCM), it covers streaming and one-shot Final, tag generation, correct-tag acceptance, and modified-tag rejection.

##### Checklist

- [x] tests are added or updated