### PR TITLE
CI: run the asan/ubsan no-asm variant per-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,6 +442,39 @@ jobs:
         name: "ci@address_ub_sanitizer"
         path: artifacts.tar.gz
 
+  # Same configuration as the run-checker-merge variant, promoted to per-PR CI.
+  # no-asm builds the sanitizer-instrumented C fallback primitives (e.g. the
+  # OPENSSL_cleanse() C implementation), which the asm-enabled asan job above
+  # cannot observe; keep both, as each covers C code the other does not build.
+  address_ub_sanitizer_no_asm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+    - name: Adjust ASLR for sanitizer
+      run: |
+        sudo cat /proc/sys/vm/mmap_rnd_bits
+        sudo sysctl -w vm.mmap_rnd_bits=28
+    - name: config
+      run: CC=clang ./config --strict-warnings --banner=Configured enable-asan enable-ubsan no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=function && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
+    - name: make test
+      run: .github/workflows/make-test OPENSSL_TEST_RAND_ORDER=0
+    - name: save artifacts
+      if: success() || failure()
+      uses: actions/upload-artifact@v5
+      with:
+        name: "ci@address_ub_sanitizer_no_asm"
+        path: artifacts.tar.gz
+
   fuzz_tests:
     runs-on: ubuntu-latest
     steps:
@@ -627,31 +660,6 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: "ci@full_featured"
-        path: artifacts.tar.gz
-
-  no-legacy:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        persist-credentials: false
-    - name: checkout fuzz/corpora submodule
-      run: git submodule update --init --depth 1 fuzz/corpora
-    - name: config
-      run: ./config --strict-warnings --banner=Configured enable-demos enable-h3demo no-legacy enable-fips enable-lms && perl configdata.pm --dump
-    - name: make
-      run: make -s -j4
-    - name: get cpu info
-      run: |
-        cat /proc/cpuinfo
-        ./util/opensslwrap.sh version -c
-    - name: make test
-      run: .github/workflows/make-test
-    - name: save artifacts
-      if: success() || failure()
-      uses: actions/upload-artifact@v5
-      with:
-        name: "ci@no-legacy"
         path: artifacts.tar.gz
 
   legacy:


### PR DESCRIPTION
run-checker-merge has built enable-asan enable-ubsan no-shared no-asm with the full test suite since 2022, but it only runs as a merge gate.

- In no-asm builds the C fallback primitives (e.g. the OPENSSL_cleanse() implementation in crypto/mem_clr.c) are asan-instrumented, whereas in asm builds asan cannot observe their stores, so out-of-bounds accesses in those paths currently surface only at merge time instead of on the contributor's pull request.

- Drop no-legacy job. There is already a no-legacy job in runchecker CI.

I'm attaching the following draft as evidence, which is not seeking a review:
https://github.com/openssl/openssl/pull/32458
