### PR TITLE
Fix SSL_listen_ex() so peeled connections can complete the handshake

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,9 +54,16 @@ OpenSSL Releases
 
    *Ryan Hooper*
 
- * Fixed `SSL_listen_ex()` to return a usable QUIC connection and to preserve
-   queued connections on allocation failure. Invalid arguments and internal
-   failures now return `-1`, reserving `0` for "no connection available".
+ * Fixed `SSL_listen_ex()` to correctly adopt a QUIC connection and to preserve
+   queued connections on allocation failure. Invalid arguments, including
+   non-QUIC SSL objects, and internal failures now return `-1`, reserving `0`
+   for "no connection available".
+
+   *Mounir IDRASSI*
+
+ * Fixed QUIC child objects to inherit the effective flags of their explicit
+   event domain. `SSL_get0_domain()` now reports that domain for connections
+   and streams in the hierarchy.
 
    *Mounir IDRASSI*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,12 @@ OpenSSL Releases
 
    *Ryan Hooper*
 
+ * Fixed `SSL_listen_ex()` to return a usable QUIC connection and to preserve
+   queued connections on allocation failure. Invalid arguments and internal
+   failures now return `-1`, reserving `0` for "no connection available".
+
+   *Mounir IDRASSI*
+
  * Fixed TLS 1.3 clients to encrypt 0-RTT early data with the first offered
    PSK identity (RFC 9846 section 4.3.10) when a 0-RTT-capable resumption
    ticket has aged out and an external PSK is offered in its place. The early

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -138,10 +138,11 @@ in that it polls a listening SSL object, and, if a new connection is available,
 writes that connection into the SSL object pointed to by B<new_conn>.  Note that
 once a connection is returned from a listener via this call, accepting
 connections via L<SSL_accept_connection(3)> is no longer permissible, and will
-result in an error.  Note that many calls into the QUIC api may trigger the quic reactor
-(such as L<SSL_poll(3)>), and will set the port into a mode in which L<SSL_accept_connection(3)>
-is assumed.  To avoid this, it is recommended that, if the use of SSL_listen_ex use is desired, that
-it is the first I/O call made to the SSL object to which the port is attached.
+result in an error. Many calls into the QUIC API may trigger the QUIC reactor
+(such as L<SSL_poll(3)>) and select L<SSL_accept_connection(3)> mode for the
+port. Applications intending to use SSL_listen_ex() must call it before any
+operation selects that mode; in practice, it should be the first I/O call made
+on the listener.
 
 Likewise, if a listener has accepted a connection via
 L<SSL_accept_connection(3)>, it is impermissible to accept connections via
@@ -149,14 +150,22 @@ B<SSL_listen_ex()>. The SSL object passed in the B<new_conn> parameter must be
 a fresh standalone connection returned by L<SSL_new(3)>.
 L<OSSL_QUIC_method(3)> is intended for this use. The connection must not use
 thread assisted mode, have been started or shut down, have streams or network
-BIOs configured on it, or belong to another QUIC object hierarchy.
+BIOs configured on it, or belong to another QUIC object hierarchy. The
+application must not access I<new_conn> concurrently while SSL_listen_ex() is
+executing.
 
 On success, I<new_conn> is adopted into the listener's object hierarchy and
 uses its shared network port and TLS configuration derived from the listener.
 Certificates, verification parameters, ciphersuites, ALPN configuration and
 other security policy must be configured on the listener's
-B<SSL_CTX>. Applications must not install a private connected BIO or file
-descriptor on the returned connection.
+B<SSL_CTX>. The connection is reset to accepted-connection defaults. TLS
+callbacks and QUIC message tracing callbacks are derived from the listener.
+Except for application ex data associated with the outer SSL object,
+applications must not rely on configuration applied to I<new_conn> before the
+call being retained; configure it on the listener or after SSL_listen_ex()
+succeeds. Applications must not call L<SSL_set_bio(3)> or L<SSL_set_fd(3)> to
+install a private connected BIO or file descriptor on the returned connection;
+it continues to use the listener's shared network port.
 
 Once B<SSL_listen_ex()> returns success, the connection written to I<new_conn>
 is already in the accept (server) state. Use L<SSL_do_handshake(3)> (or

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -160,9 +160,9 @@ Certificates, verification parameters, ciphersuites, ALPN configuration and
 other security policy must be configured on the listener's
 B<SSL_CTX>. The connection is reset to accepted-connection defaults. TLS
 callbacks and QUIC message tracing callbacks are derived from the listener.
-Except for application ex data associated with the outer SSL object,
-applications must not rely on configuration applied to I<new_conn> before the
-call being retained; configure it on the listener or after SSL_listen_ex()
+Application ex data set on I<new_conn> is retained. Applications must not rely
+on any other configuration applied to I<new_conn> before the call being
+retained. Configure such settings on the listener or after SSL_listen_ex()
 succeeds. Applications must not call L<SSL_set_bio(3)> or L<SSL_set_fd(3)> to
 install a private connected BIO or file descriptor on the returned connection;
 it continues to use the listener's shared network port.

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -145,9 +145,24 @@ it is the first I/O call made to the SSL object to which the port is attached.
 
 Likewise, if a listener has accepted a connection via
 L<SSL_accept_connection(3)>, it is impermissible to accept connections via
-B<SSL_listen_ex()>.  Note also that SSL objects passed in the B<new_conn>
-parameter to B<SSL_listen_ex()> must be created using L<OSSL_QUIC_method(3)> or
-L<OSSL_QUIC_server_method(3)>.
+B<SSL_listen_ex()>. The SSL object passed in the B<new_conn> parameter must be
+a fresh standalone connection returned by L<SSL_new(3)>.
+L<OSSL_QUIC_method(3)> is intended for this use. The connection must not use
+thread assisted mode, have been started or shut down, have streams or network
+BIOs configured on it, or belong to another QUIC object hierarchy.
+
+On success, I<new_conn> is adopted into the listener's object hierarchy and
+uses its shared network port and TLS configuration derived from the listener.
+Certificates, verification parameters, ciphersuites, ALPN configuration and
+other security policy must be configured on the listener's
+B<SSL_CTX>. Applications must not install a private connected BIO or file
+descriptor on the returned connection.
+
+Once B<SSL_listen_ex()> returns success, the connection written to I<new_conn>
+is already in the accept (server) state. Use L<SSL_do_handshake(3)> (or
+L<SSL_handle_events(3)>) to progress its handshake towards completion.
+L<SSL_accept(3)> must not be used for this purpose; use
+L<SSL_do_handshake(3)> instead.
 
 The SSL_accept_connection() call is supported only on a listener SSL object and
 accepts a new incoming connection. A new SSL object representing the accepted
@@ -341,8 +356,7 @@ SSL_listen() returns 1 on success or 0 on failure.
 
 SSL_listen_ex() returns 1 when a new connection was accepted on the new_conn
 parameter, 0 if no new connection was available at the time of the call, or -1
-in the event an internal error occurred, signaling a need to check the error
-queue.
+on error, signaling a need to check the error queue.
 
 SSL_accept_connection() returns a pointer to a new SSL object on success or NULL
 on failure. On success, the caller assumes ownership of the reference.
@@ -409,7 +423,7 @@ OpenSSL 4.1.
 
 =head1 COPYRIGHT
 
-Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -332,7 +332,7 @@ OSSL_STATM *ossl_quic_channel_get_statm(QUIC_CHANNEL *ch);
 SSL *ossl_quic_channel_get0_tls(QUIC_CHANNEL *ch);
 
 /* Attaches the TLS layer to a deferred channel. */
-void ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl);
+int ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl);
 
 /* Gets the channels short header connection id length */
 size_t ossl_quic_channel_get_short_header_conn_id_len(QUIC_CHANNEL *ch);

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -331,7 +331,7 @@ OSSL_STATM *ossl_quic_channel_get_statm(QUIC_CHANNEL *ch);
 /* Gets the TLS handshake layer used with the channel. */
 SSL *ossl_quic_channel_get0_tls(QUIC_CHANNEL *ch);
 
-/* Sets the TLS handshake layer used for the channel */
+/* Attaches the TLS layer to a deferred channel. */
 void ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl);
 
 /* Gets the channels short header connection id length */

--- a/include/internal/quic_port.h
+++ b/include/internal/quic_port.h
@@ -95,6 +95,9 @@ QUIC_CHANNEL *ossl_quic_port_create_incoming(QUIC_PORT *port, SSL *tls);
  */
 QUIC_CHANNEL *ossl_quic_port_pop_incoming(QUIC_PORT *port);
 
