### PR TITLE
dtls: BIO_snprintf() to snprintf() in the DTLS echo demos

### DIFF
--- a/demos/dtlsecho/main.c
+++ b/demos/dtlsecho/main.c
@@ -53,7 +53,7 @@ static SOCKET create_socket(void)
      * single socket that, BIO_listen will clear IPV6_V6ONLY below, and the
      * socket accepts both IPv6 and IPv4 clients.
      */
-    BIO_snprintf(port_str, sizeof(port_str), "%d", server_port);
+    snprintf(port_str, sizeof(port_str), "%d", server_port);
     if (!BIO_lookup_ex(NULL, port_str, BIO_LOOKUP_SERVER, AF_INET6,
             SOCK_DGRAM, 0, &res)) {
         fprintf(stderr, "Unable to resolve local address\n");
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
         configure_client_context(ssl_ctx);
 
         /* Resolve server hostname or IP address (IPv4 or IPv6) */
-        BIO_snprintf(port_str, sizeof(port_str), "%d", server_port);
+        snprintf(port_str, sizeof(port_str), "%d", server_port);
         if (!BIO_lookup(rem_server_name, port_str, BIO_LOOKUP_CLIENT,
                 AF_UNSPEC, SOCK_DGRAM, &res)) {
             fprintf(stderr, "Unable to resolve server: %s\n", rem_server_name);

--- a/demos/dtlslistenerecho/main.c
+++ b/demos/dtlslistenerecho/main.c
@@ -124,7 +124,7 @@ static int create_dtls_listener(SSL_CTX *ssl_ctx, int port,
      * single socket that, since we do not pass BIO_SOCK_V6_ONLY to BIO_listen,
      * serves both IPv6 and IPv4 clients.
      */
-    BIO_snprintf(port_str, sizeof(port_str), "%d", port);
+    snprintf(port_str, sizeof(port_str), "%d", port);
     if (!BIO_lookup_ex(NULL, port_str, BIO_LOOKUP_SERVER, AF_INET6,
             SOCK_DGRAM, 0, &res)) {
         fprintf(stderr, "Unable to resolve local address\n");
@@ -636,7 +636,7 @@ static int create_dtls_client(SSL_CTX *ssl_ctx, const char *server_name, int por
      * matching family to the first address that works. For UDP, BIO_connect
      * just records the default peer.
      */
-    BIO_snprintf(port_str, sizeof(port_str), "%d", port);
+    snprintf(port_str, sizeof(port_str), "%d", port);
     if (!BIO_lookup(server_name, port_str, BIO_LOOKUP_CLIENT, AF_UNSPEC,
             SOCK_DGRAM, &res)) {
         fprintf(stderr, "Unable to resolve server: %s\n", server_name);


### PR DESCRIPTION
The BIO_snprintf() deprecation series was not rebased over the DTLS demos before merging, which breaks no-deprecated builds with an implicit-function-declaration error. Convert the port formatting calls to snprintf() as done for the other callers in that series.

Assisted-by: Claude:claude-fable-5