### PR TITLE
QUIC: check both incoming default stream candidates

### DIFF
--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -1093,11 +1093,14 @@ size_t SSL_get_accept_stream_queue_len(SSL *ssl);
 /*
  * Sets the policy for incoming streams. If `policy` is `AUTO` (the default):
  *
- *   - if the default stream mode is
- *     `SSL_DEFAULT_STREAM_MODE_AUTO_BIDI` or
- *     `SSL_DEFAULT_STREAM_MODE_AUTO_UNI`, this is equivalent to `REJECT`;
+ *   - if the default stream mode is `SSL_DEFAULT_STREAM_MODE_NONE`, this is
+ *     equivalent to `ACCEPT`;
  *
- *   - otherwise, this is equivalent to `ACCEPT`.
+ *   - otherwise, this is equivalent to `ACCEPT` while automatic default stream
+ *     creation remains possible. Once a default stream has been created, or
+ *     automatic default stream creation has been inhibited by a successful
+ *     call to `SSL_new_stream` or `SSL_accept_stream`, this is equivalent to
+ *     `REJECT`.
  *
  * If configured to `ACCEPT`, incoming streams are placed on the accept queue
  * for application consumption. `aec` is ignored in this case.

--- a/doc/man3/SSL_set_default_stream_mode.pod
+++ b/doc/man3/SSL_set_default_stream_mode.pod
@@ -93,8 +93,15 @@ L<SSL_accept_stream(3)> in order to communicate with the peer.
 A default stream will not be automatically created on a QUIC connection SSL
 object if the default stream mode is set to B<SSL_DEFAULT_STREAM_MODE_NONE>.
 
-L<SSL_set_incoming_stream_policy(3)> interacts significantly with the default
-stream functionality.
+The default stream mode affects the effective value of
+B<SSL_INCOMING_STREAM_POLICY_AUTO>. With B<SSL_DEFAULT_STREAM_MODE_NONE>, the
+effective incoming stream policy remains B<SSL_INCOMING_STREAM_POLICY_ACCEPT>.
+With either automatic default stream mode, it is initially
+B<SSL_INCOMING_STREAM_POLICY_ACCEPT> and changes to
+B<SSL_INCOMING_STREAM_POLICY_REJECT> once a default stream has been created or
+automatic default stream creation has been inhibited by a successful call to
+L<SSL_new_stream(3)> or L<SSL_accept_stream(3)>. See
+L<SSL_set_incoming_stream_policy(3)>.
 
 =head1 RETURN VALUES
 
@@ -117,7 +124,7 @@ These functions were added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 
-Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2002-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_set_incoming_stream_policy.pod
+++ b/doc/man3/SSL_set_incoming_stream_policy.pod
@@ -20,7 +20,7 @@ policy
 
 =head1 DESCRIPTION
 
-SSL_set_incoming_stream_policy() policy changes the incoming stream policy for a
+SSL_set_incoming_stream_policy() changes the incoming stream policy for a
 QUIC connection. Depending on the policy configured, OpenSSL QUIC may
 automatically reject incoming streams initiated by the peer. This is intended to
 ensure that legacy applications using single-stream operation with a default
@@ -45,14 +45,15 @@ following rules:
 =item *
 
 If the default stream mode (configured using L<SSL_set_default_stream_mode(3)>)
-is set to B<SSL_DEFAULT_STREAM_MODE_AUTO_BIDI> (the default) or
-B<SSL_DEFAULT_STREAM_MODE_AUTO_UNI>, the incoming stream is rejected.
+is B<SSL_DEFAULT_STREAM_MODE_NONE>, incoming streams are accepted.
 
 =item *
 
-Otherwise (where the default stream mode is B<SSL_DEFAULT_STREAM_MODE_NONE>),
-the application is assumed to be stream aware, and the incoming stream is
-accepted.
+Otherwise, incoming streams are accepted while automatic default stream
+creation remains possible. Once a default stream has been created, or automatic
+default stream creation has been inhibited by a successful call to
+L<SSL_new_stream(3)> or L<SSL_accept_stream(3)>, further incoming streams are
+rejected.
 
 =back
 
@@ -89,7 +90,7 @@ SSL_set_incoming_stream_policy() was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 
-Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2002-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -839,6 +839,12 @@ QUIC_STREAM *ossl_quic_stream_map_peek_accept_queue(QUIC_STREAM_MAP *qsm);
  */
 QUIC_STREAM *ossl_quic_stream_map_find_in_accept_queue(QUIC_STREAM_MAP *qsm,
     int is_uni);