+/* Returns the first incoming channel without removing it, or NULL. */
+QUIC_CHANNEL *ossl_quic_port_peek_incoming(QUIC_PORT *port);
+
 /* Returns 1 if there is at least one connection incoming. */
 int ossl_quic_port_have_incoming(QUIC_PORT *port);
 

--- a/include/internal/quic_tls.h
+++ b/include/internal/quic_tls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -88,6 +88,9 @@ typedef struct quic_tls_args_st {
 } QUIC_TLS_ARGS;
 
 QUIC_TLS *ossl_quic_tls_new(const QUIC_TLS_ARGS *args);
+
+/* Attach an SSL to an unconfigured, deferred handshake layer. */
+int ossl_quic_tls_set0_ssl(QUIC_TLS *qtls, SSL *ssl);
 
 void ossl_quic_tls_free(QUIC_TLS *qtls);
 

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -582,7 +582,7 @@ SSL *ossl_quic_channel_get0_tls(QUIC_CHANNEL *ch)
     return ch->tls;
 }
 
-void ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl)
+int ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl)
 {
     /*
      * Rebind the handshake layer first, so that a failure leaves the channel
@@ -591,19 +591,10 @@ void ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl)
      */
     if (!ossl_assert(ch != NULL && ssl != NULL && ch->tls == NULL)
         || !ossl_quic_tls_set0_ssl(ch->qtls, ssl))
-        return;
+        return 0;
 
     ch->tls = ssl;
-#ifndef OPENSSL_NO_QLOG
-    /*
-     * If we're using qlog, make sure the tls gets further configured properly
-     */
-    ch->use_qlog = 1;
-    if (ch->tls->ctx->qlog_title != NULL) {
-        OPENSSL_free(ch->qlog_title);
-        ch->qlog_title = OPENSSL_strdup(ch->tls->ctx->qlog_title);
-    }
-#endif
+    return 1;
 }
 
 static void free_buf_mem(unsigned char *buf, size_t buf_len, void *arg)

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -584,7 +584,15 @@ SSL *ossl_quic_channel_get0_tls(QUIC_CHANNEL *ch)
 
 void ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl)
 {
-    SSL_free(ch->tls);
+    /*
+     * Rebind the handshake layer first, so that a failure leaves the channel
+     * entirely unmodified rather than with a TLS connection the handshake
+     * layer does not know about.
+     */
+    if (!ossl_assert(ch != NULL && ssl != NULL && ch->tls == NULL)
+        || !ossl_quic_tls_set0_ssl(ch->qtls, ssl))
+        return;
+
     ch->tls = ssl;
 #ifndef OPENSSL_NO_QLOG
     /*

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -307,8 +307,10 @@ static int expect_quic_as(const SSL *s, QCTX *ctx, uint32_t flags)
     case SSL_TYPE_QUIC_CONNECTION:
         qc = (QUIC_CONNECTION *)s;
         ctx->obj = &qc->obj;
-        ctx->qd = qc->domain;
-        ctx->ql = qc->listener; /* never changes, so can be read without lock */
+        ctx->qd = qc->domain != NULL
+            ? qc->domain
+            : (qc->listener != NULL ? qc->listener->domain : NULL);
+        ctx->ql = qc->listener;
         ctx->qc = qc;
 
         if ((flags & QCTX_AUTO_S) != 0) {
@@ -357,7 +359,11 @@ static int expect_quic_as(const SSL *s, QCTX *ctx, uint32_t flags)
 
         xso = (QUIC_XSO *)s;
         ctx->obj = &xso->obj;
-        ctx->qd = xso->conn->domain;
+        ctx->qd = xso->conn->domain != NULL
+            ? xso->conn->domain
+            : (xso->conn->listener != NULL
+                      ? xso->conn->listener->domain
+                      : NULL);
         ctx->ql = xso->conn->listener;
         ctx->qc = xso->conn;
         ctx->xso = xso;
@@ -5019,7 +5025,7 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
 {
     QCTX lctx;
     QCTX cctx;
-    QUIC_CHANNEL *new_ch, *old_ch;
+    QUIC_CHANNEL *new_ch, *old_ch, *popped_ch;
     QUIC_PORT *old_port;
     QUIC_ENGINE *old_engine;
 #if defined(OPENSSL_THREADS)
@@ -5071,7 +5077,8 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
     }
 
     /* Do all fallible setup before consuming the queued channel. */
-    if (!ossl_quic_port_have_incoming(lctx.ql->port))
+    new_ch = ossl_quic_port_peek_incoming(lctx.ql->port);
+    if (new_ch == NULL)
         goto out;
 
     qc = cctx.qc;
@@ -5105,10 +5112,24 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
         goto out;
     }
 
-    new_ch = ossl_quic_port_pop_incoming(ql->port);
-
     /* Bind TLS before adopting the deferred incoming channel. */
-    ossl_quic_channel_set0_tls(new_ch, tls);
+    if (!ossl_quic_channel_set0_tls(new_ch, tls)) {
+        QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);
+        SSL_free(tls);
+        SSL_free(&ql->obj.ssl);
+        ret = -1;
+        goto out;
+    }
+
+    ossl_quic_channel_set_msg_callback(new_ch,
+        ql->obj.ssl.ctx->msg_callback, new_conn);
+    ossl_quic_channel_set_msg_callback_arg(new_ch,
+        ql->obj.ssl.ctx->msg_callback_arg);
+
+    /* The listener lock guarantees that the queue head has not changed. */
+    popped_ch = ossl_quic_port_pop_incoming(ql->port);
+    assert(popped_ch == new_ch);
+    (void)popped_ch;
 
     old_ch = qc->ch;
     old_port = qc->port;
@@ -5147,11 +5168,14 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
     qc->as_server_state = 1;
     /* Reinitialise configuration to the accepted-connection defaults. */
     qc->default_stream_mode = SSL_DEFAULT_STREAM_MODE_AUTO_BIDI;
+    qc->default_ssl_mode = ql->obj.ssl.ctx->mode;
     qc->default_ssl_options
         = ql->obj.ssl.ctx->options & OSSL_QUIC_PERMITTED_OPTIONS;
     qc->incoming_stream_policy = SSL_INCOMING_STREAM_POLICY_AUTO;
     qc->incoming_stream_aec = 0;
     qc->last_error = SSL_ERROR_NONE;
+    ossl_quic_obj_set_blocking_mode(&qc->obj, QUIC_BLOCKING_MODE_INHERIT);
+    qc->obj.event_handling_mode = SSL_VALUE_EVENT_HANDLING_MODE_INHERIT;
     qc_update_reject_policy(qc);
     ret = 1;
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5037,6 +5037,30 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
     if (!expect_quic_c(new_conn, &cctx))
         return -1;
 
+#if !defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
+    if (cctx.qc->is_thread_assisted) {
+        QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_PASSED_INVALID_ARGUMENT,
+            "SSL_listen_ex requires new_conn without thread assistance");
+        return -1;
+    }
+#endif
+
+    /* The standalone transport is replaced, so new_conn must be unused. */
+    if (cctx.qc->started || cctx.qc->shutting_down
+        || cctx.qc->num_xso != 0
+        || cctx.qc->default_xso_created
+        || cctx.qc->listener != NULL
+        || ossl_quic_port_get_net_rbio(cctx.qc->port) != NULL
+        || ossl_quic_port_get_net_wbio(cctx.qc->port) != NULL
+        || ossl_quic_channel_is_active(cctx.qc->ch)
+        || ossl_quic_channel_is_term_any(cctx.qc->ch)
+        || !cctx.obj->is_event_leader || !cctx.obj->is_port_leader
+        || cctx.obj->parent_obj != NULL) {
+        QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_PASSED_INVALID_ARGUMENT,
+            "SSL_listen_ex requires a fresh connection created by SSL_new()");
+        return -1;
+    }
+
     qctx_lock_for_io(&lctx);
 
     if (!ossl_quic_port_test_and_set_peeloff(lctx.ql->port, PEELOFF_LISTEN)) {
@@ -5046,8 +5070,8 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
         goto out;
     }
 
-    new_ch = ossl_quic_port_pop_incoming(lctx.ql->port);
-    if (new_ch == NULL)
+    /* Do all fallible setup before consuming the queued channel. */
+    if (!ossl_quic_port_have_incoming(lctx.ql->port))
         goto out;
 
     qc = cctx.qc;
@@ -5055,13 +5079,17 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
 
     tls = ossl_ssl_connection_new_int(
         ossl_quic_port_get_channel_ctx(ql->port), new_conn, TLS_method());
