### PR TITLE
providers: initialize ML-DSA-MU before empty-message finalization

### DIFF
--- a/providers/implementations/digests/ml_dsa_mu_prov.c
+++ b/providers/implementations/digests/ml_dsa_mu_prov.c
@@ -319,7 +319,7 @@ static int mu_final(void *vctx, uint8_t *out, size_t *outl, size_t outsz)
         if (outsz < len)
             return 0;
 
-        if (ctx->remaining != 0)
+        if (ctx->remaining != 0 || !check_init(ctx))
             return 0;
         if (!ossl_ml_dsa_mu_finalize(ctx->mdctx, out, len))
             return 0;

--- a/test/ml_dsa_test.c
+++ b/test/ml_dsa_test.c
@@ -645,6 +645,39 @@ err:
     OPENSSL_free(sig);
     return ret;
 }
+static int ml_dsa_mu_empty_message_final_test(void)
+{
+    int ret = 0;
+    EVP_PKEY *key = NULL;
+    EVP_MD *md = NULL;
+    EVP_MD_CTX *mdctx = NULL;
+    uint8_t pub[ML_DSA_44_PUB_LEN];
+    uint8_t mu[ML_DSA_MU_BYTES];
+    size_t publen = 0;
+    OSSL_PARAM params[2];
+
+    if (!TEST_ptr(key = do_gen_key("ML-DSA-44", NULL, 0))
+        || !TEST_true(EVP_PKEY_get_octet_string_param(key,
+                          OSSL_PKEY_PARAM_PUB_KEY, pub, sizeof(pub), &publen))) {
+        goto err;
+    }
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_DIGEST_PARAM_MU_PUB_KEY,
+        pub, publen);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(md = EVP_MD_fetch(lib_ctx, "ML-DSA-MU", NULL))
+        || !TEST_ptr(mdctx = EVP_MD_CTX_new())
+        || !TEST_true(EVP_DigestInit_ex2(mdctx, md, params))
+        || !TEST_true(EVP_DigestFinalXOF(mdctx, mu, sizeof(mu))))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_MD_CTX_free(mdctx);
+    EVP_MD_free(md);
+    EVP_PKEY_free(key);
+    return ret;
+}
 
 static int ml_dsa_priv_pub_bad_t0_test(void)
 {
@@ -831,6 +864,7 @@ int setup_tests(void)
     ADD_TEST(ml_dsa_digest_sign_verify_test);
     ADD_TEST(ml_dsa_priv_pub_bad_t0_test);
     ADD_TEST(ml_dsa_newdata_bad_propq_test);
+    ADD_TEST(ml_dsa_mu_empty_message_final_test);
 
     /*
      * Tested only in the default configuration, with a non-default provider

--- a/test/ml_dsa_test.c
+++ b/test/ml_dsa_test.c
@@ -645,8 +645,26 @@ err:
     OPENSSL_free(sig);
     return ret;
 }
-static int ml_dsa_mu_empty_message_final_test(void)
+
+/*
+ * Finalizing an ML-DSA-MU digest that has had no message data supplied.
+ *
+ * For pure ML-DSA (no "digest" parameter) the empty message is a valid input,
+ * so mu is well defined and the final must succeed.
+ *
+ * For HASH-ML-DSA (a "digest" parameter is set) the input must be a prehashed
+ * message whose size matches the digest, so a prehash of the empty message is
+ * never itself empty and the final must fail.
+ */
+static const char *ml_dsa_mu_empty_message_digest[] = {
+    NULL,
+    "SHA-512",
+};
+
+static int ml_dsa_mu_empty_message_final_test(int tst)
 {
+    const char *digestname = ml_dsa_mu_empty_message_digest[tst];
+    int expected = (digestname == NULL);
     int ret = 0;
     EVP_PKEY *key = NULL;
     EVP_MD *md = NULL;
@@ -654,21 +672,26 @@ static int ml_dsa_mu_empty_message_final_test(void)
     uint8_t pub[ML_DSA_44_PUB_LEN];
     uint8_t mu[ML_DSA_MU_BYTES];
     size_t publen = 0;
-    OSSL_PARAM params[2];
+    OSSL_PARAM params[3], *p = params;
 
     if (!TEST_ptr(key = do_gen_key("ML-DSA-44", NULL, 0))
         || !TEST_true(EVP_PKEY_get_octet_string_param(key,
-                          OSSL_PKEY_PARAM_PUB_KEY, pub, sizeof(pub), &publen))) {
+            OSSL_PKEY_PARAM_PUB_KEY, pub, sizeof(pub), &publen)))
         goto err;
