### PR TITLE
Rate limit TLS 1.3 KeyUpdates in both directions

### DIFF
--- a/doc/man3/SSL_key_update.pod
+++ b/doc/man3/SSL_key_update.pod
@@ -41,7 +41,9 @@ SSL_do_handshake() can be called to force the update to take place immediately.
 Locally initiated key updates on a TLS connection are rate limited, which
 keeps the connection within the key update limits of RFC 9846.
 SSL_key_update() fails, leaving the connection otherwise unaffected, if
-called too soon after a previous successful call.
+called too soon after a previous successful call, or with
+B<SSL_KEY_UPDATE_REQUESTED> while an earlier requested update is still
+awaiting a KeyUpdate message from the peer.
 
 SSL_get_key_update_type() can be used to determine whether a key update
 operation has been scheduled but not yet performed. The type of the pending key

--- a/doc/man3/SSL_key_update.pod
+++ b/doc/man3/SSL_key_update.pod
@@ -38,6 +38,11 @@ update will not take place until the next time an IO operation such as
 SSL_read_ex() or SSL_write_ex() takes place on the connection. Alternatively
 SSL_do_handshake() can be called to force the update to take place immediately.
 
+Locally initiated key updates on a TLS connection are rate limited, which
+keeps the connection within the key update limits of RFC 9846.
+SSL_key_update() fails, leaving the connection otherwise unaffected, if
+called too soon after a previous successful call.
+
 SSL_get_key_update_type() can be used to determine whether a key update
 operation has been scheduled but not yet performed. The type of the pending key
 update operation will be returned if there is one, or SSL_KEY_UPDATE_NONE

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -610,6 +610,7 @@ int ossl_ssl_connection_reset(SSL *s)
     sc->key_update = SSL_KEY_UPDATE_NONE;
     sc->last_key_update_time = ossl_time_zero();
     sc->key_update_request_pending = 0;
+    sc->last_key_update_recv_time = ossl_time_zero();
     memset(sc->ext.compress_certificate_from_peer, 0,
         sizeof(sc->ext.compress_certificate_from_peer));
     sc->ext.compress_certificate_sent = 0;