-    if (tls == NULL)
+    if (tls == NULL) {
+        /* An internal failure is not "no connection available" */
+        ret = -1;
         goto out;
+    }
 
     tls_conn = SSL_CONNECTION_FROM_SSL(tls);
     if (tls_conn == NULL) {
         QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);
         SSL_free(tls);
+        ret = -1;
         goto out;
     }
 
@@ -5071,9 +5099,13 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
 
     /* The connection keeps its listener alive. */
     if (!SSL_up_ref(&ql->obj.ssl)) {
+        QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);
         SSL_free(tls);
+        ret = -1;
         goto out;
     }
+
+    new_ch = ossl_quic_port_pop_incoming(ql->port);
 
     /* Bind TLS before adopting the deferred incoming channel. */
     ossl_quic_channel_set0_tls(new_ch, tls);
@@ -5091,10 +5123,6 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
     qc->port = ql->port;
     /* The connection is handed to the caller, as in SSL_accept_connection() */
     qc->pending = 0;
-#if !defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
-    /* Incoming connections never start a thread-assist worker. */
-    qc->is_thread_assisted = 0;
-#endif
     /* Demote the standalone object into the listener's hierarchy. */
     ossl_quic_obj_reparent(&qc->obj, &ql->obj);
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5019,10 +5019,16 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
 {
     QCTX lctx;
     QCTX cctx;
-    QUIC_CHANNEL *new_ch;
+    QUIC_CHANNEL *new_ch, *old_ch;
+    QUIC_PORT *old_port;
+    QUIC_ENGINE *old_engine;
+#if defined(OPENSSL_THREADS)
+    CRYPTO_MUTEX *old_mutex = NULL;
+#endif
     QUIC_CONNECTION *qc = NULL;
     QUIC_LISTENER *ql = NULL;
     SSL *tls = NULL;
+    SSL_CONNECTION *tls_conn = NULL;
     int ret = 0;
 
     if (!expect_quic_listener(listener, &lctx))
@@ -5041,52 +5047,86 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
     }
 
     new_ch = ossl_quic_port_pop_incoming(lctx.ql->port);
-    if (new_ch != NULL) {
-        tls = ossl_ssl_connection_new_int(ossl_quic_port_get_channel_ctx(lctx.ql->port),
-            new_conn, TLS_method());
-        if (tls == NULL)
-            goto out;
+    if (new_ch == NULL)
+        goto out;
 
-        qc = cctx.qc;
-        ql = lctx.ql;
-        /*
-         * Need to ensure that we take a reference on our new listener
-         * so that we don't free it before this connection
-         */
-        if (!SSL_up_ref(&ql->obj.ssl))
-            goto out;
+    qc = cctx.qc;
+    ql = lctx.ql;
 
-        ossl_quic_channel_free(qc->ch);
-        ossl_quic_port_free(qc->port);
-        ossl_quic_engine_free(qc->engine);
-        /*
-         * Ensure that we point to our listener so we can drop
-         * the above refcount when this SSL object is freed
-         */
-        qc->listener = ql;
-        qc->obj.engine = ql->engine;
-        qc->engine = ql->engine;
-        qc->port = ql->port;
-        qc->pending = 1;
-#if defined(OPENSSL_THREADS)
-        ossl_crypto_mutex_free(&qc->mutex);
-        qc->mutex = ql->mutex;
-#endif
-        qc->ch = new_ch;
-        SSL_free(qc->tls);
-        ossl_quic_channel_set0_tls(new_ch, tls);
-        qc->tls = tls;
-        ossl_quic_channel_get_peer_addr(new_ch, &qc->init_peer_addr); /* best effort */
-        qc->started = 1;
-        qc->as_server = 1;
-        qc->as_server_state = 1;
-        qc->default_stream_mode = SSL_DEFAULT_STREAM_MODE_AUTO_BIDI;
-        qc->default_ssl_options = ql->obj.ssl.ctx->options & OSSL_QUIC_PERMITTED_OPTIONS;
-        qc->incoming_stream_policy = SSL_INCOMING_STREAM_POLICY_AUTO;
-        qc->last_error = SSL_ERROR_NONE;
-        qc_update_reject_policy(qc);
-        ret = 1;
+    tls = ossl_ssl_connection_new_int(
+        ossl_quic_port_get_channel_ctx(ql->port), new_conn, TLS_method());
+    if (tls == NULL)
+        goto out;
+
+    tls_conn = SSL_CONNECTION_FROM_SSL(tls);
+    if (tls_conn == NULL) {
+        QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);
+        SSL_free(tls);
+        goto out;
     }
+
+    tls_conn->s3.flags |= TLS1_FLAGS_QUIC | TLS1_FLAGS_QUIC_INTERNAL;
+    tls_conn->options &= OSSL_QUIC_PERMITTED_OPTIONS_CONN;
+    tls_conn->pha_enabled = 0;
+
+    /* The connection keeps its listener alive. */
+    if (!SSL_up_ref(&ql->obj.ssl)) {
+        SSL_free(tls);
+        goto out;
+    }
+
+    /* Bind TLS before adopting the deferred incoming channel. */
+    ossl_quic_channel_set0_tls(new_ch, tls);
+
+    old_ch = qc->ch;
+    old_port = qc->port;
+    old_engine = qc->engine;
+#if defined(OPENSSL_THREADS)
+    old_mutex = qc->mutex;
+#endif
+
+    /* Ensure that SSL_free() drops the listener reference. */
+    qc->listener = ql;
+    qc->engine = ql->engine;
+    qc->port = ql->port;
+    /* The connection is handed to the caller, as in SSL_accept_connection() */
+    qc->pending = 0;
+#if !defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
+    /* Incoming connections never start a thread-assist worker. */
+    qc->is_thread_assisted = 0;
+#endif
+    /* Demote the standalone object into the listener's hierarchy. */
+    ossl_quic_obj_reparent(&qc->obj, &ql->obj);
+
+    /* Release the resources the connection owned as a standalone object. */
+    ossl_quic_channel_free(old_ch);
+    quic_unref_port_bios(old_port);
+    ossl_quic_port_free(old_port);
+    ossl_quic_engine_free(old_engine);
+#if defined(OPENSSL_THREADS)
+    /* The standalone mutex was borrowed by all three resources above. */
+    qc->mutex = ql->mutex;
+    ossl_crypto_mutex_free(&old_mutex);
+#endif
+
+    qc->ch = new_ch;
+    SSL_free(qc->tls);
+    qc->tls = tls;
+    ossl_quic_channel_get_peer_addr(new_ch,
+        &qc->init_peer_addr); /* best effort */
+    qc->started = 1;
+    qc->as_server = 1;
+    qc->as_server_state = 1;
+    /* Reinitialise configuration to the accepted-connection defaults. */
+    qc->default_stream_mode = SSL_DEFAULT_STREAM_MODE_AUTO_BIDI;
+    qc->default_ssl_options
+        = ql->obj.ssl.ctx->options & OSSL_QUIC_PERMITTED_OPTIONS;
+    qc->incoming_stream_policy = SSL_INCOMING_STREAM_POLICY_AUTO;
+    qc->incoming_stream_aec = 0;
+    qc->last_error = SSL_ERROR_NONE;
+    qc_update_reject_policy(qc);
+    ret = 1;
+
 out:
     qctx_unlock(&lctx);
     return ret;

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -185,7 +185,7 @@ struct quic_conn_st {
      */
     unsigned int as_server_state : 1;
 
-    /* Are we using thread assisted mode? Cleared on SSL_listen_ex adoption. */
+    /* Are we using thread assisted mode? Never changes after init. */
     unsigned int is_thread_assisted : 1;
 
     /* Have we created a default XSO yet? */

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -185,7 +185,7 @@ struct quic_conn_st {
      */
     unsigned int as_server_state : 1;
 
-    /* Are we using thread assisted mode? Never changes after init. */
+    /* Are we using thread assisted mode? Cleared on SSL_listen_ex adoption. */
     unsigned int is_thread_assisted : 1;
 
     /* Have we created a default XSO yet? */

--- a/ssl/quic/quic_obj.c
+++ b/ssl/quic/quic_obj.c
@@ -20,11 +20,13 @@ int ossl_quic_obj_init(QUIC_OBJ *obj,
     QUIC_ENGINE *engine,
     QUIC_PORT *port)
 {
+    QUIC_OBJ *parent = (QUIC_OBJ *)parent_obj;
     int is_event_leader = (engine != NULL);
     int is_port_leader = (port != NULL);
 
     if (!ossl_assert(obj != NULL && !obj->init_done && SSL_TYPE_IS_QUIC(type)
-            && (parent_obj == NULL || IS_QUIC(parent_obj))))
+            && (parent_obj == NULL
+                || (IS_QUIC(parent_obj) && parent->init_done))))
         return 0;
 
     /* Event leader is always the root object. */
@@ -34,8 +36,9 @@ int ossl_quic_obj_init(QUIC_OBJ *obj,
     if (!ossl_ssl_init(&obj->ssl, ctx, ctx->method, type))
         goto err;
 
-    obj->domain_flags = ctx->domain_flags;
-    obj->parent_obj = (QUIC_OBJ *)parent_obj;
+    obj->domain_flags
+        = parent != NULL ? parent->domain_flags : ctx->domain_flags;
+    obj->parent_obj = parent;
     obj->is_event_leader = is_event_leader;
     obj->is_port_leader = is_port_leader;
     obj->engine = engine;

--- a/ssl/quic/quic_obj.c
+++ b/ssl/quic/quic_obj.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -51,6 +51,21 @@ err:
     obj->is_event_leader = 0;
     obj->is_port_leader = 0;
     return 0;
+}
+
+void ossl_quic_obj_reparent(QUIC_OBJ *obj, QUIC_OBJ *parent)
+{
+    if (!ossl_assert(obj != NULL && obj->init_done
+            && parent != NULL && parent->init_done
+            && obj->is_event_leader && obj->is_port_leader
+            && obj->parent_obj == NULL))
+        return;
+
+    obj->parent_obj = parent;
+    obj->is_event_leader = 0;
+    obj->is_port_leader = 0;
+    obj->domain_flags = parent->domain_flags;
+    (void)obj_update_cache(obj);
 }
 
 static int obj_update_cache(QUIC_OBJ *obj)

--- a/ssl/quic/quic_obj_local.h
+++ b/ssl/quic/quic_obj_local.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -154,6 +154,9 @@ int ossl_quic_obj_init(QUIC_OBJ *obj,
     SSL *parent_obj,
     QUIC_ENGINE *engine,
     QUIC_PORT *port);
+
+/* Reparent a standalone leader; the caller must release its old resources. */
+void ossl_quic_obj_reparent(QUIC_OBJ *obj, QUIC_OBJ *parent);
 
 /*
  * Returns a pointer to the handshake layer object which should be accessible on

--- a/ssl/quic/quic_obj_local.h
+++ b/ssl/quic/quic_obj_local.h
@@ -100,7 +100,7 @@ struct quic_obj_st {
      */
     QUIC_PORT *port;
 
-    /* SSL_DOMAIN_FLAG values taken from SSL_CTX at construction time. */
+    /* Effective SSL_DOMAIN_FLAG values inherited from the object hierarchy. */
     uint64_t domain_flags;
 
     unsigned int init_done : 1;

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -591,6 +591,9 @@ static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, OSSL_QRX *qrx,
     QUIC_CHANNEL_ARGS args = { 0 };
     QUIC_CHANNEL *ch;
     SSL *user_ssl = NULL;
+#ifndef OPENSSL_NO_QLOG
+    SSL_CTX *qlog_ctx;
+#endif
 
     args.port = port;
     args.is_server = is_server;
@@ -649,12 +652,15 @@ static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, OSSL_QRX *qrx,
     }
 #ifndef OPENSSL_NO_QLOG
     /*
-     * If we're using qlog, make sure the tls get further configured properly
+     * A deferred SSL_listen_ex() channel does not have its TLS object yet, but
+     * it still uses the port's channel context. Configure its qlog title before
+     * the first packet can cause the qlog object to be instantiated.
      */
     ch->use_qlog = 1;
