### PR TITLE
Fix potential double-free in DSA/DH finish slots

### DIFF
--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -207,6 +207,7 @@ static int dh_init(DH *dh)
 static int dh_finish(DH *dh)
 {
     BN_MONT_CTX_free(dh->method_mont_p);
+    dh->method_mont_p = NULL;
     return 1;
 }
 

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -468,6 +468,7 @@ static int dsa_init(DSA *dsa)
 static int dsa_finish(DSA *dsa)
 {
     BN_MONT_CTX_free(dsa->method_mont_p);
+    dsa->method_mont_p = NULL;
     return 1;
 }
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -9316,8 +9316,10 @@ static int test_low_level_dsa_method(void)
     DSA *dsa = NULL;
     const DSA_METHOD *def = DSA_get_default_method();
     DSA_METHOD *method = DSA_meth_dup(def);
+    DSA_SIG *dsa_sig = NULL;
     EVP_PKEY *pkey = NULL;
     int testresult = 0;
+    unsigned char dgst[32];
 
     if (nullprov != NULL) {
         testresult = TEST_skip("Test does not support a non-default library context");
@@ -9336,6 +9338,12 @@ static int test_low_level_dsa_method(void)
         goto err;
     if (!TEST_true(DSA_generate_key(dsa)))
         goto err;
+
+    /* Warm the Montgomery cache so the finish slot touches it (Issue: 32541) */
+    memset(dgst, 0, sizeof(dgst));
+    if (!TEST_ptr(dsa_sig = DSA_do_sign(dgst, sizeof(dgst), dsa)))
+        goto err;
+    DSA_SIG_free(dsa_sig);
 
     orig_dsa_sign = DSA_meth_get_sign(def);
     if (!TEST_true(DSA_meth_set_sign(method, tst_dsa_sign)))
@@ -9488,12 +9496,7 @@ static int test_low_level_dh_method(void)
     if (!TEST_true(DH_set_ex_data(dh, dh_ex_idx, (void *)"test")))
         goto err;
 
-    orig_dh_compute_key = DH_meth_get_compute_key(def);
-    if (!TEST_true(DH_meth_set_compute_key(method, tst_dh_compute_key)))
-        goto err;
-    if (!TEST_true(DH_set_method(dh, method)))
-        goto err;
-
+    /* Prepare the API for warming the cache */
     p = BN_dup(DH_get0_p(cdh));
     g = BN_dup(DH_get0_g(cdh));
     if (!TEST_ptr(p) || !TEST_ptr(g))
@@ -9503,6 +9506,21 @@ static int test_low_level_dh_method(void)
     p = g = NULL;
 
     if (!TEST_true(DH_generate_key(dh)))
+        goto err;
+
+    /* Warm the Montgomery cache before the switch (Issue: #32541) */
+    buf = OPENSSL_malloc(DH_size(dh));
+    if (!TEST_ptr(buf))
+        goto err;
+    if (!TEST_int_gt(DH_compute_key(buf, DH_get0_pub_key(dh), dh), 0))
+        goto err;
+    OPENSSL_free(buf);
+    buf = NULL;
+
+    orig_dh_compute_key = DH_meth_get_compute_key(def);
+    if (!TEST_true(DH_meth_set_compute_key(method, tst_dh_compute_key)))
+        goto err;
+    if (!TEST_true(DH_set_method(dh, method)))
         goto err;
 
     ctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);


### PR DESCRIPTION
The default DSA method's finish slot (`crypto/dsa/dsa_ossl.c`) and the
default DH method's finish slot (`crypto/dh/dh_key.c`) free the cached
Montgomery context without NULLing the pointer.  Once the cache has
been warmed (e.g. by signing in DSA, or deriving in DH), a subsequent
finish call — e.g. via `DSA_free()`/`DH_free()` after
`DSA_set_method()`/`DH_set_method()` — frees it again.

Both slots now NULL the pointer after `BN_MONT_CTX_free()`.  The
existing `test_low_level_dsa_method()` and `test_low_level_dh_method()`
in evp_extra warm the cache before switching methods, making the
regression deterministic: they segfault without the fix.

Please see individual commit messages for details.

Fixes: https://github.com/openssl/openssl/issues/32541