@@ -895,6 +896,7 @@ SSL *ossl_ssl_connection_new_int(SSL_CTX *ctx, SSL *user_ssl,
     s->key_update = SSL_KEY_UPDATE_NONE;
     s->last_key_update_time = ossl_time_zero();
     s->key_update_request_pending = 0;
+    s->last_key_update_recv_time = ossl_time_zero();
 
     if (!IS_QUIC_CTX(ctx)) {
         s->allow_early_data_cb = ctx->allow_early_data_cb;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -609,6 +609,7 @@ int ossl_ssl_connection_reset(SSL *s)
 
     sc->key_update = SSL_KEY_UPDATE_NONE;
     sc->last_key_update_time = ossl_time_zero();
+    sc->key_update_request_pending = 0;
     memset(sc->ext.compress_certificate_from_peer, 0,
         sizeof(sc->ext.compress_certificate_from_peer));
     sc->ext.compress_certificate_sent = 0;
@@ -893,6 +894,7 @@ SSL *ossl_ssl_connection_new_int(SSL_CTX *ctx, SSL *user_ssl,
 
     s->key_update = SSL_KEY_UPDATE_NONE;
     s->last_key_update_time = ossl_time_zero();
+    s->key_update_request_pending = 0;
 
     if (!IS_QUIC_CTX(ctx)) {
         s->allow_early_data_cb = ctx->allow_early_data_cb;
@@ -3054,6 +3056,16 @@ int SSL_key_update(SSL *s, int updatetype)
 
     if (RECORD_LAYER_write_pending(&sc->rlayer)) {
         ERR_raise(ERR_LIB_SSL, SSL_R_BAD_WRITE_RETRY);
+        return 0;
+    }
+
+    /*
+     * RFC 9846 section 4.7.3: until receiving a subsequent KeyUpdate from
+     * the peer, we must not send another KeyUpdate with update_requested.
+     */
+    if (updatetype == SSL_KEY_UPDATE_REQUESTED
+        && sc->key_update_request_pending) {
+        ERR_raise(ERR_LIB_SSL, SSL_R_TOO_MANY_KEY_UPDATES);
         return 0;
     }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -608,6 +608,7 @@ int ossl_ssl_connection_reset(SSL *s)
     sc->first_packet = 0;
 
     sc->key_update = SSL_KEY_UPDATE_NONE;
+    sc->last_key_update_time = ossl_time_zero();
     memset(sc->ext.compress_certificate_from_peer, 0,
         sizeof(sc->ext.compress_certificate_from_peer));
     sc->ext.compress_certificate_sent = 0;
@@ -891,6 +892,7 @@ SSL *ossl_ssl_connection_new_int(SSL_CTX *ctx, SSL *user_ssl,
     s->default_passwd_callback_userdata = ctx->default_passwd_callback_userdata;
 
     s->key_update = SSL_KEY_UPDATE_NONE;
+    s->last_key_update_time = ossl_time_zero();
 
     if (!IS_QUIC_CTX(ctx)) {
         s->allow_early_data_cb = ctx->allow_early_data_cb;
@@ -3024,6 +3026,7 @@ int SSL_shutdown(SSL *s)
 int SSL_key_update(SSL *s, int updatetype)
 {
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    OSSL_TIME now;
 
 #ifndef OPENSSL_NO_QUIC
     if (IS_QUIC(s))
@@ -3054,8 +3057,19 @@ int SSL_key_update(SSL *s, int updatetype)
         return 0;
     }
 
+    /* Rate-limit KeyUpdates; see KEY_UPDATE_MIN_INTERVAL */
+    now = ossl_time_now();
+    if (ossl_time_compare(now, sc->last_key_update_time) >= 0
+        && ossl_time_compare(ossl_time_subtract(now, sc->last_key_update_time),
+               ossl_ms2time(KEY_UPDATE_MIN_INTERVAL))
+            < 0) {
+        ERR_raise(ERR_LIB_SSL, SSL_R_TOO_MANY_KEY_UPDATES);
+        return 0;
+    }
+
     ossl_statem_set_in_init(sc, 1);
     sc->key_update = updatetype;
+    sc->last_key_update_time = now;
     return 1;
 }
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -69,6 +69,14 @@
 
 #define SSL_AD_NO_ALERT -1
 
+/*-
+ * The minimum interval, in milliseconds, between locally-initiated
+ * KeyUpdates. RFC 9846 section 4.7.3 forbids a sender from performing
+ * more than 2^48 - 1 re-keys on a connection; a minimum interval makes
+ * that unreachable.
+ */
+#define KEY_UPDATE_MIN_INTERVAL 100
+
 /*
  * Define the Bitmasks for SSL_CIPHER.algorithms.
  * This bits are used packed as dense as possible. If new methods/ciphers
@@ -1847,6 +1855,8 @@ struct ssl_connection_st {
     int renegotiate;
     /* If sending a KeyUpdate is pending */
     int key_update;
+    /* Time of the last accepted SSL_key_update() call */
+    OSSL_TIME last_key_update_time;
     /* Post-handshake authentication state */
     SSL_PHA_STATE post_handshake_auth;
     int pha_enabled;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1857,6 +1857,8 @@ struct ssl_connection_st {
     int key_update;
     /* Time of the last accepted SSL_key_update() call */
     OSSL_TIME last_key_update_time;
+    /* An update_requested KeyUpdate we sent awaits the peer's KeyUpdate */
+    int key_update_request_pending;
     /* Post-handshake authentication state */
     SSL_PHA_STATE post_handshake_auth;
     int pha_enabled;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -77,6 +77,12 @@
  */
 #define KEY_UPDATE_MIN_INTERVAL 100
 
+/*-
+ * The minimum interval, in milliseconds, between KeyUpdates we will accept
+ * from the peer. A KeyUpdate received sooner terminates the connection.
+ */
+#define KEY_UPDATE_MIN_RECV_INTERVAL 100
+
 /*
  * Define the Bitmasks for SSL_CIPHER.algorithms.
  * This bits are used packed as dense as possible. If new methods/ciphers
@@ -1859,6 +1865,8 @@ struct ssl_connection_st {
     OSSL_TIME last_key_update_time;
     /* An update_requested KeyUpdate we sent awaits the peer's KeyUpdate */
     int key_update_request_pending;
+    /* Time of the last KeyUpdate accepted from the peer */
+    OSSL_TIME last_key_update_recv_time;
     /* Post-handshake authentication state */
     SSL_PHA_STATE post_handshake_auth;
     int pha_enabled;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -732,15 +732,36 @@ MSG_PROCESS_RETURN tls_process_key_update(SSL_CONNECTION *s, PACKET *pkt)
     }
 
     /*
+     * Rate-limit KeyUpdates from the peer to bound the key derivations it can
+     * force on us: one arriving within KEY_UPDATE_MIN_RECV_INTERVAL of the
+     * last accepted KeyUpdate terminates the connection. A KeyUpdate that
+     * answers our own outstanding update_requested is exempt and does not
+     * update the timestamp; the flag also covers a KeyUpdate that crossed our
+     * request in flight (RFC 9846 section 4.7.3).
+     */
+    if (s->key_update_request_pending) {
+        s->key_update_request_pending = 0;
+    } else {
+        OSSL_TIME now = ossl_time_now();
+
+        if (ossl_time_compare(now, s->last_key_update_recv_time) >= 0
+            && ossl_time_compare(ossl_time_subtract(now,
+                                     s->last_key_update_recv_time),
+                   ossl_ms2time(KEY_UPDATE_MIN_RECV_INTERVAL))
+                < 0) {
+            SSLfatal(s, SSL_AD_UNEXPECTED_MESSAGE, SSL_R_TOO_MANY_KEY_UPDATES);
+            return MSG_PROCESS_ERROR;
+        }
+        s->last_key_update_recv_time = now;
+    }
+
+    /*
      * If we get a request for us to update our sending keys too then, we need
      * to additionally send a KeyUpdate message. However that message should
      * not also request an update (otherwise we get into an infinite loop).
      */
     if (updatetype == SSL_KEY_UPDATE_REQUESTED)
         s->key_update = SSL_KEY_UPDATE_NOT_REQUESTED;
-
-    /* Any KeyUpdate from the peer releases our outstanding update request */
-    s->key_update_request_pending = 0;
 
     if (!tls13_update_key(s, 0)) {
         /* SSLfatal() already called */

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -691,6 +691,13 @@ CON_FUNC_RETURN tls_construct_key_update(SSL_CONNECTION *s, WPACKET *pkt)
         return CON_FUNC_ERROR;
     }
 
+    /*
+     * RFC 9846 section 4.7.3: until receiving a subsequent KeyUpdate from
+     * the peer, we must not send another KeyUpdate with update_requested.
+     */
+    if (s->key_update == SSL_KEY_UPDATE_REQUESTED)
+        s->key_update_request_pending = 1;
+
     s->key_update = SSL_KEY_UPDATE_NONE;
     return CON_FUNC_SUCCESS;
 }
@@ -731,6 +738,9 @@ MSG_PROCESS_RETURN tls_process_key_update(SSL_CONNECTION *s, PACKET *pkt)
      */
     if (updatetype == SSL_KEY_UPDATE_REQUESTED)
         s->key_update = SSL_KEY_UPDATE_NOT_REQUESTED;
+
+    /* Any KeyUpdate from the peer releases our outstanding update request */
+    s->key_update_request_pending = 0;
 
     if (!tls13_update_key(s, 0)) {
         /* SSLfatal() already called */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7808,8 +7808,9 @@ static int test_key_update(void)
     for (j = 0; j < 2; j++) {
         /* Send lots of KeyUpdate messages */
         for (i = 0; i < NUM_KEY_UPDATE_MESSAGES; i++) {
-            /* Bypass the KeyUpdate rate limit for this stress loop */
+            /* Bypass the KeyUpdate sender-side limits for this stress loop */
             clientsc->last_key_update_time = ossl_time_zero();
+            clientsc->key_update_request_pending = 0;
             if (!TEST_true(SSL_key_update(clientssl,
                     (j == 0)
                         ? SSL_KEY_UPDATE_NOT_REQUESTED
@@ -7913,6 +7914,82 @@ static int test_key_update_ratelimit(void)
             (int)strlen(mess))
         || !TEST_int_eq(SSL_read(clientssl, buf, sizeof(buf)),
             (int)strlen(mess)))
+        goto end;
+
+    testresult = 1;
+
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+/*
+ * Test that after sending a KeyUpdate with update_requested, another
+ * SSL_KEY_UPDATE_REQUESTED update is refused with
+ * SSL_R_TOO_MANY_KEY_UPDATES until a KeyUpdate is received from the peer,
+ * while SSL_KEY_UPDATE_NOT_REQUESTED updates remain permitted.
+ */
+static int test_key_update_request_pending(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *clientsc = NULL;
+    int testresult = 0;
+    char buf[20];
+    static char *mess = "A test message";
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            TLS1_3_VERSION,
+            0,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
+        goto end;
+
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_REQUESTED))
+        || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    /* Another requested update must be refused until the peer responds */
+    clientsc->last_key_update_time = ossl_time_zero();
+    if (!TEST_false(SSL_key_update(clientssl, SSL_KEY_UPDATE_REQUESTED))
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_error()),
+            SSL_R_TOO_MANY_KEY_UPDATES))
+        goto end;
+
+    ERR_clear_error();
+
+    /* An unrequested update is still permitted */
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    /*
+     * Exchange data so the server processes our KeyUpdates and its
+     * responding KeyUpdate reaches us, releasing the outstanding request.
+     */
+    if (!TEST_int_eq(SSL_write(clientssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_write(serverssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(clientssl, buf, sizeof(buf)),
+            (int)strlen(mess)))
+        goto end;
+
+    /* A requested update is permitted again */
+    clientsc->last_key_update_time = ossl_time_zero();
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_REQUESTED))
+        || !TEST_true(SSL_do_handshake(clientssl)))
         goto end;
 
     testresult = 1;
@@ -15800,6 +15877,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_export_key_mat_early, 3);
     ADD_TEST(test_key_update);
     ADD_TEST(test_key_update_ratelimit);
+    ADD_TEST(test_key_update_request_pending);
     ADD_ALL_TESTS(test_key_update_peer_in_write, 2);
     ADD_ALL_TESTS(test_key_update_peer_in_read, 2);
     ADD_ALL_TESTS(test_key_update_local_in_write, 2);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7788,6 +7788,7 @@ static int test_key_update(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *clientsc = NULL;
     int testresult = 0, i, j;
     char buf[20];
     static char *mess = "A test message";
@@ -7800,12 +7801,15 @@ static int test_key_update(void)
         || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
             NULL, NULL))
         || !TEST_true(create_ssl_connection(serverssl, clientssl,
-            SSL_ERROR_NONE)))
+            SSL_ERROR_NONE))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
         goto end;
 
     for (j = 0; j < 2; j++) {
         /* Send lots of KeyUpdate messages */
         for (i = 0; i < NUM_KEY_UPDATE_MESSAGES; i++) {
+            /* Bypass the KeyUpdate rate limit for this stress loop */
+            clientsc->last_key_update_time = ossl_time_zero();
             if (!TEST_true(SSL_key_update(clientssl,
                     (j == 0)
                         ? SSL_KEY_UPDATE_NOT_REQUESTED
@@ -7825,6 +7829,91 @@ static int test_key_update(void)
                 (int)strlen(mess)))
             goto end;
     }
+
+    testresult = 1;
+
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+/*
+ * Test that locally-initiated KeyUpdates are rate limited. A second
+ * SSL_key_update() within KEY_UPDATE_MIN_INTERVAL of the previous one must
+ * fail with SSL_R_TOO_MANY_KEY_UPDATES and leave the connection usable, and
+ * an update must be accepted again once the interval has elapsed (simulated
+ * by rewinding the recorded update time) or if the clock has stepped
+ * backwards (simulated by a recorded update time in the future).
+ */
+static int test_key_update_ratelimit(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *clientsc = NULL;
+    int testresult = 0;
+    char buf[20];
+    static char *mess = "A test message";
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            TLS1_3_VERSION,
+            0,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
+        goto end;
+
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    /*
+     * An immediate second update must be refused. Re-arm the recorded time
+     * first so the test cannot become flaky on a machine slow enough for
+     * the interval to elapse between the two calls.
+     */
+    clientsc->last_key_update_time = ossl_time_now();
+    if (!TEST_false(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_error()),
+            SSL_R_TOO_MANY_KEY_UPDATES))
+        goto end;
+
+    ERR_clear_error();
+
+    /* The refusal must not have scheduled an update */
+    if (!TEST_int_eq(SSL_get_key_update_type(clientssl), SSL_KEY_UPDATE_NONE))
+        goto end;
+
+    /* Once the interval has elapsed an update is accepted again */
+    clientsc->last_key_update_time = ossl_time_subtract(clientsc->last_key_update_time,
+        ossl_ms2time(KEY_UPDATE_MIN_INTERVAL));
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    /* A clock that has stepped backwards permits an update */
+    clientsc->last_key_update_time = ossl_time_add(ossl_time_now(), ossl_seconds2time(3600));
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    /* The connection must still be usable in both directions */
+    if (!TEST_int_eq(SSL_write(clientssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_write(serverssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(clientssl, buf, sizeof(buf)),
+            (int)strlen(mess)))
+        goto end;
 
     testresult = 1;
 
@@ -15710,6 +15799,7 @@ int setup_tests(void)
 #ifndef OSSL_NO_USABLE_TLS1_3
     ADD_ALL_TESTS(test_export_key_mat_early, 3);
     ADD_TEST(test_key_update);
+    ADD_TEST(test_key_update_ratelimit);
     ADD_ALL_TESTS(test_key_update_peer_in_write, 2);
     ADD_ALL_TESTS(test_key_update_peer_in_read, 2);
     ADD_ALL_TESTS(test_key_update_local_in_write, 2);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7780,68 +7780,6 @@ end:
     return testresult;
 }
 
-#define NUM_KEY_UPDATE_MESSAGES 40
-/*
- * Test KeyUpdate.
- */
-static int test_key_update(void)
-{
-    SSL_CTX *cctx = NULL, *sctx = NULL;
-    SSL *clientssl = NULL, *serverssl = NULL;
-    SSL_CONNECTION *clientsc = NULL;
-    int testresult = 0, i, j;
-    char buf[20];
-    static char *mess = "A test message";
-
-    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
-            TLS_client_method(),
-            TLS1_3_VERSION,
-            0,
-            &sctx, &cctx, cert, privkey))
-        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-            NULL, NULL))
-        || !TEST_true(create_ssl_connection(serverssl, clientssl,
-            SSL_ERROR_NONE))
-        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
-        goto end;
-
-    for (j = 0; j < 2; j++) {
-        /* Send lots of KeyUpdate messages */
-        for (i = 0; i < NUM_KEY_UPDATE_MESSAGES; i++) {
-            /* Bypass the KeyUpdate sender-side limits for this stress loop */
-            clientsc->last_key_update_time = ossl_time_zero();
-            clientsc->key_update_request_pending = 0;
-            if (!TEST_true(SSL_key_update(clientssl,
-                    (j == 0)
-                        ? SSL_KEY_UPDATE_NOT_REQUESTED
-                        : SSL_KEY_UPDATE_REQUESTED))
-                || !TEST_true(SSL_do_handshake(clientssl)))
-                goto end;
-        }
-
-        /* Check that sending and receiving app data is ok */
-        if (!TEST_int_eq(SSL_write(clientssl, mess, (int)strlen(mess)), (int)strlen(mess))
-            || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)),
-                (int)strlen(mess)))
-            goto end;
-
-        if (!TEST_int_eq(SSL_write(serverssl, mess, (int)strlen(mess)), (int)strlen(mess))
-            || !TEST_int_eq(SSL_read(clientssl, buf, sizeof(buf)),
-                (int)strlen(mess)))
-            goto end;
-    }
-
-    testresult = 1;
-
-end:
-    SSL_free(serverssl);
-    SSL_free(clientssl);
-    SSL_CTX_free(sctx);
-    SSL_CTX_free(cctx);
-
-    return testresult;
-}
-
 /*
  * Test that locally-initiated KeyUpdates are rate limited. A second
  * SSL_key_update() within KEY_UPDATE_MIN_INTERVAL of the previous one must
@@ -7854,7 +7792,7 @@ static int test_key_update_ratelimit(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
-    SSL_CONNECTION *clientsc = NULL;
+    SSL_CONNECTION *clientsc = NULL, *serversc = NULL;
     int testresult = 0;
     char buf[20];
     static char *mess = "A test message";
@@ -7868,11 +7806,18 @@ static int test_key_update_ratelimit(void)
             NULL, NULL))
         || !TEST_true(create_ssl_connection(serverssl, clientssl,
             SSL_ERROR_NONE))
-        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl))
+        || !TEST_ptr(serversc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl)))
         goto end;
 
     if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
         || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    /* Server reads the KeyUpdate; reset its receive rate limit first */
