### PR TITLE
Add a test of the exported CMake config

### DIFF
--- a/build.info
+++ b/build.info
@@ -539,7 +539,7 @@ DEPEND[openssl.pc]=libcrypto.pc libssl.pc
 
 GENERATE[builddata.pm]=util/mkinstallvars.pl \
     COMMENT="This file should be used when building against this OpenSSL build, and should never be installed" \
-    PREFIX=. BINDIR=apps APPLINKDIR=ms \
+    PREFIX=. BINDIR=apps "APPLINKDIR=$(SRCDIR)/ms" \
     LIBDIR= INCLUDEDIR=include "INCLUDEDIR=$(SRCDIR)/include" \
     MODULESDIR=providers \
     libdir= CMAKECONFIGDIR= PKGCONFIGDIR= \

--- a/test/recipes/94-test_cmake_config.t
+++ b/test/recipes/94-test_cmake_config.t
@@ -1,0 +1,54 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use Cwd qw(abs_path);
+use IPC::Cmd;
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT bldtop_dir bldtop_file data_dir result_dir/;
+
+setup("test_cmake_config");
+
+plan skip_all => "cmake is not available"
+    unless IPC::Cmd::can_run("cmake");
+
+# We require cmake 3.22 or later
+my $cmake_version_output = `cmake --version`;
+my ($cmake_major, $cmake_minor) =
+    $cmake_version_output =~ /version (\d+)\.(\d+)/;
+plan skip_all => "cmake version could not be determined"
+    unless defined $cmake_major;
+plan skip_all => "cmake 3.22 or later is required (found $cmake_major.$cmake_minor)"
+    unless $cmake_major > 3 || ($cmake_major == 3 && $cmake_minor >= 22);
+
+plan tests => 3;
+
+my $cmake_build_dir = result_dir("cmake-build");
+
+my @cmake_configure =
+    ("cmake",
+     "-S", abs_path(data_dir()),
+     "-B", $cmake_build_dir,
+     # Point find_package() at the build tree's exported config
+     "-DCMAKE_PREFIX_PATH=" . abs_path(bldtop_dir()),
+     # The dummy programs are run through the same wrapper that the rest
+     # of the test suite uses, so the loader path is set up for them
+     "-DOPENSSL_WRAP_PL=" . abs_path(bldtop_file("util", "wrap.pl")));
+push @cmake_configure, "-DTEST_LEGACY_PROVIDER=OFF"
+    if disabled("legacy") || disabled("module");
+
+ok(run(cmd([@cmake_configure])),
+   "configure the cmake test project");
+ok(run(cmd(["cmake", "--build", $cmake_build_dir, "--config", "Release"])),
+   "build the cmake test project");
+ok(run(cmd(["ctest", "--test-dir", $cmake_build_dir,
+            "-C", "Release", "--output-on-failure"])),
+   "run the cmake test project");

--- a/test/recipes/94-test_cmake_config.t
+++ b/test/recipes/94-test_cmake_config.t
@@ -55,6 +55,13 @@ my @cmake_configure =
      # The dummy programs are run through the same wrapper that the rest
      # of the test suite uses, so the loader path is set up for them
      "-DOPENSSL_WRAP_PL=" . abs_path(bldtop_file("util", "wrap.pl")));
+# With Visual Studio generators, cmake defaults to the x64 platform.
+# The dummy programs must match the architecture of the OpenSSL build,
+# so say it explicitly when it deviates from that default.
+push @cmake_configure, "-A", "Win32"
+    if config('target') =~ /^VC-WIN32/;
+push @cmake_configure, "-A", "ARM64"
+    if config('target') =~ /^VC-WIN64-ARM/;
 push @cmake_configure, "-DTEST_LEGACY_PROVIDER=OFF"
     if disabled("legacy") || disabled("module");
 

--- a/test/recipes/94-test_cmake_config.t
+++ b/test/recipes/94-test_cmake_config.t
@@ -62,6 +62,32 @@ push @cmake_configure, "-A", "Win32"
     if config('target') =~ /^VC-WIN32/;
 push @cmake_configure, "-A", "ARM64"
     if config('target') =~ /^VC-WIN64-ARM/;
