### PR TITLE
providers: accept 512-byte cSHAKE customization

### DIFF
--- a/providers/implementations/digests/cshake_prov.c
+++ b/providers/implementations/digests/cshake_prov.c
@@ -151,7 +151,7 @@ static int cshake_set_encode_string(const char *in,
      */
     if (inlen == 0)
         return 1;
-    if (inlen >= CSHAKE_MAX_STRING)
+    if (inlen > CSHAKE_MAX_STRING)
         return 0;
     return ossl_sp800_185_encode_string(out, outmax, outlen,
         (const unsigned char *)in, inlen);

--- a/test/evp_xof_test.c
+++ b/test/evp_xof_test.c
@@ -613,6 +613,66 @@ err:
     return ret;
 }
 
+static int xof_customization_boundary_test(void)
+{
+    static const struct {
+        size_t len;
+        int should_pass;
+    } test_cases[] = {
+        { 511, 1 },
+        { 512, 1 },
+        { 513, 0 }
+    };
+    int ret = 0;
+    EVP_MD *md = NULL;
+    EVP_MD_CTX *ctx = NULL;
+    char *custom = NULL;
+    unsigned char out[32];
+    size_t i, j;
+    OSSL_PARAM params[2];
+
+    if (!TEST_ptr(md = EVP_MD_fetch(NULL, "CSHAKE128", NULL)))
+        goto err;
+
+    for (i = 0; i < OSSL_NELEM(test_cases); ++i) {
+        if (!TEST_ptr(custom = OPENSSL_malloc(test_cases[i].len + 1))
+            || !TEST_ptr(ctx = EVP_MD_CTX_new()))
+            goto err;
+
+        for (j = 0; j < test_cases[i].len; ++j)
+            custom[j] = 'A';
+        custom[test_cases[i].len] = '\0';
+
+        params[0] = OSSL_PARAM_construct_utf8_string(
+            OSSL_DIGEST_PARAM_CUSTOMIZATION, custom, 0);
+        params[1] = OSSL_PARAM_construct_end();
+
+        if (test_cases[i].should_pass) {
+            if (!TEST_true(EVP_DigestInit_ex2(ctx, md, params))
+                || !TEST_true(EVP_DigestFinalXOF(ctx, out, sizeof(out))))
+                goto err;
+        } else {
+            ERR_set_mark();
+            if (!TEST_false(EVP_DigestInit_ex2(ctx, md, params))) {
+                ERR_clear_last_mark();
+                goto err;
+            }
+            ERR_pop_to_mark();
+        }
+
+        OPENSSL_free(custom);
+        custom = NULL;
+        EVP_MD_CTX_free(ctx);
+        ctx = NULL;
+    }
+    ret = 1;
+err:
+    OPENSSL_free(custom);
+    EVP_MD_CTX_free(ctx);
+    EVP_MD_free(md);
+    return ret;
+}
+
 static int xof_fail_test(void)
 {
     int ret;
@@ -634,6 +694,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(xof_squeeze_kat_test, OSSL_NELEM(stride_test_data));
     ADD_ALL_TESTS(xof_squeeze_large_test, OSSL_NELEM(stride_test_data));
     ADD_ALL_TESTS(xof_squeeze_dup_test, OSSL_NELEM(dupoffset_test_data));
+    ADD_TEST(xof_customization_boundary_test);
     ADD_TEST(xof_fail_test);
     return 1;
 }


### PR DESCRIPTION
Fixes openssl/openssl#32446.

The cSHAKE customization boundary check rejected the documented 512-byte maximum by using >= instead of >. Accept the 512-byte boundary value and keep 513-byte inputs rejected.

Add a focused EVP XOF regression that exercises 511-byte, 512-byte, and 513-byte customization strings through EVP_DigestInit_ex2() and EVP_DigestFinalXOF().