+    serversc->last_key_update_recv_time = ossl_time_zero();
+    if (!TEST_int_le(SSL_read(serverssl, buf, sizeof(buf)), 0)
+        || !TEST_int_eq(SSL_get_error(serverssl, -1), SSL_ERROR_WANT_READ))
         goto end;
 
     /*
@@ -7899,10 +7844,20 @@ static int test_key_update_ratelimit(void)
         || !TEST_true(SSL_do_handshake(clientssl)))
         goto end;
 
+    serversc->last_key_update_recv_time = ossl_time_zero();
+    if (!TEST_int_le(SSL_read(serverssl, buf, sizeof(buf)), 0)
+        || !TEST_int_eq(SSL_get_error(serverssl, -1), SSL_ERROR_WANT_READ))
+        goto end;
+
     /* A clock that has stepped backwards permits an update */
     clientsc->last_key_update_time = ossl_time_add(ossl_time_now(), ossl_seconds2time(3600));
     if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
         || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    serversc->last_key_update_recv_time = ossl_time_zero();
+    if (!TEST_int_le(SSL_read(serverssl, buf, sizeof(buf)), 0)
+        || !TEST_int_eq(SSL_get_error(serverssl, -1), SSL_ERROR_WANT_READ))
         goto end;
 
     /* The connection must still be usable in both directions */
