### PR TITLE
3.5, 3.4: fix param type bug with AES-CTR-HMAC-SHA & add range sanity checking

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -146,8 +146,6 @@ static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             || p->data == NULL
             || p->data_size < EVP_AEAD_TLS1_AAD_LEN
             || !aes_get_multiblock_interleave(p1, &mb_param.interleave)
-            || p1 == NULL
-            || !OSSL_PARAM_get_uint(p1, &mb_param.interleave)
             || tls1_aad_plaintext_len(p->data) > SSL3_RT_MAX_PLAIN_LENGTH
             || p->data_size
                 > (size_t)SSL3_RT_MAX_PLAIN_LENGTH * mb_param.interleave) {
@@ -183,7 +181,6 @@ static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             || pin->data == NULL
             || pin->data_size == 0
             || p->data_size != pin->data_size
-            || p1 == NULL
             || !aes_get_multiblock_interleave(p1, &mb_param.interleave)
             || pin->data_size
                 > (size_t)SSL3_RT_MAX_PLAIN_LENGTH * mb_param.interleave) {

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -19,6 +19,7 @@
 /* For SSL3_VERSION and TLS1_VERSION */
 #include <openssl/prov_ssl.h>
 #include <openssl/proverr.h>
+#include <openssl/ssl3.h>
 #include "cipher_aes_cbc_hmac_sha.h"
 #include "prov/implementations.h"
 #include "prov/providercommon.h"
@@ -32,6 +33,21 @@
 
 #define AES_CBC_HMAC_SHA_FLAGS (PROV_CIPHER_FLAG_AEAD \
     | PROV_CIPHER_FLAG_TLS1_MULTIBLOCK)
+
+#if !defined(OPENSSL_NO_MULTIBLOCK)
+static int aes_get_multiblock_interleave(const OSSL_PARAM *p,
+    unsigned int *interleave)
+{
+    return p != NULL
+        && OSSL_PARAM_get_uint(p, interleave)
+        && (*interleave == 4 || *interleave == 8);
+}
+
+static unsigned int tls1_aad_plaintext_len(const unsigned char *aad)
+{
+    return ((unsigned int)aad[11] << 8) | aad[12];
+}
+#endif /* !defined(OPENSSL_NO_MULTIBLOCK) */
 
 static OSSL_FUNC_cipher_encrypt_init_fn aes_einit;
 static OSSL_FUNC_cipher_decrypt_init_fn aes_dinit;
@@ -69,7 +85,7 @@ static const OSSL_PARAM cipher_aes_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD, NULL, 0),
 #if !defined(OPENSSL_NO_MULTIBLOCK)
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_MAX_SEND_FRAGMENT, NULL),
-    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_AAD, NULL),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_AAD, NULL, 0),
     OSSL_PARAM_uint(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_INTERLEAVE, NULL),
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC, NULL, 0),
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC_IN, NULL, 0),
@@ -127,8 +143,14 @@ static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         const OSSL_PARAM *p1 = OSSL_PARAM_locate_const(params,
             OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_INTERLEAVE);
         if (p->data_type != OSSL_PARAM_OCTET_STRING
+            || p->data == NULL
+            || p->data_size < EVP_AEAD_TLS1_AAD_LEN
+            || !aes_get_multiblock_interleave(p1, &mb_param.interleave)
             || p1 == NULL
-            || !OSSL_PARAM_get_uint(p1, &mb_param.interleave)) {
+            || !OSSL_PARAM_get_uint(p1, &mb_param.interleave)
+            || tls1_aad_plaintext_len(p->data) > SSL3_RT_MAX_PLAIN_LENGTH
+            || p->data_size
+                > (size_t)SSL3_RT_MAX_PLAIN_LENGTH * mb_param.interleave) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
         }
@@ -155,10 +177,17 @@ static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC_IN);
 
         if (p->data_type != OSSL_PARAM_OCTET_STRING
+            || p->data == NULL
             || pin == NULL
             || pin->data_type != OSSL_PARAM_OCTET_STRING
+            || pin->data_type != OSSL_PARAM_OCTET_STRING
+            || pin->data == NULL
+            || pin->data_size == 0
+            || p->data_size != pin->data_size
             || p1 == NULL
-            || !OSSL_PARAM_get_uint(p1, &mb_param.interleave)) {
+            || !aes_get_multiblock_interleave(p1, &mb_param.interleave)
+            || pin->data_size
+                > (size_t)SSL3_RT_MAX_PLAIN_LENGTH * mb_param.interleave) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -180,7 +180,6 @@ static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             || p->data == NULL
             || pin == NULL
             || pin->data_type != OSSL_PARAM_OCTET_STRING
