### PR TITLE
test: fix TAP stream corruption in 20-test_pkeyutl.t

### DIFF
--- a/test/recipes/20-test_pkeyutl.t
+++ b/test/recipes/20-test_pkeyutl.t
@@ -175,8 +175,12 @@ SKIP: {
                     "-rawin", "-digest", "sha256");
     };
 
+    # -verifyrecover outputs the recovered payload (binary, without a
+    # trailing newline), which would otherwise be echoed into the TAP
+    # stream by run() and corrupt it, so redirect it to a file.
     ok(run(app((['openssl', 'pkeyutl', '-verifyrecover', '-in', $sigfile,
-                 '-pubin', '-inkey', srctop_file('test', 'testrsapub.pem')]))),
+                 '-pubin', '-inkey', srctop_file('test', 'testrsapub.pem')],
+                stdout => 'rsa_verifyrecover.out'))),
        "RSA: Verify signature with -verifyrecover");
 
     subtest "RSA CLI signature and verification with pkeyopt" => sub {


### PR DESCRIPTION
Backport of the pkeyutl part of #32429 — the only part relevant on 3.5.

Fixes: https://github.com/openssl/openssl/issues/32428