### PR TITLE
Reject CAdES verification of a SignerInfo without signed attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,14 @@ OpenSSL Releases
 
    *Daniel Kubec and Viktor Dukhovni*
 
+ * CMS_verify() with the CMS_CADES flag, and `openssl cms -verify -cades`, now
+   reject a SignerInfo that has no signed attributes. CAdES requires the ESS
+   signing-certificate signed attribute, but a SignerInfo without any signed
+   attributes (as produced by `openssl cms -sign -noattr`) skipped that check
+   and was wrongly accepted.
+
+   *Jeffrey Kintscher*
+
  * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
    manpage for details.
 

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -433,11 +433,14 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
             si = sk_CMS_SignerInfo_value(sinfos, i);
             if (!si->verify_result)
                 continue;
-            if (CMS_signed_get_attr_count(si) < 0 && !cadesVerify) {
-                si->attr_verified = 1;
-                continue;
-            }
-            if (CMS_SignerInfo_verify(si) <= 0) {
+            /*
+             * A SignerInfo without signed attributes has no attribute
+             * signature to verify, but CAdES still requires the ESS
+             * signing-certificate attribute, so only skip the signature
+             * check here and let ossl_cms_check_signing_certs() fail below.
+             */
+            if (CMS_signed_get_attr_count(si) >= 0
+                && CMS_SignerInfo_verify(si) <= 0) {
                 si->verify_result = 0;
                 continue;
             }

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -433,7 +433,7 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
             si = sk_CMS_SignerInfo_value(sinfos, i);
             if (!si->verify_result)
                 continue;
-            if (CMS_signed_get_attr_count(si) < 0) {
+            if (CMS_signed_get_attr_count(si) < 0 && !cadesVerify) {
                 si->attr_verified = 1;
                 continue;
             }

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -13,6 +13,8 @@
 #include <openssl/cms.h>
 #include <openssl/bio.h>
 #include <openssl/x509.h>
+#include <openssl/err.h>
+#include <openssl/ess.h>
 #include "../crypto/cms/cms_local.h" /* for d.signedData and d.envelopedData */
 
 #include "testutil.h"
@@ -947,6 +949,67 @@ end:
 }
 #endif
 
+/*
+ * A SignerInfo without signed attributes cannot carry the ESS
+ * signing-certificate attribute that CAdES requires, so CMS_verify() with
+ * CMS_CADES must reject it even though the signature itself is valid.
+ */
+static int test_cades_verify_noattr(void)
+{
+    static const char content[] = "Content signed without signed attributes";
+    CMS_ContentInfo *cms = NULL;
+    X509_STORE *store = NULL;
+    BIO *in = NULL, *out = NULL;
+    char *outdata = NULL;
+    long outlen;
+    unsigned long err;
+    int ret = 0;
+
+    if (!TEST_ptr(in = BIO_new_mem_buf(content, sizeof(content) - 1))
+        || !TEST_ptr(cms = CMS_sign(cert, privkey, NULL, in,
+                         CMS_NOATTR | CMS_BINARY)))
+        goto end;
+
+    /*
+     * CAdES verification always verifies the signer certificate, so trust
+     * the (TLS server) test certificate directly and accept any purpose.
+     */
+    if (!TEST_ptr(store = X509_STORE_new())
+        || !TEST_true(X509_STORE_add_cert(store, cert))
+        || !TEST_true(X509_STORE_set_flags(store, X509_V_FLAG_PARTIAL_CHAIN))
+        || !TEST_true(X509_STORE_set_purpose(store, X509_PURPOSE_ANY)))
+        goto end;
+
+    /* Control: signature and certificate verify without CAdES. */
+    if (!TEST_ptr(out = BIO_new(BIO_s_mem()))
+        || !TEST_int_gt(CMS_verify(cms, NULL, store, NULL, out, CMS_BINARY), 0))
+        goto end;
+    outlen = BIO_get_mem_data(out, &outdata);
+    if (!TEST_mem_eq(outdata, outlen, content, sizeof(content) - 1))
+        goto end;
+
+    /* With CAdES the missing signing-certificate attribute must be fatal. */
+    ERR_clear_error();
+    if (!TEST_int_le(CMS_verify(cms, NULL, store, NULL, NULL,
+                         CMS_BINARY | CMS_CADES),
+            0))
+        goto end;
+    err = ERR_peek_error();
+    if (!TEST_int_eq(ERR_GET_LIB(err), ERR_LIB_ESS)
+        || !TEST_int_eq(ERR_GET_REASON(err),
+            ESS_R_MISSING_SIGNING_CERTIFICATE_ATTRIBUTE))
+        goto end;
+    ERR_clear_error();
+
+    ret = 1;
+end:
+    BIO_free(out);
+    BIO_free(in);
+    X509_STORE_free(store);
+    CMS_ContentInfo_free(cms);
+    return ret;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer pwriKekNoIv ecrecip [ed448certfile ed448privkeyfile]\n")
 
 int setup_tests(void)
@@ -1004,6 +1067,7 @@ int setup_tests(void)
     ADD_TEST(test_CMS_set1_key_mem_leak);
     ADD_TEST(test_encrypted_data);
     ADD_TEST(test_encrypted_data_aead);
+    ADD_TEST(test_cades_verify_noattr);
     ADD_ALL_TESTS(test_d2i_CMS_decode, 2);
     ADD_TEST(test_cms_aesgcm_iv_too_long);
     ADD_TEST(test_pwri_kek_unwrap_short_encrypted_key);

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -535,6 +535,16 @@ my @smime_cms_cades_ko_tests = (
       [ @prov, "-verify", "-cades", "-in", "cades-ko.cms", "-inform", "DER",
         "-CAfile", $smroot, "-out", "cades-ko.txt" ],
       \&final_compare
+    ],
+
+    [ "sign content DER format, RSA key, no signed attributes (-noattr)",
+      [ @prov, "-sign", "-in", $smcont, "-outform", "DER", "-nodetach",
+        "-noattr", "-certfile", $smroot, "-signer", $smrsa1,
+        "-out", "cades-noattr.cms" ],
+      "fail to verify token with -cades since it has no signed attributes",
+      [ @prov, "-verify", "-cades", "-in", "cades-noattr.cms", "-inform", "DER",
+        "-CAfile", $smroot, "-out", "cades-noattr.txt" ],
+      \&final_compare
     ]
 );
 


### PR DESCRIPTION
CAdES-BES (ETSI EN 319 122-1) requires every SignerInfo to carry an ESS signing-certificate (or signing-certificate-v2) signed attribute. `CMS_verify()` with `CMS_CADES` enforces this via `ossl_cms_check_signing_certs()`, but the loop in `CMS_verify()` (`crypto/cms/cms_smime.c`) skipped any SignerInfo that has no signed attributes at all before reaching that check. So a message produced with `openssl cms -sign -noattr` — which by construction cannot carry the attribute — was accepted by `openssl cms -verify -cades` as a valid CAdES signature (#27055).

The fix keeps skipping `CMS_SignerInfo_verify()` for such a SignerInfo (there is no attribute signature to verify) but still runs the CAdES signing-certificate check, which fails with the existing `ESS_R_MISSING_SIGNING_CERTIFICATE_ATTRIBUTE`. Verification without `CMS_CADES` is unchanged, and no new error codes are introduced, so this is backportable to the branches the issue is labelled for.

Tests: a recipe ko-test in `80-test_cms.t` (sign with `-noattr`, then `-verify -cades` must fail) and an API test in `cmsapitest.c` with a positive control (plain `CMS_verify` with signer-certificate verification succeeds and returns the content) followed by the `CMS_CADES` rejection with the expected ESS error. Both fail without the source change. Full `make test` passes locally on a `--strict-warnings` build; `clang-format` clean.

This supersedes #29479 by @websurfer5. Their check, adapted to the current `CMS_verify()` loop, together with their recipe test and CHANGES entry form the first commit under their authorship; the second commit (mine) restructures the check so the ESS error is reported and adds the API test. Relative to that PR it is rebased without merge commits, the check is placed so that the ESS error is what gets reported, and the API test is restructured so it exercises the CAdES path rather than failing on certificate-chain verification.

Fixes #27055

Checklist
- [x] documentation is added or updated (CHANGES.md)
- [x] tests are added or updated

