### PR TITLE
Support crypto-auditing probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,3 +848,35 @@ jobs:
         cd ../..
     - name: Test ECH with NSS
       run: make test TESTS='test_external_ech_nss' V=1
+
+  external-tests-crau:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+      options: --privileged
+    steps:
+    - name: package installs
+      run: |
+        dnf install -y --setopt=install_weak_deps=False perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy perl-Test-Simple perl-Test-Harness make g++ perl git cargo clang clippy kernel-devel libbpf-devel llvm-devel rustfmt systemtap-sdt-devel jq procps
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+        persist-credentials: false
+    - name: checkout crypto-auditing submodule
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git submodule update --init --depth 1 crypto-auditing
+    - name: Copy vmlinux.h from kernel-devel
+      run: |
+        cp $(rpm -ql kernel-devel | grep '/vmlinux.h$' | tail -1) crypto-auditing/agent/src/bpf
+        cp $(rpm -ql kernel-devel | grep '/vmlinux.h$' | tail -1) crypto-auditing/agent/tests/agenttest/src/bpf
+    - name: config
+      run: ./config --strict-warnings --banner=Configured --debug enable-external-tests no-fips && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: test external crypto-auditing
+      run: make test TESTS="test_external_crau" V=1
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -60,7 +60,8 @@ jobs:
           no-tls1_3,
           enable-trace enable-fips,
           no-quic,
-          -DOPENSSL_USE_IPV6=0
+          -DOPENSSL_USE_IPV6=0,
+          no-usdt
         ]
     runs-on: ubuntu-latest
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,6 @@
 [submodule "pkcs11-provider"]
 	path = pkcs11-provider
 	url = https://github.com/latchset/pkcs11-provider.git
+[submodule "crypto-auditing"]
+	path = crypto-auditing
+	url = https://github.com/latchset/crypto-auditing.git

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -584,6 +584,14 @@ OpenSSL 4.1
 
    *Paul Grubbs*
 
+ * `libcrypto` and `libssl` are instrumented with eBPF probes to trace
+   TLS and crypto usage, in a compatible manner with the
+   [crypto-auditing](https://github.com/latchset/crypto-auditing)
+   project. This is enabled by default if the system has a usable
+   `<sys/sdt.h>` header. Use `no-usdt` to disable the support.
+
+   *Daiki Ueno and Clemens Lang*
+
 OpenSSL 4.0
 -----------
 

--- a/Configure
+++ b/Configure
@@ -519,6 +519,7 @@ my @disablables_features = (
     "buildtest-c++",
     "bulk",
     "cached-fetch",
+    "usdt",
     "dgram",
     "winstore",
     "crypto-mdebug",
@@ -1963,6 +1964,23 @@ unless ($disabled{"unit-tests"}) {
         disable('no-unit-test-support', 'unit-tests');
     }
 }
+
+unless ($disabled{usdt}) {
+    my $cc = $config{CROSS_COMPILE}.$config{CC};
+    # eBPF USDT probes are defined using the DTRACE_PROBE* macros
+    # defined in <sys/sdt.h>. Some platforms including macOS and
+    # FreeBSD have this header as well, though they are incompatible
+    # with USDT probes. Restrict the support for Linux only for now.
+    if ($target =~ m/^linux/) {
+	system("printf '#include <sys/sdt.h>\n' | $cc -E - >/dev/null 2>&1");
+	if ($? != 0) {
+	    disable('no-sys-sdt-h', 'usdt');
+	}
+    } else {
+	disable('not-linux', 'usdt');
+    }
+}
+push @{$config{openssl_other_defines}}, "OPENSSL_NO_USDT" if ($disabled{usdt});
 
 # Get the extra flags used when building shared libraries and modules.  We
 # do this late because some of them depend on %disabled.

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -16,6 +16,7 @@
 #include "internal/provider.h"
 #include "internal/core.h"
 #include "internal/numbers.h" /* includes SIZE_MAX */
+#include "internal/usdt.h"
 #include "crypto/evp.h"
 #include "evp_local.h"
 
@@ -371,6 +372,9 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }
+
+    OSSL_USDT_new_child(ctx, ctx->op.kex.algctx);
+
     ret = exchange->init(ctx->op.kex.algctx, provkey, params);
 
     EVP_KEYMGMT_free(tmp_keymgmt);

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -14,6 +14,7 @@
 #include "internal/cryptlib.h"
 #include "internal/provider.h"
 #include "internal/core.h"