@@ -7937,7 +7892,7 @@ static int test_key_update_request_pending(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
-    SSL_CONNECTION *clientsc = NULL;
+    SSL_CONNECTION *clientsc = NULL, *serversc = NULL;
     int testresult = 0;
     char buf[20];
     static char *mess = "A test message";
@@ -7951,11 +7906,18 @@ static int test_key_update_request_pending(void)
             NULL, NULL))
         || !TEST_true(create_ssl_connection(serverssl, clientssl,
             SSL_ERROR_NONE))
-        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl))
+        || !TEST_ptr(serversc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl)))
         goto end;
 
     if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_REQUESTED))
         || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    /* Server reads the KeyUpdate; reset its receive rate limit first */
+    serversc->last_key_update_recv_time = ossl_time_zero();
+    if (!TEST_int_le(SSL_read(serverssl, buf, sizeof(buf)), 0)
+        || !TEST_int_eq(SSL_get_error(serverssl, -1), SSL_ERROR_WANT_READ))
         goto end;
 
     /* Another requested update must be refused until the peer responds */
@@ -7972,9 +7934,14 @@ static int test_key_update_request_pending(void)
         || !TEST_true(SSL_do_handshake(clientssl)))
         goto end;
 
+    serversc->last_key_update_recv_time = ossl_time_zero();
+    if (!TEST_int_le(SSL_read(serverssl, buf, sizeof(buf)), 0)
+        || !TEST_int_eq(SSL_get_error(serverssl, -1), SSL_ERROR_WANT_READ))
+        goto end;
+
     /*
-     * Exchange data so the server processes our KeyUpdates and its
-     * responding KeyUpdate reaches us, releasing the outstanding request.
+     * Exchange data so the server's responding KeyUpdate reaches us,
+     * releasing the outstanding request.
      */
     if (!TEST_int_eq(SSL_write(clientssl, mess, (int)strlen(mess)),
             (int)strlen(mess))
@@ -7990,6 +7957,208 @@ static int test_key_update_request_pending(void)
     clientsc->last_key_update_time = ossl_time_zero();
     if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_REQUESTED))
         || !TEST_true(SSL_do_handshake(clientssl)))
