### PR TITLE
Enforce the supported_groups/key_share pairing in TLS 1.3 ClientHellos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,15 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * The TLS 1.3 server now enforces the RFC 8446 section 9.2 requirement that
+   a ClientHello containing a supported_groups extension also contains a
+   key_share extension and vice versa, aborting the handshake with a
+   missing_extension alert otherwise. Previously a PSK resumption ClientHello
+   that offered psk_ke and carried supported_groups but no key_share was
+   accepted when the server allowed non-DHE PSK key exchange.
+
+   *Paul Grubbs*
+
  * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
    manpage for details.
 

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1766,6 +1766,23 @@ static int final_key_share(SSL_CONNECTION *s, unsigned int context, int sent)
      *             send a HelloRetryRequest
      */
     if (s->server) {
+        /*
+         * RFC 8446, section 9.2: a ClientHello containing a supported_groups
+         * extension MUST also contain a key_share extension, and vice versa
+         * (an empty KeyShare.client_shares vector is permitted).  Servers
+         * MUST abort the handshake with a missing_extension alert otherwise.
+         */
+        if (s->clienthello != NULL) {
+            const RAW_EXTENSION *groups = &s->clienthello->pre_proc_exts[TLSEXT_IDX_supported_groups];
+
+            if ((sent != 0) != (groups->present != 0)) {
+                SSLfatal(s, SSL_AD_MISSING_EXTENSION,
+                    sent ? SSL_R_MISSING_SUPPORTED_GROUPS_EXTENSION
+                         : SSL_R_NO_SUITABLE_KEY_SHARE);
+                return 0;
+            }
+        }
+
         if (s->s3.peer_tmp != NULL) {
             /* We have a suitable key_share */
             if ((s->s3.flags & TLS1_FLAGS_STATELESS) != 0

--- a/test/recipes/70-test_tls13kexmodes.t
+++ b/test/recipes/70-test_tls13kexmodes.t
@@ -194,9 +194,11 @@ use constant {
     NON_DHE_KEX_MODE_ONLY => 2,
     DHE_KEX_MODE_ONLY => 3,
     UNKNOWN_KEX_MODES => 4,
-    BOTH_KEX_MODES => 5
+    BOTH_KEX_MODES => 5,
+    BOTH_KEX_MODES_NO_KEY_SHARE => 6,
+    NON_DHE_KEX_MODE_ONLY_NO_GROUPS => 7
 };
-my $testcount = 13;
+my $testcount = 15;
 
 $ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
 
@@ -429,6 +431,35 @@ sub run_tests
     $proxy->start();
     ok(TLSProxy::Message->fail(), "Resume with dhe kex mode, no overlapping groups");
 
+    #Test 14: Attempt a resume with both non-dhe and dhe kex mode and a
+    #         supported_groups extension but no key_share extension. Should fail
+    #         (RFC 8446 section 9.2: a ClientHello containing supported_groups
+    #         MUST also contain key_share), even though non-dhe resumption is
+    #         allowed by the server
+    $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
+    $proxy->clientflags("-curves P-256:P-384:X25519:X448 -no_rx_cert_comp -allow_no_dhe_kex -sess_in " . $session);
+    $proxy->serverflags("-curves P-256:P-384:X25519:X448 -allow_no_dhe_kex");
+    $testtype = BOTH_KEX_MODES_NO_KEY_SHARE;
+    $proxy->start();
+    ok(TLSProxy::Message->fail()
+       && TLSProxy::Message->alert->description()
+          == TLSProxy::Message::AL_DESC_MISSING_EXTENSION,
+       "Resume with both kex modes, supported_groups but no key_share");
+
+    #Test 15: Attempt a resume with non-dhe kex mode only and with neither a
+    #         supported_groups nor a key_share extension. Should resume without
+    #         a key_share (omitting both extensions is permitted for a PSK-only
+    #         ClientHello)
+    $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
+    $proxy->clientflags("-curves P-256:P-384:X25519:X448 -no_rx_cert_comp -allow_no_dhe_kex -sess_in " . $session);
+    $proxy->serverflags("-curves P-256:P-384:X25519:X448 -allow_no_dhe_kex");
+    $testtype = NON_DHE_KEX_MODE_ONLY_NO_GROUPS;
+    $proxy->start();
+    ok(TLSProxy::Message->success(),
+       "Resume with non-dhe kex mode, no supported_groups and no key_share");
+
     unlink $session;
 }
 
@@ -446,7 +477,8 @@ sub modify_kex_modes_filter
             if ($testtype == EMPTY_EXTENSION) {
                 $ext = pack "C",
                     0x00;       #List length
-            } elsif ($testtype == NON_DHE_KEX_MODE_ONLY) {
+            } elsif ($testtype == NON_DHE_KEX_MODE_ONLY
+                     || $testtype == NON_DHE_KEX_MODE_ONLY_NO_GROUPS) {
                 $ext = pack "C2",
                     0x01,       #List length
                     0x00;       #psk_ke
@@ -459,7 +491,8 @@ sub modify_kex_modes_filter
                     0x02,       #List length
                     0xfe,       #unknown
                     0xff;       #unknown
-            } elsif ($testtype == BOTH_KEX_MODES) {
+            } elsif ($testtype == BOTH_KEX_MODES
+                     || $testtype == BOTH_KEX_MODES_NO_KEY_SHARE) {
                 #We deliberately list psk_ke first...should still use psk_dhe_ke, except if the server is configured otherwise.
                 $ext = pack "C3",
                     0x02,       #List length
@@ -473,6 +506,15 @@ sub modify_kex_modes_filter
             } else {
                 $message->set_extension(
                     TLSProxy::Message::EXT_PSK_KEX_MODES, $ext);
+            }
+
+            if ($testtype == BOTH_KEX_MODES_NO_KEY_SHARE
+                || $testtype == NON_DHE_KEX_MODE_ONLY_NO_GROUPS) {
+                $message->delete_extension(TLSProxy::Message::EXT_KEY_SHARE);
+            }
+            if ($testtype == NON_DHE_KEX_MODE_ONLY_NO_GROUPS) {
+                $message->delete_extension(
+                    TLSProxy::Message::EXT_SUPPORTED_GROUPS);
             }
 
             $message->repack();


### PR DESCRIPTION
RFC 8446 §9.2 requires that a TLS 1.3 ClientHello, "if containing a `supported_groups` extension, … MUST also contain a `key_share` extension, and vice versa. An empty KeyShare.client_shares vector is permitted", and that servers receiving a ClientHello violating this "MUST abort the handshake with a `missing_extension` alert". The server enforced only one direction: `tls_parse_ctos_key_share()` rejects a `key_share` without `supported_groups` (and even that is skipped when resuming without `psk_dhe_ke` offered), but nothing rejected `supported_groups` without `key_share`. A PSK resumption ClientHello carrying `supported_groups` and `psk_key_exchange_modes = {psk_ke, psk_dhe_ke}` but no `key_share` was therefore accepted and resumed with `psk_ke` whenever the server sets `SSL_OP_ALLOW_NO_DHE_KEX` (#25124 — closed by the backlog bot, but still present on master).

The fix adds a single presence check at the start of the server branch of `final_key_share()` in `ssl/statem/extensions.c`, which runs for every TLS 1.3 / DTLS 1.3 ClientHello (initial and post-HRR) once all extensions are parsed, mirroring how `final_psk()` checks for `psk_key_exchange_modes`. Both directions are checked; a ClientHello with neither extension remains valid; an empty `key_share` counts as present. The §4.2.9 wording about `psk_dhe_ke` is deliberately not enforced — it describes the mode the server selects, not a ClientHello well-formedness rule — and can be discussed separately. OpenSSL's own client always sends `key_share` with `supported_groups` in TLS 1.3, so it is unaffected.

Before: resumption ClientHello with `supported_groups`, both kex modes and no `key_share` → server resumes with `psk_ke`.
After: server sends `missing_extension` (109) with `SSL_R_NO_SUITABLE_KEY_SHARE`.

Tests: `70-test_tls13kexmodes.t` gains two cases, run for both TLS 1.3 and DTLS 1.3: `key_share` stripped with both kex modes offered → handshake fails with a `missing_extension` alert; `psk_ke` only with both `supported_groups` and `key_share` stripped → still resumes. The former fail without the fix. Full `make test` passes locally on a `--strict-warnings` build; the changed hunk is `clang-format` clean. A CHANGES.md entry documents the server behaviour change.

Fixes #25124

Checklist
- [x] documentation is added or updated (CHANGES.md; no API change)
- [x] tests are added or updated
