### PR TITLE
CMS/PKCS7: do not leave stale errors on the queue

### DIFF
--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -1588,8 +1588,11 @@ int CMS_add_simple_smimecap(STACK_OF(X509_ALGOR) **algs,
 static int cms_add_cipher_smcap(STACK_OF(X509_ALGOR) **sk, int nid, int arg,
     OSSL_LIB_CTX *libctx, const char *propq)
 {
-    EVP_CIPHER *cipher = EVP_CIPHER_fetch(libctx, OBJ_nid2sn(nid), propq);
+    EVP_CIPHER *cipher;
 
+    ERR_set_mark();
+    cipher = EVP_CIPHER_fetch(libctx, OBJ_nid2sn(nid), propq);
+    ERR_pop_to_mark();
     if (cipher != NULL) {
         EVP_CIPHER_free(cipher);
         return CMS_add_simple_smimecap(sk, nid, arg);
@@ -1600,8 +1603,11 @@ static int cms_add_cipher_smcap(STACK_OF(X509_ALGOR) **sk, int nid, int arg,
 static int cms_add_digest_smcap(STACK_OF(X509_ALGOR) **sk, int nid, int arg,
     OSSL_LIB_CTX *libctx, const char *propq)
 {
-    EVP_MD *md = EVP_MD_fetch(libctx, OBJ_nid2sn(nid), propq);
+    EVP_MD *md;
 
+    ERR_set_mark();
+    md = EVP_MD_fetch(libctx, OBJ_nid2sn(nid), propq);
+    ERR_pop_to_mark();
     if (md != NULL) {
         EVP_MD_free(md);
         return CMS_add_simple_smimecap(sk, nid, arg);

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -100,8 +100,11 @@ err:
 static int add_cipher_smcap(STACK_OF(X509_ALGOR) *sk, int nid, int arg,
     OSSL_LIB_CTX *libctx, const char *propq)
 {
-    EVP_CIPHER *cipher = EVP_CIPHER_fetch(libctx, OBJ_nid2sn(nid), propq);
+    EVP_CIPHER *cipher;
 
+    ERR_set_mark();
+    cipher = EVP_CIPHER_fetch(libctx, OBJ_nid2sn(nid), propq);
+    ERR_pop_to_mark();
     if (cipher != NULL) {
         EVP_CIPHER_free(cipher);
         return PKCS7_simple_smimecap(sk, nid, arg);
@@ -112,8 +115,11 @@ static int add_cipher_smcap(STACK_OF(X509_ALGOR) *sk, int nid, int arg,
 static int add_digest_smcap(STACK_OF(X509_ALGOR) *sk, int nid, int arg,
     OSSL_LIB_CTX *libctx, const char *propq)
 {
-    EVP_MD *md = EVP_MD_fetch(libctx, OBJ_nid2sn(nid), propq);
+    EVP_MD *md;
 
+    ERR_set_mark();
+    md = EVP_MD_fetch(libctx, OBJ_nid2sn(nid), propq);
+    ERR_pop_to_mark();
     if (md != NULL) {
         EVP_MD_free(md);
         return PKCS7_simple_smimecap(sk, nid, arg);

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -296,7 +296,8 @@ static int test_CMS_add_standard_smimecap_ex(void)
     STACK_OF(X509_ALGOR) *smcap = NULL;
     int ret = 0;
 
-    if (!TEST_true(CMS_add_standard_smimecap_ex(&smcap, NULL, NULL)))
+    if (!TEST_true(CMS_add_standard_smimecap_ex(&smcap, NULL, NULL))
+        || !TEST_int_eq(ERR_peek_error(), 0))
         goto end;
 
     /* AES ciphers must be present with the default provider */

--- a/test/pkcs7_test.c
+++ b/test/pkcs7_test.c
@@ -42,7 +42,8 @@ static int test_pkcs7_smimecap(void)
         || !TEST_true(PKCS7_set_type(p7, NID_pkcs7_signed))
         || !TEST_true(PKCS7_content_new(p7, NID_pkcs7_data))
         || !TEST_ptr(si = PKCS7_sign_add_signer(p7, smimecap_cert,
-                         smimecap_privkey, NULL, 0)))
+                         smimecap_privkey, NULL, 0))
+        || !TEST_int_eq(ERR_peek_error(), 0))
         goto end;
 
     if (!TEST_ptr(smcap = PKCS7_get_smimecap(si)))


### PR DESCRIPTION
`EVP_{CIPHER,MD}_fetch()` raise an error when the requested algorithm is not available, unlike `EVP_get_{cipher,digest}bynid()`.

These are used here only to probe whether particular algorithms are available in the currently active providers. Remove the error queue entries so they are not exposed to the user.

Fixes: 02d0f65c9f85 "CMS/PKCS7: use EVP_CIPHER_fetch() for SMIMECapabilities" (merged from https://github.com/openssl/openssl/pull/31990)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