+        goto end;
+
+    testresult = 1;
+
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+/*
+ * Test that a KeyUpdate with update_requested is handled: the peer sends its
+ * own KeyUpdate in response and application data continues to flow.
+ */
+static int test_key_update_requested(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+    char buf[20];
+    static char *mess = "A test message";
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            TLS1_3_VERSION,
+            0,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_REQUESTED))
+        || !TEST_int_eq(SSL_do_handshake(clientssl), 1))
+        goto end;
+
+    /* The server processes the request and sends its reply on its next write */
+    if (!TEST_int_eq(SSL_write(clientssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_write(serverssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(clientssl, buf, sizeof(buf)),
+            (int)strlen(mess)))
+        goto end;
+
+    testresult = 1;
+
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+/*
+ * Test that a KeyUpdate with update_not_requested is handled with no reply
+ * owed and application data continues to flow.
+ */
+static int test_key_update_not_requested(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+    char buf[20];
+    static char *mess = "A test message";
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            TLS1_3_VERSION,
+            0,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_int_eq(SSL_do_handshake(clientssl), 1))
+        goto end;
+
+    if (!TEST_int_eq(SSL_write(clientssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_write(serverssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(clientssl, buf, sizeof(buf)),
+            (int)strlen(mess)))
+        goto end;
+
+    testresult = 1;
+
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+/*
+ * Test that KeyUpdates received from the peer faster than
+ * KEY_UPDATE_MIN_RECV_INTERVAL terminate the connection with
+ * SSL_R_TOO_MANY_KEY_UPDATES.
+ */
+static int test_key_update_too_fast(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *clientsc = NULL;
+    int testresult = 0, i;
+    char buf[20];
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            TLS1_3_VERSION,
+            0,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
+        goto end;
+
+    /*
+     * Send two KeyUpdates back to back, bypassing the client's own sender-side
+     * rate limit, to mimic a peer that re-keys faster than we will accept.
+     */
+    for (i = 0; i < 2; i++) {
+        clientsc->last_key_update_time = ossl_time_zero();
+        if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+            || !TEST_int_eq(SSL_do_handshake(clientssl), 1))
+            goto end;
+    }
+
+    if (!TEST_int_le(SSL_read(serverssl, buf, sizeof(buf)), 0)
+        || !TEST_int_eq(SSL_get_error(serverssl, -1), SSL_ERROR_SSL)
+        || !TEST_int_eq(ERR_GET_REASON(ERR_get_error()),
+            SSL_R_TOO_MANY_KEY_UPDATES))
+        goto end;
+
+    testresult = 1;
+
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+/*
+ * Test that a KeyUpdate answering our own outstanding update_requested is
+ * exempt from the receive rate limit, so a reply crossing our request in
+ * flight does not terminate the connection.
+ */
+static int test_key_update_reply_exempt(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *serversc = NULL;
+    int testresult = 0;
+    char buf[20];
+    static char *mess = "A test message";
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            TLS1_3_VERSION,
+            0,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_ptr(serversc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl)))
+        goto end;
+
+    /* Server recently accepted a KeyUpdate and has a request outstanding */
+    serversc->last_key_update_recv_time = ossl_time_now();
+    serversc->key_update_request_pending = 1;
+
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_int_eq(SSL_do_handshake(clientssl), 1))
+        goto end;
+
+    if (!TEST_int_eq(SSL_write(clientssl, mess, (int)strlen(mess)),
+            (int)strlen(mess))
+        || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)),
+            (int)strlen(mess))
+        || !TEST_int_eq(serversc->key_update_request_pending, 0))
         goto end;
 
     testresult = 1;
