### PR TITLE
Dont have dgram_pairs track bios, track bio_dgram_pair_st instead

### DIFF
--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -253,11 +253,51 @@ struct rbuf_map_st {
     CRYPTO_RWLOCK *lock;
 };
 
+/**
+ * \defgroup peer_state Peer pairing states
+ *
+ * State values describing whether a peer is still associated with its
+ * counterpart. Stored in the peer's state field and compared for
+ * equality; the values are not a bitmask and must not be OR'd
+ * together.
+ *
+ * @{
+ */
+
+/** Peer is associated with a live counterpart. */
 #define PEER_STATE_PAIRED 0
+
+/** Peer's counterpart has gone away; the peer is unassociated. */
 #define PEER_STATE_ORPHANED 1
+/**
+ * \brief Shared state for a datagram BIO pair.
+ *
+ * Refcounted so that both ends of a pair (and any BIO holding a
+ * reference to the peer) can keep the structure alive independently.
+ * The object is freed when the last reference is dropped, and the peer_state
+ * is set to PEER_STATE_ORPHANED when either side leaves the pair, either
+ * via BIO_free() or BIO_destroy_dgram_pair()
+ *
+ * This structure is pointed to by each half of a BIO_dgram pair via the pair pointer
+ * It is only allocated and assigned when a pair is formed.
+ */
 struct bio_dgram_peer_st {
+    /**
+     * Reference count. Initialised with CRYPTO_NEW_REF() and
+     * released with CRYPTO_FREE_REF() once it reaches zero.
+     */
     CRYPTO_REF_COUNT ref_cnt;
+
+    /**
+     * Current pairing state; one of \c PEER_STATE_PAIRED or
+     * \c PEER_STATE_ORPHANED (see \ref peer_state).
+     */
     int peer_state;
+
+    /**
+     * Ring buffer mappings for the two datagram directions,
+     * indexed one per direction.
+     */
     struct rbuf_map_st map[2];
 };
 
@@ -286,6 +326,11 @@ struct bio_dgram_pair_st {
     unsigned int grows_on_write : 1; /* Set for BIO_s_dgram_mem only */
 };
 
+/*
+ * When operating as a pair, we use the shared structure to hold our ring buffers
+ * and locks to ensure that they remain allocated until the last half of a pair
+ * dissolves the pair.
+ */
 static struct rbuf_map_st *dgram_rbuf_map_get_self(struct bio_dgram_pair_st *self)
 {
     if (self->pair->map[0].self == self)
@@ -455,6 +500,13 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
         return 0;
     }
 
+    /*
+     * Create a new pair structure, init it with appropriate
+     * ring buffers and lock, and assign it to each half of the
+     * pair.
+     * Once this is done, each half of the pair uses the shared
+     * ring buffers/lock available here instead of their own private copy
+     */
     pair = OPENSSL_zalloc(sizeof(*pair));
     if (pair == NULL) {
         ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
@@ -517,10 +569,18 @@ static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1)
     if (ring_buf_init(&b1->rbuf, b1->req_buf_len) == 0)
         return 0;
 
+    /*
+     * Since one half of the pair is going away, we are now
+     * orphaned
+     */
     b1->pair->peer_state = PEER_STATE_ORPHANED;
     if (!CRYPTO_DOWN_REF(&b1->pair->ref_cnt, &ref))
         return 0;
     if (ref == 0) {
+        /*
+         * The last half of the pair is leaving, clean up the
+         * shared data
+         */
         CRYPTO_FREE_REF(&b1->pair->ref_cnt);
         CRYPTO_THREAD_lock_free(b1->pair->map[0].lock);
         CRYPTO_THREAD_lock_free(b1->pair->map[1].lock);
@@ -528,6 +588,10 @@ static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1)
         ring_buf_destroy(&b1->pair->map[1].rbuf);
         OPENSSL_free(b1->pair);
     }
+    /*
+     * Make sure the leaving pair no longer references the shared peer data,
+     * since it is no longer part of the pair.
+     */
     b1->pair = NULL;
     return 1;
 }

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -15,6 +15,8 @@
 
 #if !defined(OPENSSL_NO_DGRAM) && !defined(OPENSSL_NO_SOCK)
 
+#define is_dgram_pair(b) (b->pair != NULL)
+
 OSSL_SAFE_MATH_UNSIGNED(size_t, size_t)
 
 /* ===========================================================================
@@ -245,9 +247,23 @@ struct dgram_hdr {
     BIO_ADDR src_addr, dst_addr; /* family == 0: not present */
 };
 
