### PR TITLE
Accept a {NULL, 0} octet string as an empty context string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,14 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * The ML-DSA, SLH-DSA and EdDSA signature algorithms and the ML-DSA-MU
+   digest now accept a context string parameter given as an octet string with
+   a NULL data pointer and a length of 0, treating it as an empty context
+   string. Previously such a parameter was rejected, while an empty context
+   string with a non-NULL data pointer was accepted.
+
+   *Paul Grubbs*
+
  * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
    manpage for details.
 

--- a/providers/common/include/prov/provider_util.h
+++ b/providers/common/include/prov/provider_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -112,5 +112,14 @@ void ossl_prov_cache_exported_algorithms(const OSSL_ALGORITHM_CAPABLE *in,
 /* Duplicate a lump of memory safely */
 int ossl_prov_memdup(const void *src, size_t src_len,
     unsigned char **dest, size_t *dest_len);
+
+/*
+ * Get an octet string parameter that may legitimately be empty into a caller
+ * supplied buffer of |max_len| bytes.  Unlike OSSL_PARAM_get_octet_string(),
+ * a parameter with a NULL data pointer and a data size of 0 is accepted as an
+ * empty string.
+ */
+int ossl_prov_get_octet_string_allow_empty(const OSSL_PARAM *p, void *buf,
+    size_t max_len, size_t *used_len);
 
 #endif /* !defined(OSSL_PROVIDERS_COMMON_INCLUDE_PROV_PROVIDER_UTIL_H) */

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -244,3 +244,16 @@ int ossl_prov_memdup(const void *src, size_t src_len,
     }
     return 1;
 }
+
+int ossl_prov_get_octet_string_allow_empty(const OSSL_PARAM *p, void *buf,
+    size_t max_len, size_t *used_len)
+{
+    void *vp = buf;
+
+    if (p->data_type == OSSL_PARAM_OCTET_STRING && p->data == NULL
+        && p->data_size == 0) {
+        *used_len = 0;
+        return 1;
+    }
+    return OSSL_PARAM_get_octet_string(p, &vp, max_len, used_len);
+}

--- a/providers/implementations/digests/ml_dsa_mu_prov.c
+++ b/providers/implementations/digests/ml_dsa_mu_prov.c
@@ -29,6 +29,7 @@
 #include "prov/digestcommon.h"
 #include "prov/der_pq_dsa.h"
 #include "prov/implementations.h"
+#include "prov/provider_util.h"
 #include "internal/common.h"
 #include "internal/sha3.h"
 #include "providers/implementations/digests/ml_dsa_mu_prov.inc"
@@ -198,14 +199,11 @@ static int mu_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (ctx == NULL || !ml_dsa_mu_set_ctx_params_decoder(params, &p))
         return 0;
 
