### PR TITLE
dtls: fix flaky cookie exchange loop in listener test

### DIFF
--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -5411,7 +5411,7 @@ static int drive_until_connection_queued(SSL *listener, SSL *clientssl)
 
     SSL_set_connect_state(clientssl);
 
-    for (abortctr = 0; abortctr < 100; abortctr++) {
+    for (abortctr = 0; abortctr < 200; abortctr++) {
         retc = SSL_connect(clientssl);
         err_code = SSL_get_error(clientssl, retc);
         if (retc <= 0
@@ -5431,6 +5431,9 @@ static int drive_until_connection_queued(SSL *listener, SSL *clientssl)
 
         if ((poll_item.revents & SSL_POLL_EVENT_IC) != 0)
             return 1;
+
+        /* Loopback delivery can lag and a lost datagram needs a retransmit */
+        OSSL_sleep(10);
     }
 
     TEST_error("cookie exchange loop did not converge");


### PR DESCRIPTION
drive_until_connection_queued() spun through its iterations with a zero-timeout poll and no waiting, so over real loopback sockets the loop could run dry in microseconds if a datagram was not yet readable. On macOS loopback delivery is asynchronous, which made the blocking mode tests fail intermittently on slow runners with "cookie exchange loop did not converge". Sleep between iterations so a delayed datagram can arrive, and raise the iteration cap so the budget also covers the client's 1s initial retransmit timer if a datagram is lost outright.

This should fix this CI failure that can occasionally happen: https://github.com/openssl/openssl/actions/runs/33091149224/job/98583992012?pr=32550 . Marking urgent as it's a CI fix but happy to remove that label if someone thinks it's not that urgent as it doesn't happen too often.