### PR TITLE
Fix test for CVE-2026-63072

### DIFF
--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -855,7 +855,7 @@ end:
     return ret;
 }
 
-#ifndef OPENSSL_NO_EC
+#if !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_X963KDF)
 /*
  * Regression test for CVE-2026-63072: an 8-byte out-of-bounds heap write
  * reachable through CMS_decrypt() when a KeyAgreeRecipientInfo names an
@@ -1013,7 +1013,8 @@ int setup_tests(void)
         ADD_TEST(test_CMS_add1_signer_ed448_signed_attrs_md);
         ADD_TEST(test_CMS_add1_signer_ed448_noattr);
     }
-#ifndef OPENSSL_NO_EC
+
+#if !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_X963KDF)
     ADD_TEST(test_kari_wrap_pad_unwrap_overflow);
 #endif
     return 1;


### PR DESCRIPTION
Fixes the build/test failure when OpenSSL is configured with no-x963kdf.