### PR TITLE
add VS2013 compiler testing job to CI workflow

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -85,6 +85,70 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
+  vs2013:
+    needs: [validate-dispatch-inputs]
+    if: |
+      !cancelled() &&
+      (needs.validate-dispatch-inputs.result == 'success' || needs.validate-dispatch-inputs.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            target: VC-WIN64A
+          - arch: x86
+            target: VC-WIN32
+    runs-on: windows-2022
+    env:
+      IMAGE: ghcr.io/openssl/openssl-vs2013:latest
+      VCVARS: C:\vc12\vcvars_${{ matrix.arch }}.cmd
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+        ref: ${{ github.event.inputs.head_sha || github.sha }}
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+    - name: pull the VS2013 toolchain image
+      shell: cmd
+      run: docker pull %IMAGE%
+    - name: config
+      run: |
+        $config = @(
+          'no-makedepend'
+          'no-shared'
+          'enable-fips'
+          '-DOSSL_WINCTX=openssl'
+        ) -join ' '
+        $chain = @(
+          # 'call', not a bare invocation: cmd does not necessarily return from a
+          # batch file run without it, which would skip the rest of the chain.
+          "call $env:VCVARS"
+          'mkdir _build'
+          'cd _build'
+          "perl ..\Configure ${{ matrix.target }} --banner=Configured $config"
+          'perl configdata.pm --dump'
+        ) -join ' && '
+        docker run --rm --isolation=process -v "${env:GITHUB_WORKSPACE}:C:\src" `
+          -w C:\src ${env:IMAGE} cmd /S /C $chain
+    - name: make
+      run: |
+        $chain = @(
+          "call $env:VCVARS"
+          'jom /j4 /S'
+          'apps\openssl.exe version -c'
+        ) -join ' && '
+        docker run --rm --isolation=process -v "${env:GITHUB_WORKSPACE}:C:\src" `
+          -w C:\src\_build ${env:IMAGE} cmd /S /C $chain
+    - name: make test
+      run: |
+        $chain = @(
+          "call $env:VCVARS"
+          'jom test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4'
+        ) -join ' && '
+        docker run --rm --isolation=process -v "${env:GITHUB_WORKSPACE}:C:\src" `
+          -w C:\src\_build ${env:IMAGE} cmd /S /C $chain
+
   clang:
     needs: [validate-dispatch-inputs]
     if: |

--- a/crypto/defaults.c
+++ b/crypto/defaults.c
@@ -61,8 +61,12 @@ static char *get_windows_regdirs(char *dst, DWORD dstsizebytes, LPCWSTR valuenam
     DWORD index = 0;
     LPCWSTR tempstr = NULL;
 
-    ret = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
-        TEXT(REGISTRY_KEY), KEY_WOW64_32KEY,
+    /*
+     * Narrow call: TEXT(REGISTRY_KEY) would widen only the first literal of the
+     * concatenation, which MSVC 12.0 rejects.  The subkey path is ASCII.
+     */
+    ret = RegOpenKeyExA(HKEY_LOCAL_MACHINE,
+        REGISTRY_KEY, KEY_WOW64_32KEY,
         KEY_QUERY_VALUE, &hkey);
     if (ret != ERROR_SUCCESS)
         goto out;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -101,7 +101,7 @@ typedef struct fips_global_st {
 
 } FIPS_GLOBAL;
 
-static inline FIPS_PARAMS *get_fips_params(FIPS_GLOBAL *fgbl)
+static ossl_inline FIPS_PARAMS *get_fips_params(FIPS_GLOBAL *fgbl)
 {
     return &fgbl->fips_params;
 }


### PR DESCRIPTION
I built a [container image](https://github.com/openssl/images/tree/main/openssl-vs2013) that carries the Visual Studio 2013 C toolchain (MSVC 12.0, _MSC_VER 1800) plus everything else needed to configure, build and test openssl against it: the Windows SDK 8.1, Strawberry Perl, jom and NASM. Build failed with error:

```
jom: C:\src\_build\Makefile [crypto\libcrypto-lib-defaults.obj] Error 2
..\crypto\defaults.c(65) : error C2308: concatenating mismatched strings
        Concatenating wide "SOFTWARE\WOW6432Node\OpenSSL" with narrow "-"
```

https://github.com/quarckster/openssl-fork/actions/runs/33039509950/job/98409670235

https://github.com/quarckster/openssl-fork/actions/runs/33039509950/job/98409670389