+
+/*
+ * Returns 1 if s is currently in an accept queue. A NULL stream is not in an
+ * accept queue.
+ */
+int ossl_quic_stream_map_is_in_accept_queue(const QUIC_STREAM *s);
 
 /*
  * Removes a stream from the accept queue. rtt is the estimated connection RTT.

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2158,12 +2158,15 @@ static QUIC_STREAM *quic_get_incoming_default_stream(QUIC_CONNECTION *qc,
 
     qs = ossl_quic_stream_map_get_by_id(qsm,
         expect_id | QUIC_STREAM_DIR_BIDI);
-    if (qs == NULL)
-        qs = ossl_quic_stream_map_get_by_id(qsm,
-            expect_id | QUIC_STREAM_DIR_UNI);
+    if (ossl_quic_stream_map_is_in_accept_queue(qs))
+        return qs;
 
-    /* Auto-rejected streams remain in the map until garbage collection. */
-    return qs != NULL && qs->accept_node.next != NULL ? qs : NULL;
+    qs = ossl_quic_stream_map_get_by_id(qsm,
+        expect_id | QUIC_STREAM_DIR_UNI);
+    if (ossl_quic_stream_map_is_in_accept_queue(qs))
+        return qs;
+
+    return NULL;
 }
 
 QUIC_NEEDS_LOCK

--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -772,6 +772,11 @@ QUIC_STREAM *ossl_quic_stream_map_find_in_accept_queue(QUIC_STREAM_MAP *qsm,
         qs = accept_next(&qsm->accept_list, qs);
     }
     return qs;
+}
+
+int ossl_quic_stream_map_is_in_accept_queue(const QUIC_STREAM *s)
+{
+    return s != NULL && s->accept_node.next != NULL;
 }
 
 void ossl_quic_stream_map_push_accept_queue(QUIC_STREAM_MAP *qsm,

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -3280,6 +3280,95 @@ err:
 }
 
 /*
+ * A rejected ordinal-0 bidirectional stream remains in the stream map until
+ * garbage collection. It must not mask an accepted ordinal-0 unidirectional
+ * stream when a connection-level read chooses its incoming default stream.
+ * Explicit event handling prevents that read from incidentally collecting the
+ * rejected object through an implicit reactor tick.
+ */
+static int test_incoming_default_stream_candidates(void)
+{
+    static const unsigned char bidi_msg[] = "rejected";
+    static const unsigned char uni_msg[] = "accepted";
+    unsigned char buf[32];
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL, *qlistener = NULL;
+    SSL *bidissl = NULL, *unissl = NULL;
+    QUIC_CHANNEL *ch;
+    QUIC_STREAM_MAP *qsm;
+    QUIC_STREAM *qs;
+    size_t written = 0, readbytes = 0;
+    int testresult = 0, ret, i;
+
+    if (!TEST_ptr(sctx = create_server_ctx())
+        || !TEST_ptr(cctx = create_client_ctx())
+        || !create_quic_ssl_objects(sctx, cctx, &qlistener, &clientssl))
+        goto err;
+
+    for (i = 0; i < 2; i++) {
+        ret = SSL_connect(clientssl);
+        if (!TEST_int_le(ret, 0)
+            || !TEST_int_eq(SSL_get_error(clientssl, ret),
+                SSL_ERROR_WANT_READ))
+            goto err;
+        SSL_handle_events(qlistener);
+    }
+
+    if (!TEST_ptr(serverssl = SSL_accept_connection(qlistener, 0))
+        || !TEST_true(create_bare_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE, 0, 0))
+        || !TEST_true(SSL_set_event_handling_mode(clientssl,
+            SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT))
+        || !TEST_ptr(ch = ossl_quic_conn_get_channel(clientssl)))
+        goto err;
+
+    qsm = ossl_quic_channel_get_qsm(ch);
+
+    if (!TEST_true(SSL_set_incoming_stream_policy(clientssl,
+            SSL_INCOMING_STREAM_POLICY_REJECT, 42))
+        || !TEST_ptr(bidissl = SSL_new_stream(serverssl, 0))
+        || !TEST_true(SSL_write_ex(bidissl, bidi_msg, sizeof(bidi_msg),
+            &written))
+        || !TEST_size_t_eq(written, sizeof(bidi_msg))
+        || !TEST_int_eq(SSL_handle_events(clientssl), 1)
+        || !TEST_ptr(qs = ossl_quic_stream_map_get_by_id(qsm,
+                         SSL_get_stream_id(bidissl)))
+        || !TEST_false(ossl_quic_stream_map_is_in_accept_queue(qs))
+        || !TEST_size_t_eq(SSL_get_accept_stream_queue_len(clientssl), 0)
+        || !TEST_true(SSL_set_incoming_stream_policy(clientssl,
+            SSL_INCOMING_STREAM_POLICY_ACCEPT, 0))
+        || !TEST_ptr(unissl = SSL_new_stream(serverssl, SSL_STREAM_FLAG_UNI))
+        || !TEST_true(SSL_write_ex(unissl, uni_msg, sizeof(uni_msg),
+            &written))
+        || !TEST_size_t_eq(written, sizeof(uni_msg))
+        || !TEST_int_eq(SSL_handle_events(clientssl), 1)
+        || !TEST_ptr(qs = ossl_quic_stream_map_get_by_id(qsm,
+                         SSL_get_stream_id(bidissl)))
+        || !TEST_false(ossl_quic_stream_map_is_in_accept_queue(qs))
+        || !TEST_ptr(qs = ossl_quic_stream_map_get_by_id(qsm,
+                         SSL_get_stream_id(unissl)))
+        || !TEST_true(ossl_quic_stream_map_is_in_accept_queue(qs))
+        || !TEST_size_t_eq(SSL_get_accept_stream_queue_len(clientssl), 1)
+        || !TEST_true(SSL_read_ex(clientssl, buf, sizeof(buf), &readbytes))
+        || !TEST_mem_eq(buf, readbytes, uni_msg, sizeof(uni_msg))
+        || !TEST_uint64_t_eq(SSL_get_stream_id(clientssl),
+            SSL_get_stream_id(unissl))
+        || !TEST_size_t_eq(SSL_get_accept_stream_queue_len(clientssl), 0))
+        goto err;
+
+    testresult = 1;
+err:
+    SSL_free(unissl);
+    SSL_free(bidissl);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_free(qlistener);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
  * When the server has a different primary group than the client, the server
  * should not fail on the client hello retry.
  */
