### PR TITLE
Fix NULL dereference in SSL_get0_group_name() before a handshake

### DIFF
--- a/doc/man3/SSL_get0_group_name.pod
+++ b/doc/man3/SSL_get0_group_name.pod
@@ -20,8 +20,9 @@ the key agreement of the current TLS session establishment.
 
 If non-NULL, SSL_get0_group_name() returns the name of the group that was used for
 the key agreement of the current TLS session establishment.
-If SSL_get0_group_name() returns NULL, an error occurred; possibly no TLS session
-has been established. See also L<SSL_get_negotiated_group(3)>.
+SSL_get0_group_name() returns NULL if no group is available, for example
+because no TLS session has been established yet, or because the handshake did
+not use a key agreement group. See also L<SSL_get_negotiated_group(3)>.
 
 Note that the return value is valid only during the lifetime of the
 SSL object I<ssl>.
@@ -37,7 +38,7 @@ This function was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 
-Copyright 2023-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2023-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -5664,8 +5664,10 @@ const char *SSL_get0_group_name(SSL *s)
 
     if (SSL_CONNECTION_IS_TLS13(sc) && sc->s3.did_kex)
         id = sc->s3.group_id;
-    else
+    else if (sc->session != NULL)
         id = sc->session->kex_group;
+    else
+        return NULL;
 
     return tls1_group_id2name(s->ctx, id);
 }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7012,6 +7012,37 @@ end:
 }
 #endif /* OSSL_NO_USABLE_TLS1_3 */
 
+/*
+ * Test that the group accessors report "no group" rather than crashing when
+ * they are called on a connection that has not performed a handshake yet.
+ */
+#if !defined(OPENSSL_NO_TLS1_2) || !defined(OSSL_NO_USABLE_TLS1_3)
+static int test_group_before_handshake(void)
+{
+    SSL_CTX *cctx = NULL;
+    SSL *clientssl = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(cctx = SSL_CTX_new_ex(libctx, NULL, TLS_client_method())))
+        goto end;
+
+    if (!TEST_ptr(clientssl = SSL_new(cctx)))
+        goto end;
+
+    if (!TEST_ptr_null(SSL_get0_group_name(clientssl)))
+        goto end;
+
+    if (!TEST_int_eq(SSL_get_negotiated_group(clientssl), NID_undef))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(clientssl);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+#endif
+
 static int clntaddoldcb = 0;
 static int clntparseoldcb = 0;
 static int srvaddoldcb = 0;
@@ -15607,6 +15638,9 @@ int setup_tests(void)
 #ifndef OSSL_NO_USABLE_TLS1_3
     ADD_TEST(test_ktls_moving_write_buffer);
 #endif
+#endif
+#if !defined(OPENSSL_NO_TLS1_2) || !defined(OSSL_NO_USABLE_TLS1_3)
+    ADD_TEST(test_group_before_handshake);
 #endif
     ADD_TEST(test_large_message_tls);
     ADD_TEST(test_large_message_tls_read_ahead);


### PR DESCRIPTION
Fixes #32379.

### What is wrong

`SSL_get0_group_name()` falls back to `sc->session->kex_group` for anything that is not a TLSv1.3 connection which has already done a key exchange:

```c
    if (SSL_CONNECTION_IS_TLS13(sc) && sc->s3.did_kex)
        id = sc->s3.group_id;
    else
        id = sc->session->kex_group;
```

On a connection where no handshake has started yet, `sc->session` is still NULL, so this crashes. The manual page already promises a NULL return in that case.

Reproducer (segfaults on master):

```c
#include <openssl/ssl.h>

int main(void)
{
    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
    SSL *ssl = SSL_new(ctx);

    SSL_get0_group_name(ssl);   /* boom */
    SSL_free(ssl);
    SSL_CTX_free(ctx);
    return 0;
}
```

This is the same bug pattern that was fixed for `SSL_get_negotiated_group()` in 4ca80d3941 (#26722), as @idrassi pointed out on the issue. It reaches TLS, DTLS and QUIC, and is present on every branch since the accessor landed in 3.2.

### What this changes

* `ssl/s3_lib.c`: only read the session when there is one, otherwise return NULL. Same shape as the `SSL_CTRL_GET_NEGOTIATED_GROUP` handler right above it.
* `doc/man3/SSL_get0_group_name.pod`: the RETURN VALUES section claimed a NULL return meant an error occurred. It does not. NULL just means no group is available, which is the normal answer before a handshake or after one that used no key agreement group.
* `test/sslapitest.c`: a regression test that calls both group accessors on a fresh `SSL` object.

### Verification

Built `linux-x86_64` and ran `make test TESTS=test_sslapi`.

* Without the `ssl/s3_lib.c` change the new test crashes the test binary: `not ok 1 - running sslapitest`, `Result: FAIL`.
* With it: `ok 1 - test_group_before_handshake`, whole recipe `Result: PASS`.

The reproducer above prints `(NULL)` and exits 0 after the change.

### Notes

The commit carries an `Assisted-by:` trailer as required by CONTRIBUTING.md. I will complete the CLA before this is merged; happy to adjust anything here in the meantime.