-    if (ch->tls != NULL && ch->tls->ctx->qlog_title != NULL) {
+    qlog_ctx = ch->tls != NULL ? ch->tls->ctx : port->channel_ctx;
+    if (qlog_ctx != NULL && qlog_ctx->qlog_title != NULL) {
         OPENSSL_free(ch->qlog_title);
-        if ((ch->qlog_title = OPENSSL_strdup(ch->tls->ctx->qlog_title)) == NULL)
+        if ((ch->qlog_title = OPENSSL_strdup(qlog_ctx->qlog_title)) == NULL)
             goto err;
     }
 #endif
@@ -713,9 +719,14 @@ QUIC_CHANNEL *ossl_quic_port_pop_incoming(QUIC_PORT *port)
     return ch;
 }
 
+QUIC_CHANNEL *ossl_quic_port_peek_incoming(QUIC_PORT *port)
+{
+    return ossl_list_incoming_ch_head(&port->incoming_channel_list);
+}
+
 int ossl_quic_port_have_incoming(QUIC_PORT *port)
 {
-    return ossl_list_incoming_ch_head(&port->incoming_channel_list) != NULL;
+    return ossl_quic_port_peek_incoming(port) != NULL;
 }
 
 void ossl_quic_port_drop_incoming(QUIC_PORT *port)

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -731,6 +731,12 @@ void ossl_quic_port_drop_incoming(QUIC_PORT *port)
             break;
 
         tls = ossl_quic_channel_get0_tls(ch);
+        if (tls == NULL) {
+            /* Unpeeled SSL_listen_ex() channels have no user SSL. */
+            ossl_quic_channel_free(ch);
+            continue;
+        }
+
         /*
          * The user ssl may or may not have been created via the
          * get_conn_user_ssl callback in the QUIC stack.  The

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -664,6 +664,16 @@ QUIC_TLS *ossl_quic_tls_new(const QUIC_TLS_ARGS *args)
     return qtls;
 }
 
+int ossl_quic_tls_set0_ssl(QUIC_TLS *qtls, SSL *ssl)
+{
+    if (!ossl_assert(qtls != NULL && ssl != NULL
+            && qtls->args.s == NULL && !qtls->configured))
+        return 0;
+
+    qtls->args.s = ssl;
+    return 1;
+}
+
 void ossl_quic_tls_free(QUIC_TLS *qtls)
 {
     if (qtls == NULL)
@@ -766,6 +776,10 @@ int ossl_quic_tls_tick(QUIC_TLS *qtls)
 
     if (qtls->inerror)
         return 0;
+
+    /* SSL_listen_ex() attaches the SSL after the channel is queued. */
+    if (qtls->args.s == NULL)
+        return 1;
 
     /*
      * SSL_get_error does not truly know what the cause of an SSL_read failure

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -8506,7 +8506,7 @@ int SSL_listen_ex(SSL *listener, SSL *new_conn)
 #endif
         ERR_raise_data(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT,
             "SSL_listen_ex only operates on QUIC SSL objects");
-    return 0;
+    return -1;
 }
 
 int SSL_listen(SSL *ssl)

--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -2006,7 +2006,7 @@ err:
 
 /*
  * Test SSL_listen_ex for DTLS.
- * Currently SSL_listen_ex is QUIC-only, so it should return 0 for DTLS.
+ * SSL_listen_ex is QUIC-only, so it should reject DTLS objects.
  */
 static int test_dtls_listen_ex_returns_error(void)
 {
@@ -2024,8 +2024,9 @@ static int test_dtls_listen_ex_returns_error(void)
     if (!TEST_ptr(new_conn = SSL_new(ctx)))
         goto err;
 
-    /* SSL_listen_ex should return 0 for DTLS */
-    if (!TEST_int_eq(SSL_listen_ex(listener, new_conn), 0))
+    if (!TEST_int_eq(SSL_listen_ex(listener, new_conn), -1)
+        || !TEST_int_eq(ERR_GET_REASON(ERR_get_error()),
+            ERR_R_PASSED_INVALID_ARGUMENT))
         goto err;
 
     success = 1;

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -2424,7 +2424,9 @@ static int test_domain_flags(void)
 {
     int testresult = 0;
     SSL_CTX *ctx = NULL;
-    SSL *domain = NULL, *listener = NULL, *other_conn = NULL;
+    SSL *inherited_domain = NULL, *domain = NULL, *listener = NULL;
+    SSL *listener_conn = NULL;
+    SSL *other_conn = NULL;
     uint64_t domain_flags = 0;
 
     if (!TEST_ptr(ctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_client_method()))
@@ -2432,15 +2434,19 @@ static int test_domain_flags(void)
         || !TEST_uint64_t_ne(domain_flags, 0)
         || !TEST_uint64_t_ne(domain_flags & (SSL_DOMAIN_FLAG_SINGLE_THREAD | SSL_DOMAIN_FLAG_MULTI_THREAD), 0)
         || !TEST_uint64_t_ne(domain_flags & SSL_DOMAIN_FLAG_LEGACY_BLOCKING, 0)
-        || !TEST_true(SSL_CTX_set_domain_flags(ctx, SSL_DOMAIN_FLAG_SINGLE_THREAD))
+        || !TEST_true(SSL_CTX_set_domain_flags(ctx, SSL_DOMAIN_FLAG_MULTI_THREAD))
         || !TEST_true(SSL_CTX_get_domain_flags(ctx, &domain_flags))
-        || !TEST_uint64_t_eq(domain_flags, SSL_DOMAIN_FLAG_SINGLE_THREAD)
-        || !TEST_ptr(domain = SSL_new_domain(ctx, 0))
+        || !TEST_uint64_t_eq(domain_flags, SSL_DOMAIN_FLAG_MULTI_THREAD)
+        || !TEST_ptr(inherited_domain = SSL_new_domain(ctx, 0))
+        || !TEST_true(SSL_get_domain_flags(inherited_domain, &domain_flags))
+        || !TEST_uint64_t_eq(domain_flags, SSL_DOMAIN_FLAG_MULTI_THREAD)
+        || !TEST_ptr(domain = SSL_new_domain(ctx,
+                         SSL_DOMAIN_FLAG_SINGLE_THREAD))
         || !TEST_true(SSL_get_domain_flags(domain, &domain_flags))
         || !TEST_uint64_t_eq(domain_flags, SSL_DOMAIN_FLAG_SINGLE_THREAD)
         || !TEST_true(other_conn = SSL_new(ctx))
         || !TEST_true(SSL_get_domain_flags(other_conn, &domain_flags))
-        || !TEST_uint64_t_eq(domain_flags, SSL_DOMAIN_FLAG_SINGLE_THREAD)
+        || !TEST_uint64_t_eq(domain_flags, SSL_DOMAIN_FLAG_MULTI_THREAD)
         || !TEST_true(SSL_is_domain(domain))
         || !TEST_false(SSL_is_domain(other_conn))
         || !TEST_ptr_eq(SSL_get0_domain(domain), domain)
@@ -2449,13 +2455,22 @@ static int test_domain_flags(void)
         || !TEST_true(SSL_is_listener(listener))
         || !TEST_false(SSL_is_domain(listener))
         || !TEST_ptr_eq(SSL_get0_domain(listener), domain)
-        || !TEST_ptr_eq(SSL_get0_listener(listener), listener))
+        || !TEST_ptr_eq(SSL_get0_listener(listener), listener)
+        || !TEST_true(SSL_get_domain_flags(listener, &domain_flags))
+        || !TEST_uint64_t_eq(domain_flags, SSL_DOMAIN_FLAG_SINGLE_THREAD)
+        || !TEST_ptr(listener_conn = SSL_new_from_listener(listener, 0))
+        || !TEST_ptr_eq(SSL_get0_domain(listener_conn), domain)
+        || !TEST_ptr_eq(SSL_get0_listener(listener_conn), listener)
+        || !TEST_true(SSL_get_domain_flags(listener_conn, &domain_flags))
+        || !TEST_uint64_t_eq(domain_flags, SSL_DOMAIN_FLAG_SINGLE_THREAD))
         goto err;
 
     testresult = 1;
 err:
