### PR TITLE
[3.3] Don't restrict what EVP_PKEY_Q_keygen can be used for

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1221,17 +1221,10 @@ EVP_PKEY *EVP_PKEY_Q_keygen(OSSL_LIB_CTX *libctx, const char *propq,
         name = va_arg(args, char *);
         params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
             name, 0);
-    } else if (OPENSSL_strcasecmp(type, "ED25519") != 0
-        && OPENSSL_strcasecmp(type, "X25519") != 0
-        && OPENSSL_strcasecmp(type, "ED448") != 0
-        && OPENSSL_strcasecmp(type, "X448") != 0
-        && OPENSSL_strcasecmp(type, "SM2") != 0) {
-        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_INVALID_ARGUMENT);
-        goto end;
     }
+
     ret = evp_pkey_keygen(libctx, type, propq, params);
 
-end:
     va_end(args);
     return ret;
 }

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -103,7 +103,9 @@ a B<size_t> parameter must be given to specify the size of the RSA key.
 If I<type> is C<EC>,
 a string parameter must be given to specify the name of the EC curve.
 If I<type> is C<X25519>, C<X448>, C<ED25519>, C<ED448>, or C<SM2>
-no further parameter is needed.
+no further parameter is needed. Other key types may be possible if they are
+supplied by the loaded providers. EVP_PKEY_Q_keygen() may be usable with such
+key types as long as they do not require further parameters.
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
Port this PR back to the 3.3 branch by cherry-pick:

* https://github.com/openssl/openssl/pull/25468

> The EVP_PKEY_Q_keygen function contains a list of algorithm type names and fails if the requested name is not in the list. This prevents the use of this function for externally supplied key type names.
> 
> We should just assume that any unrecognised key type name does not require a parameter.

In the original PR's thread, there's some discussion about whether this change should be backported. There was some support for porting it and no major objections, but nobody ended up submitting the PR at the time.

I'm using a provider on a Linux distro that uses OpenSSL 3.3, and I hit this issue. It behaves like a compatibility problem: programs written and tested against newer versions of OpenSSL assume this function works with more algorithms, and the programs break when running on the Linux distro that uses 3.3.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
