### PR TITLE
Init libssl to sort the ciphers

### DIFF
--- a/test/cipher_overhead_test.c
+++ b/test/cipher_overhead_test.c
@@ -101,6 +101,7 @@ static int dtls13_cipher_overhead(int idx)
 
 int setup_tests(void)
 {
+    OPENSSL_init_ssl(0, NULL);
     ADD_TEST(cipher_overhead);
     ADD_ALL_TESTS(dtls13_cipher_overhead, OSSL_NELEM(dtls13_ciphers));
     return 1;


### PR DESCRIPTION
Otherwise ssl3_get_cipher_by_id() cannot work properly.

Urgent CI fix for the dtls-1.3 feature branch.