### PR TITLE
[3.6] Backport: fail EVP_DecryptFinal_ex() for AEAD ciphers when no tag was set

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
@@ -350,8 +350,10 @@ static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,
         return 0;
 
     /* The tag must be set before actually decrypting data */
-    if (!ctx->base.enc && ctx->tag_len == 0)
+    if (!ctx->base.enc && ctx->tag_len == 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
         return 0;
+    }
 
     if (hw->aead_cipher((PROV_CIPHER_CTX *)ctx, out, outl, NULL, 0) <= 0)
         return 0;

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
@@ -343,13 +343,17 @@ static int chacha20_poly1305_update(void *vctx, unsigned char *out,
 static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,
     size_t outsize)
 {
-    PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
-    PROV_CIPHER_HW_CHACHA20_POLY1305 *hw = (PROV_CIPHER_HW_CHACHA20_POLY1305 *)ctx->hw;
+    PROV_CHACHA20_POLY1305_CTX *ctx = (PROV_CHACHA20_POLY1305_CTX *)vctx;
+    PROV_CIPHER_HW_CHACHA20_POLY1305 *hw = (PROV_CIPHER_HW_CHACHA20_POLY1305 *)ctx->base.hw;
 
     if (!ossl_prov_is_running())
         return 0;
 
-    if (hw->aead_cipher(ctx, out, outl, NULL, 0) <= 0)
+    /* The tag must be set before actually decrypting data */
+    if (!ctx->base.enc && ctx->tag_len == 0)
+        return 0;
+
+    if (hw->aead_cipher((PROV_CIPHER_CTX *)ctx, out, outl, NULL, 0) <= 0)
         return 0;
 
     *outl = 0;

--- a/providers/implementations/ciphers/ciphercommon_ccm.c.in
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c.in
@@ -454,8 +454,10 @@ static int ccm_cipher_internal(PROV_CCM_CTX *ctx, unsigned char *out,
             ctx->tag_set = 1;
         } else {
             /* The tag must be set before actually decrypting data */
-            if (!ctx->tag_set)
+            if (!ctx->tag_set) {
+                ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
                 goto err;
+            }
 
             if (!hw->auth_decrypt(ctx, in, out, len, ctx->buf, ctx->m))
                 goto err;

--- a/providers/implementations/ciphers/ciphercommon_gcm.c.in
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c.in
@@ -470,8 +470,10 @@ static int gcm_cipher_internal(PROV_GCM_CTX *ctx, unsigned char *out,
         }
     } else {
         /* The tag must be set before actually decrypting data */
-        if (!ctx->enc && ctx->taglen == UNINITIALISED_SIZET)
+        if (!ctx->enc && ctx->taglen == UNINITIALISED_SIZET) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
             goto err;
+        }
         if (!hw->cipherfinal(ctx, ctx->buf))
             goto err;
         ctx->iv_state = IV_STATE_FINISHED; /* Don't reuse the IV */

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4471,10 +4471,16 @@ static int test_decrypt_null_chunks(void)
     unsigned char msg[] = "It was the best of times, it was the worst of times";
     unsigned char ciphertext[80];
     unsigned char plaintext[80];
+    unsigned char tag[16];
     /* We initialise tmp to a non zero value on purpose */
     int ctlen, ptlen, tmp = 99;
     int ret = 0;
     const int enc_offset = 10, dec_offset = 20;
+    OSSL_PARAM params[2];
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+        tag, sizeof(tag));
+    params[1] = OSSL_PARAM_construct_end();
 
     if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, "ChaCha20-Poly1305", testpropq))
         || !TEST_ptr(ctx = EVP_CIPHER_CTX_new())
@@ -4491,12 +4497,13 @@ static int test_decrypt_null_chunks(void)
             sizeof(msg) - enc_offset))
         || !TEST_int_eq(ctlen += tmp, sizeof(msg))
         || !TEST_true(EVP_EncryptFinal(ctx, ciphertext + ctlen, &tmp))
-        || !TEST_int_eq(tmp, 0))
+        || !TEST_int_eq(tmp, 0)
+        || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params)))
         goto err;
 
     /* Deliberately initialise tmp to a non zero value */
     tmp = 99;
