### PR TITLE
Validate the host name passed to SSL_set_tlsext_host_name()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,17 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * SSL_set_tlsext_host_name() now validates that the given name is a DNS
+   hostname suitable for the server_name extension as specified in RFC 6066:
+   ASCII labels of letters, digits, hyphens or underscores, no trailing dot,
+   and no IPv4 or IPv6 address literal. Previously any string of at most 255
+   characters was accepted and sent verbatim, producing a non-compliant
+   ClientHello for names such as IP addresses. The function now fails with
+   SSL_R_TLS_EXT_INVALID_SERVERNAME for such names; applications that connect
+   to servers by IP address must not set an SNI host name in that case.
+
+   *Paul Grubbs*
+
  * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
    manpage for details.
 

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -135,6 +135,13 @@ ClientHello extension defined in RFC 3546 section 3.1
 to contain the value I<name> of type B<TLSEXT_NAMETYPE_host_name>.
 If I<name> is NULL, it clears the SNI extension.
 
+I<name> must be a DNS hostname as required by RFC 6066 section 3: a sequence
+of dot-separated labels of 1 to 63 ASCII letters, digits, hyphens or
+underscores, without a trailing dot, at most 255 characters in total, and
+with a top-level label that is not all-numeric. In particular, IPv4 and IPv6
+address literals are not permitted. If I<name> is not a valid hostname the
+function fails and the SNI extension is cleared.
+
 Using this function may also be important for correct routing of connection requests.
 TLS clients should call this function alongside L<SSL_set1_dnsname(3)> or
 L<SSL_add1_dnsname(3)> to set the expected server hostname(s) for certificate validation.
@@ -153,7 +160,8 @@ executed first, then the servername callback, followed by the ALPN callback.
 
 SSL_CTX_set_tlsext_servername_callback() and
 SSL_CTX_set_tlsext_servername_arg() both always return 1 indicating success.
-SSL_set_tlsext_host_name() returns 1 on success, 0 in case of error.
+SSL_set_tlsext_host_name() returns 1 on success, 0 in case of error, for
+example if I<name> is not a valid hostname.
 
 =head1 SEE ALSO
 
@@ -163,6 +171,9 @@ L<SSL_set1_dnsname(3)>, L<SSL_add1_dnsname(3)>,
 L<X509_VERIFY_PARAM_set1_host(3)>, L<X509_VERIFY_PARAM_add1_host(3)>
 
 =head1 HISTORY
+
+SSL_set_tlsext_host_name() validates I<name> as a DNS hostname since
+OpenSSL 4.1. Previously any string of at most 255 characters was accepted.
 
 SSL_get_servername() historically provided some unexpected results in certain
 corner cases. This has been fixed from OpenSSL 1.1.1e.

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3951,6 +3951,45 @@ static char *srp_password_from_info_cb(SSL *s, void *arg)
 
 static int ssl3_set_req_cert_type(CERT *c, const unsigned char *p, size_t len);
 