-            || pin->data_type != OSSL_PARAM_OCTET_STRING
             || pin->data == NULL
             || pin->data_size == 0
             || p->data_size != pin->data_size

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -22,6 +22,8 @@
 #include <openssl/pem.h>
 #include <openssl/kdf.h>
 #include <openssl/provider.h>
+#include <openssl/prov_ssl.h>
+#include <openssl/ssl3.h>
 #include <openssl/core_names.h>
 #include <openssl/params.h>
 #include <openssl/param_build.h>
@@ -6729,6 +6731,71 @@ err:
 #endif /* OPENSSL_NO_DYNAMIC_ENGINE */
 #endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
+#if !defined(OPENSSL_NO_MULTIBLOCK)
+static int test_aes_cbc_hmac_sha_reject_multiblock_params(const OSSL_PARAM *params)
+{
+    static const unsigned char key[16] = { 0 };
+    static const unsigned char iv[16] = { 0 };
+    EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER_CTX *ctx = NULL;
+    int ret = 0;
+
+    cipher = EVP_CIPHER_fetch(testctx, "AES-128-CBC-HMAC-SHA256",
+        "provider=default");
+    if (cipher == NULL) {
+        ERR_clear_error();
+        return TEST_skip("AES-CBC-HMAC-SHA multiblock cipher is not available");
+    }
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_true(EVP_EncryptInit_ex2(ctx, cipher, key, iv, NULL))
+        || !TEST_false(EVP_CIPHER_CTX_set_params(ctx, params)))
+        goto end;
+
+    ERR_clear_error();
+    ret = 1;
+end:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    return ret;
+}
+
+static int test_aes_cbc_hmac_sha_short_multiblock_aad(void)
+{
+    unsigned char aad[EVP_AEAD_TLS1_AAD_LEN - 1] = { 0 };
+    unsigned int interleave = 4;
+    OSSL_PARAM params[3], *p = params;
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_AAD,
+        aad, sizeof(aad));
+    *p++ = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_INTERLEAVE,
+        &interleave);
+    *p = OSSL_PARAM_construct_end();
+
+    return test_aes_cbc_hmac_sha_reject_multiblock_params(params);
+}
+
+static int test_aes_cbc_hmac_sha_large_multiblock_aad(void)
+{
+    static const unsigned int oversized_len = SSL3_RT_MAX_PLAIN_LENGTH + 1;
+    unsigned char aad[EVP_AEAD_TLS1_AAD_LEN] = { 0 };
+    unsigned int interleave = 4;
+    OSSL_PARAM params[3], *p = params;
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_AAD,
+        aad, sizeof(aad));
+    *p++ = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_INTERLEAVE,
+        &interleave);
+    *p = OSSL_PARAM_construct_end();
+
+    aad[9] = (unsigned char)(TLS1_2_VERSION >> 8);
+    aad[10] = (unsigned char)TLS1_2_VERSION;
+    aad[11] = (unsigned char)(oversized_len >> 8);
+    aad[12] = (unsigned char)oversized_len;
+
+    return test_aes_cbc_hmac_sha_reject_multiblock_params(params);
+}
+#endif
+
 #ifndef OPENSSL_NO_ECX
 static int ecxnids[] = {
     NID_X25519,
@@ -8456,6 +8523,10 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_ivlen_change, OSSL_NELEM(ivlen_change_ciphers));
     if (OSSL_NELEM(keylen_change_ciphers) - 1 > 0)
         ADD_ALL_TESTS(test_keylen_change, OSSL_NELEM(keylen_change_ciphers) - 1);
+#if !defined(OPENSSL_NO_MULTIBLOCK)
+    ADD_TEST(test_aes_cbc_hmac_sha_short_multiblock_aad);
+    ADD_TEST(test_aes_cbc_hmac_sha_large_multiblock_aad);
+#endif
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_ALL_TESTS(test_custom_pmeth, 12);


### PR DESCRIPTION
This introduces a fuzzer failure, so add some range sanity checking and unit tests.

- [ ] documentation is added or updated
- [x] tests are added or updated