### PR TITLE
Revert "SSL_dup() should copy additional members"

### DIFF
--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -102,14 +102,6 @@ SSL_set0_client_CA_list() or similar functions
 
 =item OCSP validation set via L<SSL_set_tlsext_status_type(3)>.
 
-=item type of server certificate set via L<SSL_set1_server_cert_type(3)>.
-
-=item type of client certificate set via L<SSL_set1_client_cert_type(3)>.
-
-=item certificate transparency validation callback set via L<SSL_set_ct_validation_callback(3)>,
-
-=item OCSP validation set via L<SSL_set_tlsext_status_type(3)>.
-
 =back
 
 SSL_dup() is not supported on QUIC SSL objects and returns NULL if called on


### PR DESCRIPTION
This reverts commit 887ac7ece3facd430e67a6906d3dec1046dbf670.

This commit was mistakenly added during merge cherry-picking to 3.6 branch.

The proper commit fixing the bug is the previous one on the branch https://github.com/openssl/openssl/commit/b67319bfa1bf11f9f43ba25b70156003ebed6f40