### PR TITLE
Fix CMS one-shot signing of content at exact 10 KiB boundaries

### DIFF
--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -967,18 +967,30 @@ static int cms_bio_read(BIO *in,
     *buffer = NULL;
     *buffer_len = 0;
 
-    /* read data from BIO into memory */
-    do {
-        *buffer_len += 10240;
-        tmp = OPENSSL_realloc(*buffer, *buffer_len);
-        if (!tmp)
-            goto err;
-        *buffer = tmp;
+    /*
+     * Read data from BIO into memory.  A file BIO only reports EOF once a
+     * read has hit the end of the file, so a read returning 0 is the normal
+     * end of the content (which may be empty or an exact multiple of the
+     * chunk size) rather than an error.
+     */
+    for (;;) {
+        if (offset == *buffer_len) {
+            *buffer_len += 10240;
+            tmp = OPENSSL_realloc(*buffer, *buffer_len);
+            if (tmp == NULL)
+                goto err;
+            *buffer = tmp;
+        }
 
-        if ((n = BIO_read(in, &(*buffer)[offset], 10240)) <= 0)
+        n = BIO_read(in, &(*buffer)[offset], (int)(*buffer_len - offset));
+        if (n < 0)
             goto err;
+        if (n == 0)
+            break;
         offset += n;
-    } while (BIO_eof(in) != 1);
+        if (BIO_eof(in) == 1)
+            break;
+    }
 
     *buffer_len = offset;
 

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -954,6 +954,56 @@ ASN1_OCTET_STRING *CMS_SignerInfo_get0_signature(CMS_SignerInfo *si)
     return si->signature;
 }
 