@@ -15875,9 +16044,12 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_export_key_mat, 6);
 #ifndef OSSL_NO_USABLE_TLS1_3
     ADD_ALL_TESTS(test_export_key_mat_early, 3);
-    ADD_TEST(test_key_update);
     ADD_TEST(test_key_update_ratelimit);
     ADD_TEST(test_key_update_request_pending);
+    ADD_TEST(test_key_update_requested);
+    ADD_TEST(test_key_update_not_requested);
+    ADD_TEST(test_key_update_too_fast);
+    ADD_TEST(test_key_update_reply_exempt);
     ADD_ALL_TESTS(test_key_update_peer_in_write, 2);
     ADD_ALL_TESTS(test_key_update_peer_in_read, 2);
     ADD_ALL_TESTS(test_key_update_local_in_write, 2);


### PR DESCRIPTION
Tighten KeyUpdate handling per RFC 9846 and close a receive-side DoS, in three commits:

- Rate limit locally-initiated KeyUpdates. SSL_key_update() fails (non-fatally) if called within 100ms of the last one. RFC 9846 Section 4.7.3 caps a sender at 2^48−1 re-keys per connection; the interval makes that unreachable without affecting any real rekeying cadence.

- Permit only one outstanding requested KeyUpdate. §4.7.3 forbids sending another update_requested before the peer's reply arrives; SSL_key_update() now refuses to, so we don't emit the non-conforming message.

 - Rate limit received KeyUpdates. Each one forces a receive-key derivation, so a flood is an asymmetric CPU drain. A KeyUpdate arriving within 100ms of the last accepted one now terminates the connection with SSL_R_TOO_MANY_KEY_UPDATES, bounding forced re-keying to ~10/sec. A reply to our own update_requested is exempt (handles the crossing case). Being time-based, it can't be reset and bypassed by interleaving application data.

the 100ms rate limit in no way limits the ability for a legitimate client to re-key for AEAD usage limits as it's effectively impossible to send/receive enough traffic in 100 ms so that you would to need to do it at line rates below 31 TB/second. 

RFC 9846 Section 5.5 (re-key or close before the AEAD usage limits) is not addressed here - we don't do that yet in TLS (QUIC does). We can address it separately from this PR. 

Fixes: https://github.com/openssl/openssl/issues/32497

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