-    SSL_free(domain);
+    SSL_free(listener_conn);
     SSL_free(listener);
+    SSL_free(domain);
+    SSL_free(inherited_domain);
     SSL_free(other_conn);
     SSL_CTX_free(ctx);
     return testresult;
@@ -2807,7 +2822,7 @@ static OSSL_TIME fake_now_cb(void *arg)
 }
 
 static int create_quic_ssl_objects_ex(SSL_CTX *sctx, SSL_CTX *cctx,
-    SSL **lssl, SSL **cssl, int use_fake_time)
+    SSL *domain, SSL **lssl, SSL **cssl, int use_fake_time)
 {
     BIO_ADDR *addr = NULL;
     struct in_addr ina;
@@ -2827,10 +2842,19 @@ static int create_quic_ssl_objects_ex(SSL_CTX *sctx, SSL_CTX *cctx,
         goto err;
     addr = NULL;
 
-    *lssl = ql_create(sctx, sbio);
-    sbio = NULL;
-    if (!TEST_ptr(*lssl))
-        goto err;
+    if (domain == NULL) {
+        *lssl = ql_create(sctx, sbio);
+        sbio = NULL;
+        if (!TEST_ptr(*lssl))
+            goto err;
+    } else {
+        if (!TEST_ptr(*lssl = SSL_new_listener_from(domain, 0)))
+            goto err;
+        SSL_set_bio(*lssl, sbio, sbio);
+        sbio = NULL;
+        if (!TEST_true(SSL_listen(*lssl)))
+            goto err;
+    }
 
     if (!TEST_ptr(*cssl = SSL_new(cctx)))
         goto err;
@@ -2878,7 +2902,7 @@ err:
 static int create_quic_ssl_objects(SSL_CTX *sctx, SSL_CTX *cctx,
     SSL **lssl, SSL **cssl)
 {
-    return create_quic_ssl_objects_ex(sctx, cctx, lssl, cssl, 0);
+    return create_quic_ssl_objects_ex(sctx, cctx, NULL, lssl, cssl, 0);
 }
 
 static int queue_incoming_connection(SSL *qlistener, SSL *clientssl)
@@ -2897,6 +2921,39 @@ static int queue_incoming_connection(SSL *qlistener, SSL *clientssl)
     }
 
     return TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 1);
+}
+
+static SSL *listen_ex_msg_cb_ssl;
+static char listen_ex_msg_cb_arg;
+static unsigned int listen_ex_tls_msg_count;
+static unsigned int listen_ex_quic_msg_count;
+static int listen_ex_msg_cb_mismatch;
+
+static void listen_ex_msg_cb(int write_p, int version, int content_type,
+    const void *buf, size_t len, SSL *ssl, void *arg)
+{
+    (void)write_p;
+    (void)version;
+    (void)buf;
+    (void)len;
+
+    if (ssl != listen_ex_msg_cb_ssl || arg != &listen_ex_msg_cb_arg)
+        listen_ex_msg_cb_mismatch = 1;
+
+    if (content_type == SSL3_RT_HANDSHAKE)
+        ++listen_ex_tls_msg_count;
+
+    switch (content_type) {
+    case SSL3_RT_QUIC_DATAGRAM:
+    case SSL3_RT_QUIC_PACKET:
+    case SSL3_RT_QUIC_FRAME_FULL:
+    case SSL3_RT_QUIC_FRAME_HEADER:
+    case SSL3_RT_QUIC_FRAME_PADDING:
+        ++listen_ex_quic_msg_count;
+        break;
+    default:
+        break;
+    }
 }
 
 static int listen_ex_rejects_new_conn(SSL *qlistener, SSL *new_conn)
@@ -2981,35 +3038,67 @@ static int test_ssl_listen_ex(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL, *qmctx = NULL, *threadctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL, *qlistener = NULL;
+    SSL *domain = NULL;
     SSL *preconf = NULL, *prestream = NULL, *threadssl = NULL;
     SSL *cstream = NULL, *sstream = NULL;
     BIO *confbio = NULL;
     unsigned char buf[16], msg[] = "Hello, World!";
     size_t readbytes, written;
+    uint64_t listener_domain_flags, target_domain_flags;
+    uint64_t connection_domain_flags, stream_domain_flags;
+    uint64_t event_handling_mode;
+    long listener_mode, target_mode;
     int testresult = 0;
     int ret = 0, i;
 
     if (!TEST_ptr(sctx = create_server_ctx())
-        || !TEST_ptr(cctx = create_client_ctx()))
+        || !TEST_ptr(cctx = create_client_ctx())
+        || !TEST_true(SSL_CTX_set_domain_flags(sctx,
+            SSL_DOMAIN_FLAG_MULTI_THREAD)))
         goto err;
 