+/*
+ * Check that |name|, of length |len| (1 <= len <= TLSEXT_MAXLEN_host_name),
+ * is acceptable as the HostName of a server_name extension: RFC 6066,
+ * section 3, requires an ASCII DNS hostname without a trailing dot and
+ * forbids IP address literals.  Labels are separated by dots, are 1 to 63
+ * characters long and consist of ASCII letters, digits, hyphens and, as a
+ * commonly encountered deviation from RFC 1123, underscores.  The top-level
+ * label must not be all-numeric (RFC 1123, section 2.1), which excludes
+ * dotted-decimal IPv4 literals; IPv6 literals fail on the colons.
+ */
+static int is_valid_sni_hostname(const char *name, size_t len)
+{
+    size_t i, label_len = 0;
+    int label_numeric = 1;
+
+    for (i = 0; i < len; i++) {
+        char c = name[i];
+
+        if (c == '.') {
+            /* An empty label: a leading dot or two consecutive dots */
+            if (label_len == 0)
+                return 0;
+            label_len = 0;
+            label_numeric = 1;
+            continue;
+        }
+        if (c < '0' || c > '9') {
+            if ((c < 'a' || c > 'z') && (c < 'A' || c > 'Z')
+                && c != '-' && c != '_')
+                return 0;
+            label_numeric = 0;
+        }
+        if (++label_len > 63)
+            return 0;
+    }
+    /* label_len == 0 here means the name ends with a dot */
+    return label_len > 0 && !label_numeric;
+}
+
 long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 {
     int ret = 0;
@@ -4038,7 +4077,8 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             if (parg == NULL)
                 break;
             len = strlen((char *)parg);
-            if (len == 0 || len > TLSEXT_MAXLEN_host_name) {
+            if (len == 0 || len > TLSEXT_MAXLEN_host_name
+                || !is_valid_sni_hostname((char *)parg, len)) {
                 ERR_raise(ERR_LIB_SSL, SSL_R_TLS_EXT_INVALID_SERVERNAME);
                 return 0;
             }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -16598,6 +16598,83 @@ end:
 
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile srpvfile tmpfile provider config dhfile\n")
 
+/*
+ * Test that SSL_set_tlsext_host_name() accepts valid server_name HostNames
+ * (RFC 6066, section 3) and rejects invalid ones, clearing any previously
+ * set name when it does.
+ */
+static int test_set_tlsext_host_name(void)
+{
+    static const char *const valid[] = {
+        "localhost",
+        "example.com",
+        "EXAMPLE.COM",
+        "xn--nxasmq6b.example",
+        "a-b.c-d.example",
+        "under_score.example",
+        "123.example",
+        "1a.example",
+        /* A 63 character label */
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example",
+    };
+    static const char *const invalid[] = {
+        "",
+        "joe@example.com",
+        "1.1.1.1",
+        "::1",
+        "[::1]",
+        "2001:db8::1",
+        "\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c", /* UTF-8 */
+        "example.com.",
+        ".example.com",
+        "example..com",
+        "example com",
+        "example.com/path",
+        "example.com:443",
+        "123",
+        "example.123",
+        /* A 64 character label */
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example",
+    };
+    SSL_CTX *ctx = NULL;
+    SSL *ssl = NULL;
+    int testresult = 0;
+    size_t i;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new_ex(libctx, NULL, TLS_client_method()))
+        || !TEST_ptr(ssl = SSL_new(ctx)))
+        goto end;
+
+    for (i = 0; i < OSSL_NELEM(valid); i++) {
+        TEST_info("valid: \"%s\"", valid[i]);
+        if (!TEST_true(SSL_set_tlsext_host_name(ssl, valid[i]))
+            || !TEST_str_eq(SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name),
+                valid[i]))
+            goto end;
+    }
+
+    for (i = 0; i < OSSL_NELEM(invalid); i++) {
+        TEST_info("invalid: \"%s\"", invalid[i]);
+        /* A rejected name must also clear the previously set one */
+        if (!TEST_true(SSL_set_tlsext_host_name(ssl, "example.com"))
+            || !TEST_false(SSL_set_tlsext_host_name(ssl, invalid[i]))
+            || !TEST_ptr_null(SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name)))
+            goto end;
+    }
+
+    /* NULL clears the name */
+    if (!TEST_true(SSL_set_tlsext_host_name(ssl, "example.com"))
+        || !TEST_true(SSL_set_tlsext_host_name(ssl, NULL))
+        || !TEST_ptr_null(SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    return testresult;
+}
+
 int setup_tests(void)
 {
     char *modulename;
@@ -16917,6 +16994,7 @@ int setup_tests(void)
 #endif
 #if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3)
     ADD_ALL_TESTS(test_sni_tls13, 2);
+    ADD_TEST(test_set_tlsext_host_name);
     ADD_ALL_TESTS(test_ticket_lifetime, 4);
 #endif
     ADD_TEST(test_inherit_verify_param);


### PR DESCRIPTION
RFC 6066 §3 defines the `HostName` of the `server_name` extension as the fully qualified DNS hostname of the server, "represented as a byte string using ASCII encoding without a trailing dot", and states that "literal IPv4 and IPv6 addresses are not permitted". `SSL_set_tlsext_host_name()` only checked that the name was 1–255 bytes long and sent anything else verbatim, so `"1.1.1.1"`, `"joe@example.com"`, `"example.com."` or a UTF-8 string all succeeded and produced a non-conforming ClientHello (#20041; the earlier #8083 only fixed `openssl s_client`).

This PR validates the name in the `SSL_CTRL_SET_TLSEXT_HOSTNAME` ctrl (`ssl/s3_lib.c`), in a small self-contained helper:

- dot-separated labels of 1–63 ASCII letters, digits, hyphens or underscores (underscore is a deliberate deviation from RFC 1123 that `openssl s_client`'s `is_dNS_name()` already tolerates, and hostnames with `_` do occur in practice);
- no empty label, so no leading dot, no `..`, and no trailing dot;
- the top-level label must not be all-numeric (RFC 1123 §2.1: a hostname can never be dotted-decimal because the top-level label is alphabetic). This rejects IPv4 literals without any address parsing; IPv6 literals fail on the colons.

An invalid name fails with `SSL_R_TLS_EXT_INVALID_SERVERNAME` and, exactly as already happened for over-long names, clears any previously set name. `NULL` still clears the extension. The existing 255-byte limit is unchanged. QUIC is covered since `ossl_quic_ctrl()` forwards this ctrl to the inner TLS object.

Design note: Go, curl and others handle this by silently *omitting* SNI for IP literals. I chose to return an error instead, as the issue requests: silently changing what is sent is harder to test and hides caller bugs, and `openssl s_client` already implements the omit-for-IP policy at the application layer.

Compatibility: applications that pass an IP address (or a name with a trailing dot) to `SSL_set_tlsext_host_name()` will now get a failure return and must skip the call for IP addresses. This is called out in CHANGES.md and in the man page's HISTORY section.

Before:
```
$ openssl s_client -servername 1.1.1.1 -connect ...   # sends server_name = "1.1.1.1"
```
After:
```
$ openssl s_client -servername 1.1.1.1 -connect ...
Unable to set TLS servername extension.
```

Tests: `sslapitest` gets `test_set_tlsext_host_name()` with 9 valid names (including a 63-character label, punycode, underscore, digits-leading labels) and 16 invalid ones (the four examples from the issue, IPv6 forms, `..`, leading dot, space, `/`, `:`, all-numeric TLD, a 64-character label), and checks that a rejected name clears the previously set one. Full `make test` passes locally; the changed files compile cleanly with the `--strict-warnings` flag set, `make doc-nits` is clean, and `ssl/s3_lib.c` is `clang-format` clean.

Fixes #20041

Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
