### PR TITLE
quic-radix: complete thread-assisted client test coverage

### DIFF
--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -1541,6 +1541,14 @@ err:
     (OP_SIMPLE_PAIR_CONN(),      \
         OP_SET_DEFAULT_STREAM_MODE(C, SSL_DEFAULT_STREAM_MODE_NONE))
 
+/* Thread-assisted client and listener linked by an in-memory dgram pair. */
+#define OP_SIMPLE_PAIR_CONN_TA()  \
+    (OP_NEW_SSL_L_MEM(L),         \
+        OP_NEW_SSL_C_TA_MEM(C),   \
+        OP_LINK_DGRAM_PAIR(C, L), \
+        OP_LISTEN(L),             \
+        OP_CONNECT_WAIT(C))
+
 #define OP_NEW_STREAM(conn_name, stream_name, flags) \
     (OP_SELECT_SSL(0, conn_name),                    \
         OP_PUSH_PZ(#stream_name),                    \

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -1029,6 +1029,36 @@ err:
     return ok;
 }
 
+/* Local close: the thread-assisted client shuts the connection down. */
+DEF_SCRIPT(check_thread_assisted_close_local,
+    "thread-assisted client closes the connection")
+{
+    OP_SIMPLE_PAIR_CONN_TA();
+    OP_ACCEPT_CONN_WAIT(L, Sa, 0);
+
+    OP_WRITE_B(C, "raspberry");
+    OP_READ_EXPECT_B(Sa, "raspberry");
+
+    OP_SHUTDOWN_WAIT(C, 0, 0, NULL);
+    OP_EXPECT_CONN_CLOSE_INFO(C, 0, 1, 0);
+    OP_EXPECT_CONN_CLOSE_INFO(Sa, 0, 1, 1);
+}
+
+/* Remote close: the thread-assisted client handles the server's shutdown. */
+DEF_SCRIPT(check_thread_assisted_close_remote,
+    "thread-assisted client handles a remote close")
+{
+    OP_SIMPLE_PAIR_CONN_TA();
+    OP_ACCEPT_CONN_WAIT(L, Sa, 0);
+
+    OP_WRITE_B(C, "raspberry");
+    OP_READ_EXPECT_B(Sa, "raspberry");
+
+    OP_SHUTDOWN_WAIT(Sa, 0, 42, "changed my mind");
+    OP_EXPECT_CONN_CLOSE_INFO(Sa, 42, 1, 0);
+    OP_EXPECT_CONN_CLOSE_INFO(C, 42, 1, 1);
+}
+
 /*
  * script_5 - script_106 are place holders for tests we
  * currently keep in test/quic_multistream_test.c.
@@ -2498,6 +2528,8 @@ static SCRIPT_INFO *const scripts[] = {
     USE(check_ctx_cbks),
     USE(check_thread_assisted_idle),
     USE(check_thread_assisted_transfer),
+    USE(check_thread_assisted_close_local),
+    USE(check_thread_assisted_close_remote),
     USE(script_5),
     USE(script_6),
     USE(script_7),

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -1084,6 +1084,35 @@ DEF_SCRIPT(check_thread_assisted_stream_reset,
     OP_FUNC(check_stream_reset_5);
 }
 
+/* Explicitly created and accepted streams on a thread-assisted client. */
+DEF_SCRIPT(check_thread_assisted_streams,
+    "thread-assisted client with explicitly created/accepted streams")
+{
+    OP_SIMPLE_PAIR_CONN_TA();
+    OP_SET_DEFAULT_STREAM_MODE(C, SSL_DEFAULT_STREAM_MODE_NONE);
+    OP_ACCEPT_CONN_WAIT(L, Sa, 0);
+
+    /* Client-initiated stream accepted by the server */
+    OP_NEW_STREAM(C, Ca, 0 /* bidirectional */);
+    OP_WRITE_B(Ca, "raspberry");
+    OP_CONCLUDE(Ca);
+    OP_ACCEPT_STREAM_WAIT(Sa, Ss, 0);
+    OP_READ_EXPECT_B(Ss, "raspberry");
+    OP_EXPECT_FIN(Ss);
+    OP_WRITE_B(Ss, "elderberry");
+    OP_CONCLUDE(Ss);
+    OP_READ_EXPECT_B(Ca, "elderberry");
+    OP_EXPECT_FIN(Ca);
+
+    /* Server-initiated stream accepted by the client */
+    OP_NEW_STREAM(Sa, Sb, 0 /* bidirectional */);
+    OP_WRITE_B(Sb, "cranberry");
+    OP_ACCEPT_STREAM_WAIT(C, Cb, 0);
+    OP_READ_EXPECT_B(Cb, "cranberry");
+    OP_WRITE_B(Cb, "blueberry");
+    OP_READ_EXPECT_B(Sb, "blueberry");
+}
+
 /*
  * script_5 - script_106 are place holders for tests we
  * currently keep in test/quic_multistream_test.c.
@@ -2556,6 +2585,7 @@ static SCRIPT_INFO *const scripts[] = {
     USE(check_thread_assisted_close_local),
     USE(check_thread_assisted_close_remote),
     USE(check_thread_assisted_stream_reset),
+    USE(check_thread_assisted_streams),
     USE(script_5),
     USE(script_6),
     USE(script_7),

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -1059,6 +1059,31 @@ DEF_SCRIPT(check_thread_assisted_close_remote,
     OP_EXPECT_CONN_CLOSE_INFO(C, 42, 1, 1);
 }
 
+/* Stream reset sent and received by a thread-assisted client. */
+DEF_SCRIPT(check_thread_assisted_stream_reset,
+    "thread-assisted client sends and receives a stream reset")
+{
+    OP_SIMPLE_PAIR_CONN_TA();
+    OP_SET_DEFAULT_STREAM_MODE(C, SSL_DEFAULT_STREAM_MODE_NONE);
+    OP_ACCEPT_CONN_WAIT(L, Sa, 0);
+
+    /* Client-initiated reset observed by the server */
+    OP_NEW_STREAM(C, Ca, 0 /* bidirectional */);
+    OP_WRITE_B(Ca, "raspberry");
+    OP_STREAM_RESET(Ca, 42);
+    OP_ACCEPT_STREAM_WAIT(Sa, Ss, 0);
+    OP_SELECT_SSL(0, Ss);
+    OP_FUNC(check_stream_reset_5);
+
+    /* Server-initiated reset observed by the client */
+    OP_NEW_STREAM(Sa, Sb, 0 /* bidirectional */);
+    OP_WRITE_B(Sb, "elderberry");
+    OP_STREAM_RESET(Sb, 42);
+    OP_ACCEPT_STREAM_WAIT(C, Cb, 0);
+    OP_SELECT_SSL(0, Cb);
+    OP_FUNC(check_stream_reset_5);
+}
+
 /*
  * script_5 - script_106 are place holders for tests we
  * currently keep in test/quic_multistream_test.c.
@@ -2530,6 +2555,7 @@ static SCRIPT_INFO *const scripts[] = {
     USE(check_thread_assisted_transfer),
     USE(check_thread_assisted_close_local),
     USE(check_thread_assisted_close_remote),
+    USE(check_thread_assisted_stream_reset),
     USE(script_5),
     USE(script_6),
     USE(script_7),

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -979,6 +979,32 @@ DEF_SCRIPT(check_thread_assisted_idle,
     OP_TICK_ENABLE(C);
 }
 
+/*
+ * With per-op ticking disabled the client runs like a real thread-assisted
+ * app: progress comes only from API-call autoticks and the assist thread.
+ * Cover a full-duplex default-stream transfer with conclude/EOS both ways.
+ */
+DEF_SCRIPT(check_thread_assisted_transfer,
+    "thread-assisted client full-duplex transfer with conclude/EOS")
+{
+    OP_SIMPLE_PAIR_CONN_TA();
+    OP_ACCEPT_CONN_WAIT(L, Sa, 0);
+
+    OP_TICK_DISABLE(C);
+
+    OP_WRITE_B(C, "raspberry");
+    OP_CONCLUDE(C);
+    OP_READ_EXPECT_B(Sa, "raspberry");
+    OP_EXPECT_FIN(Sa);
+
+    OP_WRITE_B(Sa, "elderberry");
+    OP_CONCLUDE(Sa);
+    OP_READ_EXPECT_B(C, "elderberry");
+    OP_EXPECT_FIN(C);
+
+    OP_TICK_ENABLE(C);
+}
+
 DEF_FUNC(check_stream_reset_5)
 {
     int ok = 0;
@@ -2471,6 +2497,7 @@ static SCRIPT_INFO *const scripts[] = {
     USE(check_pc_flood),
     USE(check_ctx_cbks),
     USE(check_thread_assisted_idle),
+    USE(check_thread_assisted_transfer),
     USE(script_5),
     USE(script_6),
     USE(script_7),


### PR DESCRIPTION
Finish the thread-assist test migration for openssl/project#2012 (follow-up to #31918) by covering the remaining scenarios with radix vignettes, one commit each:

- data transfer: full-duplex default-stream echo with conclude/EOS in both directions; per-op ticking is disabled on the client so it runs like a real thread-assisted application, with progress coming only from API-call autoticks and the assist thread
- connection close: client-initiated shutdown, and a server-initiated close with an application error code that the client observes as a remote application close 
-  stream reset: reset sent by the client and observed by the server, and vice versa
- explicit streams: `SSL_stream_new()` and `SSL_accept_stream()` on a thread-assisted client (the old test only covered the default stream)

Also adds an `OP_SIMPLE_PAIR_CONN_TA()` op for the shared thread-assisted setup.

With this, the thread-assist coverage of test/quic_tserver_test.c has no unique scenarios left (its use_inject variant is already covered in quic_multistream_test.c).

Note on purpose: the thread method shares its method table with the plain client method, so these tests are not covering TA-specific stream logic. They are regression coverage for thread-assisted mode itself: all calls run concurrently with the assist thread (which only single-threaded tests would otherwise cover), the close tests exercise shutdown while the assist thread is still alive (it is only joined at SSL_free() time), and the transfer test runs the client without any SSL_handle_events() calls, the application model TA mode exists to support.