+struct rbuf_map_st {
+    struct bio_dgram_pair_st *self;
+    struct ring_buf rbuf;
+    CRYPTO_RWLOCK *lock;
+};
+
+#define PEER_STATE_PAIRED 0
+#define PEER_STATE_ORPHANED 1
+struct bio_dgram_peer_st {
+    CRYPTO_REF_COUNT ref_cnt;
+    int peer_state;
+    struct rbuf_map_st map[2];
+};
+
 struct bio_dgram_pair_st {
-    /* The other half of the BIO pair. NULL for dgram_mem. */
-    BIO *peer;
+    /* Track out pairing state */
+    struct bio_dgram_peer_st *pair;
     /* Writes are directed to our own ringbuf and reads to our peer. */
     struct ring_buf rbuf;
     /* Requested size of rbuf buffer in bytes once we initialize. */
@@ -270,9 +286,68 @@ struct bio_dgram_pair_st {
     unsigned int grows_on_write : 1; /* Set for BIO_s_dgram_mem only */
 };
 
-#define MIN_BUF_LEN (1024)
+static struct rbuf_map_st *dgram_rbuf_map_get_self(struct bio_dgram_pair_st *self)
+{
+    if (self->pair->map[0].self == self)
+        return &self->pair->map[0];
+    return &self->pair->map[1];
+}
 
-#define is_dgram_pair(b) (b->peer != NULL)
+static struct rbuf_map_st *dgram_rbuf_map_get_peer(struct bio_dgram_pair_st *self)
+{
+    if (self->pair->map[0].self == self)
+        return &self->pair->map[1];
+    return &self->pair->map[0];
+}
+
+static void dgram_bio_get_self_data(struct bio_dgram_pair_st *self, struct ring_buf **rbufptr,
+    CRYPTO_RWLOCK **lock)
+{
+    struct rbuf_map_st *map;
+    CRYPTO_RWLOCK *mylock;
+    struct ring_buf *myrbuf;
+
+    if (is_dgram_pair(self)) {
+        map = dgram_rbuf_map_get_self(self);
+        mylock = map->lock;
+        myrbuf = &map->rbuf;
+    } else {
+        mylock = self->lock;
+        myrbuf = &self->rbuf;
+    }
+    if (lock != NULL)
+        *lock = mylock;
+    if (rbufptr != NULL)
+        *rbufptr = myrbuf;
+}
+
+static void dgram_bio_get_peer_data(struct bio_dgram_pair_st *self, struct ring_buf **rbufptr,
+    CRYPTO_RWLOCK **lock, struct bio_dgram_pair_st **peer)
+{
+    struct rbuf_map_st *map;
+    CRYPTO_RWLOCK *mylock;
+    struct ring_buf *myrbuf;
+    struct bio_dgram_pair_st *mypeer;
+
+    if (is_dgram_pair(self)) {
+        map = dgram_rbuf_map_get_peer(self);
+        mylock = map->lock;
+        myrbuf = &map->rbuf;
+        mypeer = map->self;
+    } else {
+        mylock = self->lock;
+        myrbuf = &self->rbuf;
+        mypeer = self;
+    }
+    if (lock != NULL)
+        *lock = mylock;
+    if (rbufptr != NULL)
+        *rbufptr = myrbuf;
+    if (peer != NULL)
+        *peer = mypeer;
+}
+
+#define MIN_BUF_LEN (1024)
 
 static int dgram_pair_init(BIO *bio)
 {
@@ -330,6 +405,8 @@ static int dgram_pair_free(BIO *bio)
     /* We are being freed. Disconnect any peer and destroy buffers. */
     dgram_pair_ctrl_destroy_bio_pair(bio);
 
+    ring_buf_destroy(&b->rbuf);
+    BIO_ADDR_free(b->local_addr);
     CRYPTO_THREAD_lock_free(b->lock);
     OPENSSL_free(b);
     return 1;
@@ -339,6 +416,7 @@ static int dgram_pair_free(BIO *bio)
 static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
 {
     struct bio_dgram_pair_st *b1, *b2;
+    struct bio_dgram_peer_st *pair;
 
     /* peer must be non-NULL. */
     if (bio1 == NULL || bio2 == NULL) {
@@ -365,7 +443,7 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
      * This ctrl cannot be used to associate a BIO pair half which is already
      * associated.
      */
-    if (b1->peer != NULL || b2->peer != NULL) {
+    if (b1->pair != NULL || b2->pair != NULL) {
         ERR_raise_data(ERR_LIB_BIO, BIO_R_IN_USE,
             "cannot associate a BIO_dgram_pair which is already in use");
         return 0;
@@ -377,21 +455,45 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
         return 0;
     }
 
-    if (b1->rbuf.len != b1->req_buf_len)
-        if (ring_buf_init(&b1->rbuf, b1->req_buf_len) == 0) {
-            ERR_raise(ERR_LIB_BIO, ERR_R_BIO_LIB);
-            return 0;
-        }
+    pair = OPENSSL_zalloc(sizeof(*pair));
+    if (pair == NULL) {
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
+        return 0;
+    }
+    if (!CRYPTO_NEW_REF(&pair->ref_cnt, 2)) {
+        OPENSSL_free(pair);
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
+        return 0;
+    }
+    if (ring_buf_init(&pair->map[0].rbuf, b1->req_buf_len) == 0) {
+        CRYPTO_FREE_REF(&pair->ref_cnt);
+        OPENSSL_free(pair);
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
+        return 0;
+    }
 
-    if (b2->rbuf.len != b2->req_buf_len)
-        if (ring_buf_init(&b2->rbuf, b2->req_buf_len) == 0) {
-            ERR_raise(ERR_LIB_BIO, ERR_R_BIO_LIB);
-            ring_buf_destroy(&b1->rbuf);
-            return 0;
-        }
-
-    b1->peer = bio2;
-    b2->peer = bio1;
+    if (ring_buf_init(&pair->map[1].rbuf, b2->req_buf_len) == 0) {
+        CRYPTO_FREE_REF(&pair->ref_cnt);
+        OPENSSL_free(pair);
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
+        return 0;
+    }
+    ring_buf_destroy(&b1->rbuf);
+    ring_buf_destroy(&b2->rbuf);
+    pair->map[0].lock = CRYPTO_THREAD_lock_new();
+    pair->map[1].lock = CRYPTO_THREAD_lock_new();
+    if (pair->map[0].lock == NULL || pair->map[1].lock == NULL) {
+        CRYPTO_THREAD_lock_free(pair->map[0].lock);
+        CRYPTO_THREAD_lock_free(pair->map[1].lock);
+        CRYPTO_FREE_REF(&pair->ref_cnt);
+        OPENSSL_free(pair);
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
+        return 0;
+    }
+    pair->map[0].self = b1;
+    pair->map[1].self = b2;
+    b1->pair = pair;
+    b2->pair = pair;
     b1->role = 0;
     b2->role = 1;
     bio1->init = 1;
@@ -402,38 +504,38 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
 /* BIO_destroy_bio_pair (BIO_C_DESTROY_BIO_PAIR) */
 static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1)
 {
-    BIO *bio2;
-    struct bio_dgram_pair_st *b1 = bio1->ptr, *b2;
+    struct bio_dgram_pair_st *b1 = bio1->ptr;
+    int ref;
+
+    /* Early return if we don't have a peer. */
+    if (b1->pair == NULL)
+        return 1;
 
     ring_buf_destroy(&b1->rbuf);
     bio1->init = 0;
 
-    BIO_ADDR_free(b1->local_addr);
-
-    /* Early return if we don't have a peer. */
-    if (b1->peer == NULL)
-        return 1;
-
-    bio2 = b1->peer;
-    b2 = bio2->ptr;
-
-    /* Invariant. */
-    if (!ossl_assert(b2->peer == bio1))
+    if (ring_buf_init(&b1->rbuf, b1->req_buf_len) == 0)
         return 0;
 
-    /* Free buffers. */
-    ring_buf_destroy(&b2->rbuf);
-
-    bio2->init = 0;
-    b1->peer = NULL;
-    b2->peer = NULL;
+    b1->pair->peer_state = PEER_STATE_ORPHANED;
+    if (!CRYPTO_DOWN_REF(&b1->pair->ref_cnt, &ref))
+        return 0;
+    if (ref == 0) {
+        CRYPTO_FREE_REF(&b1->pair->ref_cnt);
+        CRYPTO_THREAD_lock_free(b1->pair->map[0].lock);
+        CRYPTO_THREAD_lock_free(b1->pair->map[1].lock);
+        ring_buf_destroy(&b1->pair->map[0].rbuf);
+        ring_buf_destroy(&b1->pair->map[1].rbuf);
+        OPENSSL_free(b1->pair);
+    }
+    b1->pair = NULL;
     return 1;
 }
 
 /* BIO_eof (BIO_CTRL_EOF) */
 static int dgram_pair_ctrl_eof(BIO *bio)
 {
-    struct bio_dgram_pair_st *b = bio->ptr, *peerb;
+    struct bio_dgram_pair_st *b = bio->ptr, *peerb = NULL;
 
     if (!ossl_assert(b != NULL))
         return -1;
@@ -444,7 +546,13 @@ static int dgram_pair_ctrl_eof(BIO *bio)
     if (!is_dgram_pair(b))
         return 0;
 
-    peerb = b->peer->ptr;
+    /*
+     * orphaned pairs always return EOF
+     */
+    if (b->pair->peer_state == PEER_STATE_ORPHANED)
+        return 1;
+
+    dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
     if (!ossl_assert(peerb != NULL))
         return -1;
 
@@ -461,7 +569,7 @@ static int dgram_pair_ctrl_set_write_buf_size(BIO *bio, size_t len)
     struct bio_dgram_pair_st *b = bio->ptr;
 
     /* Changing buffer sizes is not permitted while a peer is connected. */
-    if (b->peer != NULL) {
+    if (b->pair != NULL) {
         ERR_raise(ERR_LIB_BIO, BIO_R_IN_USE);
         return 0;
     }
@@ -496,27 +604,31 @@ static size_t dgram_pair_ctrl_pending(BIO *bio)
     struct bio_dgram_pair_st *b = bio->ptr, *readb;
     struct dgram_hdr hdr;
     size_t l;
+    struct ring_buf *rbufptr;
+    CRYPTO_RWLOCK *lock;
 
     /* Safe to check; init may not change during this call */
     if (!bio->init)
         return 0;
-    if (is_dgram_pair(b))
-        readb = b->peer->ptr;
-    else
-        readb = b;
+    if (is_dgram_pair(b)) {
+        if (b->pair->peer_state == PEER_STATE_ORPHANED)
+            return 0;
+    }
 
-    if (CRYPTO_THREAD_write_lock(readb->lock) == 0)
+    dgram_bio_get_peer_data(b, &rbufptr, &lock, &readb);
+
+    if (CRYPTO_THREAD_write_lock(lock) == 0)
         return 0;
 
-    saved_idx = readb->rbuf.idx[1];
-    saved_count = readb->rbuf.count;
+    saved_idx = rbufptr->idx[1];
+    saved_count = rbufptr->count;
 
     l = dgram_pair_read_inner(readb, (uint8_t *)&hdr, sizeof(hdr));
 
-    readb->rbuf.idx[1] = saved_idx;
-    readb->rbuf.count = saved_count;
+    rbufptr->idx[1] = saved_idx;
+    rbufptr->count = saved_count;
 
-    CRYPTO_THREAD_unlock(readb->lock);
+    CRYPTO_THREAD_unlock(lock);
 
     if (!ossl_assert(l == 0 || l == sizeof(hdr)))
         return 0;
@@ -529,11 +641,15 @@ static size_t dgram_pair_ctrl_get_write_guarantee(BIO *bio)
 {
     size_t l;
     struct bio_dgram_pair_st *b = bio->ptr;
+    struct ring_buf *rbufptr;
+    CRYPTO_RWLOCK *lock;
 
-    if (CRYPTO_THREAD_read_lock(b->lock) == 0)
+    dgram_bio_get_peer_data(b, &rbufptr, &lock, NULL);
+
+    if (CRYPTO_THREAD_read_lock(lock) == 0)
         return 0;
 
-    l = b->rbuf.len - b->rbuf.count;
+    l = rbufptr->len - rbufptr->count;
     if (l >= sizeof(struct dgram_hdr))
         l -= sizeof(struct dgram_hdr);
 
@@ -544,7 +660,7 @@ static size_t dgram_pair_ctrl_get_write_guarantee(BIO *bio)
     if (l < b->mtu)
         l = 0;
 
-    CRYPTO_THREAD_unlock(b->lock);
+    CRYPTO_THREAD_unlock(lock);
     return l;
 }
 
@@ -556,10 +672,7 @@ static int dgram_pair_ctrl_get_local_addr_cap(BIO *bio)
     if (!bio->init)
         return 0;
 
-    if (is_dgram_pair(b))
-        readb = b->peer->ptr;
-    else
-        readb = b;
+    dgram_bio_get_peer_data(b, NULL, NULL, &readb);
 
     return (~readb->cap & (BIO_DGRAM_CAP_HANDLES_SRC_ADDR | BIO_DGRAM_CAP_PROVIDES_DST_ADDR)) == 0;
 }
@@ -569,10 +682,10 @@ static int dgram_pair_ctrl_get_effective_caps(BIO *bio)
 {
     struct bio_dgram_pair_st *b = bio->ptr, *peerb;
 
-    if (b->peer == NULL)
+    if (b->pair == NULL)
         return 0;
 
-    peerb = b->peer->ptr;
+    dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
 
     return peerb->cap;
 }
@@ -629,8 +742,8 @@ static int dgram_pair_ctrl_set_mtu(BIO *bio, size_t mtu)
 
     b->mtu = mtu;
 
-    if (b->peer != NULL) {
-        peerb = b->peer->ptr;
+    if (b->pair != NULL) {
+        dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
         peerb->mtu = mtu;
     }
 
@@ -851,7 +964,13 @@ err:
 static size_t dgram_pair_read_inner(struct bio_dgram_pair_st *b, uint8_t *buf, size_t sz)
 {
     size_t total_read = 0;
+    struct ring_buf *rbufptr;
 
+    /*
+     * We read from the peer ring buffer, but b was already passed here
+     * as the peer bio, so we use get_self_ringbuf below
+     */
+    dgram_bio_get_self_data(b, &rbufptr, NULL);
     /*
      * We repeat pops from the ring buffer for as long as we have more
      * application *buffer to fill until we fail. We may not be able to pop
@@ -866,7 +985,7 @@ static size_t dgram_pair_read_inner(struct bio_dgram_pair_st *b, uint8_t *buf, s
          * There are two BIO instances, each with a ringbuf. We read from the
          * peer ringbuf and write to our own ringbuf.
          */
-        ring_buf_tail(&b->rbuf, &src_buf, &src_len);
+        ring_buf_tail(rbufptr, &src_buf, &src_len);
         if (src_len == 0)
             break;
 
@@ -876,7 +995,7 @@ static size_t dgram_pair_read_inner(struct bio_dgram_pair_st *b, uint8_t *buf, s
         if (buf != NULL)
             memcpy(buf, src_buf, src_len);
 
-        ring_buf_pop(&b->rbuf, src_len);
+        ring_buf_pop(rbufptr, src_len);
 
         if (buf != NULL)
             buf += src_len;
@@ -898,6 +1017,7 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
     size_t l, trunc = 0, saved_idx, saved_count;
     struct bio_dgram_pair_st *b = bio->ptr, *readb;
     struct dgram_hdr hdr;
+    struct ring_buf *rbufptr;
 
     if (!is_multi)
         BIO_clear_retry_flags(bio);
@@ -908,11 +1028,9 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
     if (!ossl_assert(b != NULL))
         return -BIO_R_TRANSFER_ERROR;
 
-    if (is_dgram_pair(b))
-        readb = b->peer->ptr;
-    else
-        readb = b;
-    if (!ossl_assert(readb != NULL && readb->rbuf.start != NULL))
+    dgram_bio_get_peer_data(b, &rbufptr, NULL, &readb);
+
+    if (!ossl_assert(readb != NULL && rbufptr->start != NULL))
         return -BIO_R_TRANSFER_ERROR;
 
     if (sz > 0 && buf == NULL)
@@ -923,8 +1041,8 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
         return -BIO_R_LOCAL_ADDR_NOT_AVAILABLE;
 
     /* Read the header. */
-    saved_idx = readb->rbuf.idx[1];
-    saved_count = readb->rbuf.count;
+    saved_idx = rbufptr->idx[1];
+    saved_count = rbufptr->count;
     l = dgram_pair_read_inner(readb, (uint8_t *)&hdr, sizeof(hdr));
     if (l == 0) {
         /* Buffer was empty. */
@@ -947,8 +1065,8 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
         trunc = hdr.len - sz;
         if (b->no_trunc) {
             /* Restore original state. */
-            readb->rbuf.idx[1] = saved_idx;
-            readb->rbuf.count = saved_count;
+            rbufptr->idx[1] = saved_idx;
+            rbufptr->count = saved_count;
             return -BIO_R_NON_FATAL;
         }
     }
@@ -980,21 +1098,30 @@ static int dgram_pair_lock_both_write(struct bio_dgram_pair_st *a,
 {
     struct bio_dgram_pair_st *x, *y;
 
-    x = (a->role == 1) ? a : b;
-    y = (a->role == 1) ? b : a;
+    if (is_dgram_pair(a)) {
+        if (CRYPTO_THREAD_write_lock(a->pair->map[0].lock) == 0)
+            return 0;
+        if (CRYPTO_THREAD_write_lock(a->pair->map[1].lock) == 0) {
+            CRYPTO_THREAD_unlock(a->pair->map[1].lock);
+            return 0;
+        }
+    } else {
+        x = (a->role == 1) ? a : b;
+        y = (a->role == 1) ? b : a;
 
-    if (!ossl_assert(a->role != b->role))
-        return 0;
+        if (!ossl_assert(a->role != b->role))
+            return 0;
 
-    if (!ossl_assert(a != b && x != y))
-        return 0;
+        if (!ossl_assert(a != b && x != y))
+            return 0;
 
-    if (CRYPTO_THREAD_write_lock(x->lock) == 0)
-        return 0;
+        if (CRYPTO_THREAD_write_lock(x->lock) == 0)
+            return 0;
 
-    if (CRYPTO_THREAD_write_lock(y->lock) == 0) {
-        CRYPTO_THREAD_unlock(x->lock);
-        return 0;
+        if (CRYPTO_THREAD_write_lock(y->lock) == 0) {
+            CRYPTO_THREAD_unlock(x->lock);
+            return 0;
+        }
     }
 
     return 1;
@@ -1003,8 +1130,13 @@ static int dgram_pair_lock_both_write(struct bio_dgram_pair_st *a,
 static void dgram_pair_unlock_both(struct bio_dgram_pair_st *a,
     struct bio_dgram_pair_st *b)
 {
-    CRYPTO_THREAD_unlock(a->lock);
-    CRYPTO_THREAD_unlock(b->lock);
+    if (is_dgram_pair(a)) {
+        CRYPTO_THREAD_unlock(a->pair->map[0].lock);
+        CRYPTO_THREAD_unlock(a->pair->map[1].lock);
+    } else {
+        CRYPTO_THREAD_unlock(a->lock);
+        CRYPTO_THREAD_unlock(b->lock);
+    }
 }
 
 /* Threadsafe */
@@ -1019,12 +1151,17 @@ static int dgram_pair_read(BIO *bio, char *buf, int sz_)
         return -1;
     }
 
-    if (b->peer == NULL) {
+    if (b->pair == NULL) {
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
+        return -1;
+    }
+
+    if (b->pair->peer_state == PEER_STATE_ORPHANED) {
         ERR_raise(ERR_LIB_BIO, BIO_R_BROKEN_PIPE);
         return -1;
     }
 
-    peerb = b->peer->ptr;
+    dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
 
     /*
      * For BIO_read we have to acquire both locks because we touch the retry
@@ -1060,6 +1197,7 @@ static int dgram_pair_recvmmsg(BIO *bio, BIO_MSG *msg,
     BIO_MSG *m;
     size_t i;
     struct bio_dgram_pair_st *b = bio->ptr, *readb;
+    CRYPTO_RWLOCK *lock;
 
     if (num_msg == 0) {
         *num_processed = 0;
@@ -1072,12 +1210,16 @@ static int dgram_pair_recvmmsg(BIO *bio, BIO_MSG *msg,
         return 0;
     }
 
-    if (is_dgram_pair(b))
-        readb = b->peer->ptr;
-    else
-        readb = b;
+    if (is_dgram_pair(b)) {
+        if (b->pair->peer_state == PEER_STATE_ORPHANED) {
+            *num_processed = 0;
+            ERR_raise(ERR_LIB_BIO, BIO_R_BROKEN_PIPE);
+            return 0;
+        }
+    }
 
-    if (CRYPTO_THREAD_write_lock(readb->lock) == 0) {
+    dgram_bio_get_peer_data(b, NULL, &lock, &readb);
+    if (CRYPTO_THREAD_write_lock(lock) == 0) {
         ERR_raise(ERR_LIB_BIO, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
         *num_processed = 0;
         return 0;
@@ -1105,7 +1247,7 @@ static int dgram_pair_recvmmsg(BIO *bio, BIO_MSG *msg,
     *num_processed = i;
     ret = 1;
 out:
-    CRYPTO_THREAD_unlock(readb->lock);
+    CRYPTO_THREAD_unlock(lock);
     return ret;
 }
 
@@ -1172,6 +1314,9 @@ static size_t dgram_pair_write_inner(struct bio_dgram_pair_st *b,
     const uint8_t *buf, size_t sz)
 {
     size_t total_written = 0;
+    struct ring_buf *rbufptr;
+
+    dgram_bio_get_self_data(b, &rbufptr, NULL);
 
     /*
      * We repeat pushes to the ring buffer for as long as we have data until we
@@ -1186,7 +1331,7 @@ static size_t dgram_pair_write_inner(struct bio_dgram_pair_st *b,
          * There are two BIO instances, each with a ringbuf. We write to our own
          * ringbuf and read from the peer ringbuf.
          */
-        ring_buf_head(&b->rbuf, &dst_buf, &dst_len);
+        ring_buf_head(rbufptr, &dst_buf, &dst_len);
         if (dst_len == 0) {
             size_t new_len;
 
@@ -1194,7 +1339,7 @@ static size_t dgram_pair_write_inner(struct bio_dgram_pair_st *b,
                 break;
             /* increase the size */
             new_len = compute_rbuf_growth(b->req_buf_len + sz, b->req_buf_len);
-            if (new_len == 0 || !ring_buf_resize(&b->rbuf, new_len))
+            if (new_len == 0 || !ring_buf_resize(rbufptr, new_len))
                 break;
             b->req_buf_len = new_len;
         }
@@ -1203,7 +1348,7 @@ static size_t dgram_pair_write_inner(struct bio_dgram_pair_st *b,
             dst_len = sz;
 
         memcpy(dst_buf, buf, dst_len);
-        ring_buf_push(&b->rbuf, dst_len);
+        ring_buf_push(rbufptr, dst_len);
 
         buf += dst_len;
         sz -= dst_len;
@@ -1225,6 +1370,7 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
     size_t saved_idx, saved_count;
     struct bio_dgram_pair_st *b = bio->ptr, *readb;
     struct dgram_hdr hdr = { 0 };
+    struct ring_buf *rbufptr;
 
     if (!is_multi)
         BIO_clear_retry_flags(bio);
@@ -1232,7 +1378,14 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
     if (!bio->init)
         return -BIO_R_UNINITIALIZED;
 
-    if (!ossl_assert(b != NULL && b->rbuf.start != NULL))
+    if (is_dgram_pair(b)) {
+        if (b->pair->peer_state == PEER_STATE_ORPHANED)
+            return -BIO_R_BROKEN_PIPE;
+    }
+
+    dgram_bio_get_self_data(b, &rbufptr, NULL);
+
+    if (!ossl_assert(b != NULL && rbufptr->start != NULL))
         return -BIO_R_TRANSFER_ERROR;
 
     if (sz > 0 && buf == NULL)
@@ -1241,10 +1394,12 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
     if (local != NULL && b->local_addr_enable == 0)
         return -BIO_R_LOCAL_ADDR_NOT_AVAILABLE;
 
-    if (is_dgram_pair(b))
-        readb = b->peer->ptr;
-    else
-        readb = b;
+    if (is_dgram_pair(b)) {
+        if (b->pair->peer_state == PEER_STATE_ORPHANED)
+            return -BIO_R_BROKEN_PIPE;
+    }
+    dgram_bio_get_peer_data(b, NULL, NULL, &readb);
+
     if (peer != NULL && (readb->cap & BIO_DGRAM_CAP_HANDLES_DST_ADDR) == 0)
         return -BIO_R_PEER_ADDR_NOT_AVAILABLE;
 
@@ -1254,16 +1409,16 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
         local = b->local_addr;
     hdr.src_addr = (local != NULL ? *local : zero_addr);
 
-    saved_idx = b->rbuf.idx[0];
-    saved_count = b->rbuf.count;
+    saved_idx = rbufptr->idx[0];
+    saved_count = rbufptr->count;
     if (dgram_pair_write_inner(b, (const uint8_t *)&hdr, sizeof(hdr)) != sizeof(hdr)
         || dgram_pair_write_inner(b, (const uint8_t *)buf, sz) != sz) {
         /*
          * We were not able to push the header and the entirety of the payload
          * onto the ring buffer, so abort and roll back the ring buffer state.
          */
-        b->rbuf.idx[0] = saved_idx;
-        b->rbuf.count = saved_count;
+        rbufptr->idx[0] = saved_idx;
+        rbufptr->count = saved_count;
         if (!is_multi)
             BIO_set_retry_write(bio);
         return -BIO_R_NON_FATAL;
@@ -1278,13 +1433,16 @@ static int dgram_pair_write(BIO *bio, const char *buf, int sz_)
     int ret;
     ossl_ssize_t l;
     struct bio_dgram_pair_st *b = bio->ptr;
+    CRYPTO_RWLOCK *lock;
 
     if (sz_ < 0) {
         ERR_raise(ERR_LIB_BIO, BIO_R_INVALID_ARGUMENT);
         return -1;
     }
 
-    if (CRYPTO_THREAD_write_lock(b->lock) == 0) {
+    dgram_bio_get_self_data(b, NULL, &lock);
+
+    if (CRYPTO_THREAD_write_lock(lock) == 0) {
         ERR_raise(ERR_LIB_BIO, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
         return -1;
     }
@@ -1297,7 +1455,7 @@ static int dgram_pair_write(BIO *bio, const char *buf, int sz_)
         ret = (int)l;
     }
 
-    CRYPTO_THREAD_unlock(b->lock);
+    CRYPTO_THREAD_unlock(lock);
     return ret;
 }
 
@@ -1311,13 +1469,16 @@ static int dgram_pair_sendmmsg(BIO *bio, BIO_MSG *msg,
     size_t i;
     struct bio_dgram_pair_st *b = bio->ptr;
     int ret = 0;
+    CRYPTO_RWLOCK *lock;
 
     if (num_msg == 0) {
         *num_processed = 0;
         return 1;
     }
 
-    if (CRYPTO_THREAD_write_lock(b->lock) == 0) {
+    dgram_bio_get_self_data(b, NULL, &lock);
+
+    if (CRYPTO_THREAD_write_lock(lock) == 0) {
         ERR_raise(ERR_LIB_BIO, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
         *num_processed = 0;
         return 0;
@@ -1343,7 +1504,7 @@ static int dgram_pair_sendmmsg(BIO *bio, BIO_MSG *msg,
     *num_processed = i;
     ret = 1;
 out:
-    CRYPTO_THREAD_unlock(b->lock);
+    CRYPTO_THREAD_unlock(lock);
     return ret;
 }
 

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -193,7 +193,7 @@ static int dgram_pair_recvmmsg(BIO *b, BIO_MSG *msg, size_t stride,
     size_t *num_processed);
 
 static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1);
-static size_t dgram_pair_read_inner(struct bio_dgram_pair_st *b, uint8_t *buf,
+static size_t dgram_pair_read_inner(struct ring_buf *rbufptr, uint8_t *buf,
     size_t sz);
 
 #define BIO_MSG_N(array, n) (*(BIO_MSG *)((char *)(array) + (n) * stride))
@@ -687,7 +687,7 @@ static size_t dgram_pair_ctrl_pending(BIO *bio)
     saved_idx = rbufptr->idx[1];
     saved_count = rbufptr->count;
 
-    l = dgram_pair_read_inner(readb, (uint8_t *)&hdr, sizeof(hdr));
+    l = dgram_pair_read_inner(rbufptr, (uint8_t *)&hdr, sizeof(hdr));
 
     rbufptr->idx[1] = saved_idx;
     rbufptr->count = saved_count;
@@ -1025,16 +1025,10 @@ err:
 }
 
 /* Must hold peer write lock */
-static size_t dgram_pair_read_inner(struct bio_dgram_pair_st *b, uint8_t *buf, size_t sz)
+static size_t dgram_pair_read_inner(struct ring_buf *rbufptr, uint8_t *buf, size_t sz)
 {
     size_t total_read = 0;
-    struct ring_buf *rbufptr;
 
-    /*
-     * We read from the peer ring buffer, but b was already passed here
-     * as the peer bio, so we use get_self_ringbuf below
-     */
-    dgram_bio_get_self_data(b, &rbufptr, NULL);
     /*
      * We repeat pops from the ring buffer for as long as we have more
      * application *buffer to fill until we fail. We may not be able to pop
@@ -1079,7 +1073,7 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
     int is_multi)
 {
     size_t l, trunc = 0, saved_idx, saved_count;
-    struct bio_dgram_pair_st *b = bio->ptr, *readb;
+    struct bio_dgram_pair_st *b = bio->ptr;
     struct dgram_hdr hdr;
     struct ring_buf *rbufptr;
 
@@ -1092,9 +1086,9 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
     if (!ossl_assert(b != NULL))
         return -BIO_R_TRANSFER_ERROR;
 
-    dgram_bio_get_peer_data(b, &rbufptr, NULL, &readb);
+    dgram_bio_get_peer_data(b, &rbufptr, NULL, NULL);
 
-    if (!ossl_assert(readb != NULL && rbufptr->start != NULL))
+    if (!ossl_assert(rbufptr->start != NULL))
         return -BIO_R_TRANSFER_ERROR;
 
     if (sz > 0 && buf == NULL)
@@ -1107,7 +1101,7 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
     /* Read the header. */
     saved_idx = rbufptr->idx[1];
     saved_count = rbufptr->count;
-    l = dgram_pair_read_inner(readb, (uint8_t *)&hdr, sizeof(hdr));
+    l = dgram_pair_read_inner(rbufptr, (uint8_t *)&hdr, sizeof(hdr));
     if (l == 0) {
         /* Buffer was empty. */
         if (!is_multi)
@@ -1135,7 +1129,7 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
         }
     }
 
-    l = dgram_pair_read_inner(readb, (uint8_t *)buf, sz);
+    l = dgram_pair_read_inner(rbufptr, (uint8_t *)buf, sz);
     if (!ossl_assert(l == sz))
         /* We were somehow not able to read the entire datagram. */
         return -BIO_R_TRANSFER_ERROR;
@@ -1144,7 +1138,7 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
      * If the datagram was truncated due to an inadequate buffer, discard the
      * remainder.
      */
-    if (trunc > 0 && !ossl_assert(dgram_pair_read_inner(readb, NULL, trunc) == trunc))
+    if (trunc > 0 && !ossl_assert(dgram_pair_read_inner(rbufptr, NULL, trunc) == trunc))
         /* We were somehow not able to read/skip the entire datagram. */
         return -BIO_R_TRANSFER_ERROR;
 
@@ -1163,10 +1157,10 @@ static int dgram_pair_lock_both_write(struct bio_dgram_pair_st *a,
     struct bio_dgram_pair_st *x, *y;
 
     if (is_dgram_pair(a)) {
-        if (CRYPTO_THREAD_write_lock(a->pair->map[0].lock) == 0)
+        if (CRYPTO_THREAD_write_lock(b->pair->map[0].lock) == 0)
             return 0;
-        if (CRYPTO_THREAD_write_lock(a->pair->map[1].lock) == 0) {
-            CRYPTO_THREAD_unlock(a->pair->map[1].lock);
+        if (CRYPTO_THREAD_write_lock(b->pair->map[1].lock) == 0) {
+            CRYPTO_THREAD_unlock(b->pair->map[1].lock);
             return 0;
         }
     } else {
@@ -1194,9 +1188,9 @@ static int dgram_pair_lock_both_write(struct bio_dgram_pair_st *a,
 static void dgram_pair_unlock_both(struct bio_dgram_pair_st *a,
     struct bio_dgram_pair_st *b)
 {
-    if (is_dgram_pair(a)) {
-        CRYPTO_THREAD_unlock(a->pair->map[0].lock);
-        CRYPTO_THREAD_unlock(a->pair->map[1].lock);
+    if (is_dgram_pair(b)) {
+        CRYPTO_THREAD_unlock(b->pair->map[0].lock);
+        CRYPTO_THREAD_unlock(b->pair->map[1].lock);
     } else {
         CRYPTO_THREAD_unlock(a->lock);
         CRYPTO_THREAD_unlock(b->lock);

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -251,6 +251,7 @@ struct dgram_hdr {
 struct rbuf_map_st {
     struct bio_dgram_pair_st *self;
     struct ring_buf rbuf;
+    uint32_t cap;
     CRYPTO_RWLOCK *lock;
 };
 
@@ -373,22 +374,25 @@ static void dgram_bio_get_self_data(struct bio_dgram_pair_st *self, struct ring_
 }
 
 static void dgram_bio_get_peer_data(struct bio_dgram_pair_st *self, struct ring_buf **rbufptr,
-    CRYPTO_RWLOCK **lock, struct bio_dgram_pair_st **peer)
+    CRYPTO_RWLOCK **lock, uint32_t *caps, struct bio_dgram_pair_st **peer)
 {
     struct rbuf_map_st *map;
     CRYPTO_RWLOCK *mylock;
     struct ring_buf *myrbuf;
     struct bio_dgram_pair_st *mypeer;
+    uint32_t mycaps;
 
     if (is_dgram_pair(self)) {
         map = dgram_rbuf_map_get_peer(self);
         mylock = map->lock;
         myrbuf = &map->rbuf;
         mypeer = map->self;
+        mycaps = map->cap;
     } else {
         mylock = self->lock;
         myrbuf = &self->rbuf;
         mypeer = self;
+        mycaps = self->cap;
     }
     if (lock != NULL)
         *lock = mylock;
@@ -396,6 +400,8 @@ static void dgram_bio_get_peer_data(struct bio_dgram_pair_st *self, struct ring_
         *rbufptr = myrbuf;
     if (peer != NULL)
         *peer = mypeer;
+    if (caps != NULL)
+        *caps = mycaps;
 }
 
 #define MIN_BUF_LEN (1024)
@@ -561,6 +567,8 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
     }
     pair->map[0].self = b1;
     pair->map[1].self = b2;
+    pair->map[0].cap = b1->cap;
+    pair->map[1].cap = b2->cap;
     TSAN_BENIGN(pair, "publishing pair");
     b1->pair = pair;
     b2->pair = pair;
@@ -643,7 +651,7 @@ static int dgram_pair_ctrl_eof(BIO *bio)
     if (peer_state == PEER_STATE_ORPHANED)
         return 1;
 
-    dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
+    dgram_bio_get_peer_data(b, NULL, NULL, NULL, &peerb);
     if (!ossl_assert(peerb != NULL))
         return -1;
 
@@ -710,7 +718,7 @@ static size_t dgram_pair_ctrl_pending(BIO *bio)
             return 0;
     }
 
-    dgram_bio_get_peer_data(b, &rbufptr, &lock, &readb);
+    dgram_bio_get_peer_data(b, &rbufptr, &lock, NULL, &readb);
 
     if (CRYPTO_THREAD_write_lock(lock) == 0)
         return 0;
@@ -739,7 +747,7 @@ static size_t dgram_pair_ctrl_get_write_guarantee(BIO *bio)
     struct ring_buf *rbufptr;
     CRYPTO_RWLOCK *lock;
 
-    dgram_bio_get_peer_data(b, &rbufptr, &lock, NULL);
+    dgram_bio_get_peer_data(b, &rbufptr, &lock, NULL, NULL);
 
     if (CRYPTO_THREAD_read_lock(lock) == 0)
         return 0;
@@ -764,6 +772,7 @@ static int dgram_pair_ctrl_get_local_addr_cap(BIO *bio)
 {
     struct bio_dgram_pair_st *b = bio->ptr, *readb;
     int peer_state;
+    uint32_t caps;
 
     if (!bio->init)
         return 0;
@@ -776,9 +785,9 @@ static int dgram_pair_ctrl_get_local_addr_cap(BIO *bio)
             return 0;
     }
 
-    dgram_bio_get_peer_data(b, NULL, NULL, &readb);
+    dgram_bio_get_peer_data(b, NULL, NULL, &caps, &readb);
 
-    return (~readb->cap & (BIO_DGRAM_CAP_HANDLES_SRC_ADDR | BIO_DGRAM_CAP_PROVIDES_DST_ADDR)) == 0;
+    return (~caps & (BIO_DGRAM_CAP_HANDLES_SRC_ADDR | BIO_DGRAM_CAP_PROVIDES_DST_ADDR)) == 0;
 }
 
 /* BIO_dgram_get_effective_caps (BIO_CTRL_DGRAM_GET_EFFECTIVE_CAPS) */
@@ -786,6 +795,7 @@ static int dgram_pair_ctrl_get_effective_caps(BIO *bio)
 {
     struct bio_dgram_pair_st *b = bio->ptr, *peerb;
     int peer_state;
+    uint32_t caps;
 
     if (b->pair == NULL)
         return 0;
@@ -796,9 +806,9 @@ static int dgram_pair_ctrl_get_effective_caps(BIO *bio)
     if (peer_state == PEER_STATE_ORPHANED)
         return 0;
 
-    dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
+    dgram_bio_get_peer_data(b, NULL, NULL, &caps, &peerb);
 
-    return peerb->cap;
+    return caps;
 }
 
 /* BIO_dgram_get_caps (BIO_CTRL_DGRAM_GET_CAPS) */
@@ -813,8 +823,14 @@ static uint32_t dgram_pair_ctrl_get_caps(BIO *bio)
 static int dgram_pair_ctrl_set_caps(BIO *bio, uint32_t caps)
 {
     struct bio_dgram_pair_st *b = bio->ptr;
+    struct rbuf_map_st *map;
 
     b->cap = caps;
+
+    if (is_dgram_pair(b)) {
+        map = dgram_rbuf_map_get_self(b);
+        map->cap = caps;
+    }
     return 1;
 }
 
@@ -859,7 +875,7 @@ static int dgram_pair_ctrl_set_mtu(BIO *bio, size_t mtu)
             return 0;
 
         if (peer_state == PEER_STATE_PAIRED) {
-            dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
+            dgram_bio_get_peer_data(b, NULL, NULL, NULL, &peerb);
             peerb->mtu = mtu;
         }
     }
@@ -1139,7 +1155,7 @@ static ossl_ssize_t dgram_pair_read_actual(BIO *bio, char *buf, size_t sz,
     if (!ossl_assert(b != NULL))
         return -BIO_R_TRANSFER_ERROR;
 
-    dgram_bio_get_peer_data(b, &rbufptr, NULL, NULL);
+    dgram_bio_get_peer_data(b, &rbufptr, NULL, NULL, NULL);
 
     if (!ossl_assert(rbufptr->start != NULL))
         return -BIO_R_TRANSFER_ERROR;
@@ -1276,7 +1292,7 @@ static int dgram_pair_read(BIO *bio, char *buf, int sz_)
         return -1;
     }
 
-    dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
+    dgram_bio_get_peer_data(b, NULL, NULL, NULL, &peerb);
 
     /*
      * For BIO_read we have to acquire both locks because we touch the retry
@@ -1339,7 +1355,7 @@ static int dgram_pair_recvmmsg(BIO *bio, BIO_MSG *msg,
         }
     }
 
-    dgram_bio_get_peer_data(b, NULL, &lock, &readb);
+    dgram_bio_get_peer_data(b, NULL, &lock, NULL, &readb);
     if (CRYPTO_THREAD_write_lock(lock) == 0) {
         ERR_raise(ERR_LIB_BIO, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
         *num_processed = 0;
@@ -1489,10 +1505,11 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
 {
     static const BIO_ADDR zero_addr;
     size_t saved_idx, saved_count;
-    struct bio_dgram_pair_st *b = bio->ptr, *readb;
+    struct bio_dgram_pair_st *b = bio->ptr;
     struct dgram_hdr hdr = { 0 };
     struct ring_buf *rbufptr;
     int peer_state;
+    uint32_t caps;
 
     if (!is_multi)
         BIO_clear_retry_flags(bio);
@@ -1518,9 +1535,9 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
     if (local != NULL && b->local_addr_enable == 0)
         return -BIO_R_LOCAL_ADDR_NOT_AVAILABLE;
 
-    dgram_bio_get_peer_data(b, NULL, NULL, &readb);
+    dgram_bio_get_peer_data(b, NULL, NULL, &caps, NULL);
 
-    if (peer != NULL && (readb->cap & BIO_DGRAM_CAP_HANDLES_DST_ADDR) == 0)
+    if (peer != NULL && (caps & BIO_DGRAM_CAP_HANDLES_DST_ADDR) == 0)
         return -BIO_R_PEER_ADDR_NOT_AVAILABLE;
 
     hdr.len = sz;

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -763,9 +763,18 @@ static size_t dgram_pair_ctrl_get_write_guarantee(BIO *bio)
 static int dgram_pair_ctrl_get_local_addr_cap(BIO *bio)
 {
     struct bio_dgram_pair_st *b = bio->ptr, *readb;
+    int peer_state;
 
     if (!bio->init)
         return 0;
+
+    if (is_dgram_pair(b)) {
+        if (!CRYPTO_atomic_load_int(&b->pair->peer_state, &peer_state, b->pair->peerlock))
+            return 0;
+
+        if (peer_state == PEER_STATE_ORPHANED)
+            return 0;
+    }
 
     dgram_bio_get_peer_data(b, NULL, NULL, &readb);
 
@@ -776,8 +785,15 @@ static int dgram_pair_ctrl_get_local_addr_cap(BIO *bio)
 static int dgram_pair_ctrl_get_effective_caps(BIO *bio)
 {
     struct bio_dgram_pair_st *b = bio->ptr, *peerb;
+    int peer_state;
 
     if (b->pair == NULL)
+        return 0;
+
+    if (!CRYPTO_atomic_load_int(&b->pair->peer_state, &peer_state, b->pair->peerlock))
+        return 0;
+
+    if (peer_state == PEER_STATE_ORPHANED)
         return 0;
 
     dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
@@ -834,12 +850,18 @@ static int dgram_pair_ctrl_get_mtu(BIO *bio)
 static int dgram_pair_ctrl_set_mtu(BIO *bio, size_t mtu)
 {
     struct bio_dgram_pair_st *b = bio->ptr, *peerb;
+    int peer_state;
 
     b->mtu = mtu;
 
-    if (b->pair != NULL) {
-        dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
-        peerb->mtu = mtu;
+    if (is_dgram_pair(b)) {
+        if (!CRYPTO_atomic_load_int(&b->pair->peer_state, &peer_state, b->pair->peerlock))
+            return 0;
+
+        if (peer_state == PEER_STATE_PAIRED) {
+            dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
+            peerb->mtu = mtu;
+        }
     }
 
     return 1;

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -12,6 +12,7 @@
 #include "bio_local.h"
 #include "internal/cryptlib.h"
 #include "internal/safe_math.h"
+#include "internal/threads_common.h"
 
 #if !defined(OPENSSL_NO_DGRAM) && !defined(OPENSSL_NO_SOCK)
 
@@ -294,6 +295,11 @@ struct bio_dgram_peer_st {
      */
     int peer_state;
 
+    /*
+     * Lock for peer_state atomic ops where needed
+     */
+    CRYPTO_RWLOCK *peerlock;
+
     /**
      * Ring buffer mappings for the two datagram directions,
      * indexed one per direction.
@@ -517,8 +523,17 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
         ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
         return 0;
     }
+    pair->peerlock = CRYPTO_THREAD_lock_new();
+    if (pair->peerlock == NULL) {
+        CRYPTO_FREE_REF(&pair->ref_cnt);
+        OPENSSL_free(pair->peerlock);
+        OPENSSL_free(pair);
+        return 0;
+    }
+
     if (ring_buf_init(&pair->map[0].rbuf, b1->req_buf_len) == 0) {
         CRYPTO_FREE_REF(&pair->ref_cnt);
+        CRYPTO_THREAD_lock_free(pair->peerlock);
         OPENSSL_free(pair);
         ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
         return 0;
@@ -526,6 +541,7 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
 
     if (ring_buf_init(&pair->map[1].rbuf, b2->req_buf_len) == 0) {
         CRYPTO_FREE_REF(&pair->ref_cnt);
+        CRYPTO_THREAD_lock_free(pair->peerlock);
         OPENSSL_free(pair);
         ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
         return 0;
@@ -537,6 +553,7 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
     if (pair->map[0].lock == NULL || pair->map[1].lock == NULL) {
         CRYPTO_THREAD_lock_free(pair->map[0].lock);
         CRYPTO_THREAD_lock_free(pair->map[1].lock);
+        CRYPTO_THREAD_lock_free(pair->peerlock);
         CRYPTO_FREE_REF(&pair->ref_cnt);
         OPENSSL_free(pair);
         ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
@@ -544,6 +561,7 @@ static int dgram_pair_ctrl_make_bio_pair(BIO *bio1, BIO *bio2)
     }
     pair->map[0].self = b1;
     pair->map[1].self = b2;
+    TSAN_BENIGN(pair, "publishing pair");
     b1->pair = pair;
     b2->pair = pair;
     b1->role = 0;
@@ -558,6 +576,7 @@ static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1)
 {
     struct bio_dgram_pair_st *b1 = bio1->ptr;
     int ref;
+    int newval = PEER_STATE_ORPHANED;
 
     /* Early return if we don't have a peer. */
     if (b1->pair == NULL)
@@ -573,7 +592,9 @@ static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1)
      * Since one half of the pair is going away, we are now
      * orphaned
      */
-    b1->pair->peer_state = PEER_STATE_ORPHANED;
+    if (!CRYPTO_atomic_store_int(&b1->pair->peer_state, newval, b1->pair->peerlock))
+        return 0;
+
     if (!CRYPTO_DOWN_REF(&b1->pair->ref_cnt, &ref))
         return 0;
     if (ref == 0) {
@@ -584,6 +605,7 @@ static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1)
         CRYPTO_FREE_REF(&b1->pair->ref_cnt);
         CRYPTO_THREAD_lock_free(b1->pair->map[0].lock);
         CRYPTO_THREAD_lock_free(b1->pair->map[1].lock);
+        CRYPTO_THREAD_lock_free(b1->pair->peerlock);
         ring_buf_destroy(&b1->pair->map[0].rbuf);
         ring_buf_destroy(&b1->pair->map[1].rbuf);
         OPENSSL_free(b1->pair);
@@ -592,6 +614,7 @@ static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1)
      * Make sure the leaving pair no longer references the shared peer data,
      * since it is no longer part of the pair.
      */
+    TSAN_BENIGN(b1->pair, "b1 no longer accesses b1->pair");
     b1->pair = NULL;
     return 1;
 }
@@ -600,6 +623,7 @@ static int dgram_pair_ctrl_destroy_bio_pair(BIO *bio1)
 static int dgram_pair_ctrl_eof(BIO *bio)
 {
     struct bio_dgram_pair_st *b = bio->ptr, *peerb = NULL;
+    int peer_state;
 
     if (!ossl_assert(b != NULL))
         return -1;
@@ -613,7 +637,10 @@ static int dgram_pair_ctrl_eof(BIO *bio)
     /*
      * orphaned pairs always return EOF
      */
-    if (b->pair->peer_state == PEER_STATE_ORPHANED)
+    if (!CRYPTO_atomic_load_int(&b->pair->peer_state, &peer_state, b->pair->peerlock))
+        return -1;
+
+    if (peer_state == PEER_STATE_ORPHANED)
         return 1;
 
     dgram_bio_get_peer_data(b, NULL, NULL, &peerb);
@@ -670,12 +697,16 @@ static size_t dgram_pair_ctrl_pending(BIO *bio)
     size_t l;
     struct ring_buf *rbufptr;
     CRYPTO_RWLOCK *lock;
+    int peer_state;
 
     /* Safe to check; init may not change during this call */
     if (!bio->init)
         return 0;
     if (is_dgram_pair(b)) {
-        if (b->pair->peer_state == PEER_STATE_ORPHANED)
+        if (!CRYPTO_atomic_load_int(&b->pair->peer_state, &peer_state, b->pair->peerlock))
+            return 0;
+
+        if (peer_state == PEER_STATE_ORPHANED)
             return 0;
     }
 
@@ -1156,11 +1187,11 @@ static int dgram_pair_lock_both_write(struct bio_dgram_pair_st *a,
 {
     struct bio_dgram_pair_st *x, *y;
 
-    if (is_dgram_pair(a)) {
+    if (is_dgram_pair(b)) {
         if (CRYPTO_THREAD_write_lock(b->pair->map[0].lock) == 0)
             return 0;
         if (CRYPTO_THREAD_write_lock(b->pair->map[1].lock) == 0) {
-            CRYPTO_THREAD_unlock(b->pair->map[1].lock);
+            CRYPTO_THREAD_unlock(b->pair->map[0].lock);
             return 0;
         }
     } else {
@@ -1203,6 +1234,7 @@ static int dgram_pair_read(BIO *bio, char *buf, int sz_)
     int ret;
     ossl_ssize_t l;
     struct bio_dgram_pair_st *b = bio->ptr, *peerb;
+    int peer_state;
 
     if (sz_ < 0) {
         ERR_raise(ERR_LIB_BIO, BIO_R_INVALID_ARGUMENT);
@@ -1214,7 +1246,10 @@ static int dgram_pair_read(BIO *bio, char *buf, int sz_)
         return -1;
     }
 
-    if (b->pair->peer_state == PEER_STATE_ORPHANED) {
+    if (!CRYPTO_atomic_load_int(&b->pair->peer_state, &peer_state, b->pair->peerlock))
+        return -1;
+
+    if (peer_state == PEER_STATE_ORPHANED) {
         ERR_raise(ERR_LIB_BIO, BIO_R_BROKEN_PIPE);
         return -1;
     }
@@ -1256,6 +1291,7 @@ static int dgram_pair_recvmmsg(BIO *bio, BIO_MSG *msg,
     size_t i;
     struct bio_dgram_pair_st *b = bio->ptr, *readb;
     CRYPTO_RWLOCK *lock;
+    int peer_state;
 
     if (num_msg == 0) {
         *num_processed = 0;
@@ -1269,7 +1305,12 @@ static int dgram_pair_recvmmsg(BIO *bio, BIO_MSG *msg,
     }
 
     if (is_dgram_pair(b)) {
-        if (b->pair->peer_state == PEER_STATE_ORPHANED) {
+        if (!CRYPTO_atomic_load_int(&b->pair->peer_state, &peer_state, b->pair->peerlock)) {
+            *num_processed = 0;
+            return 0;
+        }
+
+        if (peer_state == PEER_STATE_ORPHANED) {
             *num_processed = 0;
             ERR_raise(ERR_LIB_BIO, BIO_R_BROKEN_PIPE);
             return 0;
@@ -1429,6 +1470,7 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
     struct bio_dgram_pair_st *b = bio->ptr, *readb;
     struct dgram_hdr hdr = { 0 };
     struct ring_buf *rbufptr;
+    int peer_state;
 
     if (!is_multi)
         BIO_clear_retry_flags(bio);
@@ -1437,7 +1479,9 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
         return -BIO_R_UNINITIALIZED;
 
     if (is_dgram_pair(b)) {
-        if (b->pair->peer_state == PEER_STATE_ORPHANED)
+        if (!CRYPTO_atomic_load_int(&b->pair->peer_state, &peer_state, b->pair->peerlock))
+            return -BIO_R_UNINITIALIZED;
+        if (peer_state == PEER_STATE_ORPHANED)
             return -BIO_R_BROKEN_PIPE;
     }
 
@@ -1452,10 +1496,6 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
     if (local != NULL && b->local_addr_enable == 0)
         return -BIO_R_LOCAL_ADDR_NOT_AVAILABLE;
 
-    if (is_dgram_pair(b)) {
-        if (b->pair->peer_state == PEER_STATE_ORPHANED)
-            return -BIO_R_BROKEN_PIPE;
-    }
     dgram_bio_get_peer_data(b, NULL, NULL, &readb);
 
     if (peer != NULL && (readb->cap & BIO_DGRAM_CAP_HANDLES_DST_ADDR) == 0)

--- a/doc/man3/BIO_s_dgram_pair.pod
+++ b/doc/man3/BIO_s_dgram_pair.pod
@@ -55,7 +55,10 @@ The two BIOs must both use the method returned by BIO_s_dgram_pair() and neither
 of the BIOs may currently be associated in a pair.
 
 L<BIO_destroy_bio_pair(3)> destroys the association between two connected BIOs.
-Freeing either half of the pair will automatically destroy the association.
+Freeing either half of the pair will automatically destroy the association.  This
+destruction is implied if L<BIO_free(3)> is used to free one half of a BIO pair.
+Note that the other half of the BIO pair in such a situation may be joined to a
+new BIO, but only after calling L<BIO_destroy_bio_pair(3)> on itself.
 
 L<BIO_reset(3)> clears any data in the write buffer of the given BIO. This means
 that the opposite BIO in the pair will no longer have any data waiting to be

--- a/include/internal/threads_common.h
+++ b/include/internal/threads_common.h
@@ -14,7 +14,9 @@
 
 #if defined(__clang__) && defined(__has_feature)
 #if __has_feature(thread_sanitizer)
+#if !defined(__SANITIZE_THREAD__)
 #define __SANITIZE_THREAD__
+#endif
 #endif
 #endif
 

--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -9,6 +9,7 @@
 
 #include <string.h>
 #include <openssl/bio.h>
+#include <openssl/err.h>
 #include <openssl/rand.h>
 #include "testutil.h"
 #include "internal/sockets.h"
@@ -777,6 +778,209 @@ err:
 }
 #endif /* !defined(OPENSSL_NO_CHACHA) */
 
+/* Checks that a half without a usable peer fails cleanly. */
+static int check_detached(BIO *bio, int reason)
+{
+    char buf[16];
+    BIO_MSG msg;
+    size_t num_processed = 1;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.data = buf;
+    msg.data_len = sizeof(buf);
+
+    if (!TEST_int_eq(BIO_eof(bio), 1)
+        || !TEST_int_eq(BIO_pending(bio), 0))
+        return 0;
+
+    ERR_clear_error();
+    if (!TEST_int_lt(BIO_read(bio, buf, sizeof(buf)), 0)
+        || !TEST_false(BIO_should_retry(bio))
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_error()), reason))
+        return 0;
+
+    ERR_clear_error();
+    if (!TEST_int_lt(BIO_write(bio, "x", 1), 0)
+        || !TEST_false(BIO_should_retry(bio))
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_error()), reason))
+        return 0;
+
+    ERR_clear_error();
+    if (!TEST_false(BIO_recvmmsg(bio, &msg, sizeof(msg), 1, 0, &num_processed))
+        || !TEST_size_t_eq(num_processed, 0)
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_error()), reason))
+        return 0;
+
+    num_processed = 1;
+    ERR_clear_error();
+    if (!TEST_false(BIO_sendmmsg(bio, &msg, sizeof(msg), 1, 0, &num_processed))
+        || !TEST_size_t_eq(num_processed, 0)
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_error()), reason))
+        return 0;
+
+    ERR_clear_error();
+    return 1;
+}
+
+static int test_bio_dgram_pair_free_half(void)
+{
+    int testresult = 0;
+    BIO *bio1 = NULL, *bio2 = NULL, *bio3 = NULL;
+    char buf[16];
+
+    if (!TEST_true(BIO_new_bio_dgram_pair(&bio1, 0, &bio2, 0))
+        || !TEST_int_eq(BIO_write(bio1, "hello", 5), 5)
+        || !TEST_int_eq(BIO_write(bio2, "world", 5), 5))
+        goto err;
+
+    /* Freeing one half must leave the other detached but usable. */
+    BIO_free(bio1);
+    bio1 = NULL;
+    if (!check_detached(bio2, BIO_R_BROKEN_PIPE))
+        goto err;
+
+    /* Which includes pairing it with a new peer. */
+    if (!TEST_ptr(bio3 = BIO_new(BIO_s_dgram_pair()))
+        || !TEST_true(BIO_destroy_bio_pair(bio2))
+        || !TEST_true(BIO_make_bio_pair(bio2, bio3))
+        || !TEST_int_eq(BIO_eof(bio2), 0)
+        || !TEST_int_eq(BIO_write(bio2, "again", 5), 5)
+        || !TEST_int_eq(BIO_read(bio3, buf, sizeof(buf)), 5)
+        || !TEST_mem_eq(buf, 5, "again", 5))
+        goto err;
+
+    /* Destroying the pair on the survivor must cope with a freed peer. */
+    BIO_free(bio3);
+    bio3 = NULL;
+    if (!TEST_true(BIO_destroy_bio_pair(bio2))
+        || !check_detached(bio2, BIO_R_UNINITIALIZED))
+        goto err;
+
+    testresult = 1;
+err:
+    BIO_free(bio1);
+    BIO_free(bio2);
+    BIO_free(bio3);
+    return testresult;
+}
+
+static int test_bio_dgram_pair_destroy(int idx)
+{
+    int testresult = 0;
+    BIO *bio1 = NULL, *bio2 = NULL;
+    BIO_ADDR *addr;
+    char buf[16];
+
+    if (!TEST_true(BIO_new_bio_dgram_pair(&bio1, 0, &bio2, 0))
+        || !TEST_ptr(addr = BIO_ADDR_new())
+        || !TEST_true(BIO_dgram_set0_local_addr(bio1, addr)))
+        goto err;
+
+    if (!TEST_int_eq(BIO_write(bio1, "hello", 5), 5)
+        || !TEST_int_eq(BIO_read(bio2, buf, sizeof(buf)), 5)
+        || !TEST_int_eq(BIO_write(bio2, "world", 5), 5)
+        || !TEST_int_eq(BIO_read(bio1, buf, sizeof(buf)), 5))
+        goto err;
+
+    /* Destroying the pair on either half must detach both cleanly. */
+    if (!TEST_true(BIO_destroy_bio_pair(idx == 0 ? bio1 : bio2))
+        || !check_detached(bio1, idx == 0 ? BIO_R_UNINITIALIZED : BIO_R_BROKEN_PIPE)
+        || !check_detached(bio2, idx == 0 ? BIO_R_BROKEN_PIPE : BIO_R_UNINITIALIZED)
+        || !TEST_true(BIO_destroy_bio_pair(bio1))
+        || !TEST_true(BIO_destroy_bio_pair(bio2)))
+        goto err;
+
+    /* Both halves are free to be paired again. */
+    if (!TEST_true(BIO_make_bio_pair(bio1, bio2))
+        || !TEST_int_eq(BIO_write(bio1, "again", 5), 5)
+        || !TEST_int_eq(BIO_read(bio2, buf, sizeof(buf)), 5)
+        || !TEST_mem_eq(buf, 5, "again", 5))
+        goto err;
+
+    testresult = 1;
+err:
+    BIO_free(bio1);
+    BIO_free(bio2);
+    return testresult;
+}
+
+#if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG)
+#include "threadstest.h"
+
+static BIO *reader_bio;
+static int reader_reason, reader_eof, reader_write;
+
+/* Keeps receiving on its half until the peer is freed underneath it. */
+static void free_race_reader(void)
+{
+    char buf[16];
+    BIO_MSG msg;
+    size_t num_processed;
+    int r;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.data = buf;
+    msg.data_len = sizeof(buf);
+
+    for (;;) {
+        if (BIO_recvmmsg(reader_bio, &msg, sizeof(msg), 1, 0, &num_processed))
+            continue;
+        /* Writes look at the peer too, so keep them in the mix. */
+        ERR_clear_error();
+        r = BIO_write(reader_bio, "x", 1);
+        if (r < 0 && !BIO_should_retry(reader_bio))
+            break;
+        ERR_clear_error();
+        r = BIO_read(reader_bio, buf, sizeof(buf));
+        if (r < 0 && !BIO_should_retry(reader_bio))
+            break;
+    }
+
+    reader_reason = ERR_GET_REASON(ERR_peek_error());
+    reader_eof = BIO_eof(reader_bio);
+    reader_write = BIO_write(reader_bio, "x", 1);
+    ERR_clear_error();
+}
+
+static int test_bio_dgram_pair_free_race(void)
+{
+    int testresult = 0, written = 0, r;
+    BIO *bio1 = NULL, *bio2 = NULL;
+    thread_t thread;
+
+    if (!TEST_true(BIO_new_bio_dgram_pair(&bio1, 0, &bio2, 0)))
+        goto err;
+
+    reader_bio = bio2;
+    if (!TEST_true(run_thread(&thread, free_race_reader)))
+        goto err;
+
+    /* Keep the reader busy, then pull its peer out from under it. */
+    while (written < 1000) {
+        r = BIO_write(bio1, "ping", 4);
+        if (r == 4)
+            written++;
+        else if (!BIO_should_retry(bio1))
+            break;
+    }
+    BIO_free(bio1);
+    bio1 = NULL;
+
+    if (!TEST_true(wait_for_thread(thread))
+        || !TEST_int_eq(written, 1000)
+        || !TEST_int_eq(reader_reason, BIO_R_BROKEN_PIPE)
+        || !TEST_int_eq(reader_eof, 1)
+        || !TEST_int_lt(reader_write, 0))
+        goto err;
+
+    testresult = 1;
+err:
+    BIO_free(bio1);
+    BIO_free(bio2);
+    return testresult;
+}
+#endif
+
 static int test_bio_dgram_mfail(void)
 {
     BIO *bio;
@@ -805,6 +1009,11 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_bio_dgram, OSSL_NELEM(bio_dgram_cases));
 #if !defined(OPENSSL_NO_CHACHA)
     ADD_ALL_TESTS(test_bio_dgram_pair, 3);
+#endif
+    ADD_TEST(test_bio_dgram_pair_free_half);
+    ADD_ALL_TESTS(test_bio_dgram_pair_destroy, 2);
+#if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG)
+    ADD_TEST(test_bio_dgram_pair_free_race);
 #endif
     ADD_MFAIL_TEST(test_bio_dgram_mfail);
 #endif

--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -793,6 +793,13 @@ static int check_detached(BIO *bio, int reason)
         || !TEST_int_eq(BIO_pending(bio), 0))
         return 0;
 
+    /* Ctrls reaching for peer data must not touch the freed half. */
+    if (!TEST_uint_eq(BIO_dgram_get_effective_caps(bio), 0)
+        || !TEST_int_eq(BIO_dgram_get_local_addr_cap(bio), 0)
+        || !TEST_true(BIO_dgram_set_mtu(bio, 1506))
+        || !TEST_uint_eq(BIO_dgram_get_mtu(bio), 1506))
+        return 0;
+
     ERR_clear_error();
     if (!TEST_int_lt(BIO_read(bio, buf, sizeof(buf)), 0)
         || !TEST_false(BIO_should_retry(bio))

--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -439,22 +439,6 @@ static int RADIX_PROCESS_join_all_threads(RADIX_PROCESS *rp, int *testresult)
     return ok;
 }
 
-/*
- * Free every non-listener object's SSL before cleanup_one() frees any listener.
- *
- * A connection's assist thread reads from its network BIO, and for a dgram BIO
- * pair (see hf_link_dgram_pair) that BIO belongs to the linked listener. Freeing
- * the connection joins its assist thread (see ossl_quic_free), so doing so first
- * ensures no assist thread is still reading when the listener BIOs are freed.
- */
-static void cleanup_nonlistener(RADIX_OBJ *obj)
-{
-    if (obj->ssl != NULL && !SSL_is_listener(obj->ssl)) {
-        SSL_free(obj->ssl);
-        obj->ssl = NULL;
-    }
-}
-
 static void cleanup_one(RADIX_OBJ *obj)
 {
     obj->registered = 0;
@@ -475,7 +459,6 @@ static void RADIX_PROCESS_cleanup(RADIX_PROCESS *rp)
     sk_RADIX_THREAD_free(rp->threads);
     rp->threads = NULL;
 
-    lh_RADIX_OBJ_doall(rp->objs, cleanup_nonlistener);
     lh_RADIX_OBJ_doall(rp->objs, cleanup_one);
     lh_RADIX_OBJ_free(rp->objs);
     rp->objs = NULL;


### PR DESCRIPTION
@ifranzki anzki reported an asan issue with the quic_radix_test in: https://github.com/openssl/openssl/issues/32420

And we've tried fixing it a few different ways, with varying amounts of success

This commit represents an alternative approach which I think is more general to the bio_dgram_pair bio type.

The problem:
We have a race condition as reported above in which freeing one side of a BIO dgram pair results in a use after free

The root cause:
BIO_new_bio_dgram_pair creates 2 dgram BIOS, each with a reference count of one (which is sensible, as each bio has a single owner).  However, after creating the bios, it calls BIO_make_bio_pair(), which links the two together.  Under the covers in the bio_dgram_pair implementation, each bio stores the pointer of its peer bio _without_ taking an additional reference on the bio. This means that, once the first bio is freed, the second bio may be doing subsequent io, which requires dereferencing of the peer bio , which is already release, leading to the use after free case observed.

Nominally this isn't an issue, as most code that uses BIO_dgram_pairs are single threaded, and freeing of the component bios only occurs after any i/o is already terminated, avoiding the observed UAF.  However, the QUIC radix test exercises the thread assisted mode of the quic stack, and in so doing passes each half of a bio dgram pair to a separate thread.

The fix:

Nominally we could resolve this by increasing the reference count on each of the peer bios, and dropping that ref count when each is freed, so that only the last to free actually deallocates both instances, but this creates a chicken and egg issue.  Since the the stored reference to each bio lives in the dgram pair implementation, upping the refcount of the bios prevents either bio from ever reaching the implementation free code (dgram_pair_free)

So instead I'm proposing the following in this commit: 1) Instead of having the internal bio data track the peer bio, instead
   have the internal data track the peers bio_dgram_pair_st internal
   data pointer

2) Add a refcount to that internal data, and increase the count on each
   bio_dgram_pair_st when pairing the two bios together

3) During BIO_free()->dgram_pair_free, drop the refcount on both the
   local bios dgram_pair_st and the peer dgram_pair_st, and free them
   only when the ref count reaches zero.

4) Add an internal peer_init value to the dgram_pair_st to shadow the
   value of bio->init that was previously manipulated by bio_dgram_pair,
   to maintain the behavior that the use of bio->init previously
   provided.

Fixes #32420

