### PR TITLE
Leave BIO_f_ssl() consistent when replacing its SSL object fails

### DIFF
--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -80,6 +80,8 @@ static int ssl_free(BIO *a)
     if (a == NULL)
         return 0;
     bs = BIO_get_data(a);
+    if (bs == NULL)
+        return 1;
     if (BIO_get_shutdown(a)) {
         if (bs->ssl != NULL && !SSL_in_init(bs->ssl))
             SSL_shutdown(bs->ssl);
@@ -89,6 +91,8 @@ static int ssl_free(BIO *a)
         BIO_set_init(a, 0);
     }
     OPENSSL_free(bs);
+    /* The BIO may be freed again, or given a new SSL, after this */
+    BIO_set_data(a, NULL);
     return 1;
 }
 
@@ -103,6 +107,8 @@ static int ssl_read(BIO *b, char *buf, size_t size, size_t *readbytes)
     if (buf == NULL)
         return 0;
     sb = BIO_get_data(b);
+    if (sb == NULL)
+        return 0;
     ssl = sb->ssl;
 
     BIO_clear_retry_flags(b);
@@ -175,6 +181,8 @@ static int ssl_write(BIO *b, const char *buf, size_t size, size_t *written)
     if (buf == NULL)
         return 0;
     bs = BIO_get_data(b);
+    if (bs == NULL)
+        return 0;
     ssl = bs->ssl;
 
     BIO_clear_retry_flags(b);
@@ -238,7 +246,7 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
 
     bs = BIO_get_data(b);
     next = BIO_next(b);
-    ssl = bs->ssl;
+    ssl = bs != NULL ? bs->ssl : NULL;
     if (ssl == NULL && cmd != BIO_C_SET_SSL)
         return 0;
     switch (cmd) {
@@ -291,12 +299,15 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = bs->num_renegotiates;
         break;
     case BIO_C_SET_SSL:
-        if (ssl != NULL) {
+        if (ssl != NULL)
             ssl_free(b);
-            if (!ssl_new(b))
-                return 0;
-            bs = BIO_get_data(b);
-        }
+        /*
+         * ssl_free() has released the state, or an earlier ssl_new() failed:
+         * in both cases the BIO has no state, so allocate it afresh.
+         */
+        if (BIO_get_data(b) == NULL && !ssl_new(b))
+            return 0;
+        bs = BIO_get_data(b);
         BIO_set_shutdown(b, num);
         ssl = (SSL *)ptr;
         bio = SSL_get_rbio(ssl);
@@ -432,6 +443,8 @@ static long ssl_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
     long ret = 1;
 
     bs = BIO_get_data(b);
+    if (bs == NULL)
+        return 0;
     ssl = bs->ssl;
     switch (cmd) {
     case BIO_CTRL_SET_CALLBACK:
@@ -535,7 +548,8 @@ int BIO_ssl_copy_session_id(BIO *t, BIO *f)
         return 0;
     tdata = BIO_get_data(t);
     fdata = BIO_get_data(f);
-    if ((tdata->ssl == NULL) || (fdata->ssl == NULL))
+    if (tdata == NULL || fdata == NULL
+        || tdata->ssl == NULL || fdata->ssl == NULL)
         return 0;
     if (!SSL_copy_session_id(tdata->ssl, (fdata->ssl)))
         return 0;

--- a/test/bio_ssl_test.c
+++ b/test/bio_ssl_test.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include <openssl/bio.h>
+#include <openssl/crypto.h>
+#include <openssl/ssl.h>
+#include "testutil.h"
+
+/*
+ * Number of allocations that are still to be failed.  Set to a positive
+ * value right before the call whose allocation should fail.
+ */
+static int fail_allocs = 0;
+
+static void *test_malloc(size_t num, const char *file, int line)
+{
+    if (fail_allocs > 0) {
+        fail_allocs--;
+        return NULL;
+    }
+    return malloc(num);
+}
+
+static void *test_realloc(void *addr, size_t num, const char *file, int line)
+{
+    return realloc(addr, num);
+}
+
+static void test_free(void *addr, const char *file, int line)
+{
+    free(addr);
+}
+
+int global_init(void)
+{
+    return CRYPTO_set_mem_functions(test_malloc, test_realloc, test_free);
+}
+
+/*
+ * Replacing the SSL object of a BIO_f_ssl() with BIO_set_ssl() frees the
+ * BIO's internal state and allocates it afresh.  If that allocation fails
+ * the BIO must be left in a consistent state: BIO_free() must not touch the
+ * freed state and a further BIO_set_ssl() must work again.
+ */
+static int test_bio_set_ssl_alloc_failure(void)
+{
+    SSL_CTX *ctx = NULL;
+    SSL *ssl1 = NULL, *ssl2 = NULL, *ssl3 = NULL, *got = NULL;
+    BIO *bio = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new(TLS_method()))
+        || !TEST_ptr(ssl1 = SSL_new(ctx))
+        || !TEST_ptr(ssl2 = SSL_new(ctx))
+        || !TEST_ptr(ssl3 = SSL_new(ctx))
+        || !TEST_ptr(bio = BIO_new(BIO_f_ssl()))
+        || !TEST_true(BIO_set_ssl(bio, ssl1, BIO_CLOSE)))
+        goto end;
+    /* Owned by the BIO from now on */
+    ssl1 = NULL;
+
+    /* Replacing the SSL frees the old one and allocates new BIO state */
+    fail_allocs = 1;
+    if (!TEST_false(BIO_set_ssl(bio, ssl2, BIO_CLOSE)))
+        goto end;
+    fail_allocs = 0;
+    /* ssl2 was not adopted; the BIO must know it has no SSL */
+    if (!TEST_false(BIO_get_ssl(bio, &got))
+        || !TEST_ptr_null(got))
+        goto end;
+
+    /* The BIO must be usable again */
+    if (!TEST_true(BIO_set_ssl(bio, ssl3, BIO_CLOSE)))
+        goto end;
+    ssl3 = NULL;
+    if (!TEST_true(BIO_get_ssl(bio, &got))
+        || !TEST_ptr(got))
+        goto end;
+
+    testresult = 1;
+end:
+    fail_allocs = 0;
+    /* Frees the SSL the BIO owns; must not double free the BIO state */
+    BIO_free(bio);
+    SSL_free(ssl1);
+    SSL_free(ssl2);
+    SSL_free(ssl3);
+    SSL_CTX_free(ctx);
+    return testresult;
+}
+
+/* Replacing the SSL object without any allocation failure */
+static int test_bio_set_ssl_replace(void)
+{
+    SSL_CTX *ctx = NULL;
+    SSL *ssl1 = NULL, *ssl2 = NULL, *got = NULL;
+    BIO *bio = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new(TLS_method()))
+        || !TEST_ptr(ssl1 = SSL_new(ctx))
+        || !TEST_ptr(ssl2 = SSL_new(ctx))
+        || !TEST_ptr(bio = BIO_new(BIO_f_ssl()))
+        || !TEST_true(BIO_set_ssl(bio, ssl1, BIO_CLOSE)))
+        goto end;
+    ssl1 = NULL;
+    if (!TEST_true(BIO_set_ssl(bio, ssl2, BIO_CLOSE)))
+        goto end;
+    ssl2 = NULL;
+    if (!TEST_true(BIO_get_ssl(bio, &got))
+        || !TEST_ptr(got))
+        goto end;
+
+    testresult = 1;
+end:
+    BIO_free(bio);
+    SSL_free(ssl1);
+    SSL_free(ssl2);
+    SSL_CTX_free(ctx);
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_bio_set_ssl_replace);
+    ADD_TEST(test_bio_set_ssl_alloc_failure);
+    return 1;
+}

