### PR TITLE
ssl/s3_lib: avoid NULL deref when session is unset

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -5665,7 +5665,7 @@ const char *SSL_get0_group_name(SSL *s)
     if (SSL_CONNECTION_IS_TLS13(sc) && sc->s3.did_kex)
         id = sc->s3.group_id;
     else
-        id = sc->session->kex_group;
+        id = (sc->session != NULL) ? sc->session->kex_group : NID_undef;
 
     return tls1_group_id2name(s->ctx, id);
 }


### PR DESCRIPTION
Guards the non-TLS1.3 path so a NULL `sc->session` falls back to `NID_undef` instead of crashing.

Fixes #32379

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
