### PR TITLE
[4.0, 3.6] `CHANGES.md`, `NEWS.md`: tfix in CVE-2026-54876 description

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,7 +158,7 @@ OpenSSL 4.0
 
    *Matt Caswell*
 
- * Fixed client-side nemory leak in OCSP response checking.
+ * Fixed client-side memory leak in OCSP response checking.
 
    Severity: Low
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,7 +56,7 @@ This release incorporates the following bug fixes and mitigations:
   * Fixed excessive memory use buffering DTLS records for a future epoch.
     ([CVE-2026-54874])
 
-  * Fixed client-side nemory leak in OCSP response checking.
+  * Fixed client-side memory leak in OCSP response checking.
     ([CVE-2026-54876])
 
   * Fixed untrusted Sender DN being used as a format string in CMP response


### PR DESCRIPTION
Fix a typo in the description of CVE-2026-54876: "memory" instead of "nemory".