-    if (p.ctx != NULL) {
-        void *vp = ctx->context;
-
-        if (!OSSL_PARAM_get_octet_string(p.ctx, &vp, sizeof(ctx->context),
-                &(ctx->context_len))) {
-            ctx->context_len = 0;
-            return 0;
-        }
+    if (p.ctx != NULL
+        && !ossl_prov_get_octet_string_allow_empty(p.ctx, ctx->context,
+            sizeof(ctx->context), &(ctx->context_len))) {
+        ctx->context_len = 0;
+        return 0;
     }
     if (p.propq != NULL) {
         if (p.propq->data_type != OSSL_PARAM_UTF8_STRING

--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -22,6 +22,7 @@
 #include "prov/securitycheck.h"
 #include "prov/provider_ctx.h"
 #include "prov/der_ecx.h"
+#include "prov/provider_util.h"
 #include "crypto/ecx.h"
 #include "internal/fips.h"
 
@@ -898,15 +899,12 @@ static int eddsa_set_ctx_params_internal(PROV_EDDSA_CTX *peddsactx, const struct
         }
     }
 
-    if (p->ctx != NULL) {
-        void *vp_context_string = peddsactx->context_string;
-
-        if (!OSSL_PARAM_get_octet_string(p->ctx, &vp_context_string,
-                sizeof(peddsactx->context_string),
-                &(peddsactx->context_string_len))) {
-            peddsactx->context_string_len = 0;
-            return 0;
-        }
+    if (p->ctx != NULL
+        && !ossl_prov_get_octet_string_allow_empty(p->ctx,
+            peddsactx->context_string, sizeof(peddsactx->context_string),
+            &(peddsactx->context_string_len))) {
+        peddsactx->context_string_len = 0;
+        return 0;
     }
 
     return 1;

--- a/providers/implementations/signature/ml_dsa_sig.c
+++ b/providers/implementations/signature/ml_dsa_sig.c
@@ -19,6 +19,7 @@
 #include "prov/providercommon.h"
 #include "prov/provider_ctx.h"
 #include "prov/der_ml_dsa.h"
+#include "prov/provider_util.h"
 #include "crypto/ml_dsa.h"
 #include "internal/common.h"
 #include "internal/packet.h"
@@ -388,14 +389,11 @@ static int ml_dsa_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (pctx == NULL || !ml_dsa_verifymsg_set_ctx_params_decoder(params, &p))
         return 0;
 
-    if (p.ctx != NULL) {
-        void *vp = pctx->context_string;
-
-        if (!OSSL_PARAM_get_octet_string(p.ctx, &vp, sizeof(pctx->context_string),
-                &(pctx->context_string_len))) {
-            pctx->context_string_len = 0;
-            return 0;
-        }
+    if (p.ctx != NULL
+        && !ossl_prov_get_octet_string_allow_empty(p.ctx, pctx->context_string,
+            sizeof(pctx->context_string), &(pctx->context_string_len))) {
+        pctx->context_string_len = 0;
+        return 0;
     }
 
     if (p.ent != NULL) {

--- a/providers/implementations/signature/slh_dsa_sig.c
+++ b/providers/implementations/signature/slh_dsa_sig.c
@@ -16,6 +16,7 @@
 #include "prov/providercommon.h"
 #include "prov/provider_ctx.h"
 #include "prov/der_slh_dsa.h"
+#include "prov/provider_util.h"
 #include "crypto/slh_dsa.h"
 #include "internal/cryptlib.h"
 #include "internal/sizes.h"
@@ -284,15 +285,12 @@ static int slh_dsa_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (pctx == NULL || !slh_dsa_set_ctx_params_decoder(params, &p))
         return 0;
 
-    if (p.context != NULL) {
-        void *vp = pctx->context_string;
-
-        if (!OSSL_PARAM_get_octet_string(p.context, &vp,
-                sizeof(pctx->context_string),
-                &(pctx->context_string_len))) {
-            pctx->context_string_len = 0;
-            return 0;
-        }
+    if (p.context != NULL
+        && !ossl_prov_get_octet_string_allow_empty(p.context,
+            pctx->context_string, sizeof(pctx->context_string),
+            &(pctx->context_string_len))) {
+        pctx->context_string_len = 0;
+        return 0;
     }
 
     if (p.entropy != NULL) {

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -7714,6 +7714,57 @@ err:
 }
 #endif /* OPENSSL_NO_ECX */
 
+#ifndef OPENSSL_NO_ECX
+/*
+ * A context string parameter of {NULL, 0} is an empty context string, the same
+ * as no context string parameter at all.  Ed448 always uses a context string
+ * (empty by default), so check that a signature made with one verifies with
+ * the other.
+ */
+static int test_ed448_empty_context(void)
+{
+    int ret = 0;
+    EVP_PKEY *pkey = NULL;
+    EVP_MD_CTX *mctx = NULL;
+    static const unsigned char msg[] = "Hello World";
+    unsigned char sig[114];
+    size_t siglen = sizeof(sig);
+    OSSL_PARAM null_ctx[2];
+
+    null_ctx[0] = OSSL_PARAM_construct_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING,
+        NULL, 0);
+    null_ctx[1] = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(testctx, testpropq, "ED448"))
+        || !TEST_ptr(mctx = EVP_MD_CTX_new()))
+        goto err;
+
+    /* Sign with {NULL, 0}, verify with the parameter omitted */
+    if (!TEST_true(EVP_DigestSignInit_ex(mctx, NULL, NULL, testctx, testpropq,
+            pkey, null_ctx))
+        || !TEST_true(EVP_DigestSign(mctx, sig, &siglen, msg, sizeof(msg)))
+        || !TEST_true(EVP_DigestVerifyInit_ex(mctx, NULL, NULL, testctx,
+            testpropq, pkey, NULL))
+        || !TEST_true(EVP_DigestVerify(mctx, sig, siglen, msg, sizeof(msg))))
+        goto err;
+
+    /* Sign with the parameter omitted, verify with {NULL, 0} */
+    siglen = sizeof(sig);
+    if (!TEST_true(EVP_DigestSignInit_ex(mctx, NULL, NULL, testctx, testpropq,
+            pkey, NULL))
+        || !TEST_true(EVP_DigestSign(mctx, sig, &siglen, msg, sizeof(msg)))
+        || !TEST_true(EVP_DigestVerifyInit_ex(mctx, NULL, NULL, testctx,
+            testpropq, pkey, null_ctx))
+        || !TEST_true(EVP_DigestVerify(mctx, sig, siglen, msg, sizeof(msg))))
+        goto err;
+    ret = 1;
+err:
+    EVP_MD_CTX_free(mctx);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+#endif
+
 static int test_sign_continuation(void)
 {
     OSSL_PROVIDER *fake_rsa = NULL;
@@ -9640,6 +9691,8 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_ECX
     ADD_ALL_TESTS(test_ecx_short_keys, OSSL_NELEM(ecxnids));
     ADD_ALL_TESTS(test_ecx_not_private_key, OSSL_NELEM(keys));
+    if (fips_provider_version_ge(testctx, 4, 1, 0))
+        ADD_TEST(test_ed448_empty_context);
 #endif
 
     ADD_TEST(test_sign_continuation);

--- a/test/ml_dsa_test.c
+++ b/test/ml_dsa_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -617,6 +617,94 @@ err:
     return ret;
 }
 
+/*
+ * A context string parameter of {NULL, 0} is an empty context string, the same
+ * as a parameter with a non-NULL pointer and a length of 0 or no parameter at
+ * all.  Check that signatures made with any one of those verify with any other,
+ * and that the ML-DSA-MU digest agrees.
+ */
+static int ml_dsa_empty_context_test(void)
+{
+    int ret = 0;
+    const char *alg = "ML-DSA-44";
+    EVP_PKEY *key = NULL;
+    EVP_PKEY_CTX *sctx = NULL, *vctx = NULL;
+    EVP_SIGNATURE *sig_alg = NULL;
+    EVP_MD *md = NULL;
+    EVP_MD_CTX *mctx = NULL;
+    uint8_t *sig = NULL, *pub = NULL;
+    size_t sig_len = 0, pub_len = 0;
+    uint8_t mu1[64], mu2[64];
+    OSSL_PARAM null_ctx[2], mu_params[3];
+
+    null_ctx[0] = OSSL_PARAM_construct_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING,
+        NULL, 0);
+    null_ctx[1] = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(key = do_gen_key(alg, NULL, 0))
+        || !TEST_ptr(sig_alg = EVP_SIGNATURE_fetch(lib_ctx, alg, NULL)))
+        goto err;
+
+    /* Sign with {NULL, 0}, verify with the parameter omitted */
+    if (!TEST_ptr(sctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL))
+        || !TEST_int_eq(EVP_PKEY_sign_message_init(sctx, sig_alg, null_ctx), 1)
+        || !TEST_int_eq(EVP_PKEY_sign(sctx, NULL, &sig_len, msg1, sizeof(msg1)), 1)
+        || !TEST_ptr(sig = OPENSSL_malloc(sig_len))
+        || !TEST_int_eq(EVP_PKEY_sign(sctx, sig, &sig_len, msg1, sizeof(msg1)), 1)
+        || !TEST_ptr(vctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL))
+        || !TEST_int_eq(EVP_PKEY_verify_message_init(vctx, sig_alg, NULL), 1)
+        || !TEST_int_eq(EVP_PKEY_verify(vctx, sig, sig_len, msg1, sizeof(msg1)), 1))
+        goto err;
+    EVP_PKEY_CTX_free(sctx);
+    EVP_PKEY_CTX_free(vctx);
+    sctx = vctx = NULL;
+
+    /* Sign with the parameter omitted, verify with {NULL, 0} */
+    if (!TEST_ptr(sctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL))
+        || !TEST_int_eq(EVP_PKEY_sign_message_init(sctx, sig_alg, NULL), 1)
+        || !TEST_int_eq(EVP_PKEY_sign(sctx, sig, &sig_len, msg1, sizeof(msg1)), 1)
+        || !TEST_ptr(vctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL))
+        || !TEST_int_eq(EVP_PKEY_verify_message_init(vctx, sig_alg, null_ctx), 1)
+        || !TEST_int_eq(EVP_PKEY_verify(vctx, sig, sig_len, msg1, sizeof(msg1)), 1))
+        goto err;
+
+    /* ML-DSA-MU with {NULL, 0} gives the same mu as with no context string */
+    if (!TEST_int_eq(EVP_PKEY_get_raw_public_key(key, NULL, &pub_len), 1)
+        || !TEST_ptr(pub = OPENSSL_malloc(pub_len))
+        || !TEST_int_eq(EVP_PKEY_get_raw_public_key(key, pub, &pub_len), 1)
+        || !TEST_ptr(md = EVP_MD_fetch(lib_ctx, "ML-DSA-MU", NULL))
+        || !TEST_ptr(mctx = EVP_MD_CTX_new()))
+        goto err;
+    mu_params[0] = OSSL_PARAM_construct_octet_string(OSSL_DIGEST_PARAM_MU_PUB_KEY,
+        pub, pub_len);
+    mu_params[1] = OSSL_PARAM_construct_end();
+    if (!TEST_true(EVP_DigestInit_ex2(mctx, md, mu_params))
+        || !TEST_true(EVP_DigestUpdate(mctx, msg1, sizeof(msg1)))
+        || !TEST_true(EVP_DigestFinalXOF(mctx, mu1, sizeof(mu1))))
+        goto err;
+    mu_params[1] = OSSL_PARAM_construct_octet_string(OSSL_DIGEST_PARAM_MU_CONTEXT_STRING,
+        NULL, 0);
+    mu_params[2] = OSSL_PARAM_construct_end();
+    EVP_MD_CTX_free(mctx);
+    if (!TEST_ptr(mctx = EVP_MD_CTX_new())
+        || !TEST_true(EVP_DigestInit_ex2(mctx, md, mu_params))
+        || !TEST_true(EVP_DigestUpdate(mctx, msg1, sizeof(msg1)))
+        || !TEST_true(EVP_DigestFinalXOF(mctx, mu2, sizeof(mu2)))
+        || !TEST_mem_eq(mu1, sizeof(mu1), mu2, sizeof(mu2)))
+        goto err;
+    ret = 1;
+err:
+    EVP_MD_CTX_free(mctx);
+    EVP_MD_free(md);
+    EVP_PKEY_CTX_free(sctx);
+    EVP_PKEY_CTX_free(vctx);
+    EVP_SIGNATURE_free(sig_alg);
+    EVP_PKEY_free(key);
+    OPENSSL_free(sig);
+    OPENSSL_free(pub);
+    return ret;
+}
+
 static int ml_dsa_priv_pub_bad_t0_test(void)
 {
     int ret = 0;
@@ -796,6 +884,8 @@ int setup_tests(void)
     ADD_TEST(from_data_invalid_public_test);
     ADD_TEST(from_data_bad_input_test);
     ADD_TEST(ml_dsa_digest_sign_verify_test);
+    if (fips_provider_version_ge(lib_ctx, 4, 1, 0))
+        ADD_TEST(ml_dsa_empty_context_test);
     ADD_TEST(ml_dsa_priv_pub_bad_t0_test);
 
     /*

--- a/test/slh_dsa_test.c
+++ b/test/slh_dsa_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -585,6 +585,63 @@ err:
     return ret;
 }
 
+/*
+ * A context string parameter of {NULL, 0} is an empty context string, the same
+ * as no context string parameter at all.  Check that a signature made with one
+ * verifies with the other.
+ */
+static int slh_dsa_empty_context_test(void)
+{
+    int ret = 0;
+    const char *alg = "SLH-DSA-SHA2-128f";
+    EVP_PKEY *key = NULL;
+    EVP_PKEY_CTX *sctx = NULL, *vctx = NULL;
+    EVP_SIGNATURE *sig_alg = NULL;
+    uint8_t *sig = NULL;
+    size_t sig_len = 0;
+    static uint8_t msg[] = "Hello World";
+    OSSL_PARAM null_ctx[2];
+
+    null_ctx[0] = OSSL_PARAM_construct_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING,
+        NULL, 0);
+    null_ctx[1] = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(key = do_gen_key(alg, NULL, 0))
+        || !TEST_ptr(sig_alg = EVP_SIGNATURE_fetch(lib_ctx, alg, NULL)))
+        goto err;
+
+    /* Sign with {NULL, 0}, verify with the parameter omitted */
+    if (!TEST_ptr(sctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL))
+        || !TEST_int_eq(EVP_PKEY_sign_message_init(sctx, sig_alg, null_ctx), 1)
+        || !TEST_int_eq(EVP_PKEY_sign(sctx, NULL, &sig_len, msg, sizeof(msg)), 1)
+        || !TEST_ptr(sig = OPENSSL_malloc(sig_len))
+        || !TEST_int_eq(EVP_PKEY_sign(sctx, sig, &sig_len, msg, sizeof(msg)), 1)
+        || !TEST_ptr(vctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL))
+        || !TEST_int_eq(EVP_PKEY_verify_message_init(vctx, sig_alg, NULL), 1)
+        || !TEST_int_eq(EVP_PKEY_verify(vctx, sig, sig_len, msg, sizeof(msg)), 1))
+        goto err;
+    EVP_PKEY_CTX_free(sctx);
+    EVP_PKEY_CTX_free(vctx);
+    sctx = vctx = NULL;
+
+    /* Sign with the parameter omitted, verify with {NULL, 0} */
+    if (!TEST_ptr(sctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL))
+        || !TEST_int_eq(EVP_PKEY_sign_message_init(sctx, sig_alg, NULL), 1)
+        || !TEST_int_eq(EVP_PKEY_sign(sctx, sig, &sig_len, msg, sizeof(msg)), 1)
+        || !TEST_ptr(vctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL))
+        || !TEST_int_eq(EVP_PKEY_verify_message_init(vctx, sig_alg, null_ctx), 1)
+        || !TEST_int_eq(EVP_PKEY_verify(vctx, sig, sig_len, msg, sizeof(msg)), 1))
+        goto err;
+    ret = 1;
+err:
+    EVP_PKEY_CTX_free(sctx);
+    EVP_PKEY_CTX_free(vctx);
+    EVP_SIGNATURE_free(sig_alg);
+    EVP_PKEY_free(key);
+    OPENSSL_free(sig);
+    return ret;
+}
+
 static int slh_dsa_keygen_invalid_test(void)
 {
     int ret = 0;
@@ -670,6 +727,8 @@ int setup_tests(void)
     ADD_ALL_TESTS(slh_dsa_sign_verify_test, OSSL_NELEM(slh_dsa_sig_testdata));
     ADD_ALL_TESTS(slh_dsa_keygen_test, OSSL_NELEM(slh_dsa_keygen_testdata));
     ADD_TEST(slh_dsa_digest_sign_verify_test);
+    if (fips_provider_version_ge(lib_ctx, 4, 1, 0))
+        ADD_TEST(slh_dsa_empty_context_test);
     ADD_TEST(slh_dsa_keygen_invalid_test);
     return 1;
 }