-    if (!create_quic_ssl_objects_ex(sctx, cctx,
+    listener_mode = SSL_CTX_set_mode(sctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
+    SSL_CTX_set_msg_callback(sctx, listen_ex_msg_cb);
+    SSL_CTX_set_msg_callback_arg(sctx, &listen_ex_msg_cb_arg);
+
+    if (!TEST_ptr(domain = SSL_new_domain(sctx,
+                      SSL_DOMAIN_FLAG_MULTI_THREAD))
+        || !create_quic_ssl_objects_ex(sctx, cctx, domain,
             &qlistener, &clientssl, 1))
         goto err;
 
     qmctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_method());
-    if (!TEST_ptr(qmctx))
+    if (!TEST_ptr(qmctx)
+        || !TEST_true(SSL_CTX_set_domain_flags(qmctx,
+            SSL_DOMAIN_FLAG_SINGLE_THREAD)))
         goto err;
 
+    SSL_CTX_set_mode(qmctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
     serverssl = SSL_new(qmctx);
     if (!TEST_ptr(serverssl))
         goto err;
+
+    SSL_clear_mode(serverssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
+    if (!TEST_true(SSL_set_event_handling_mode(serverssl,
+            SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT)))
+        goto err;
+    target_mode = SSL_get_mode(serverssl);
+    listen_ex_msg_cb_ssl = serverssl;
+    listen_ex_tls_msg_count = 0;
+    listen_ex_quic_msg_count = 0;
+    listen_ex_msg_cb_mismatch = 0;
 
     if (!TEST_int_eq(SSL_listen_ex(NULL, serverssl), -1)
         || !TEST_true(ERR_GET_REASON(ERR_get_error())
             == ERR_R_PASSED_INVALID_ARGUMENT)
         || !TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 0)
-        || !queue_incoming_connection(qlistener, clientssl))
+        || !queue_incoming_connection(qlistener, clientssl)
+        || !TEST_true(SSL_get_domain_flags(qlistener,
+            &listener_domain_flags))
+        || !TEST_true(SSL_get_domain_flags(serverssl,
+            &target_domain_flags))
+        || !TEST_uint64_t_ne(listener_domain_flags, target_domain_flags)
+        || !TEST_long_ne(listener_mode, target_mode))
         goto err;
     ERR_clear_error();
 
@@ -3068,8 +3157,31 @@ static int test_ssl_listen_ex(void)
     preconf = NULL;
 
     if (!TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 1)
-        || !TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 0))
+        || !TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 0)
+        || !TEST_true(SSL_get_domain_flags(serverssl,
+            &connection_domain_flags))
+        || !TEST_uint64_t_eq(connection_domain_flags,
+            listener_domain_flags)
+        || !TEST_ptr_eq(SSL_get0_domain(serverssl), domain)
+        || !TEST_ptr_eq(SSL_get0_listener(serverssl), qlistener)
+        || !TEST_long_eq(SSL_get_mode(serverssl), listener_mode)
+        || !TEST_true(SSL_get_event_handling_mode(serverssl,
+            &event_handling_mode))
+        || !TEST_uint64_t_eq(event_handling_mode,
+            SSL_VALUE_EVENT_HANDLING_MODE_INHERIT))
         goto err;
+
+    if (!TEST_ptr_null(SSL_accept_connection(qlistener, 0))
+        || !TEST_true(ERR_GET_REASON(ERR_get_error())
+            == ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED))
+        goto err;
+    ERR_clear_error();
+
+    /* The adopted connection keeps the listener hierarchy alive. */
+    SSL_free(qlistener);
+    qlistener = NULL;
+    SSL_free(domain);
+    domain = NULL;
 
     for (i = 0; i < 10; i++) {
         ret = SSL_do_handshake(serverssl);
@@ -3092,12 +3204,6 @@ static int test_ssl_listen_ex(void)
         || !TEST_true(SSL_is_init_finished(clientssl)))
         goto err;
 
-    if (!TEST_ptr_null(SSL_accept_connection(qlistener, 0))
-        || !TEST_true(ERR_GET_REASON(ERR_get_error())
-            == ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED))
-        goto err;
-    ERR_clear_error();
-
     if (!TEST_true(SSL_set_default_stream_mode(serverssl,
             SSL_DEFAULT_STREAM_MODE_NONE))
         || !TEST_true(SSL_set_default_stream_mode(clientssl,
@@ -3110,6 +3216,12 @@ static int test_ssl_listen_ex(void)
 
     sstream = SSL_accept_stream(serverssl, 0);
     if (!TEST_ptr(sstream)
+        || !TEST_true(SSL_get_domain_flags(sstream, &stream_domain_flags))
+        || !TEST_uint64_t_eq(stream_domain_flags, listener_domain_flags)
+        || !TEST_ptr_eq(SSL_get0_domain(sstream),
+            SSL_get0_domain(serverssl))
+        || !TEST_ptr_eq(SSL_get0_listener(sstream),
+            SSL_get0_listener(serverssl))
         || !TEST_true(SSL_read_ex(sstream, buf, sizeof(buf), &readbytes))
         || !TEST_size_t_eq(readbytes, sizeof(msg))
         || !TEST_mem_eq(buf, readbytes, msg, sizeof(msg))
@@ -3118,6 +3230,11 @@ static int test_ssl_listen_ex(void)
         || !TEST_true(SSL_read_ex(cstream, buf, sizeof(buf), &readbytes))
         || !TEST_size_t_eq(readbytes, sizeof(msg))
         || !TEST_mem_eq(buf, readbytes, msg, sizeof(msg)))
+        goto err;
+
+    if (!TEST_uint_gt(listen_ex_tls_msg_count, 0)
+        || !TEST_uint_gt(listen_ex_quic_msg_count, 0)
+        || !TEST_false(listen_ex_msg_cb_mismatch))
         goto err;
 
     testresult = 1;
@@ -3132,10 +3249,12 @@ err:
     SSL_free(qlistener);
     SSL_free(serverssl);
     SSL_free(clientssl);
+    SSL_free(domain);
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     SSL_CTX_free(qmctx);
     SSL_CTX_free(threadctx);
+    listen_ex_msg_cb_ssl = NULL;
 
     return testresult;
 }
@@ -3149,7 +3268,7 @@ static int test_ssl_listen_ex_teardown(void)
 
     if (!TEST_ptr(sctx = create_server_ctx())
         || !TEST_ptr(cctx = create_client_ctx())
-        || !create_quic_ssl_objects_ex(sctx, cctx,
+        || !create_quic_ssl_objects_ex(sctx, cctx, NULL,
             &qlistener, &clientssl, 1)
         || !TEST_ptr(qmctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_method()))
         || !TEST_ptr(serverssl = SSL_new(qmctx))
@@ -3180,7 +3299,7 @@ static int test_ssl_listen_ex_mfail(void)
 
     if (!TEST_ptr(sctx = create_server_ctx())
         || !TEST_ptr(cctx = create_client_ctx())
-        || !create_quic_ssl_objects_ex(sctx, cctx,
+        || !create_quic_ssl_objects_ex(sctx, cctx, NULL,
             &qlistener, &clientssl, 1)
         || !TEST_ptr(qmctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_method()))
         || !TEST_ptr(serverssl = SSL_new(qmctx))
@@ -3197,6 +3316,14 @@ static int test_ssl_listen_ex_mfail(void)
         if (!TEST_int_eq(ret, -1)
             || !TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 1)) {
             /* ADD_MFAIL_NO_CHECK_TEST treats -1 as an unconditional failure. */
+            testresult = -1;
+            goto err;
+        }
+
+        ERR_clear_error();
+        if (!TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 1)
+            || !TEST_size_t_eq(
+                SSL_get_accept_connection_queue_len(qlistener), 0)) {
             testresult = -1;
             goto err;
         }
@@ -3764,7 +3891,8 @@ static int test_quic_handshake_multipkt_mfail(void)
         || !TEST_ptr(cctx = create_client_ctx()))
         goto err;
 
-    if (!create_quic_ssl_objects_ex(sctx, cctx, &qlistener, &clientssl, 1))
+    if (!create_quic_ssl_objects_ex(sctx, cctx, NULL,
+            &qlistener, &clientssl, 1))
         goto err;
 
     if (!TEST_true(SSL_set_tlsext_host_name(clientssl, "localhost")))

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -2899,6 +2899,18 @@ static int queue_incoming_connection(SSL *qlistener, SSL *clientssl)
     return TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 1);
 }
 
+static int listen_ex_rejects_new_conn(SSL *qlistener, SSL *new_conn)
+{
+    int ret = SSL_listen_ex(qlistener, new_conn);
+    unsigned long err = ERR_get_error();
+    int ok = TEST_int_eq(ret, -1)
+        && TEST_int_eq(ERR_GET_REASON(err), ERR_R_PASSED_INVALID_ARGUMENT)
+        && TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 1);
+
+    ERR_clear_error();
+    return ok;
+}
+
 static int test_ssl_client_as_ossl_quic_method(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
@@ -2965,21 +2977,17 @@ err:
     return testresult;
 }
 