@@ -4070,6 +4159,7 @@ int setup_tests(void)
     ADD_TEST(test_ssl_accept_connection);
     ADD_TEST(test_ssl_set_verify);
     ADD_TEST(test_accept_stream);
+    ADD_TEST(test_incoming_default_stream_candidates);
     ADD_TEST(test_client_hello_retry);
 #if OPENSSL_USE_IPV6
     ADD_TEST(test_quic_peer_addr_v6);


### PR DESCRIPTION
While reviewing the changes around #31685, I found a lookup problem in the path changed by 20da449b76daf8c93fd38cfbfac2a6776217a8f8.

`quic_get_incoming_default_stream` looks for the peer bidirectional ordinal 0 stream first. It only looks for the unidirectional ordinal 0 stream if no bidirectional object exists in the stream map. A rejected stream isn't on the accept queue, but its `QUIC_STREAM` object can remain in the map until garbage collection.

The following sequence exposes the problem:

1. Use explicit event handling and reject the peer bidirectional ordinal 0 stream.
2. Change the incoming stream policy to `ACCEPT`.
3. Admit the peer's unidirectional ordinal 0 stream.
4. Call `SSL_read` on the QUIC connection SSL object.

The retained bidirectional object is rejected as a default stream candidate, but the queued unidirectional candidate is never examined. In explicit event handling mode, a nonblocking read reports `SSL_ERROR_WANT_READ` even though the unidirectional stream and its data are already available. An implicit reactor tick can collect the rejected object and mask the defect.

This change checks each ID space independently. It also moves the accept queue membership test into a small stream map helper instead of having the default stream code inspect the list node directly.

The regression test enables explicit event handling so the rejected bidirectional object remains in the map. It then queues the accepted unidirectional object and verifies that a connection level read selects it.

The documentation also corrects a factual error in the existing `AUTO` description. The implementation accepts incoming streams while automatic default stream creation remains possible. With an automatic default stream mode, the policy changes to `REJECT` after a default stream is created or automatic creation is inhibited by a successful call to `SSL_new_stream` or `SSL_accept_stream`. With `SSL_DEFAULT_STREAM_MODE_NONE`, it remains `ACCEPT`.

This PR doesn't change admission for newly arriving streams or the treatment of queued streams when the effective policy changes. Accept queue accounting and MAX_STREAMS accounting remain unchanged. The patch also leaves poll readiness and blocking wakeups as they are. It sends no new `STOP_SENDING` or `RESET_STREAM` frames.

**The broader choice can change application behavior and what is sent on the wire. It can also affect object lifetime and blocking calls. It needs a separate design decision.**

Tests run:

    make test TESTS='test_quicapi test_quicfaults test_quic_multistream test_quic_radix'

All tests passed in an AddressSanitizer build with assertions disabled.

Related to #32466

##### Checklist

- [x] documentation is added or updated
- [x] tests are added or updated