### PR DESCRIPTION
The ML-DSA, SLH-DSA and EdDSA signature implementations and the ML-DSA-MU digest take their context string from an octet-string `OSSL_PARAM` via `OSSL_PARAM_get_octet_string()`, which rejects a parameter whose data pointer is NULL regardless of its length. A caller that passes an empty context string as `{NULL, 0}` — for instance because it propagates a NULL pointer / zero length pair from its own API — therefore had the operation fail with "passed a null parameter", while the same empty context string given as `{"", 0}` was accepted, and omitting the parameter altogether has the same meaning (#31783, #31066).

This PR adds `ossl_prov_get_octet_string_allow_empty()` to the provider utilities (`providers/common/provider_util.c`, part of `$FIPSCOMMON`), which treats a NULL data pointer with a zero size as an empty string and otherwise behaves exactly like `OSSL_PARAM_get_octet_string()`, and uses it at the four context-string sites. The public `OSSL_PARAM_get_octet_string()` is deliberately left unchanged: its NULL check applies to all octet-string parameters and callers may rely on it. A CHANGES.md entry documents the newly accepted input.

Before:
```c
OSSL_PARAM p[] = { OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING, NULL, 0), OSSL_PARAM_END };
EVP_PKEY_sign_message_init(ctx, sig, p);   /* fails: passed a null parameter */
```
After: succeeds, and the signature verifies with the parameter omitted (and vice versa).

Tests: new cases in `test/ml_dsa_test.c`, `test/slh_dsa_test.c` and `test/evp_extra_test.c` (Ed448) check that a signature made with a `{NULL, 0}` context string verifies with the parameter omitted and vice versa, and that ML-DSA-MU computes the same mu with a `{NULL, 0}` context string as with none; they fail without the fix. Full `make test` passes locally on a `--strict-warnings` build, and the same recipes pass on an `enable-fips` build (the FIPS module compiles the changed sites). All changed hunks are `clang-format` clean.

Fixes #31783
Fixes #31066

Checklist
- [x] documentation is added or updated (CHANGES.md)
- [x] tests are added or updated