+/*
+ * The md-less signing and verification paths below re-read the content from
+ * |in| after CMS_final() or CMS_verify() has already drained it once.  That
+ * is only sound for a rewindable source BIO: for a filter chain (such as
+ * BIO_f_cipher or BIO_f_base64 over a source) BIO_seek() resets only the
+ * underlying source while the filter keeps its end-of-data (or error) state,
+ * which on the next read is indistinguishable from an empty source.  Reject
+ * chains instead of signing or verifying wrong content: transforming filters
+ * never worked on these paths, and their exhausted or failed state cannot be
+ * told apart from a clean end of content at read time.
+ */
+static int cms_bio_rewind(BIO *in)
+{
+    if (BIO_next(in) != NULL) {
+        ERR_raise(ERR_LIB_CMS, ERR_R_UNSUPPORTED);
+        return 0;
+    }
+    return BIO_seek(in, 0) >= 0;
+}
+
+/*
+ * Read the next chunk of content from |in| into |buf|.
+ * Returns the number of bytes read, 0 at the clean end of the content, or
+ * -1 on error.  A read result of 0 is the normal end of the content (a file
+ * BIO only reports EOF once a read has hit the end of the file, so the
+ * content may be empty or an exact multiple of the previous read sizes),
+ * unless the BIO asks for a retry: content that is not fully available
+ * cannot be signed or verified here.  A memory BIO at the end of its data
+ * returns a negative value with the retry flag set, but also reports EOF,
+ * which distinguishes it from a genuine retry request.
+ */
+static int cms_bio_read_chunk(BIO *in, unsigned char *buf, size_t buf_len)
+{
+    int n = BIO_read(in, buf, buf_len > INT_MAX ? INT_MAX : (int)buf_len);
+
+    if (n > 0)
+        return n;
+    if (BIO_should_retry(in)) {
+        if (n < 0 && BIO_eof(in) == 1)
+            return 0;
+        ERR_raise(ERR_LIB_CMS, ERR_R_BIO_LIB);
+        return -1;
+    }
+    if (n < 0) {
+        ERR_raise(ERR_LIB_CMS, ERR_R_BIO_LIB);
+        return -1;
+    }
+    return 0;
+}
+
 static int cms_bio_read(BIO *in,
     unsigned char **buffer, size_t *buffer_len)
 {
@@ -961,18 +1011,9 @@ static int cms_bio_read(BIO *in,
     size_t offset = 0;
     int n;
 
-    if (BIO_seek(in, 0) < 0)
-        return -1;
-
     *buffer = NULL;
     *buffer_len = 0;
 
-    /*
-     * Read data from BIO into memory.  A file BIO only reports EOF once a
-     * read has hit the end of the file, so a read returning 0 is the normal
-     * end of the content (which may be empty or an exact multiple of the
-     * chunk size) rather than an error.
-     */
     for (;;) {
         if (offset == *buffer_len) {
             *buffer_len += 10240;
@@ -982,7 +1023,7 @@ static int cms_bio_read(BIO *in,
             *buffer = tmp;
         }
 
-        n = BIO_read(in, &(*buffer)[offset], (int)(*buffer_len - offset));
+        n = cms_bio_read_chunk(in, &(*buffer)[offset], *buffer_len - offset);
         if (n < 0)
             goto err;
         if (n == 0)
@@ -1009,6 +1050,9 @@ static int cms_EVP_PKEY_sign(EVP_PKEY_CTX *pctx, BIO *in,
     size_t buffer_len;
     int ret;
 
+    if (cms_bio_rewind(in) != 1)
+        return 0;
+
     if (!has_msg_update) {
         unsigned char *buffer = NULL;
 
@@ -1020,16 +1064,15 @@ static int cms_EVP_PKEY_sign(EVP_PKEY_CTX *pctx, BIO *in,
         unsigned char buffer[1024];
         int n;
 
-        if (BIO_seek(in, 0) < 0)
-            return 0;
-
         do {
-            n = BIO_read(in, buffer, sizeof(buffer));
-            if (n <= 0)
+            n = cms_bio_read_chunk(in, buffer, sizeof(buffer));
+            if (n < 0)
+                return 0;
+            if (n == 0)
                 break;
             if (EVP_PKEY_sign_message_update(pctx, buffer, n) != 1)
                 return 0;
-        } while (!BIO_eof(in));
+        } while (BIO_eof(in) != 1);
         ret = EVP_PKEY_sign_message_final(pctx, sig, sig_len);
     }
     return ret;
@@ -1040,6 +1083,9 @@ static int cms_EVP_PKEY_verify(EVP_PKEY_CTX *pctx, BIO *in, unsigned char *sig,
 {
     size_t buffer_len;
     int ret;
+
+    if (cms_bio_rewind(in) != 1)
+        return 0;
 
     if (!has_msg_update) {
         unsigned char *buffer = NULL;
@@ -1053,16 +1099,15 @@ static int cms_EVP_PKEY_verify(EVP_PKEY_CTX *pctx, BIO *in, unsigned char *sig,
         unsigned char buffer[1024];
         int n;
 
-        if (BIO_seek(in, 0) < 0)
-            return 0;
-
         do {
-            n = BIO_read(in, buffer, sizeof(buffer));
-            if (n <= 0)
+            n = cms_bio_read_chunk(in, buffer, sizeof(buffer));
+            if (n < 0)
+                return 0;
+            if (n == 0)
                 break;
             if (EVP_PKEY_verify_message_update(pctx, buffer, n) != 1)
                 return 0;
-        } while (!BIO_eof(in));
+        } while (BIO_eof(in) != 1);
         if (EVP_PKEY_CTX_set_signature(pctx, sig, siglen) != 1)
             return 0;
         ret = EVP_PKEY_verify_message_final(pctx);

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -21,6 +21,8 @@ static X509 *cert = NULL;
 static EVP_PKEY *privkey = NULL;
 static X509 *ed448_cert = NULL;
 static EVP_PKEY *ed448_privkey = NULL;
+static X509 *ml_dsa_cert = NULL;
+static EVP_PKEY *ml_dsa_privkey = NULL;
 static char *derin = NULL;
 static char *too_long_iv_cms_in = NULL;
 static char *pwri_kek_oob_der_in = NULL;
@@ -948,7 +950,156 @@ end:
 }
 #endif
 
-OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer pwriKekNoIv ecrecip [ed448certfile ed448privkeyfile]\n")
+/*
+ * A BIO_METHOD for the content read tests below: reads deliver
+ * |content_bio_data| bytes of 'A' in chunks and then either request a read
+ * retry or report an error, depending on |content_bio_retry|.  A seek or
+ * reset rewinds it, as the CMS code re-reads the content it signs.
+ */
+static size_t content_bio_pos;
+static size_t content_bio_data;
+static int content_bio_retry;
+
+static int content_bio_read(BIO *b, char *out, int outl)
+{
+    size_t n = content_bio_data - content_bio_pos;
+
+    if (n == 0) {
+        if (content_bio_retry) {
+            BIO_set_retry_read(b);
+            return 0;
+        }
+        return -1;
+    }
+    if (n > (size_t)outl)
+        n = (size_t)outl;
+    memset(out, 'A', n);
+    content_bio_pos += n;
+    return (int)n;
+}
+
+static long content_bio_ctrl(BIO *b, int cmd, long num, void *ptr)
+{
+    switch (cmd) {
+    case BIO_C_FILE_SEEK:
+    case BIO_CTRL_RESET:
+        content_bio_pos = 0;
+        return 0;
+    case BIO_CTRL_EOF:
+        return 0;
+    }
+    return 0;
+}
+
+static BIO *content_bio_new(BIO_METHOD **meth, size_t datalen, int retry)
+{
+    BIO *bio;
+
+    *meth = BIO_meth_new(BIO_get_new_index() | BIO_TYPE_SOURCE_SINK,
+        "test content source");
+    if (*meth == NULL
+        || !BIO_meth_set_read(*meth, content_bio_read)
+        || !BIO_meth_set_ctrl(*meth, content_bio_ctrl)
+        || (bio = BIO_new(*meth)) == NULL) {
+        BIO_meth_free(*meth);
+        *meth = NULL;
+        return NULL;
+    }
+    BIO_set_init(bio, 1);
+    content_bio_pos = 0;
+    content_bio_data = datalen;
+    content_bio_retry = retry;
+    return bio;
+}
+
+/*
+ * Signing and verifying detached empty content supplied in an empty
+ * writable memory BIO must work: such a BIO reports the end of its data
+ * with a negative read result and the retry flag set, alongside EOF.
+ */
+static int test_cms_sign_verify_empty_mem_content(void)
+{
+    BIO *content = NULL, *vcontent = NULL;
+    CMS_ContentInfo *cms = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(content = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(cms = CMS_sign(ed448_cert, ed448_privkey, NULL, content,
+                         CMS_DETACHED | CMS_BINARY | CMS_NOATTR)))
+        goto end;
+    /*
+     * An empty read-only memory BIO for the verification side: the generic
+     * content copying in CMS_verify() (cms_copy_content()) predates this
+     * code in rejecting the negative read result of an empty writable
+     * memory BIO.
+     */
+    if (!TEST_ptr(vcontent = BIO_new_mem_buf("", 0))
+        || !TEST_int_eq(CMS_verify(cms, NULL, NULL, vcontent, NULL,
+                            CMS_BINARY | CMS_NO_SIGNER_CERT_VERIFY),
+            1))
+        goto end;
+    ret = 1;
+end:
+    CMS_ContentInfo_free(cms);
+    BIO_free(content);
+    BIO_free(vcontent);
+    return ret;
+}
+
+/*
+ * A content BIO that delivers some data and then requests a read retry has
+ * not delivered the complete content: signing must fail rather than sign
+ * the prefix that arrived before the retry.
+ */
+static int test_cms_sign_content_read_retry(void)
+{
+    BIO_METHOD *meth = NULL;
+    BIO *content = NULL;
+    CMS_ContentInfo *cms = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(content = content_bio_new(&meth, 100, 1)))
+        goto end;
+    cms = CMS_sign(ed448_cert, ed448_privkey, NULL, content,
+        CMS_DETACHED | CMS_BINARY | CMS_NOATTR);
+    if (!TEST_ptr_null(cms))
+        goto end;
+    ERR_clear_error();
+    ret = 1;
+end:
+    CMS_ContentInfo_free(cms);
+    BIO_free(content);
+    BIO_meth_free(meth);
+    return ret;
+}
+
+/*
+ * The same for a mid-content read error on the message update path
+ * (ML-DSA): the error must not be treated as the end of the content.
+ */
+static int test_cms_sign_content_read_error(void)
+{
+    BIO_METHOD *meth = NULL;
+    BIO *content = NULL;
+    CMS_ContentInfo *cms = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(content = content_bio_new(&meth, 2048, 0)))
+        goto end;
+    cms = CMS_sign(ml_dsa_cert, ml_dsa_privkey, NULL, content,
+        CMS_DETACHED | CMS_BINARY | CMS_NOATTR);
+    if (!TEST_ptr_null(cms))
+        goto end;
+    ERR_clear_error();
+    ret = 1;
+end:
+    CMS_ContentInfo_free(cms);
+    BIO_free(content);
+    BIO_meth_free(meth);
+    return ret;
+}
+
+OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer pwriKekNoIv ecrecip [ed448certfile ed448privkeyfile [mldsacertfile mldsaprivkeyfile]]\n")
 
 int setup_tests(void)
 {
@@ -982,14 +1133,27 @@ int setup_tests(void)
         ed448_certin = test_get_argument(7);
         ed448_privkeyin = test_get_argument(8);
 
-        if (!TEST_ptr(ed448_cert = load_cert_pem(ed448_certin, NULL))
-            || !TEST_ptr(ed448_privkey = load_pkey_pem(ed448_privkeyin, NULL))) {
+        if (strcmp(ed448_certin, "none") != 0
+            && (!TEST_ptr(ed448_cert = load_cert_pem(ed448_certin, NULL))
+                || !TEST_ptr(ed448_privkey = load_pkey_pem(ed448_privkeyin,
+                                 NULL)))) {
             X509_free(ed448_cert);
             ed448_cert = NULL;
             EVP_PKEY_free(ed448_privkey);
             ed448_privkey = NULL;
             return 0;
         }
+    }
+
+    if (test_get_argument_count() > 10) {
+        const char *ml_dsa_certin = test_get_argument(9);
+        const char *ml_dsa_privkeyin = test_get_argument(10);
+
+        if (strcmp(ml_dsa_certin, "none") != 0
+            && (!TEST_ptr(ml_dsa_cert = load_cert_pem(ml_dsa_certin, NULL))
+                || !TEST_ptr(ml_dsa_privkey = load_pkey_pem(ml_dsa_privkeyin,
+                                 NULL))))
+            return 0;
     }
 
     ADD_TEST(test_encrypt_decrypt_aes_cbc);
@@ -1013,7 +1177,11 @@ int setup_tests(void)
         ADD_TEST(test_CMS_add1_signer_ed448_signed_attrs);
         ADD_TEST(test_CMS_add1_signer_ed448_signed_attrs_md);
         ADD_TEST(test_CMS_add1_signer_ed448_noattr);
+        ADD_TEST(test_cms_sign_verify_empty_mem_content);
+        ADD_TEST(test_cms_sign_content_read_retry);
     }
+    if (ml_dsa_cert != NULL && ml_dsa_privkey != NULL)
+        ADD_TEST(test_cms_sign_content_read_error);
 
 #if !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_X963KDF)
     ADD_TEST(test_kari_wrap_pad_unwrap_overflow);
@@ -1027,4 +1195,6 @@ void cleanup_tests(void)
     EVP_PKEY_free(privkey);
     X509_free(ed448_cert);
     EVP_PKEY_free(ed448_privkey);
+    X509_free(ml_dsa_cert);
+    EVP_PKEY_free(ml_dsa_privkey);
 }

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -1616,6 +1616,54 @@ subtest "EdDSA -noattr tests for CMS" => sub {
     }
 };
 
+subtest "CMS -noattr with content sizes at the internal read boundary" => sub {
+    plan tests => 9;
+
+    SKIP: {
+        skip "ECX (EdDSA) is not supported in this build", 9
+            if disabled("ecx");
+        skip "ECX (EdDSA) -noattr is not supported with old FIPS providers", 9
+            if $old_fips;
+
+        my $crt = srctop_file("test", "certs", "root-ed25519.pem");
+        my $key = srctop_file("test", "certs", "root-ed25519.privkey.pem");
+
+        # Signing and verifying with a one-shot (md-less) algorithm reads the
+        # content from the input BIO in 10240 byte chunks.  Content that is
+        # empty or an exact multiple of the chunk size used to be rejected
+        # because a file BIO does not report EOF until a read hits the end.
+        foreach my $size (0, 10240, 20480) {
+            my $content = "boundary-$size.bin";
+            my $tampered = "boundary-$size-tampered.bin";
+            my $sig = "boundary-$size.cms";
+
+            open(my $fh, ">", $content) or die "Cannot write $content: $!";
+            binmode $fh;
+            print $fh "A" x $size;
+            close $fh;
+            open($fh, ">", $tampered) or die "Cannot write $tampered: $!";
+            binmode $fh;
+            print $fh "A" x $size, "B";
+            close $fh;
+
+            ok(run(app(["openssl", "cms", @prov, "-sign", "-binary", "-noattr",
+                        "-in", $content, "-outform", "DER", "-signer", $crt,
+                        "-inkey", $key, "-out", $sig])),
+               "sign $size bytes of content with Ed25519 and -noattr");
+
+            ok(run(app(["openssl", "cms", @prov, "-verify", "-binary",
+                        "-in", $sig, "-inform", "DER", "-certfile", $crt,
+                        "-noverify", "-content", $content])),
+               "verify the detached signature over $size bytes of content");
+
+            ok(!run(app(["openssl", "cms", @prov, "-verify", "-binary",
+                         "-in", $sig, "-inform", "DER", "-certfile", $crt,
+                         "-noverify", "-content", $tampered])),
+               "reject the signature for $size bytes of tampered content");
+        }
+    }
+};
+
 subtest "ML-DSA tests for CMS" => sub {
     plan tests => 4;
 

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -56,7 +56,7 @@ my ($no_des, $no_dh, $no_dsa, $no_ec, $no_ec2m, $no_rc2, $no_zlib)
 
 $no_rc2 = 1 if disabled("legacy");
 
-plan tests => 42;
+plan tests => 43;
 
 ok(run(test(["pkcs7_test", srctop_file("test", "certs", "servercert.pem"),
              srctop_file("test", "certs", "serverkey.pem")])), "test pkcs7");
@@ -1617,12 +1617,12 @@ subtest "EdDSA -noattr tests for CMS" => sub {
 };
 
 subtest "CMS -noattr with content sizes at the internal read boundary" => sub {
-    plan tests => 9;
+    plan tests => 15;
 
     SKIP: {
-        skip "ECX (EdDSA) is not supported in this build", 9
+        skip "ECX (EdDSA) is not supported in this build", 15
             if disabled("ecx");
-        skip "ECX (EdDSA) -noattr is not supported with old FIPS providers", 9
+        skip "ECX (EdDSA) -noattr is not supported with old FIPS providers", 15
             if $old_fips;
 
         my $crt = srctop_file("test", "certs", "root-ed25519.pem");
@@ -1632,7 +1632,7 @@ subtest "CMS -noattr with content sizes at the internal read boundary" => sub {
         # content from the input BIO in 10240 byte chunks.  Content that is
         # empty or an exact multiple of the chunk size used to be rejected
         # because a file BIO does not report EOF until a read hits the end.
-        foreach my $size (0, 10240, 20480) {
+        foreach my $size (0, 10239, 10240, 10241, 20480) {
             my $content = "boundary-$size.bin";
             my $tampered = "boundary-$size-tampered.bin";
             my $sig = "boundary-$size.cms";

--- a/test/recipes/80-test_cmsapi.t
+++ b/test/recipes/80-test_cmsapi.t
@@ -16,9 +16,12 @@ plan skip_all => "CMS is disabled in this build" if disabled("cms");
 
 plan tests => 1;
 
-my @ed448_args = disabled("ecx") ? () : (
+my @ed448_args = disabled("ecx") ? ("none", "none") : (
     srctop_file("test", "certs", "server-ed448-cert.pem"),
     srctop_file("test", "certs", "server-ed448-key.pem"));
+my @mldsa_args = disabled("ml-dsa") ? ("none", "none") : (
+    srctop_file("test", "certs", "server-ml-dsa-44-cert.pem"),
+    srctop_file("test", "certs", "server-ml-dsa-44-key.pem"));
 
 ok(run(test(["cmsapitest", srctop_file("test", "certs", "servercert.pem"),
              srctop_file("test", "certs", "serverkey.pem"),
@@ -27,5 +30,5 @@ ok(run(test(["cmsapitest", srctop_file("test", "certs", "servercert.pem"),
              srctop_file("test", "recipes", "80-test_cmsapi_data", "cms_pwri_kek_oob.der"),
              srctop_file("test", "recipes", "80-test_cmsapi_data", "cms_pwri_kek_NoIV.der"),
              srctop_file("test", "smime-certs", "smec1.pem"),
-             @ed448_args])),
+             @ed448_args, @mldsa_args])),
              "running cmsapitest");


### PR DESCRIPTION
For signature algorithms without a message-update interface (Ed25519, Ed448, SLH-DSA), `cms_bio_read()` in `crypto/cms/cms_sd.c` gathers the whole content into memory before `EVP_PKEY_sign()`/`EVP_PKEY_verify()`. It read the input in 10240-byte chunks, treated a `BIO_read()` return of 0 as an error, and only stopped once `BIO_eof()` reported end of input. A file BIO does not report EOF until a read has actually hit the end of the file, so content of exactly 10240, 20480, … bytes failed on the read after the last full chunk, and empty content failed on the first read for every BIO type (#32347). The streaming path for algorithms with message update already treats a zero-length read as end of content.

The fix treats `n == 0` as end of input, fails only on a negative return, and grows the buffer only when it is full. The `BIO_eof()` early exit is kept so memory BIOs behave exactly as before.

Before:
```
$ truncate -s 10240 content.bin
$ openssl cms -sign -binary -noattr -in content.bin -signer root-ed25519.pem \
      -inkey root-ed25519.privkey.pem -outform DER -out sig.cms
Error signing data
```
After: the command succeeds and `openssl cms -verify -binary -content content.bin …` verifies the result; likewise for 0- and 20480-byte content.

Tests: `80-test_cms.t` gets a subtest that signs and verifies detached Ed25519 `-noattr` signatures over content of exactly 0, 10240 and 20480 bytes, and checks that tampered content is rejected. All six sign/verify checks fail without the fix. Full `make test` passes locally on a `--strict-warnings` build; the changed hunk is `clang-format` clean.

Note: attached (`-nodetach`) verification of md-less signatures is not exercised here because it fails for the unrelated reason tracked in #32351.

Fixes #32347

Checklist
- [ ] documentation is added or updated (n/a — no documented behaviour changes)
- [x] tests are added or updated