+#include "internal/usdt.h"
 #include "crypto/evp.h"
 #include "evp_local.h"
 
@@ -180,6 +181,8 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }
+
+    OSSL_USDT_new_child(ctx, ctx->op.encap.algctx);
 
     switch (operation) {
     case EVP_PKEY_OP_ENCAPSULATE:

--- a/include/internal/usdt.h
+++ b/include/internal/usdt.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_USDT_H
+#define OSSL_USDT_H
+#pragma once
+
+#include <openssl/opensslconf.h>
+
+#ifndef OPENSSL_NO_USDT
+#include <stdint.h>
+#include <sys/sdt.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ossl_usdt_data_st {
+    char *key;
+    void *value;
+    unsigned long value_size;
+} OSSL_USDT_DATA;
+
+#define OSSL_USDT_STRING(s) s, (unsigned long)-1
+#define OSSL_USDT_WORD(w) (void *)(intptr_t)w, (unsigned long)-2
+#define OSSL_USDT_BLOB(b, s) b, s
+
+/*
+ * Emits a context event with the given |name|.
+ */
+#define OSSL_USDT_new_context(context, name)                                    \
+    do {                                                                        \
+        OSSL_USDT_DATA data_[] = { { "name", OSSL_USDT_STRING(name) } };        \
+        DTRACE_PROBE4(crypto_auditing, new_context_with_data, context, context, \
+            data_, sizeof(data_) / sizeof(data_[0]));                           \
+    } while (0)
+
+/*
+ * Combines OSSL_USDT_new_context() followed by OSSL_USDT_data() as a
+ * single probe.
+ */
+#define OSSL_USDT_new_context_with_data(context, name, ...)                           \
+    do {                                                                              \
+        OSSL_USDT_DATA data_[] = { { "name", OSSL_USDT_STRING(name) }, __VA_ARGS__ }; \
+        DTRACE_PROBE4(crypto_auditing, new_context_with_data, context, context,       \
+            data_, sizeof(data_) / sizeof(data_[0]));                                 \
+    } while (0)
+
+/*
+ * Emits multiple data events at once as a variadic array of
+ * OSSL_USDT_DATA in the current event context.
+ */
+#define OSSL_USDT_data(context, ...)                                                            \
+    do {                                                                                        \
+        OSSL_USDT_DATA data_[] = { __VA_ARGS__ };                                               \
+        DTRACE_PROBE3(crypto_auditing, data, context, data_, sizeof(data_) / sizeof(data_[0])); \
+    } while (0)
+
+/*
+ * Asserts an explicit parent-child relationship of context.
+ */
+#define OSSL_USDT_new_child(parent_context, context) \
+    DTRACE_PROBE2(crypto_auditing, new_context, context, parent_context)
+
+#ifdef __cplusplus
+}
+#endif
+
+#else
+
+#define OSSL_USDT_STRING(s)
+#define OSSL_USDT_WORD(w)
+#define OSSL_USDT_BLOB(b, s)
+
+#define OSSL_USDT_new_context(context, name)
+#define OSSL_USDT_new_context_with_data(context, name, ...)
+#define OSSL_USDT_data(context, ...)
+#define OSSL_USDT_new_child(parent_context, context)
+
+#endif
+#endif /* OSSL_USDT_H */

--- a/providers/implementations/exchange/ecx_exch.c
+++ b/providers/implementations/exchange/ecx_exch.c
@@ -14,6 +14,7 @@
 #include <openssl/err.h>
 #include <openssl/proverr.h>
 #include "internal/cryptlib.h"
+#include "internal/usdt.h"
 #include "crypto/ecx.h"
 #include "prov/implementations.h"
 #include "prov/providercommon.h"