-static int test_ssl_listen_ex(int idx)
+static int test_ssl_listen_ex(void)
 {
-    SSL_CTX *cctx = NULL, *sctx = NULL, *qmctx = NULL;
+    SSL_CTX *cctx = NULL, *sctx = NULL, *qmctx = NULL, *threadctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL, *qlistener = NULL;
+    SSL *preconf = NULL, *prestream = NULL, *threadssl = NULL;
     SSL *cstream = NULL, *sstream = NULL;
+    BIO *confbio = NULL;
     unsigned char buf[16], msg[] = "Hello, World!";
     size_t readbytes, written;
     int testresult = 0;
     int ret = 0, i;
-
-#if !defined(OPENSSL_THREADS) || defined(OPENSSL_NO_THREAD_POOL) \
-    || defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
-    if (idx == 1)
-        return TEST_skip("thread assisted mode not available in this build");
-#endif
 
     if (!TEST_ptr(sctx = create_server_ctx())
         || !TEST_ptr(cctx = create_client_ctx()))
@@ -2993,18 +3001,71 @@ static int test_ssl_listen_ex(int idx)
     if (!TEST_ptr(qmctx))
         goto err;
 
-    if (idx == 1
-        && !TEST_true(SSL_CTX_set_domain_flags(qmctx,
-            SSL_DOMAIN_FLAG_THREAD_ASSISTED | SSL_DOMAIN_FLAG_BLOCKING)))
-        goto err;
-
     serverssl = SSL_new(qmctx);
     if (!TEST_ptr(serverssl))
         goto err;
 
-    if (!TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 0)
+    if (!TEST_int_eq(SSL_listen_ex(NULL, serverssl), -1)
+        || !TEST_true(ERR_GET_REASON(ERR_get_error())
+            == ERR_R_PASSED_INVALID_ARGUMENT)
+        || !TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 0)
         || !queue_incoming_connection(qlistener, clientssl))
         goto err;
+    ERR_clear_error();
+
+#if defined(OPENSSL_THREADS) && !defined(OPENSSL_NO_THREAD_POOL) \
+    && !defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
+    /* Thread assistance can't be transferred to an accepted connection. */
+    threadctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_method());
+    if (!TEST_ptr(threadctx)
+        || !TEST_true(SSL_CTX_set_domain_flags(threadctx,
+            SSL_DOMAIN_FLAG_THREAD_ASSISTED | SSL_DOMAIN_FLAG_BLOCKING))
+        || !TEST_ptr(threadssl = SSL_new(threadctx))
+        || !listen_ex_rejects_new_conn(qlistener, threadssl))
+        goto err;
+
+    SSL_free(threadssl);
+    threadssl = NULL;
+#endif
+
+    /* A connection which has already been started is not fresh. */
+    if (!listen_ex_rejects_new_conn(qlistener, clientssl))
+        goto err;
+
+    /* A connection which belongs to this listener isn't standalone. */
+    preconf = SSL_new_from_listener(qlistener, 0);
+    if (!TEST_ptr(preconf)
+        || !listen_ex_rejects_new_conn(qlistener, preconf))
+        goto err;
+
+    SSL_free(preconf);
+    preconf = NULL;
+
+    /* Network BIOs may not already be attached. */
+    preconf = SSL_new(qmctx);
+    if (!TEST_ptr(preconf)
+        || !TEST_ptr(confbio = BIO_new(BIO_s_mem())))
+        goto err;
+    SSL_set_bio(preconf, confbio, confbio);
+    confbio = NULL;
+    if (!listen_ex_rejects_new_conn(qlistener, preconf))
+        goto err;
+
+    SSL_free(preconf);
+    preconf = NULL;
+
+    /* Streams may not already have been created. */
+    preconf = SSL_new(qmctx);
+    if (!TEST_ptr(preconf)
+        || !TEST_ptr(prestream = SSL_new_stream(preconf,
+                         SSL_STREAM_FLAG_ADVANCE))
+        || !listen_ex_rejects_new_conn(qlistener, preconf))
+        goto err;
+
+    SSL_free(prestream);
+    prestream = NULL;
+    SSL_free(preconf);
+    preconf = NULL;
 
     if (!TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 1)
         || !TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 0))
@@ -3064,12 +3125,17 @@ static int test_ssl_listen_ex(int idx)
 err:
     SSL_free(sstream);
     SSL_free(cstream);
+    SSL_free(prestream);
+    SSL_free(preconf);
+    SSL_free(threadssl);
+    BIO_free(confbio);
     SSL_free(qlistener);
     SSL_free(serverssl);
     SSL_free(clientssl);
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     SSL_CTX_free(qmctx);
+    SSL_CTX_free(threadctx);
 
     return testresult;
 }
@@ -3096,6 +3162,53 @@ static int test_ssl_listen_ex_teardown(void)
     testresult = 1;
 
 err:
+    SSL_free(qlistener);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    SSL_CTX_free(qmctx);
+    return testresult;
+}
+
+/* Internal failures are errors and must not consume the queued channel. */
+static int test_ssl_listen_ex_mfail(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL, *qmctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL, *qlistener = NULL;
+    int testresult = 0, ret;
+
+    if (!TEST_ptr(sctx = create_server_ctx())
+        || !TEST_ptr(cctx = create_client_ctx())
+        || !create_quic_ssl_objects_ex(sctx, cctx,
+            &qlistener, &clientssl, 1)
+        || !TEST_ptr(qmctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_method()))
+        || !TEST_ptr(serverssl = SSL_new(qmctx))
+        || !TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 0)
+        || !queue_incoming_connection(qlistener, clientssl))
+        goto err;
+
+    MFAIL_start();
+    ret = SSL_listen_ex(qlistener, serverssl);
+    MFAIL_end();
+    ERR_clear_error();
+
+    if (mfail_was_triggered()) {
+        if (!TEST_int_eq(ret, -1)
+            || !TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 1)) {
+            /* ADD_MFAIL_NO_CHECK_TEST treats -1 as an unconditional failure. */
+            testresult = -1;
+            goto err;
+        }
+    } else if (!TEST_int_eq(ret, 1)
+        || !TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 0)) {
+        goto err;
+    }
+
+    testresult = 1;
+
+err:
+    MFAIL_end();
     SSL_free(qlistener);
     SSL_free(serverssl);
     SSL_free(clientssl);
@@ -4138,8 +4251,9 @@ int setup_tests(void)
     ADD_TEST(test_quic_forbidden_options);
     ADD_ALL_TESTS(test_quic_set_fd, 3);
     ADD_TEST(test_bio_ssl);
-    ADD_ALL_TESTS(test_ssl_listen_ex, 2);
+    ADD_TEST(test_ssl_listen_ex);
     ADD_TEST(test_ssl_listen_ex_teardown);
+    ADD_MFAIL_NO_CHECK_TEST(test_ssl_listen_ex_mfail);
     ADD_TEST(test_ssl_client_as_ossl_quic_method);
     ADD_TEST(test_back_pressure);
     ADD_TEST(test_multiple_dgrams);

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -44,6 +44,7 @@ static SSL_CTX *create_server_ctx(void);
 static SSL_CTX *create_client_ctx(void);
 static int create_quic_ssl_objects(SSL_CTX *sctx, SSL_CTX *cctx,
     SSL **lssl, SSL **cssl);
+static void quic_advance_time(SSL *clientssl, SSL *serverssl);
 static int qc_init(SSL *qconn, BIO_ADDR *dst_addr);
 
 /* The ssltrace test assumes some options are switched on/off */
@@ -2880,6 +2881,24 @@ static int create_quic_ssl_objects(SSL_CTX *sctx, SSL_CTX *cctx,
     return create_quic_ssl_objects_ex(sctx, cctx, lssl, cssl, 0);
 }
 
+static int queue_incoming_connection(SSL *qlistener, SSL *clientssl)
+{
+    int i, ret;
+
+    for (i = 0; i < 5; i++) {
+        ret = SSL_connect(clientssl);
+        if (!TEST_int_le(ret, 0)
+            || !TEST_int_eq(SSL_get_error(clientssl, ret), SSL_ERROR_WANT_READ))
+            return 0;
+
+        SSL_handle_events(qlistener);
+        if (SSL_get_accept_connection_queue_len(qlistener) == 1)
+            break;
+    }
+
+    return TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 1);
+}
+
 static int test_ssl_client_as_ossl_quic_method(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
@@ -2946,60 +2965,134 @@ err:
     return testresult;
 }
 
-static int test_ssl_listen_ex(void)
+static int test_ssl_listen_ex(int idx)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL, *qmctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL, *qlistener = NULL;
+    SSL *cstream = NULL, *sstream = NULL;
+    unsigned char buf[16], msg[] = "Hello, World!";
+    size_t readbytes, written;
     int testresult = 0;
     int ret = 0, i;
