### PR TITLE
Keep GREASE key shares valid after HelloRetryRequest

### DIFF
--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -421,6 +421,8 @@ suites, supported groups, supported versions, signature algorithms, key share
 entries, and extensions. GREASE values help prevent ecosystem ossification by
 ensuring servers and middleboxes tolerate unknown values. The injected values
 are consistent across HelloRetryRequest replays within the same connection.
+If a HelloRetryRequest asks for a new key share, the second ClientHello omits
+the GREASE key share so that the requested key share is the only entry.
 
 =back
 

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -913,8 +913,14 @@ EXT_RETURN tls_construct_ctos_key_share(SSL_CONNECTION *s, WPACKET *pkt,
         return EXT_RETURN_FAIL;
     }
 
-    /* RFC 8701: prepend a GREASE key share entry (1 byte of 0x00) */
-    if ((s->options & SSL_OP_GREASE) && !s->server) {
+    /*
+     * RFC 8701: prepend a GREASE key share entry (1 byte of 0x00). After an
+     * HRR requesting a new key share, RFC 9846 requires the requested entry
+     * to be the only one in the second ClientHello.
+     */
+    if ((s->options & SSL_OP_GREASE) && !s->server
+        && !(s->hello_retry_request == SSL_HRR_PENDING
+            && s->s3.group_id != 0 && s->s3.tmp.pkey == NULL)) {
         uint16_t grease_group = ossl_grease_value(s, OSSL_GREASE_GROUP);
 
         if (!WPACKET_put_bytes_u16(pkt, grease_group)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -15074,8 +15074,22 @@ err:
  * PACKET functions to confirm that GREASE values (matching 0x?A?A) are
  * present in the expected fields.
  */
-static unsigned char *grease_ch_buf;
-static size_t grease_ch_len;
+#define MAX_GREASE_CLIENT_HELLOS 2
+
+typedef struct grease_capture_st {
+    unsigned char *buf[MAX_GREASE_CLIENT_HELLOS];
+    size_t len[MAX_GREASE_CLIENT_HELLOS];
+    size_t count;
+} GREASE_CAPTURE;
+
+static void grease_capture_reset(GREASE_CAPTURE *capture)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(capture->buf); i++)
+        OPENSSL_free(capture->buf[i]);
+    memset(capture, 0, sizeof(*capture));
+}
 
 static int is_grease(unsigned int v)
 {
@@ -15085,6 +15099,7 @@ static int is_grease(unsigned int v)
 static void grease_msg_cb(int write_p, int version, int content_type,
     const void *buf, size_t len, SSL *ssl, void *arg)
 {
+    GREASE_CAPTURE *capture = arg;
     const unsigned char *p = buf;
 
     /*
@@ -15097,12 +15112,14 @@ static void grease_msg_cb(int write_p, int version, int content_type,
         || p[0] != SSL3_MT_CLIENT_HELLO)
         return;
 
-    /* Only capture the first ClientHello (not HRR retry) */
-    if (grease_ch_buf != NULL)
+    if (capture == NULL || capture->count >= OSSL_NELEM(capture->buf))
         return;
 
-    grease_ch_buf = OPENSSL_memdup(buf, len);
-    grease_ch_len = len;
+    capture->buf[capture->count] = OPENSSL_memdup(buf, len);
+    if (capture->buf[capture->count] == NULL)
+        return;
+    capture->len[capture->count] = len;
+    capture->count++;
 }
 
 /*
@@ -15111,11 +15128,13 @@ static void grease_msg_cb(int write_p, int version, int content_type,
  * groups, key shares, and signature algorithms.
  * Returns 1 on success, 0 on failure.
  */
-static int check_grease_in_client_hello(void)
+static int check_grease_in_client_hello(const unsigned char *buf, size_t len,
+    int expect_grease_keyshare)
 {
     PACKET pkt, ciphers, session, compression, exts, ext_data;
     PACKET inner;
     unsigned int ext_type = 0, val = 0;
+    size_t keyshare_count = 0;
     int found_grease_cipher = 0;
     int found_grease_ext = 0;
     int found_grease_group = 0;
@@ -15131,9 +15150,8 @@ static int check_grease_in_client_hello(void)
     memset(&ext_data, 0, sizeof(ext_data));
     memset(&inner, 0, sizeof(inner));
 
-    if (!TEST_ptr(grease_ch_buf)
-        || !TEST_true(PACKET_buf_init(&pkt, grease_ch_buf,
-            grease_ch_len))
+    if (!TEST_ptr(buf)
+        || !TEST_true(PACKET_buf_init(&pkt, buf, len))
         /* Skip handshake message header */
         || !TEST_true(PACKET_forward(&pkt, SSL3_HM_HEADER_LENGTH))
         /* Skip client_version + random */
@@ -15206,6 +15224,7 @@ static int check_grease_in_client_hello(void)
                     || !TEST_true(PACKET_get_length_prefixed_2(
                         &inner, &ks_entry)))
                     return 0;
+                keyshare_count++;
                 if (is_grease(val))
                     found_grease_kshare = 1;
             }
@@ -15233,9 +15252,11 @@ static int check_grease_in_client_hello(void)
         return 0;
     if (!TEST_true(found_grease_group))
         return 0;
-    if (!TEST_true(found_grease_kshare))
+    if (!TEST_int_eq(found_grease_kshare, expect_grease_keyshare))
         return 0;
     if (!TEST_true(found_grease_sigalg))
+        return 0;
+    if (!expect_grease_keyshare && !TEST_size_t_eq(keyshare_count, 1))
         return 0;
 
     return 1;
@@ -15245,10 +15266,8 @@ static int test_grease(void)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *serverssl = NULL, *clientssl = NULL;
+    GREASE_CAPTURE capture = { 0 };
     int testresult = 0;
-
-    grease_ch_buf = NULL;
-    grease_ch_len = 0;
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
             TLS_client_method(),
@@ -15262,23 +15281,65 @@ static int test_grease(void)
             &clientssl, NULL, NULL)))
         goto end;
 
