### PR TITLE
s_server: Do not override -Verify with -verify_return_error

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2025,7 +2025,7 @@ int s_server_main(int argc, char *argv[])
                 goto end;
             break;
         case OPT_VERIFY_RET_ERROR:
-            s_server_verify = SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE;
+            s_server_verify |= SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE;
             verify_args.return_error = 1;
             break;
         case OPT_VERIFY_QUIET:


### PR DESCRIPTION
Or the verification flags in instead of overriding the previous value with -verify_return_error.

Fixes e5f01903ed7
