### PR TITLE
Do not stop scanning CRL entries on an undecodable entry extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,15 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * A CRL in which an entry carries an undecodable or duplicated reasonCode
+   or certificateIssuer extension is no longer accepted for revocation
+   checking if a later entry carries a critical extension that OpenSSL does
+   not handle. Previously the scan for critical CRL entry extensions stopped
+   at the malformed entry, so such a CRL was used as if it had no critical
+   entry extensions.
+
+   *Paul Grubbs*
+
  * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
    manpage for details.
 

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -126,11 +126,15 @@ static int crl_set_issuers(X509_CRL *crl)
             return 0;
         }
 
+        /*
+         * A present but undecodable (or duplicated) entry extension makes
+         * the CRL invalid, but must not stop the processing of this and the
+         * remaining entries: in particular the scan for critical entry
+         * extensions below has to run for every entry.
+         */
         gtmp = X509_REVOKED_get_ext_d2i(rev, NID_certificate_issuer, &j, NULL);
-        if (gtmp == NULL && j != -1) {
+        if (gtmp == NULL && j != -1)
             crl->flags |= EXFLAG_INVALID;
-            return 1;
-        }
 
         if (gtmp != NULL) {
             /*
@@ -163,10 +167,8 @@ static int crl_set_issuers(X509_CRL *crl)
         rev->issuer = most_recent_issuer;
 
         reason = X509_REVOKED_get_ext_d2i(rev, NID_crl_reason, &j, NULL);
-        if (reason == NULL && j != -1) {
+        if (reason == NULL && j != -1)
             crl->flags |= EXFLAG_INVALID;
-            return 1;
-        }
 
         if (reason != NULL) {
             rev->reason = ASN1_ENUMERATED_get(reason);

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -1031,6 +1031,56 @@ static const char *kCrlIndirectNoChain[] = {
 };
 
 /*
+ * kCrlBadEntryExtThenCritical is issued by kRoot and revokes serials 0x2001
+ * and 0x2002 (neither is kLeaf).  The first entry carries a non-critical
+ * reasonCode extension whose extnValue is a NULL (undecodable as an
+ * ENUMERATED); the second entry carries a holdInstructionCode extension
+ * marked critical.  The CRL must be rejected because of the unhandled
+ * critical entry extension irrespective of the order of the entries.
+ */
+static const char *kCrlBadEntryExtThenCritical[] = {
+    "-----BEGIN X509 CRL-----\n",
+    "MIICXDCCAUQCAQEwDQYJKoZIhvcNAQELBQAwgZAxCzAJBgNVBAYTAlVTMRMwEQYD\n",
+    "VQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMRUwEwYDVQQK\n",
+    "DAxFeGFtcGxlIENvcnAxHjAcBgNVBAsMFUNlcnRpZmljYXRlIEF1dGhvcml0eTEd\n",
+    "MBsGA1UEAwwURXhhbXBsZSBDb3JwIFJvb3QgQ0EXDTI2MDMxMDA4MDAwMFoXDTI2\n",
+    "MDYwODA4MDAwMFowTjAgAgIgARcNMjYwMzA5MDgwMDAwWjALMAkGA1UdFQQCBQAw\n",
+    "KgICIAIXDTI2MDMwOTA4MDAwMFowFTATBgNVHRcBAf8ECQYHKoZIzjgCAqAvMC0w\n",
+    "HwYDVR0jBBgwFoAU/hQOExsJZ8tKDUvaT/PvkLVD2zMwCgYDVR0UBAMCARQwDQYJ\n",
+    "KoZIhvcNAQELBQADggEBACWCR/fLsbFGa8Q5qEki6k8KcJHaNLLow2+R5vXnjJNU\n",
+    "zDOiDOcFyO4jGQH57qv4X426MysjI/w7HVzr0IXqU1uTeUFTePx44DhInF0tBlRw\n",
+    "v3HA+OvgZRr5iAIMmLt05KFECA2a6dCyVAFbA3EG5xwESUKQ8Fe06GaaeSeNb+MW\n",
+    "sNEFGjYMMR10jCqhXHNXhDMpi/FwCtIlgSgjOic9Dl+DblBpsMyKtzce0fIqk3Wv\n",
+    "YxtTmPL/ApnYxwS7bMuB0GEoJY8FkTblzrI5g3dJMMXMjmnDjpNl51bpabLVbEP/\n",
+    "ax8SSa45mqfU91qgxhAF/ioU6iJdhEbn1m6dtPbcLcE=\n",
+    "-----END X509 CRL-----\n",
+    NULL
+};
+
+/*
+ * kCrlCriticalThenBadEntryExt is kCrlBadEntryExtThenCritical with the two
+ * entries in the opposite order (and CRL number 21 instead of 20).
+ */
+static const char *kCrlCriticalThenBadEntryExt[] = {
+    "-----BEGIN X509 CRL-----\n",
+    "MIICXDCCAUQCAQEwDQYJKoZIhvcNAQELBQAwgZAxCzAJBgNVBAYTAlVTMRMwEQYD\n",
+    "VQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMRUwEwYDVQQK\n",
+    "DAxFeGFtcGxlIENvcnAxHjAcBgNVBAsMFUNlcnRpZmljYXRlIEF1dGhvcml0eTEd\n",
+    "MBsGA1UEAwwURXhhbXBsZSBDb3JwIFJvb3QgQ0EXDTI2MDMxMDA4MDAwMFoXDTI2\n",
+    "MDYwODA4MDAwMFowTjAqAgIgARcNMjYwMzA5MDgwMDAwWjAVMBMGA1UdFwEB/wQJ\n",
+    "BgcqhkjOOAICMCACAiACFw0yNjAzMDkwODAwMDBaMAswCQYDVR0VBAIFAKAvMC0w\n",
+    "HwYDVR0jBBgwFoAU/hQOExsJZ8tKDUvaT/PvkLVD2zMwCgYDVR0UBAMCARUwDQYJ\n",
+    "KoZIhvcNAQELBQADggEBAGmwTI/yvJleHEdABJ4Al6A5nbSbVVepcLQQrQO1G5n2\n",
+    "deP3jpKlhY95uC1PMm4l+dGAMDBAzWbErYwjiNNM6w8wgwjGq/3nry2ODQW+YiAV\n",
+    "MO2e8CEttvsIfa/xXs32AR7rlNgGNbAxyoMKrsNpKmfOBzdYyWWolhrb0xPOHH7c\n",
+    "qT2Agm88A9zRWBwDurerUUl5/iliTm77+Z8o/6PFSufo4j1FvhRrXympKdPjnKNa\n",
+    "K47XR2Cm6pXF0gjn2kAdLxeJ26APt5I+aFXagGgSDRT/zvWFFPTMfjUK8cKwR3VX\n",
+    "W01kNw/zS5Yb/f//BvM8iNhzcgijC9O2WgZMeLY7LFY=\n",
+    "-----END X509 CRL-----\n",
+    NULL
+};
+
+/*
  * A well-formed CRL issued by kRoot (sha256WithRSAEncryption, inner and
  * outer signatureAlgorithm identical), used as the positive test case in
  * test_crl_sigalg_mismatch.
@@ -1748,6 +1798,37 @@ static int test_crl_extension_duplicate_entry(void)
     return test;
 }
 
+/*
+ * An undecodable entry extension must not stop the scan for critical CRL
+ * entry extensions on the remaining entries.
+ */
+static int test_crl_bad_entry_ext_critical(void)
+{
+    X509 *root = NULL;
+    X509 *leaf = NULL;
+    X509_CRL *crl1 = NULL;
+    X509_CRL *crl2 = NULL;
+    STACK_OF(X509_CRL) *crls;
+    unsigned int flags = X509_V_FLAG_CRL_CHECK;
+    unsigned int expect = X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION;
+    int test;
+
+    test = TEST_ptr(root = X509_from_strings(kRoot))
+        && TEST_ptr(leaf = X509_from_strings(kLeaf))
+        && TEST_ptr((crl1 = CRL_from_strings(kCrlBadEntryExtThenCritical)))
+        && TEST_ptr((crls = make_CRL_stack(crl1, NULL)))
+        && TEST_int_eq(verify(leaf, root, crls, flags, kVerify), expect)
+        && TEST_ptr((crl2 = CRL_from_strings(kCrlCriticalThenBadEntryExt)))
+        && TEST_ptr((crls = make_CRL_stack(crl2, NULL)))
+        && TEST_int_eq(verify(leaf, root, crls, flags, kVerify), expect);
+
+    X509_CRL_free(crl1);
+    X509_CRL_free(crl2);
+    X509_free(root);
+    X509_free(leaf);
+    return test;
+}
+
 static int test_crl_extension_duplicate_serial(void)
 {
     X509 *root = NULL;
@@ -2027,6 +2108,7 @@ int setup_tests(void)
     ADD_TEST(test_crl_extension_duplicate);
     ADD_TEST(test_crl_extension_duplicate_entry);
     ADD_TEST(test_crl_extension_duplicate_serial);
+    ADD_TEST(test_crl_bad_entry_ext_critical);
     ADD_MFAIL_NO_CHECK_TEST(test_crl_indirect_mfail);
     ADD_TEST(test_crl_indirect_revoked);
     ADD_TEST(test_crl_indirect_wrong_ta);


### PR DESCRIPTION
`crl_set_issuers()` (`crypto/x509/x_crl.c`) caches the `certificateIssuer` and `reasonCode` extensions of each CRL entry and, in the same loop, sets `EXFLAG_CRITICAL` if any entry carries a critical extension OpenSSL does not handle; `X509_verify_cert()` then refuses to use such a CRL (RFC 5280 §5.3). When either cached extension was present but undecodable (or duplicated), the loop set `EXFLAG_INVALID` and **returned 1**, so the remaining entries were never scanned. `EXFLAG_INVALID` is not consulted anywhere for CRLs, so a CRL whose first entry has a malformed non-critical `reasonCode` and whose second entry has a critical extension was accepted for revocation checking, while the same CRL with the entries swapped was rejected (#32366).

This PR keeps setting `EXFLAG_INVALID` but continues processing the entry and the entries after it, so the critical-extension scan covers the whole CRL. The malformed entry is otherwise treated as if the extension were absent (it inherits the previous `certificateIssuer`, as §5.3.3 prescribes). The CRL still loads as before; rejecting it outright at decode time (`return 0`) would be a behaviour change for CRLs that are accepted today and is deliberately not done here — happy to switch if maintainers prefer strictness. A CHANGES.md entry documents the new rejection.

Before:
```
$ openssl verify -crl_check -CAfile root.pem -CRLfile bad-then-critical.crl leaf.pem
leaf.pem: OK
```
After:
```
error 36 at 0 depth lookup: unhandled critical CRL extension
```

Tests: `test/crltest.c` gains two CRLs signed by the existing test root — a malformed `reasonCode` (`extnValue` = NULL) on the first entry followed by a critical `holdInstructionCode` on the second, and the same two entries in the opposite order — and a test expecting `X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION` for both. The first case fails before this change and passes after; the second is the regression guard. Full `make test` passes locally on a `--strict-warnings` build; `clang-format` clean.

Fixes #32366

Checklist
- [x] documentation is added or updated (CHANGES.md)
- [x] tests are added or updated
