### PR TITLE
Fix TAP stream corruption in ML codec and pkeyutl test recipes

### DIFF
--- a/test/recipes/15-test_ml_dsa_codecs.t
+++ b/test/recipes/15-test_ml_dsa_codecs.t
@@ -194,10 +194,9 @@ foreach my $alg (@algs) {
         sprintf("create fake private key: %s", $alg));
     my $realfh = IO::File->new($real, "<:raw");
     my $fakefh = IO::File->new($fake, "<:raw");
-    local $/ = undef;
-    my $realder = <$realfh>;
+    my $realder = do { local $/; <$realfh> };
     $realfh->close();
-    my $fakeder = <$fakefh>;
+    my $fakeder = do { local $/; <$fakefh> };
     $fakefh->close();
     #
     # - 20 bytes PKCS8 fixed overhead,

--- a/test/recipes/15-test_ml_kem_codecs.t
+++ b/test/recipes/15-test_ml_kem_codecs.t
@@ -179,9 +179,8 @@ foreach my $alg (@algs) {
         sprintf("create fake private key: %s", $alg));
     my $realfh = IO::File->new($real, "<:raw");
     my $fakefh = IO::File->new($fake, "<:raw");
-    local $/ = undef;
-    my $realder = <$realfh>;
-    my $fakeder = <$fakefh>;
+    my $realder = do { local $/; <$realfh> };
+    my $fakeder = do { local $/; <$fakefh> };
     $realfh->close();
     $fakefh->close();
     #

--- a/test/recipes/20-test_pkeyutl.t
+++ b/test/recipes/20-test_pkeyutl.t
@@ -175,8 +175,12 @@ SKIP: {
                     "-rawin", "-digest", "sha256");
     };
 
+    # -verifyrecover outputs the recovered payload (binary, without a
+    # trailing newline), which would otherwise be echoed into the TAP
+    # stream by run() and corrupt it, so redirect it to a file.
     ok(run(app((['openssl', 'pkeyutl', '-verifyrecover', '-in', $sigfile,
-                 '-pubin', '-inkey', srctop_file('test', 'testrsapub.pem')]))),
+                 '-pubin', '-inkey', srctop_file('test', 'testrsapub.pem')],
+                stdout => 'rsa_verifyrecover.out'))),
        "RSA: Verify signature with -verifyrecover");
 
     subtest "RSA CLI signature and verification with pkeyopt" => sub {

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -510,6 +510,10 @@ sub run {
     local $_;
 
     open($pipe, '-|', "$prefix$cmd") or die "Can't start command: $!";
+    # Read line by line, even if a recipe played with $/ (slurp or
+    # paragraph mode).  Otherwise, a bare prefix (or only the first
+    # line of a multi-line read) would hit the TAP stream unguarded.
+    local $/ = "\n";
     while(<$pipe>) {
         my $l = ($opts{prefix} // $default_prefix) . $_;
         if ($opts{capture}) {


### PR DESCRIPTION
Three test recipes failed under a plain `prove` run with TAP parse errors while all subtests passed; `make test` hid it thanks to output merging.

- ebb34143c3 fixes the recipes (see also #32428)
- bb56281ceb hardens `OpenSSL::Test::run()` against the same class of bug

Fixes #32428