-    if (!TEST_true(EVP_DecryptInit_ex(ctx, cipher, NULL, key, iv))
+    if (!TEST_true(EVP_DecryptInit_ex2(ctx, cipher, key, iv, params))
         || !TEST_true(EVP_DecryptUpdate(ctx, plaintext, &ptlen, ciphertext,
             dec_offset))
         /*
@@ -5737,6 +5744,79 @@ err:
         TEST_info("test_evp_updated_iv %d: %s", idx, errmsg);
     EVP_CIPHER_CTX_free(ctx);
     EVP_CIPHER_free(type);
+    return testresult;
+}
+
+typedef struct {
+    const char *cipher;
+} EVP_FINAL_NO_TAG_TEST_st;
+
+static const EVP_FINAL_NO_TAG_TEST_st evp_final_no_tag[] = {
+    { "chacha20-poly1305" },
+    { "aes-256-gcm" }
+};
+
+static int test_evp_final_no_tag(int idx)
+{
+    const EVP_FINAL_NO_TAG_TEST_st *t = &evp_final_no_tag[idx];
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *cipher = NULL;
+    unsigned char tag[16];
+    unsigned char data[5] = { 1, 1, 1, 1, 1 };
+    uint32_t data_len = 5;
+    unsigned char ctext[1024], plaintext[1024];
+    int ctext_len = 0, len = 0, testresult = 0;
+    unsigned char key[] = {
+        0xc9, 0xee, 0xa3, 0x0c, 0x1c, 0x59, 0x0c, 0x8b, 0xd8, 0xbb, 0xa1, 0x1c,
+        0xbc, 0x3a, 0x56, 0xe7, 0xb7, 0xe1, 0x9f, 0xfd, 0x3b, 0x4a, 0xa3, 0xd5,
+        0xc4, 0xdc, 0x2e, 0x62, 0xe6, 0x75, 0x15, 0x5c
+    };
+    unsigned char iv[16] = {
+        0x03, 0x2d, 0x79, 0xef, 0xed, 0x2e, 0xad, 0x3e, 0x0b, 0xdc, 0x8f, 0x57,
+        0x0d, 0x0e, 0x0f, 0x10
+    };
+
+    if ((cipher = EVP_CIPHER_fetch(testctx, t->cipher, testpropq)) == NULL) {
+        TEST_info("cipher %s not supported, skipping", t->cipher);
+        goto ok;
+    }
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
+        goto err;
+    if (!TEST_true(EVP_EncryptInit_ex(ctx, cipher, NULL, key, iv)))
+        goto err;
+    if (!TEST_true(EVP_EncryptUpdate(ctx, ctext, &len, data, data_len)))
+        goto err;
+    ctext_len = len;
+    if (!TEST_true(EVP_EncryptFinal_ex(ctx, ctext + len, &len)))
+        goto err;
+
+    ctext_len += len;
+    if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, 16, tag)))
+        goto err;
+    EVP_CIPHER_CTX_free(ctx);
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
+        goto err;
+    if (!TEST_true(EVP_DecryptInit_ex(ctx, cipher, NULL, key, iv)))
+        goto err;
+    if (!TEST_true(EVP_DecryptUpdate(ctx, plaintext, &len, ctext, ctext_len)))
+        goto err;
+    if (!TEST_mem_eq(plaintext, 5, data, 5))
+        goto err;
+
+    /*
+     * The tag must be set before decrypting the data; here we expect failure
+     * for each of the defined ciphers.
+     */
+    if (!TEST_false(EVP_DecryptFinal_ex(ctx, ctext + len, &len)))
+        goto err;
+
+ok:
+    testresult = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
     return testresult;
 }
 
@@ -8290,6 +8370,8 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_evp_reinit_seq, OSSL_NELEM(evp_reinit_tests));
     ADD_ALL_TESTS(test_gcm_reinit, OSSL_NELEM(gcm_reinit_tests));
     ADD_ALL_TESTS(test_evp_updated_iv, OSSL_NELEM(evp_updated_iv_tests));
+    ADD_ALL_TESTS(test_evp_final_no_tag, OSSL_NELEM(evp_final_no_tag));
+
     ADD_ALL_TESTS(test_ivlen_change, OSSL_NELEM(ivlen_change_ciphers));
     if (OSSL_NELEM(keylen_change_ciphers) - 1 > 0)
         ADD_ALL_TESTS(test_keylen_change, OSSL_NELEM(keylen_change_ciphers) - 1);


### PR DESCRIPTION
Backport of #28683 and #28872 (master commits 6387ec6d492c and b9e6d360100b, both by @n13l) to openssl-3.6. openssl-4.0 already carries both.

On 3.6 the ChaCha20-Poly1305 provider's `final` runs the tag comparison with `tag_len == 0` when the caller never set a tag, so `EVP_DecryptFinal_ex()` reports success on unauthenticated data (AES-GCM already fails in this situation) — #31285. The first commit makes `chacha20_poly1305_final()` fail when decrypting with no tag set; the second raises `PROV_R_TAG_NOT_SET` for ChaCha20-Poly1305, GCM and CCM instead of failing silently.

Conflicts were formatting-only (the branch is clang-formatted with a different continuation style) and were resolved by re-running clang-format on the touched files. Both commits are cherry-picked with `-x`, authorship preserved.

Tests: the cherry-picked `test_evp_final_no_tag` fails on the unpatched branch and passes with the fix; full `make test` passes (Files=355, Tests=4513) on a `--strict-warnings` build.

Related to #31285 (the 3.5 backport, #32531, carries the `Fixes`).

Checklist
- [x] tests are added or updated
- [ ] documentation is added or updated (n/a — behaviour now matches the documented AEAD contract and master)