-    SSL_set_msg_callback(clientssl, grease_msg_cb);
+    /* Force the server to request a new key share. */
+#if defined(OPENSSL_NO_EC)
+    if (!TEST_true(SSL_set1_groups_list(serverssl, "ffdhe3072")))
+        goto end;
+#else
+    if (!TEST_true(SSL_set1_groups_list(serverssl, "P-384")))
+        goto end;
+#endif
 
-    /* A full handshake should succeed - server must tolerate GREASE */
+    SSL_set_msg_callback(clientssl, grease_msg_cb);
+    SSL_set_msg_callback_arg(clientssl, &capture);
+
+    /* A full handshake should succeed - server must tolerate GREASE. */
     if (!TEST_true(create_ssl_connection(serverssl, clientssl,
             SSL_ERROR_NONE)))
         goto end;
 
-    /* Now verify the captured ClientHello contains GREASE values */
-    if (!TEST_true(check_grease_in_client_hello()))
+    if (!TEST_size_t_eq(capture.count, 2)
+        || !TEST_true(check_grease_in_client_hello(capture.buf[0],
+            capture.len[0], 1))
+        || !TEST_true(check_grease_in_client_hello(capture.buf[1],
+            capture.len[1], 0)))
+        goto end;
+
+    shutdown_ssl_connection(serverssl, clientssl);
+    serverssl = clientssl = NULL;
+    grease_capture_reset(&capture);
+
+    /* A cookie-only retry must retain the original GREASE key share. */
+    SSL_CTX_clear_options(cctx, SSL_OP_ENABLE_MIDDLEBOX_COMPAT);
+    SSL_CTX_set_stateless_cookie_generate_cb(sctx,
+        generate_stateless_cookie_callback);
+    SSL_CTX_set_stateless_cookie_verify_cb(sctx,
+        verify_stateless_cookie_callback);
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+            &clientssl, NULL, NULL)))
+        goto end;
+
+    SSL_set_msg_callback(clientssl, grease_msg_cb);
+    SSL_set_msg_callback_arg(clientssl, &capture);
+    if (!TEST_false(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_WANT_READ))
+        || !TEST_int_eq(SSL_stateless(serverssl), 0)
+        || !TEST_false(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_WANT_READ))
+        || !TEST_int_eq(SSL_stateless(serverssl), 1)
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_size_t_eq(capture.count, 2)
+        || !TEST_true(check_grease_in_client_hello(capture.buf[0],
+            capture.len[0], 1))
+        || !TEST_true(check_grease_in_client_hello(capture.buf[1],
+            capture.len[1], 1)))
         goto end;
 
     testresult = 1;
 
 end:
-    OPENSSL_free(grease_ch_buf);
-    grease_ch_buf = NULL;
-    grease_ch_len = 0;
+    grease_capture_reset(&capture);
     SSL_free(serverssl);
     SSL_free(clientssl);
     SSL_CTX_free(sctx);


### PR DESCRIPTION
When `SSL_OP_GREASE` is enabled for a TLS 1.3 client, OpenSSL prepends a GREASE
entry to the `key_share` extension. If a HelloRetryRequest selects a new group,
RFC 9846 requires the second ClientHello to contain exactly one `KeyShareEntry`
for that group. The additional GREASE entry makes the retry invalid, and an
OpenSSL server rejects it with `SSL_R_BAD_KEY_SHARE`.

This change omits the GREASE key share only from a second ClientHello that
responds to a selected-group retry. Initial ClientHellos and cookie-only retries
continue to include the GREASE entry, and behavior without `SSL_OP_GREASE` is
unchanged.

The GREASE test now captures both ClientHellos and covers both retry cases:

- a selected-group retry completes with exactly one non-GREASE key share in the
  second ClientHello;
- a stateless cookie-only retry retains GREASE in both ClientHellos.

The option documentation now describes the selected-group retry exception.
There is no API or ABI change.

Testing:

- `make test` in the default strict-warning build (387 files, 4,575 tests)
- `make test TESTS=test_sslapi` in the default, `no-ec`, and ASan/UBSan
  strict-warning builds
- `make doc-nits`
- `clang-format` 21.1.7 with `--dry-run --Werror`

No separate CHANGES entry is included because `SSL_OP_GREASE` is new and
unreleased on the 4.1 development branch. This change corrects its existing TLS
1.3 behavior, and the option documentation is updated.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
