### PR TITLE
Dynamic compression: do not leave errors behind on success

### DIFF
--- a/crypto/comp/c_brotli.c
+++ b/crypto/comp/c_brotli.c
@@ -289,6 +289,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_brotli_init)
 #define LIBBROTLIDEC "brotlidec"
 #endif
 
+    ERR_set_mark();
     brotli_encode_dso = DSO_load(NULL, LIBBROTLIENC, NULL, 0);
     if (brotli_encode_dso != NULL) {
         p_encode_init = (encode_init_ft)DSO_bind_func(brotli_encode_dso, "BrotliEncoderCreateInstance");
@@ -315,9 +316,12 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_brotli_init)
         || p_decode_stream == NULL || p_decode_has_more == NULL || p_decode_end == NULL
         || p_decode_error == NULL || p_decode_error_string == NULL || p_decode_is_finished == NULL
         || p_decode_oneshot == NULL) {
+        ERR_clear_last_mark();
         ossl_comp_brotli_cleanup();
         return 0;
     }
+    /* Do not leave errors behind on success. */
+    ERR_pop_to_mark();
 #endif
     return 1;
 }

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -278,6 +278,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zlib_init)
 #endif
 #endif
 
+    ERR_set_mark();
     zlib_dso = DSO_load(NULL, LIBZ, NULL, 0);
     if (zlib_dso != NULL) {
         p_compress = (compress_ft)DSO_bind_func(zlib_dso, "compress");
@@ -295,9 +296,12 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zlib_init)
         || p_inflate == NULL || p_inflateInit_ == NULL
         || p_deflateEnd == NULL || p_deflate == NULL
         || p_deflateInit_ == NULL || p_zError == NULL) {
+        ERR_clear_last_mark();
         ossl_comp_zlib_cleanup();
         return 0;
     }
+    /* Do not leave errors behind on success. */
+    ERR_pop_to_mark();
 #endif
     return 1;
 }

--- a/crypto/comp/c_zstd.c
+++ b/crypto/comp/c_zstd.c
@@ -357,6 +357,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zstd_init)
 #define LIBZSTD "zstd"
 #endif
 
+    ERR_set_mark();
     zstd_dso = DSO_load(NULL, LIBZSTD, NULL, 0);
     if (zstd_dso != NULL) {
         p_createCStream = (createCStream_ft)DSO_bind_func(zstd_dso, "ZSTD_createCStream");
@@ -383,9 +384,12 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zstd_init)
         || p_freeDStream == NULL || p_decompressStream == NULL || p_decompress == NULL
         || p_isError == NULL || p_getErrorName == NULL || p_DStreamInSize == NULL
         || p_CStreamInSize == NULL) {
+        ERR_clear_last_mark();
         ossl_comp_zstd_cleanup();
         return 0;
     }
+    /* Do not leave errors behind on success. */
+    ERR_pop_to_mark();
 #endif
     return 1;
 }


### PR DESCRIPTION
When loading the compression libraries dynamically on demand, do not leave errors in the error queue
when the library is simply missing and DSO_load()
fails. We return success so there should be no error left behind.

Fixes https://github.com/openssl/openssl/issues/23558
