### PR TITLE
CI: Test asan-instrumented OPENSSL_cleanse()

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -54,7 +54,7 @@ IF[{- !$disabled{tests} -}]
           crltest danetest bad_dtls_test lhash_test sparse_array_test \
           conf_include_test params_api_test params_conversion_test \
           constant_time_test crypto_memcmp_test safe_math_test verify_extra_test clienthellotest \
-          packettest asynctest secmemtest srptest memleaktest stack_test \
+          packettest asynctest secmemtest srptest memleaktest cleansetest stack_test \
           dtlsv1listentest ct_test threadstest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bio_callback_test bio_memleak_test bio_core_test bio_dgram_test param_build_test \
@@ -497,6 +497,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[memleaktest]=memleaktest.c
   INCLUDE[memleaktest]=../include ../apps/include
   DEPEND[memleaktest]=../libcrypto libtestutil.a
+
+  SOURCE[cleansetest]=cleansetest.c
+  INCLUDE[cleansetest]=../include
+  DEPEND[cleansetest]=../libcrypto
 
   SOURCE[pkcs12_format_test]=pkcs12_format_test.c helpers/pkcs12.c
   INCLUDE[pkcs12_format_test]=../include ../apps/include

--- a/test/cleansetest.c
+++ b/test/cleansetest.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/crypto.h>
+
+int main(void)
+{
+    unsigned char *buf = OPENSSL_malloc(32);
+
+    memset((void *)buf, 0xa5, 32);
+    OPENSSL_cleanse((void *)buf, 40);
+    OPENSSL_free((void *)buf);
+    return EXIT_SUCCESS;
+}

--- a/test/recipes/90-test_cleanse.t
+++ b/test/recipes/90-test_cleanse.t
@@ -1,0 +1,32 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test qw/:DEFAULT result_file/;
+use OpenSSL::Test::Utils;
+
+setup("test_cleanse");
+
+plan tests => 1;
+
+my $report = result_file("cleansetest.err");
+
+# The program performs an out-of-bounds OPENSSL_cleanse() and dies with a
+# report on any build whose ASan instrumentation covers the cleanse, so
+# this test FAILS exactly on the CI jobs that cover the instrumentation.
+ok(run(test(["cleansetest"], stderr => $report)),
+   "out-of-bounds OPENSSL_cleanse not covered by sanitizer instrumentation");
+
+# Surface the captured ASan report as TAP diagnostics
+if (open(my $fh, "<", $report)) {
+    while (my $line = <$fh>) {
+        chomp $line;
+        diag($line);
+    }
+    close $fh;
+}


### PR DESCRIPTION
CI: Test asan-instrumented OPENSSL_cleanse()

It looks like the CI workflow for the PR doesn't have a job for ./Configure no-asm enable-asan enable-ubsan

 - When OPENSSL_cleanse() is the asan-instrumented C implementation (no-asm builds), the report fires inside the cleanse itself.
 - When OPENSSL_cleanse() is assembly, asan cannot observe its stores, so the oversized cleanse returns silently.  

./Configure no-asm enable-asan enable-ubsan && make -j20 && make test TESTS=test_cleanse

```
../../util/wrap.pl ../../test/cleansetest 2> ./cleansetest.err => 1
not ok 1 - out-of-bounds OPENSSL_cleanse not covered by sanitizer instrumentation
[21:01:03] 90-test_cleanse.t .. 1/1 --------------------------------------------
#   Failed test 'out-of-bounds OPENSSL_cleanse not covered by sanitizer instrumentation'
#   at test/recipes/90-test_cleanse.t line 22.
# =================================================================
# ==1945334==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b8a02be0060 at pc 0x7f5a067280c3 bp 0x7fff2f6637d0 sp 0x7fff2f662f88
# WRITE of size 40 at 0x7b8a02be0060 thread T0
#     #0 0x7f5a067280c2 in memset ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:89
#     #1 0x56edf6f8920d in main test/cleansetest.c:22
#     #2 0x7f5a03c2a600 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:59
#     #3 0x7f5a03c2a717 in __libc_start_main_impl ../csu/libc-start.c:360
#     #4 0x56edf6f89284 in _start (/hdd/osf/git/openssl/test/cleansetest+0x1284) (BuildId: 997f016f4df047ee482d37eba6383ce1d081843a)
#
# 0x7b8a02be0060 is located 0 bytes after 32-byte region [0x7b8a02be0040,0x7b8a02be0060)
# allocated by thread T0 here:
#     #0 0x7f5a0672b60f in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:67
#     #1 0x7f5a0550d90d in CRYPTO_malloc crypto/mem.c:230
#     #2 0x56edf6f891e2 in main test/cleansetest.c:19
#     #3 0x7f5a03c2a600 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:59
#     #4 0x7f5a03c2a717 in __libc_start_main_impl ../csu/libc-start.c:360
#     #5 0x56edf6f89284 in _start (/hdd/osf/git/openssl/test/cleansetest+0x1284) (BuildId: 997f016f4df047ee482d37eba6383ce1d081843a)
#
# SUMMARY: AddressSanitizer: heap-buffer-overflow test/cleansetest.c:22 in main
# Shadow bytes around the buggy address:
#   0x7b8a02bdfd80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
#   0x7b8a02bdfe00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
#   0x7b8a02bdfe80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
#   0x7b8a02bdff00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
#   0x7b8a02bdff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
# =>0x7b8a02be0000: fa fa 00 00 00 fa fa fa 00 00 00 00[fa]fa fa fa
#   0x7b8a02be0080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
#   0x7b8a02be0100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
#   0x7b8a02be0180: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
#   0x7b8a02be0200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
#   0x7b8a02be0280: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
```