+
+# With Unix generators, cmake compiles the consumer project with the
+# host compiler's default word size, which may deviate from the OpenSSL
+# build's (e.g. linux-x86 on an x86_64 host).  Translate the word size
+# and ABI selectors from the OpenSSL build's own flags, much like the
+# -A platform selection above.  An arch selector may come from the
+# target's flags or from user supplied ones.
+my @flag_tokens = map { split(/\s+/, $_) } (target('cflags') // '',
+                                            target('CFLAGS') // '',
+                                            @{config('cflags') // []},
+                                            @{config('CFLAGS') // []});
+my @abi_cflags;
+while (@flag_tokens) {
+    my $token = shift @flag_tokens;
+    if ($token =~ /^(-m(?:31|32|64|x32)|-mabi=.*|-maix(?:32|64)|-q(?:32|64)|-xarch=.*|\+DD(?:32|64))$/) {
+        # cmake passes CMAKE_C_FLAGS on the C link line as well
+        push @abi_cflags, $token;
+    } elsif ($token eq '-arch' && @flag_tokens) {
+        # Darwin; the Xcode generator requires the dedicated setting
+        push @cmake_configure,
+            "-DCMAKE_OSX_ARCHITECTURES=" . shift @flag_tokens;
+    }
+}
+push @cmake_configure, "-DCMAKE_C_FLAGS=" . join(" ", @abi_cflags)
+    if @abi_cflags;
+
 push @cmake_configure, "-DTEST_LEGACY_PROVIDER=OFF"
     if disabled("legacy") || disabled("module");
 

--- a/test/recipes/94-test_cmake_config.t
+++ b/test/recipes/94-test_cmake_config.t
@@ -20,6 +20,19 @@ setup("test_cmake_config");
 plan skip_all => "cmake is not available"
     unless IPC::Cmd::can_run("cmake");
 
+# The cmake-built dummies aren't sanitizer-instrumented, but wrap.pl
+# inherits the sanitizer runtime environment from the outer test run.
+# ASan refuses to attach to a non-instrumented executable, MSan
+# produces spurious link errors against the sanitized libraries, and
+# a static UBSan build leaves the consumer link without the UBSan
+# runtime (__ubsan_handle_* symbols).
+plan skip_all => "not run under address sanitizer"
+    unless disabled("asan");
+plan skip_all => "not run under memory sanitizer"
+    unless disabled("msan");
+plan skip_all => "not run under undefined behavior sanitizer"
+    unless disabled("ubsan");
+
 # We require cmake 3.22 or later
 my $cmake_version_output = `cmake --version`;
 my ($cmake_major, $cmake_minor) =

--- a/test/recipes/94-test_cmake_config.t
+++ b/test/recipes/94-test_cmake_config.t
@@ -20,6 +20,11 @@ setup("test_cmake_config");
 plan skip_all => "cmake is not available"
     unless IPC::Cmd::can_run("cmake");
 
+# Cross compiling the consumer project would require a toolchain
+# file, which is a bigger endeavour than is fitting for this test.
+plan skip_all => 'This is unsupported for cross compiled configurations'
+    if config('CROSS_COMPILE');
+
 # The cmake-built dummies aren't sanitizer-instrumented, but wrap.pl
 # inherits the sanitizer runtime environment from the outer test run.
 # ASan refuses to attach to a non-instrumented executable, MSan

--- a/test/recipes/94-test_cmake_config.t
+++ b/test/recipes/94-test_cmake_config.t
@@ -96,10 +96,26 @@ push @cmake_configure, "-DCMAKE_C_FLAGS=" . join(" ", @abi_cflags)
 push @cmake_configure, "-DTEST_LEGACY_PROVIDER=OFF"
     if disabled("legacy") || disabled("module");
 
-ok(run(cmd([@cmake_configure])),
+# cmake and ctest are host tools; wrap.pl (run by OpenSSL::Test::run())
+# would substitute the build's shared libraries into their processes
+# where sonames match (such as 3.x trees, currently), breaking them when
+# the ABIs differ. Only the dummy executables should be run through the
+# wrapper (OPENSSL_WRAP_PL in the consumer project).
+sub run_host_command {
+    my ($command) = @_;
+    my ($success, $error, $output) =
+        IPC::Cmd::run(command => $command);
+    if (!$success) {
+        diag($error) if defined $error;
+        diag(join("", @{$output})) if defined $output;
+    }
+    return $success;
+}
+
+ok(run_host_command(\@cmake_configure),
    "configure the cmake test project");
-ok(run(cmd(["cmake", "--build", $cmake_build_dir, "--config", "Release"])),
+ok(run_host_command(["cmake", "--build", $cmake_build_dir, "--config", "Release"]),
    "build the cmake test project");
-ok(run(cmd(["ctest", "--test-dir", $cmake_build_dir,
-            "-C", "Release", "--output-on-failure"])),
+ok(run_host_command(["ctest", "--test-dir", $cmake_build_dir,
+                     "-C", "Release", "--output-on-failure"]),
    "run the cmake test project");

--- a/test/recipes/94-test_cmake_config_data/CMakeLists.txt
+++ b/test/recipes/94-test_cmake_config_data/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(OpenSSL CONFIG REQUIRED
 
 add_executable(ossl_config_dummy_vars dummy.c)
 target_compile_definitions(ossl_config_dummy_vars PRIVATE DIRECT_CRYPTO_CALLS)
+target_include_directories(ossl_config_dummy_vars PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(ossl_config_dummy_vars PRIVATE ${OPENSSL_LIBRARIES})
 
 add_executable(ossl_config_dummy_tgt dummy.c)

--- a/test/recipes/94-test_cmake_config_data/CMakeLists.txt
+++ b/test/recipes/94-test_cmake_config_data/CMakeLists.txt
@@ -1,0 +1,87 @@
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+cmake_minimum_required(VERSION 3.22)
+project(OpenSSLConfigTest C)
+
+option(TEST_LEGACY_PROVIDER "Test loading the legacy provider" ON)
+
+# CONFIG mode is essential here; without it, CMake's own FindOpenSSL.cmake
+# module may be used instead of OpenSSL's exported config, which is what
+# this test is meant to exercise.  Special circumstances: this test must
+# exercise this build tree's config specifically, so OpenSSL_ROOT /
+# OPENSSL_ROOT from the environment must not redirect the search.
+find_package(OpenSSL CONFIG REQUIRED
+             PATHS "${CMAKE_PREFIX_PATH}"
+             NO_DEFAULT_PATH)
+
+# We build the same dummy program in three variants, covering the ways
+# CMake's FindOpenSSL.cmake has traditionally promoted for linking against
+# OpenSSL:
+#
+# ossl_config_dummy_vars    links with ${OPENSSL_LIBRARIES}, and calls
+#                           libssl and libcrypto functions directly
+# ossl_config_dummy_tgt     links with the OpenSSL::SSL and OpenSSL::Crypto
+#                           targets, and calls libssl and libcrypto
+#                           functions directly
+# ossl_config_dummy_sslonly links with the OpenSSL::SSL target alone, and
+#                           only calls libssl functions directly, relying
+#                           on the implied libcrypto dependency
+
+add_executable(ossl_config_dummy_vars dummy.c)
+target_compile_definitions(ossl_config_dummy_vars PRIVATE DIRECT_CRYPTO_CALLS)
+target_link_libraries(ossl_config_dummy_vars PRIVATE ${OPENSSL_LIBRARIES})
+
+add_executable(ossl_config_dummy_tgt dummy.c)
+target_compile_definitions(ossl_config_dummy_tgt PRIVATE DIRECT_CRYPTO_CALLS)
+target_link_libraries(ossl_config_dummy_tgt PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+
+add_executable(ossl_config_dummy_sslonly dummy.c)
+target_link_libraries(ossl_config_dummy_sslonly PRIVATE OpenSSL::SSL)
+
+set(all_dummies
+    ossl_config_dummy_vars ossl_config_dummy_tgt ossl_config_dummy_sslonly)
+set(crypto_dummies
+    ossl_config_dummy_vars ossl_config_dummy_tgt)
+
+if(WIN32)
+    # Console applications linking against the OpenSSL DLLs need applink,
+    # when that target exists (it's absent in no-uplink configurations)
+    if(TARGET OpenSSL::applink)
+        foreach(dummy IN LISTS all_dummies)
+            target_link_libraries(${dummy} PRIVATE OpenSSL::applink)
+        endforeach()
+    endif()
+
+    # Copy the OpenSSL DLLs next to the binaries, so the tests can run
+    if(DEFINED OPENSSL_LIBCRYPTO_SHARED)
+        foreach(dummy IN LISTS all_dummies)
+            add_custom_command(TARGET ${dummy} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${OPENSSL_LIBCRYPTO_SHARED}" "${OPENSSL_LIBSSL_SHARED}"
+                    $<TARGET_FILE_DIR:${dummy}>)
+        endforeach()
+    endif()
+endif()
+
+if(TEST_LEGACY_PROVIDER)
+    foreach(dummy IN LISTS crypto_dummies)
+        target_compile_definitions(${dummy} PRIVATE TEST_LEGACY_PROVIDER)
+    endforeach()
+endif()
+
+enable_testing()
+
+# The dummy programs are run through OpenSSL's util/wrap.pl (path passed in
+# as OPENSSL_WRAP_PL), which sets up the loader path for the platform at
+# hand, as well as OPENSSL_MODULES so the provider modules are found.
+find_program(PERL_PROGRAM perl REQUIRED)
+
+foreach(dummy IN LISTS all_dummies)
+    add_test(NAME ${dummy}
+        COMMAND ${PERL_PROGRAM} ${OPENSSL_WRAP_PL} $<TARGET_FILE:${dummy}>)
+endforeach()

--- a/test/recipes/94-test_cmake_config_data/dummy.c
+++ b/test/recipes/94-test_cmake_config_data/dummy.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <openssl/ssl.h>
+#ifdef DIRECT_CRYPTO_CALLS
+#include <openssl/crypto.h>
+#include <openssl/provider.h>
+#endif
+
+int main(void)
+{
+    SSL_CTX *ctx = NULL;
+#ifdef DIRECT_CRYPTO_CALLS
+    /* Exercise libcrypto directly */
+    printf("Linked against %s\n", OpenSSL_version(OPENSSL_VERSION));
+#endif
+
+    /* Exercise libssl */
+    ctx = SSL_CTX_new(TLS_method());
+    if (ctx == NULL) {
+        fprintf(stderr, "SSL_CTX_new() failed\n");
+        return EXIT_FAILURE;
+    }
+    SSL_CTX_free(ctx);
+
+#if defined(DIRECT_CRYPTO_CALLS) && defined(TEST_LEGACY_PROVIDER)
+    /*
+     * Exercise the provider module search path.  This relies on
+     * OPENSSL_MODULES being set appropriately in the environment.
+     */
+    {
+        OSSL_PROVIDER *legacy = NULL;
+        OSSL_PROVIDER *def = NULL;
+
+        legacy = OSSL_PROVIDER_load(NULL, "legacy");
+        if (legacy == NULL) {
+            fprintf(stderr, "OSSL_PROVIDER_load(\"legacy\") failed\n");
+            return EXIT_FAILURE;
+        }
+        def = OSSL_PROVIDER_load(NULL, "default");
+        if (def == NULL) {
+            fprintf(stderr, "OSSL_PROVIDER_load(\"default\") failed\n");
+            OSSL_PROVIDER_unload(legacy);
+            return EXIT_FAILURE;
+        }
+        OSSL_PROVIDER_unload(def);
+        OSSL_PROVIDER_unload(legacy);
+    }
+#endif
+
+    return EXIT_SUCCESS;
+}

--- a/util/perl/OpenSSL/Test/Utils.pm
+++ b/util/perl/OpenSSL/Test/Utils.pm
@@ -14,8 +14,8 @@ use Exporter;
 use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
 $VERSION = "0.1";
 @ISA = qw(Exporter);
-@EXPORT = qw(alldisabled anydisabled disabled config available_protocols
-             have_IPv4 have_IPv6);
+@EXPORT = qw(alldisabled anydisabled disabled config target
+             available_protocols have_IPv4 have_IPv6);
 
 =head1 NAME
 
@@ -66,6 +66,10 @@ disabled.
 =item B<config STRING>
 
 Returns an item from the %config hash in \$TOP/configdata.pm.
+
+=item B<target STRING>
+
+Returns an item from the %target hash in \$TOP/configdata.pm.
 
 =item B<have_IPv4>
 
@@ -164,6 +168,11 @@ sub available_protocols {
 sub config {
     load_configdata() unless $configdata_loaded;
     return $config{$_[0]};
+}
+
+sub target {
+    load_configdata() unless $configdata_loaded;
+    return $target{$_[0]};
 }
 
 # IPv4 / IPv6 checker


### PR DESCRIPTION
This adds a CI-covered test that builds and runs a small CMake consumer project against the build tree's exported CMake config (`OpenSSLConfig.cmake`), covering the linking styles that CMake's FindOpenSSL.cmake has traditionally promoted, plus loading of the legacy provider.

The test is skipped when no suitable cmake is available.  cmake is added to the Windows CI workflows; the Linux and macOS runners already provide it.

Please see individual commit messages for details.

Link: https://github.com/openssl/openssl/pull/31363