-    }
-    params[0] = OSSL_PARAM_construct_octet_string(OSSL_DIGEST_PARAM_MU_PUB_KEY,
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_DIGEST_PARAM_MU_PUB_KEY,
         pub, publen);
-    params[1] = OSSL_PARAM_construct_end();
+    if (digestname != NULL)
+        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_DIGEST_PARAM_MU_DIGEST,
+            (char *)digestname, 0);
+    *p = OSSL_PARAM_construct_end();
 
     if (!TEST_ptr(md = EVP_MD_fetch(lib_ctx, "ML-DSA-MU", NULL))
         || !TEST_ptr(mdctx = EVP_MD_CTX_new())
-        || !TEST_true(EVP_DigestInit_ex2(mdctx, md, params))
-        || !TEST_true(EVP_DigestFinalXOF(mdctx, mu, sizeof(mu))))
+        || !TEST_true(EVP_DigestInit_ex2(mdctx, md, params)))
+        goto err;
+
+    if (!TEST_int_eq(EVP_DigestFinalXOF(mdctx, mu, sizeof(mu)), expected))
         goto err;
 
     ret = 1;
@@ -864,7 +887,8 @@ int setup_tests(void)
     ADD_TEST(ml_dsa_digest_sign_verify_test);
     ADD_TEST(ml_dsa_priv_pub_bad_t0_test);
     ADD_TEST(ml_dsa_newdata_bad_propq_test);
-    ADD_TEST(ml_dsa_mu_empty_message_final_test);
+    ADD_ALL_TESTS(ml_dsa_mu_empty_message_final_test,
+        OSSL_NELEM(ml_dsa_mu_empty_message_digest));
 
     /*
      * Tested only in the default configuration, with a non-default provider

--- a/test/ml_dsa_test.c
+++ b/test/ml_dsa_test.c
@@ -887,8 +887,15 @@ int setup_tests(void)
     ADD_TEST(ml_dsa_digest_sign_verify_test);
     ADD_TEST(ml_dsa_priv_pub_bad_t0_test);
     ADD_TEST(ml_dsa_newdata_bad_propq_test);
-    ADD_ALL_TESTS(ml_dsa_mu_empty_message_final_test,
-        OSSL_NELEM(ml_dsa_mu_empty_message_digest));
+    /*
+     * mu_final() dereferenced an uninitialised digest context for an empty
+     * message, so this test crashes against a FIPS provider that predates
+     * the fix.  Only run it where the provider has it.
+     */
+    if (fips_provider_version_ge(lib_ctx, 4, 1, 0)) {
+        ADD_ALL_TESTS(ml_dsa_mu_empty_message_final_test,
+            OSSL_NELEM(ml_dsa_mu_empty_message_digest));
+    }
 
     /*
      * Tested only in the default configuration, with a non-default provider


### PR DESCRIPTION
### What was wrong

The ML-DSA-MU digest context was only initialized from `mu_update()`. If a caller finalized an empty message with `EVP_DigestFinalXOF()` before any update call, `ctx->mdctx` remained NULL and `mu_final()` passed that NULL into `ossl_ml_dsa_mu_finalize()`, which eventually reached `EVP_DigestSqueeze()` and crashed.

### What changed

- make `mu_final()` call `check_init()` before finalization, so empty-message finalization uses the same lazy initialization path as non-empty messages
- add a focused `ml_dsa_mu_empty_message_final_test()` regression in `test/ml_dsa_test.c`

### How it was verified

Local verification on current upstream HEAD:

- standalone repro from the issue crashed before the fix with exit 139
- `OPENSSL_MODULES=providers ./test/ml_dsa_test` crashed before the fix when the new regression ran
- after rebuilding with the fix, `OPENSSL_MODULES=providers ./test/ml_dsa_test` passed 17/17 tests, including `ml_dsa_mu_empty_message_final_test`
- the standalone repro then printed `Finalization succeeded` and exited 0

### User-facing impact

No API changes. This fixes a deterministic crash when finalizing an empty message through the ML-DSA-MU digest path.

### AI disclosure

Prepared with AI assistance, then manually reviewed and locally reproduced and verified.

Fixes #32445.