@@ -101,12 +102,14 @@ static int ecx_init(void *vecxctx, void *vkey, const char *algname)
 static int x25519_init(void *vecxctx, void *vkey,
     ossl_unused const OSSL_PARAM params[])
 {
+    OSSL_USDT_new_context_with_data(vecxctx, "pk::derive", { "pk::curve", OSSL_USDT_STRING("x25519") });
     return ecx_init(vecxctx, vkey, "X25519");
 }
 
 static int x448_init(void *vecxctx, void *vkey,
     ossl_unused const OSSL_PARAM params[])
 {
+    OSSL_USDT_new_context_with_data(vecxctx, "pk::derive", { "pk::curve", OSSL_USDT_STRING("x448") });
     return ecx_init(vecxctx, vkey, "X448");
 }
 

--- a/providers/implementations/kem/ml_kem_kem.c
+++ b/providers/implementations/kem/ml_kem_kem.c
@@ -18,6 +18,7 @@
 #include "crypto/ml_kem.h"
 #include "internal/cryptlib.h"
 #include "internal/fips.h"
+#include "internal/usdt.h"
 #include "prov/provider_ctx.h"
 #include "prov/implementations.h"
 #include "prov/securitycheck.h"
@@ -93,7 +94,12 @@ static int ml_kem_encapsulate_init(void *vctx, void *vkey,
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
         return 0;
     }
-    return ml_kem_init(vctx, EVP_PKEY_OP_ENCAPSULATE, key, params);
+    if (!ml_kem_init(vctx, EVP_PKEY_OP_ENCAPSULATE, key, params))
+        return 0;
+
+    OSSL_USDT_new_context_with_data(vctx, "pk::encapsulate", { "pk::algorithm", OSSL_USDT_STRING("ML-KEM") });
+
+    return 1;
 }
 
 static int ml_kem_decapsulate_init(void *vctx, void *vkey,
@@ -105,7 +111,12 @@ static int ml_kem_decapsulate_init(void *vctx, void *vkey,
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
         return 0;
     }
-    return ml_kem_init(vctx, EVP_PKEY_OP_DECAPSULATE, key, params);
+    if (!ml_kem_init(vctx, EVP_PKEY_OP_DECAPSULATE, key, params))
+        return 0;
+
+    OSSL_USDT_new_context_with_data(vctx, "pk::decapsulate", { "pk::algorithm", OSSL_USDT_STRING("ML-KEM") });
+
+    return 1;
 }
 
 static int ml_kem_set_ctx_params(void *vctx, const OSSL_PARAM params[])

--- a/providers/implementations/kem/mlx_kem.c
+++ b/providers/implementations/kem/mlx_kem.c
@@ -19,6 +19,7 @@
 #include "prov/mlx_kem.h"
 #include "prov/provider_ctx.h"
 #include "prov/providercommon.h"
+#include "internal/usdt.h"
 
 static OSSL_FUNC_kem_newctx_fn mlx_kem_newctx;
 static OSSL_FUNC_kem_freectx_fn mlx_kem_freectx;
@@ -168,6 +169,7 @@ static int mlx_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
     cbuf = ctext + ml_kem_slot * key->xinfo->pubkey_bytes;
     sbuf = shsec + ml_kem_slot * key->xinfo->shsec_bytes;
     ctx = EVP_PKEY_CTX_new_from_pkey(key->libctx, key->mkey, key->propq);
+    OSSL_USDT_new_child(vctx, ctx);
     if (ctx == NULL
         || EVP_PKEY_encapsulate_init(ctx, NULL) <= 0
         || EVP_PKEY_encapsulate(ctx, cbuf, &encap_clen, sbuf, &encap_slen) <= 0)
@@ -203,6 +205,7 @@ static int mlx_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
     cbuf = ctext + (1 - ml_kem_slot) * key->minfo->ctext_bytes;
     encap_clen = key->xinfo->pubkey_bytes;
     ctx = EVP_PKEY_CTX_new_from_pkey(key->libctx, key->xkey, key->propq);
