### PR TITLE
ci: use long calls for HPPA cross-compilation

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -96,7 +96,7 @@ jobs:
             # with -O2 on this platform, reduce optimization to -01
             arch: hppa-linux-gnu,
             libs: libc6-dev-hppa-cross,
-            target: -static -O1 linux-generic32,
+            target: -static -O1 -mlong-calls linux-generic32,
             fips: no,
             tests: -test_includes -test_store -test_x509_store
           }, {


### PR DESCRIPTION
The QUIC radix test translation unit is now large enough to exceed the PA-RISC 1.x short-call range. This causes the HPPA test binary to branch into data and terminate with SIGILL under QEMU.

Build the HPPA CI target with -mlong-calls so calls can always reach linker-generated stubs.

Assisted-by: Codex:gpt-5