+
+#if !defined(OPENSSL_THREADS) || defined(OPENSSL_NO_THREAD_POOL) \
+    || defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
+    if (idx == 1)
+        return TEST_skip("thread assisted mode not available in this build");
+#endif
 
     if (!TEST_ptr(sctx = create_server_ctx())
         || !TEST_ptr(cctx = create_client_ctx()))
         goto err;
 
-    if (!create_quic_ssl_objects(sctx, cctx, &qlistener, &clientssl))
+    if (!create_quic_ssl_objects_ex(sctx, cctx,
+            &qlistener, &clientssl, 1))
         goto err;
 
     qmctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_method());
     if (!TEST_ptr(qmctx))
         goto err;
 
+    if (idx == 1
+        && !TEST_true(SSL_CTX_set_domain_flags(qmctx,
+            SSL_DOMAIN_FLAG_THREAD_ASSISTED | SSL_DOMAIN_FLAG_BLOCKING)))
+        goto err;
+
     serverssl = SSL_new(qmctx);
     if (!TEST_ptr(serverssl))
         goto err;
 
-    /* Send ClientHello and server retry */
-    for (i = 0; i < 5; i++) {
-        ret = SSL_connect(clientssl);
-        if (!TEST_int_le(ret, 0)
-            || !TEST_int_eq(SSL_get_error(clientssl, ret), SSL_ERROR_WANT_READ))
+    if (!TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 0)
+        || !queue_incoming_connection(qlistener, clientssl))
+        goto err;
+
+    if (!TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 1)
+        || !TEST_size_t_eq(SSL_get_accept_connection_queue_len(qlistener), 0))
+        goto err;
+
+    for (i = 0; i < 10; i++) {
+        ret = SSL_do_handshake(serverssl);
+        if (ret != 1
+            && !TEST_int_eq(SSL_get_error(serverssl, ret), SSL_ERROR_WANT_READ))
             goto err;
-        ret = SSL_listen_ex(qlistener, serverssl);
-        if (ret == 1)
+
+        ret = SSL_connect(clientssl);
+        if (ret != 1
+            && !TEST_int_eq(SSL_get_error(clientssl, ret), SSL_ERROR_WANT_READ))
+            goto err;
+
+        if (SSL_is_init_finished(serverssl) && SSL_is_init_finished(clientssl))
             break;
-        SSL_handle_events(qlistener);
+        quic_advance_time(clientssl, serverssl);
     }
 
-    /*
-     * Check to make sure we got a good return code from SSL_listen_ex
-     */
-    if (!TEST_int_eq(ret, 1))
+    if (!TEST_int_lt(i, 10)
+        || !TEST_true(SSL_is_init_finished(serverssl))
+        || !TEST_true(SSL_is_init_finished(clientssl)))
         goto err;
 
-    /* Call SSL_accept() and SSL_connect() until we are connected */
-    if (!TEST_true(create_bare_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE, 0, 0)))
-
-        /*
-         * Ensure that, now that we have used SSL_listen_ex, SSL_accept_connection
-         * produces an error
-         */
-        if (!TEST_ptr_null(SSL_accept_connection(qlistener, 0)))
-            goto err;
-
-    if (!TEST_true((ERR_GET_REASON(ERR_get_error())) == ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED))
+    if (!TEST_ptr_null(SSL_accept_connection(qlistener, 0))
+        || !TEST_true(ERR_GET_REASON(ERR_get_error())
+            == ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED))
         goto err;
-
     ERR_clear_error();
+
+    if (!TEST_true(SSL_set_default_stream_mode(serverssl,
+            SSL_DEFAULT_STREAM_MODE_NONE))
+        || !TEST_true(SSL_set_default_stream_mode(clientssl,
+            SSL_DEFAULT_STREAM_MODE_NONE))
+        || !TEST_ptr(cstream = SSL_new_stream(clientssl, 0))
+        || !TEST_true(SSL_write_ex(cstream, msg, sizeof(msg), &written))
+        || !TEST_size_t_eq(written, sizeof(msg))
+        || !TEST_int_eq(SSL_handle_events(serverssl), 1))
+        goto err;
+
+    sstream = SSL_accept_stream(serverssl, 0);
+    if (!TEST_ptr(sstream)
+        || !TEST_true(SSL_read_ex(sstream, buf, sizeof(buf), &readbytes))
+        || !TEST_size_t_eq(readbytes, sizeof(msg))
+        || !TEST_mem_eq(buf, readbytes, msg, sizeof(msg))
+        || !TEST_true(SSL_write_ex(sstream, msg, sizeof(msg), &written))
+        || !TEST_size_t_eq(written, sizeof(msg))
+        || !TEST_true(SSL_read_ex(cstream, buf, sizeof(buf), &readbytes))
+        || !TEST_size_t_eq(readbytes, sizeof(msg))
+        || !TEST_mem_eq(buf, readbytes, msg, sizeof(msg)))
+        goto err;
+
+    testresult = 1;
+
+err:
+    SSL_free(sstream);
+    SSL_free(cstream);
+    SSL_free(qlistener);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    SSL_CTX_free(qmctx);
+
+    return testresult;
+}
+
+/* Free a listener which still owns a deferred, unpeeled channel. */
+static int test_ssl_listen_ex_teardown(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL, *qmctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL, *qlistener = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(sctx = create_server_ctx())
+        || !TEST_ptr(cctx = create_client_ctx())
+        || !create_quic_ssl_objects_ex(sctx, cctx,
+            &qlistener, &clientssl, 1)
+        || !TEST_ptr(qmctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_method()))
+        || !TEST_ptr(serverssl = SSL_new(qmctx))
+        || !TEST_int_eq(SSL_listen_ex(qlistener, serverssl), 0)
+        || !queue_incoming_connection(qlistener, clientssl))
+        goto err;
+
+    SSL_free(qlistener);
+    qlistener = NULL;
     testresult = 1;
 
 err:
@@ -3009,7 +3102,6 @@ err:
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     SSL_CTX_free(qmctx);
-
     return testresult;
 }
 
@@ -4046,7 +4138,8 @@ int setup_tests(void)
     ADD_TEST(test_quic_forbidden_options);
     ADD_ALL_TESTS(test_quic_set_fd, 3);
     ADD_TEST(test_bio_ssl);
-    ADD_TEST(test_ssl_listen_ex);
+    ADD_ALL_TESTS(test_ssl_listen_ex, 2);
+    ADD_TEST(test_ssl_listen_ex_teardown);
     ADD_TEST(test_ssl_client_as_ossl_quic_method);
     ADD_TEST(test_back_pressure);
     ADD_TEST(test_multiple_dgrams);


### PR DESCRIPTION
Fixes #32490

`SSL_listen_ex` could return success with a QUIC connection that could not complete its handshake. The peeloff path attached a deferred incoming channel to the caller's `SSL_new` object without rebinding the channel's handshake layer or fully adopting the object into the listener's QUIC hierarchy. The existing test hid this because a dangling `if` allowed a failed handshake check to pass and the helper drove the returned connection with unsupported `SSL_accept`.

The incomplete adoption also left stale port, hierarchy and thread-assist state, which could cause invalid memory access or a process abort during BIO operations or teardown.

This change:

- Keeps deferred channels idle until a TLS connection is attached, then binds the channel handshake layer during peeloff.
- Reparents the connection into the listener hierarchy, updates its port, engine and cached leader state, and clears state which is invalid for an accepted connection.
- Rejects a `new_conn` which is not a fresh standalone QUIC connection before modifying the incoming queue.
- Returns `-1` for invalid arguments and internal failures, reserving `0` for "no connection available", and performs fallible setup before consuming the queued connection.
- Drains unpeeled deferred channels during listener teardown.

The return value handling changes the behavior shipped in OpenSSL 4.0: invalid arguments and internal failures are now distinguished from "no connection available". This is recorded in `CHANGES.md`. The affected peeloff implementation is also present in OpenSSL 4.0.1, so a backport may be appropriate.

The tests now require the peeled connection to complete its handshake with `SSL_do_handshake` and exchange stream data. They also cover invalid and pre-used `new_conn` objects, a thread-assisted context, allocation failures and listener teardown with a queued deferred channel.

`SSL_new_listener(3)` now documents the `new_conn` requirements, listener-derived TLS and connection state, shared network BIO semantics, handshake progression and return values.

### Testing

- `make check-format`
- `git diff -U0 --no-prefix --no-color HEAD^^ HEAD | clang-format-diff`
- `perl util/find-doc-nits -c -n -e`
- `make -s -j4`
- `make test HARNESS_JOBS=4 LHASH_WORKERS=16`: all 388 test files and 4575 tests passed, including `75-test_quicapi.t`.

##### Checklist

- [x] documentation is added or updated
- [x] tests are added or updated