+    OSSL_USDT_new_child(vctx, ctx);
     if (ctx == NULL
         || EVP_PKEY_keygen_init(ctx) <= 0
         || EVP_PKEY_keygen(ctx, &xkey) <= 0
@@ -222,6 +225,7 @@ static int mlx_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
     encap_slen = key->xinfo->shsec_bytes;
     sbuf = shsec + (1 - ml_kem_slot) * ML_KEM_SHARED_SECRET_BYTES;
     ctx = EVP_PKEY_CTX_new_from_pkey(key->libctx, xkey, key->propq);
+    OSSL_USDT_new_child(vctx, ctx);
     if (ctx == NULL
         || EVP_PKEY_derive_init(ctx) <= 0
         || EVP_PKEY_derive_set_peer(ctx, key->xkey) <= 0
@@ -293,6 +297,7 @@ static int mlx_kem_decapsulate(void *vctx, uint8_t *shsec, size_t *slen,
     cbuf = ctext + ml_kem_slot * key->xinfo->pubkey_bytes;
     sbuf = shsec + ml_kem_slot * key->xinfo->shsec_bytes;
     ctx = EVP_PKEY_CTX_new_from_pkey(key->libctx, key->mkey, key->propq);
+    OSSL_USDT_new_child(vctx, ctx);
     if (ctx == NULL
         || EVP_PKEY_decapsulate_init(ctx, NULL) <= 0
         || EVP_PKEY_decapsulate(ctx, sbuf, &decap_slen, cbuf, decap_clen) <= 0)
@@ -311,6 +316,7 @@ static int mlx_kem_decapsulate(void *vctx, uint8_t *shsec, size_t *slen,
     cbuf = ctext + (1 - ml_kem_slot) * key->minfo->ctext_bytes;
     sbuf = shsec + (1 - ml_kem_slot) * ML_KEM_SHARED_SECRET_BYTES;
     ctx = EVP_PKEY_CTX_new_from_pkey(key->libctx, key->xkey, key->propq);
+    OSSL_USDT_new_child(vctx, ctx);
     if (ctx == NULL
         || (xkey = EVP_PKEY_new()) == NULL
         || EVP_PKEY_copy_parameters(xkey, key->xkey) <= 0

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -22,6 +22,7 @@
 #include <openssl/core_names.h>
 #include "internal/cryptlib.h"
 #include "internal/ssl_unwrap.h"
+#include "internal/usdt.h"
 #include <openssl/ocsp.h>
 
 #define TLS13_NUM_CIPHERS OSSL_NELEM(tls13_ciphers)
@@ -5502,6 +5503,8 @@ int ssl_derive(SSL_CONNECTION *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gense
 
     pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, sctx->propq);
 
+    OSSL_USDT_new_child(s, pctx);
+
     if (EVP_PKEY_derive_init(pctx) <= 0
         || EVP_PKEY_derive_set_peer(pctx, pubkey) <= 0
         || EVP_PKEY_derive(pctx, NULL, &pmslen) <= 0) {
@@ -5561,6 +5564,8 @@ int ssl_decapsulate(SSL_CONNECTION *s, EVP_PKEY *privkey,
 
     pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, sctx->propq);
 
+    OSSL_USDT_new_child(s, pctx);
+
     if (EVP_PKEY_decapsulate_init(pctx, NULL) <= 0
         || EVP_PKEY_decapsulate(pctx, NULL, &pmslen, ct, ctlen) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -5611,6 +5616,8 @@ int ssl_encapsulate(SSL_CONNECTION *s, EVP_PKEY *pubkey,
     }
 
     pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pubkey, sctx->propq);
+
+    OSSL_USDT_new_child(s, pctx);
 
     if (EVP_PKEY_encapsulate_init(pctx, NULL) <= 0
         || EVP_PKEY_encapsulate(pctx, NULL, &ctlen, NULL, &pmslen) <= 0

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -17,6 +17,7 @@
 #ifndef OPENSSL_NO_ECH
 #include "internal/ech_helpers.h"
 #endif
+#include "internal/usdt.h"
 
 /* Used in the negotiate_dhe function */
 typedef enum {
@@ -2313,6 +2314,9 @@ int tls_parse_stoc_key_share(SSL_CONNECTION *s, PACKET *pkt,
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);
         return 0;
     }
+
+    OSSL_USDT_new_context_with_data(s, "tls::key_exchange",
+        { "tls::group", OSSL_USDT_WORD(group_id) });
 
     if (!ginf->is_kem) {
         /* Regular KEX */

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -16,6 +16,7 @@
 #include <openssl/rand.h>
 #include <openssl/trace.h>
 #endif
+#include "internal/usdt.h"
 
 #define COOKIE_STATE_FORMAT_VERSION 1
 
@@ -2078,6 +2079,9 @@ EXT_RETURN tls_construct_stoc_key_share(SSL_CONNECTION *s, WPACKET *pkt,
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return EXT_RETURN_FAIL;
     }
+
+    OSSL_USDT_new_context_with_data(s, "tls::key_exchange",
+        { "tls::group", OSSL_USDT_WORD(ginf->group_id) });
 
     if (!ginf->is_kem) {
         /* Regular KEX */

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -17,6 +17,7 @@
 #include "internal/cryptlib.h"
 #include "internal/ssl_unwrap.h"
 #include <openssl/rand.h>
+#include "internal/usdt.h"
 #include "../ssl_local.h"
 #include "statem_local.h"
 #include <assert.h>
@@ -389,6 +390,10 @@ static int state_machine(SSL_CONNECTION *s, int server)
     cb = get_callback(s);
 
     st->in_handshake++;
+
+    OSSL_USDT_new_context_with_data(s, "tls::handshake",
+        { "tls::role", OSSL_USDT_STRING(s->server ? "server" : "client") });
+
     if (!SSL_in_init(ssl) || SSL_in_before(ssl)) {
         /*
          * If we are stateless then we already called SSL_clear() - don't do

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -29,6 +29,7 @@
 #include "internal/comp.h"
 #include "internal/ssl_unwrap.h"
 #include <openssl/ocsp.h>
+#include "internal/usdt.h"
 
 static MSG_PROCESS_RETURN tls_process_as_hello_retry_request(SSL_CONNECTION *s,
     RAW_EXTENSION *extensions);
@@ -1799,6 +1800,8 @@ static int set_client_ciphersuite(SSL_CONNECTION *s,
     }
     s->s3.tmp.new_cipher = c;
 
+    OSSL_USDT_data(s, { "tls::ciphersuite", OSSL_USDT_WORD(SSL_CIPHER_get_protocol_id(c)) });
+
     return 1;
 }
 
@@ -2024,6 +2027,9 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL_CONNECTION *s, PACKET *pkt)
             /* SSLfatal() already called */
             goto err;
         }
+
+        OSSL_USDT_data(s,
+            { "tls::protocol_version", OSSL_USDT_WORD(s->version) });
     }
 
     if (SSL_CONNECTION_IS_VERSION13(s) || hrr) {
@@ -2613,6 +2619,9 @@ WORK_STATE tls_post_process_server_certificate(SSL_CONNECTION *s,
      * set. The *documented* interface remains the same.
      */
     ERR_set_mark();
+
+    OSSL_USDT_new_context(s, "tls::verify_cert_chain");
+
     i = ssl_verify_cert_chain(s, s->session->peer_chain);
     if (i <= 0 && s->verify_mode != SSL_VERIFY_NONE) {
         ERR_clear_last_mark();

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -23,6 +23,7 @@
 #include <openssl/x509.h>
 #include <openssl/trace.h>
 #include <openssl/encoder.h>
+#include "internal/usdt.h"
 
 /*
  * Map error codes to TLS/SSL alart types.
@@ -353,6 +354,9 @@ CON_FUNC_RETURN tls_construct_cert_verify(SSL_CONNECTION *s, WPACKET *pkt)
         goto err;
     }
 
+    OSSL_USDT_new_context_with_data(s, "tls::sign",
+        { "tls::signature_algorithm", OSSL_USDT_WORD(lu->sigalg) });
+
     /*
      * To avoid problems with older RSA providers we must also pass the digest
      * name when passing any other parameters.
@@ -525,6 +529,9 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s, PACKET *pkt)
 
     OSSL_TRACE1(TLS, "Using client verify alg %s\n",
         md == NULL ? "n/a" : EVP_MD_get0_name(md));
+
+    OSSL_USDT_new_context_with_data(s, "tls::verify",
+        { "tls::signature_algorithm", OSSL_USDT_WORD(s->s3.tmp.peer_sigalg->sigalg) });
 
     /*
      * To avoid problems with older RSA providers we must also pass the digest

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -33,6 +33,7 @@
 #include <openssl/comp.h>
 #include "internal/comp.h"
 #include <openssl/ocsp.h>
+#include "internal/usdt.h"
 
 #define TICKET_NONCE_SIZE 8
 
@@ -2108,6 +2109,8 @@ static int tls_early_post_process_client_hello(SSL_CONNECTION *s)
         goto err;
     }
 
+    OSSL_USDT_data(s, { "tls::protocol_version", OSSL_USDT_WORD(s->version) });
+
     /* TLSv1.3 specifies that a ClientHello must end on a record boundary */
     if (SSL_CONNECTION_IS_VERSION13(s)
         && RECORD_LAYER_processed_read_pending(&s->rlayer)) {
@@ -2203,6 +2206,8 @@ static int tls_early_post_process_client_hello(SSL_CONNECTION *s)
             goto err;
         }
         s->s3.tmp.new_cipher = cipher;
+
+        OSSL_USDT_data(s, { "tls::ciphersuite", OSSL_USDT_WORD(SSL_CIPHER_get_protocol_id(s->s3.tmp.new_cipher)) });
     }
 
     /* We need to do this before getting the session */
@@ -2715,6 +2720,8 @@ WORK_STATE tls_post_process_client_hello(SSL_CONNECTION *s, WORK_STATE wst)
                     goto err;
                 }
                 s->s3.tmp.new_cipher = cipher;
+
+                OSSL_USDT_data(s, { "tls::ciphersuite", OSSL_USDT_WORD(SSL_CIPHER_get_protocol_id(s->s3.tmp.new_cipher)) });
             }
             if (!s->hit) {
                 if (!tls_choose_sigalg(s, 1)) {
@@ -2734,6 +2741,8 @@ WORK_STATE tls_post_process_client_hello(SSL_CONNECTION *s, WORK_STATE wst)
         } else {
             /* Session-id reuse */
             s->s3.tmp.new_cipher = s->session->cipher;
+
+            OSSL_USDT_data(s, { "tls::ciphersuite", OSSL_USDT_WORD(SSL_CIPHER_get_protocol_id(s->s3.tmp.new_cipher)) });
         }
 
         /*
@@ -4323,6 +4332,9 @@ WORK_STATE tls_post_process_client_certificate(SSL_CONNECTION *s,
     } else {
         if (s->rwstate == SSL_RETRY_VERIFY)
             s->rwstate = SSL_NOTHING;
+
+        OSSL_USDT_new_context(s, "tls::verify_cert_chain");
+
         i = ssl_verify_cert_chain(s, sk);
         if (i > 0 && s->rwstate == SSL_RETRY_VERIFY) {
             /*

--- a/test/recipes/95-test_external_crau.t
+++ b/test/recipes/95-test_external_crau.t
@@ -1,0 +1,26 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT data_file bldtop_dir srctop_dir cmdstr/;
+
+setup("test_external_crau");
+
+plan skip_all => "No external tests in this configuration"
+    if disabled("external-tests");
+plan skip_all => "crau tests only available on Linux"
+    if $^O !~ /^linux$/;
+plan skip_all => "crau tests not supported in out of tree builds"
+    if bldtop_dir() ne srctop_dir();
+
+plan tests => 1;
+
+ok(run(cmd(["sh", data_file("crau.sh")])),
+   "running crau tests");

--- a/test/recipes/95-test_external_crau_data/crau.sh
+++ b/test/recipes/95-test_external_crau_data/crau.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+#
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+#
+# OpenSSL external testing using the pkcs11-provider
+#
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Need to be root to run this test!"
+    exit 1
+fi
+
+PWD="$(pwd)"
+
+SRCTOP="$(cd $SRCTOP; pwd)"
+BLDTOP="$(cd $BLDTOP; pwd)"
+
+if [ "$SRCTOP" != "$BLDTOP" ] ; then
+    echo "Out of tree builds not supported with crau test!"
+    exit 1
+fi
+
+cd $BLDTOP
+
+O_EXE="$BLDTOP/apps"
+O_BINC="$BLDTOP/include"
+O_SINC="$SRCTOP/include"
+O_LIB="$BLDTOP"
+
+export PATH="$O_EXE:$PATH"
+export LD_LIBRARY_PATH="$O_LIB:$LD_LIBRARY_PATH"
+export OPENSSL_ROOT_DIR="$O_LIB"
+
+echo "------------------------------------------------------------------"
+echo "Building crypto-auditing"
+echo "------------------------------------------------------------------"
+
+cd $OPENSSL_ROOT_DIR/crypto-auditing
+
+cargo build --verbose
+
+cd -
+
+echo "------------------------------------------------------------------"
+echo "Running tests"
+echo "------------------------------------------------------------------"
+
+OPENSSL=$O_EXE/openssl
+CRAU_AGENT=$OPENSSL_ROOT_DIR/crypto-auditing/target/debug/crau-agent
+CRAU_QUERY=$OPENSSL_ROOT_DIR/crypto-auditing/target/debug/crau-query
+CRAU_CBOR_LOG=`mktemp`
+CRAU_JSON_LOG=`mktemp`
+
+rm -f "$CRAU_CBOR_LOG" "$CRAU_JSON_LOG"
+
+"$CRAU_AGENT" -c /dev/null \
+              --library "$O_LIB"/libssl.so.4 \
+              --library "$O_LIB"/libcrypto.so.4 \
+              --log-file "$CRAU_CBOR_LOG" &
+
+# wait until crau-agent starts
+timeout 2 sh -c "while true; do test -e \"""$CRAU_CBOR_LOG""\" && break; done"
+
+agent_pids=`ps -ef | grep crau-agent | grep -v grep | awk '{print $2}'`
+if [ -z "$agent_pids" ]
+then
+    echo "No sign of crau-agent - exiting (before client)"
+    exit 88
+fi
+
+"$O_EXE"/openssl s_server -tls1_3 -WWW -naccept 1 \
+        -cert test/certs/servercert.pem -key test/certs/serverkey.pem &
+
+server_pids=`ps -ef | grep s_server | grep -v grep | awk '{print $2}'`
+if [ -z "$server_pids" ]
+then
+    echo "No sign of s_server - exiting (before client)"
+    exit 88
+fi
+
+httpreq="GET / HTTP/1.1\\r\\nConnection: close\\r\\n\\r\\n"
+
+(echo -e "$httpreq"; sleep 2) | \
+    "$O_EXE"/openssl s_client -CAfile test/certs/rootcert.pem -connect localhost:4433
+
+
+"$CRAU_QUERY" --log-file "$CRAU_CBOR_LOG" | tee "$CRAU_JSON_LOG"
+
+# check if at least one TLS 1.3 handshake took place
+jq --exit-status '[.[] | .events | select(.name == "tls::handshake") | select(."tls::protocol_version" == 772)] | length > 0' "$CRAU_JSON_LOG"
+
+success=$?
+
+# crau-agent needs killing
+kill $agent_pids
+exit $success


### PR DESCRIPTION
This is an alternative approach to #31971. The changes from that PR include:

- Removed the context hierarchy handling from the library, as it could be implemented solely on the log consumer side (see https://github.com/latchset/crypto-auditing/issues/295)
- The functions to define USDT probes are now macros that simply wrap `DTRACE_PROBE*`
- Renamed the “provider” part of probe names from “crypto_auditing” to “openssl”

I’m marking it as a draft until the crypto-auditing side of the changes is implemented, but I would like to hear any opinions on the design and the direction.

Some implementation notes on the probe points:

- We try to make them generic (like “new_context”, “data”, etc.) rather than specific (like “tls_handshake”, “pk_sign”, etc.), so the agent can accommodate any new events in the future without modification
- These probe points take an array so multiple events can be reported at once, to reduce the number of context switches when a program is monitored

Here are a couple of open questions:

- Where should we put probe points for low-level cryptography, such as “pk::sign”? If we put them at the EVP level, they would need to access algorithm names, etc., through accessor functions, which is not zero cost. Or should we sprinkle those probes where the algorithms are actually implemented, as in [evp: instrument X25519/X448 key derivation for crypto-auditing](https://github.com/openssl/openssl/commit/f4bb28493190996be366aeabf007d24e979fd375)?
- Should the probe points have a prefix indicating that these are for crypto-auditing, such as `crau__new_context_with_data` instead of `new_context_with_data`?
