### PR TITLE
Fix NULL dereference in EVP_PKEY_CTX_set_dh_paramgen_type()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,14 @@ OpenSSL 4.1
 
    *Daniel Kubec and Viktor Dukhovni*
 
+ * Fixed a NULL pointer dereference in EVP_PKEY_CTX_set_dh_paramgen_type().
+   The legacy ctrl was translated into a UTF8 string OSSL_PARAM without
+   converting the integer type to its name, so the DH provider dereferenced a
+   NULL string for every type value, including the documented
+   DH_PARAMGEN_TYPE_GENERATOR.
+
+   *Paul Grubbs*
+
  * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
    manpage for details.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,14 +39,6 @@ OpenSSL 4.1
 
    *Daniel Kubec and Viktor Dukhovni*
 
- * Fixed a NULL pointer dereference in EVP_PKEY_CTX_set_dh_paramgen_type().
-   The legacy ctrl was translated into a UTF8 string OSSL_PARAM without
-   converting the integer type to its name, so the DH provider dereferenced a
-   NULL string for every type value, including the documented
-   DH_PARAMGEN_TYPE_GENERATOR.
-
-   *Paul Grubbs*
-
  * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
    manpage for details.
 

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1086,10 +1086,16 @@ static int fix_dh_paramgen_type(enum state state,
     if (ctx->action_type != OSSL_ACTION_SET)
         return 0;
 
-    if (state == PRE_CTRL_STR_TO_PARAMS) {
-        int id;
+    /*
+     * The provider parameter is the name of the type, so the numeric type
+     * from EVP_PKEY_CTX_set_dh_paramgen_type() (|p1|) or from a ctrl string
+     * (|p2|) must be translated to it.
+     */
+    if (state == PRE_CTRL_TO_PARAMS || state == PRE_CTRL_STR_TO_PARAMS) {
+        int id = ctx->p1;
 
-        if (!ossl_strtoint(ctx->p2, NULL, 10, &id)) {
+        if (state == PRE_CTRL_STR_TO_PARAMS
+            && !ossl_strtoint(ctx->p2, NULL, 10, &id)) {
             ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_VALUE);
             return 0;
         }

--- a/crypto/evp/dsa_ctrl.c
+++ b/crypto/evp/dsa_ctrl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -34,6 +34,11 @@ int EVP_PKEY_CTX_set_dsa_paramgen_type(EVP_PKEY_CTX *ctx, const char *name)
 
     if ((ret = dsa_paramgen_check(ctx)) <= 0)
         return ret;
+
+    if (name == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
 
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_FFC_TYPE,
         (char *)name, 0);

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -623,6 +623,7 @@ static int dh_gen_common_set_params(struct dh_gen_ctx *gctx,
 
     if (p->type != NULL) {
         if (p->type->data_type != OSSL_PARAM_UTF8_STRING
+            || p->type->data == NULL
             || ((gen_type = dh_gen_type_name2id_w_default(p->type->data, gctx->dh_type)) == -1)) {
             ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
             return 0;

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -518,6 +518,7 @@ static int dsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
 
     if (p.type != NULL) {
         if (p.type->data_type != OSSL_PARAM_UTF8_STRING
+            || p.type->data == NULL
             || ((gen_type = dsa_gen_type_name2id(p.type->data)) == -1)) {
             ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
             return 0;

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -801,6 +801,52 @@ err:
     return ok;
 }
 
+/*
+ * EVP_PKEY_CTX_set_dh_paramgen_type() goes through the ctrl to OSSL_PARAM
+ * translation, which used to build a UTF8 string parameter with a NULL data
+ * pointer and crash the provider for any type value.
+ */
+static int dh_set_dh_paramgen_type_test(void)
+{
+    int ok = 0;
+    EVP_PKEY_CTX *paramgen_ctx = NULL, *paramgen_dhx_ctx = NULL;
+
+    paramgen_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_DH, 0);
+    if (!TEST_ptr(paramgen_ctx)
+        || !TEST_int_eq(EVP_PKEY_paramgen_init(paramgen_ctx), 1))
+        goto err;
+    /* Tested function is called here */
+    if (!TEST_int_eq(EVP_PKEY_CTX_set_dh_paramgen_type(paramgen_ctx,
+                         DH_PARAMGEN_TYPE_GENERATOR),
+            1)
+        || !TEST_int_eq(EVP_PKEY_CTX_set_dh_paramgen_type(paramgen_ctx,
+                            DH_PARAMGEN_TYPE_GROUP),
+            1))
+        goto err;
+    /* Negative tests: unknown type, and a DHX-only type on a DH context */
+    if (!TEST_int_le(EVP_PKEY_CTX_set_dh_paramgen_type(paramgen_ctx, 99), 0)
+        || !TEST_int_le(EVP_PKEY_CTX_set_dh_paramgen_type(paramgen_ctx,
+                            DH_PARAMGEN_TYPE_FIPS_186_4),
+            0))
+        goto err;
+
+    paramgen_dhx_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_DHX, 0);
+    if (!TEST_ptr(paramgen_dhx_ctx)
+        || !TEST_int_eq(EVP_PKEY_paramgen_init(paramgen_dhx_ctx), 1)
+        || !TEST_int_eq(EVP_PKEY_CTX_set_dh_paramgen_type(paramgen_dhx_ctx,
+                            DH_PARAMGEN_TYPE_FIPS_186_4),
+            1)
+        || !TEST_int_le(EVP_PKEY_CTX_set_dh_paramgen_type(paramgen_dhx_ctx,
+                            DH_PARAMGEN_TYPE_GENERATOR),
+            0))
+        goto err;
+    ok = 1;
+err:
+    EVP_PKEY_CTX_free(paramgen_ctx);
+    EVP_PKEY_CTX_free(paramgen_dhx_ctx);
+    return ok;
+}
+
 static int dh_get_nid(void)
 {
     int ok = 0;
@@ -949,6 +995,7 @@ int setup_tests(void)
     ADD_TEST(dh_load_pkcs3_namedgroup_privlen_test);
     ADD_TEST(dh_rfc5114_fix_nid_test);
     ADD_TEST(dh_set_dh_nid_test);
+    ADD_TEST(dh_set_dh_paramgen_type_test);
 #endif
     return 1;
 }

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -488,6 +488,37 @@ err:
 
 #endif /* OPENSSL_NO_DSA */
 
+/*
+ * EVP_PKEY_CTX_set_dsa_paramgen_type() builds a UTF8 string OSSL_PARAM from
+ * its |name| argument; a NULL name used to crash the provider, which
+ * compared it with strcasecmp().
+ */
+static int dsa_set_dsa_paramgen_type_test(void)
+{
+    int ok = 0;
+    EVP_PKEY_CTX *paramgen_ctx = NULL;
+
+    paramgen_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_DSA, NULL);
+    if (!TEST_ptr(paramgen_ctx)
+        || !TEST_int_eq(EVP_PKEY_paramgen_init(paramgen_ctx), 1))
+        goto err;
+    if (!TEST_int_eq(EVP_PKEY_CTX_set_dsa_paramgen_type(paramgen_ctx,
+                         "fips186_4"),
+            1))
+        goto err;
+    /* An unknown name and a NULL name fail cleanly */
+    if (!TEST_int_le(EVP_PKEY_CTX_set_dsa_paramgen_type(paramgen_ctx,
+                         "no such type"),
+            0)
+        || !TEST_int_le(EVP_PKEY_CTX_set_dsa_paramgen_type(paramgen_ctx, NULL),
+            0))
+        goto err;
+    ok = 1;
+err:
+    EVP_PKEY_CTX_free(paramgen_ctx);
+    return ok;
+}
+
 int setup_tests(void)
 {
 #ifndef OPENSSL_NO_DSA
@@ -495,6 +526,7 @@ int setup_tests(void)
     ADD_TEST(dsa_keygen_test);
     ADD_TEST(test_dsa_sig_infinite_loop);
     ADD_TEST(test_dsa_sig_neg_param);
+    ADD_TEST(dsa_set_dsa_paramgen_type_test);
     ADD_ALL_TESTS(test_dsa_default_paramgen_validate, 2);
 #endif
     return 1;


### PR DESCRIPTION
`EVP_PKEY_CTX_set_dh_paramgen_type()` is a legacy ctrl that is translated into the `OSSL_PKEY_PARAM_FFC_TYPE` provider parameter, whose value is the *name* of the generation type. `fix_dh_paramgen_type()` in `crypto/evp/ctrl_params_translate.c` performed the int→name translation only for the ctrl-string path (`-pkeyopt dh_paramgen_type:N`), so on the ctrl path `default_fixup_args()` built a UTF8-string `OSSL_PARAM` with `data == NULL` and the DH keymgmt `strcmp()`'d it. The call crashed for every type value, including the documented `DH_PARAMGEN_TYPE_GENERATOR` (#30921).

This PR translates the type for both paths (an unknown type yields `EVP_R_INVALID_VALUE`, as the string path already did) and makes the keymgmt reject a type parameter with a NULL data pointer rather than dereference it. No new error codes; the ctrl-string path is unchanged in behaviour.

Before:
```c
EVP_PKEY_paramgen_init(ctx);
EVP_PKEY_CTX_set_dh_paramgen_type(ctx, DH_PARAMGEN_TYPE_GENERATOR);  /* SIGSEGV */
```
After: returns 1; `EVP_PKEY_CTX_set_dh_paramgen_type(ctx, 99)` returns 0 with `EVP_R_INVALID_VALUE`.

Tests: `test/dhtest.c` gains `dh_set_dh_paramgen_type_test`, covering valid and invalid types on DH and DHX contexts; it segfaults without the fix. Full `make test` passes locally on a `--strict-warnings` build; the changed hunks are `clang-format` clean.

Fixes #30921

Checklist
- [x] documentation is added or updated (CHANGES.md; no API change)
- [x] tests are added or updated