--- a/test/build.info
+++ b/test/build.info
@@ -744,6 +744,11 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[bio_enc_test]=../include ../apps/include
   DEPEND[bio_enc_test]=../libcrypto libtestutil.a
 
+  PROGRAMS{noinst}=bio_ssl_test
+  SOURCE[bio_ssl_test]=bio_ssl_test.c
+  INCLUDE[bio_ssl_test]=../include ../apps/include
+  DEPEND[bio_ssl_test]=../libcrypto ../libssl libtestutil.a
+
   SOURCE[pkey_meth_kdf_test]=pkey_meth_kdf_test.c
   INCLUDE[pkey_meth_kdf_test]=../include ../apps/include
   DEPEND[pkey_meth_kdf_test]=../libcrypto libtestutil.a

--- a/test/recipes/61-test_bio_ssl.t
+++ b/test/recipes/61-test_bio_ssl.t
@@ -1,0 +1,11 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_bio_ssl", "bio_ssl_test");


### PR DESCRIPTION
`BIO_set_ssl()` on a `BIO_f_ssl()` that already holds an SSL object goes through `ssl_free()` to release the BIO's state (the `BIO_SSL` structure and, with `BIO_CLOSE`, the SSL object) and then through `ssl_new()` to allocate fresh state. `ssl_free()` left the BIO's data pointer pointing at the freed `BIO_SSL`, so if the allocation in `ssl_new()` failed the BIO kept a dangling pointer: `BIO_get_ssl()` read from freed memory and the final `BIO_free()` freed it a second time (#31388, found while investigating #27357).

This PR has `ssl_free()` clear the data pointer once the state has been released and accept a BIO that has no state, so that `BIO_free()` is safe after a failed replacement. In `BIO_C_SET_SSL` new state is allocated whenever the BIO has none, which covers both the replacement case and a retry after an earlier failure. The read, write, callback_ctrl and session-id-copy paths check for missing state, as `BIO_ssl_shutdown()` already did. Behaviour in the non-failure case is unchanged.

Tests: new `test/bio_ssl_test.c` (+ `61-test_bio_ssl.t`) installs a failing allocator via `CRYPTO_set_mem_functions()` around the second `BIO_set_ssl()` call, then checks that the BIO reports no SSL object, that it can be given an SSL object afterwards, and that freeing it is clean; a second case covers the ordinary replace-the-SSL path. Before the fix the failure-injection test reads freed memory and crashes in `BIO_free()`. Full `make test` passes locally on a `--strict-warnings` build; `clang-format` clean.

Fixes #31388

Checklist
- [ ] documentation is added or updated (n/a — error-path robustness, no documented behaviour changes)
- [x] tests are added or updated
