### PR TITLE
Harden adding error text. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -216,6 +216,14 @@ OpenSSL 4.1
 
    *Jakub Zelenka*
 
+ * Deprecated ERR_add_error_data() and ERR_add_error_vdata(). Their `num`
+   argument counts the strings that follow it, nothing verifies that the
+   count is right, and a value larger than the number of arguments actually
+   passed reads beyond them. Use ERR_add_error_txt() to append a single
+   string, or ERR_raise_data() to raise an error carrying formatted text.
+
+   *Bob Beck*
+
  * Deprecated BIO_snprintf() and BIO_vsnprintf(). C99 snprintf() is now
    universally available, and the wrappers return -1 on truncation rather
    than the would-have-been length, so callers reaching for the standard

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -614,8 +614,9 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
         vtmp.section = NULL;
         vtmp.value = (char *)str;
         if (!X509V3_get_value_bool(&vtmp, &atmp->value.boolean)) {
-            ERR_raise(ERR_LIB_ASN1, ASN1_R_ILLEGAL_BOOLEAN);
-            goto bad_str;
+            ERR_raise_data(ERR_LIB_ASN1, ASN1_R_ILLEGAL_BOOLEAN,
+                "string=%s", str);
+            goto bad_form;
         }
         break;
 
@@ -628,8 +629,9 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
         if ((atmp->value.integer
                 = s2i_ASN1_INTEGER(NULL, str))
             == NULL) {
-            ERR_raise(ERR_LIB_ASN1, ASN1_R_ILLEGAL_INTEGER);
-            goto bad_str;
+            ERR_raise_data(ERR_LIB_ASN1, ASN1_R_ILLEGAL_INTEGER,
+                "string=%s", str);
+            goto bad_form;
         }
         break;
 
@@ -639,8 +641,9 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             goto bad_form;
         }
         if ((atmp->value.object = OBJ_txt2obj(str, 0)) == NULL) {
-            ERR_raise(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT);
-            goto bad_str;
+            ERR_raise_data(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT,
+                "string=%s", str);
+            goto bad_form;
         }
         break;
 
@@ -651,17 +654,20 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             goto bad_form;
         }
         if ((atmp->value.asn1_string = ASN1_STRING_new()) == NULL) {
-            ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
-            goto bad_str;
+            ERR_raise_data(ERR_LIB_ASN1, ERR_R_ASN1_LIB,
+                "string=%s", str);
+            goto bad_form;
         }
         if (!ASN1_STRING_set1_string(atmp->value.asn1_string, str)) {
-            ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
-            goto bad_str;
+            ERR_raise_data(ERR_LIB_ASN1, ERR_R_ASN1_LIB,
+                "string=%s", str);
+            goto bad_form;
         }
         atmp->value.asn1_string->type = utype;
         if (!ASN1_TIME_check(atmp->value.asn1_string)) {
-            ERR_raise(ERR_LIB_ASN1, ASN1_R_ILLEGAL_TIME_VALUE);
-            goto bad_str;
+            ERR_raise_data(ERR_LIB_ASN1, ASN1_R_ILLEGAL_TIME_VALUE,
+                "string=%s", str);
+            goto bad_form;
         }
 
         break;
@@ -687,8 +693,9 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
         if (ASN1_mbstring_copy(&atmp->value.asn1_string, (unsigned char *)str,
                 -1, format, ASN1_tag2bit(utype))
             <= 0) {
-            ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
-            goto bad_str;
+            ERR_raise_data(ERR_LIB_ASN1, ERR_R_ASN1_LIB,
+                "string=%s", str);
+            goto bad_form;
         }
 
         break;
@@ -702,22 +709,25 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
 
         if (format == ASN1_GEN_FORMAT_HEX) {
             if ((rdata = OPENSSL_hexstr2buf(str, &rdlen)) == NULL) {
-                ERR_raise(ERR_LIB_ASN1, ASN1_R_ILLEGAL_HEX);
-                goto bad_str;
+                ERR_raise_data(ERR_LIB_ASN1, ASN1_R_ILLEGAL_HEX,
+                    "string=%s", str);
+                goto bad_form;
             }
             atmp->value.asn1_string->data = rdata;
             atmp->value.asn1_string->length = rdlen;
             atmp->value.asn1_string->type = utype;
         } else if (format == ASN1_GEN_FORMAT_ASCII) {
             if (!ASN1_STRING_set1_string(atmp->value.asn1_string, str)) {
-                ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
-                goto bad_str;
+                ERR_raise_data(ERR_LIB_ASN1, ERR_R_ASN1_LIB,
+                    "string=%s", str);
+                goto bad_form;
             }
         } else if ((format == ASN1_GEN_FORMAT_BITLIST)
             && (utype == V_ASN1_BIT_STRING)) {
             if (!CONF_parse_list(str, ',', 1, bitstr_cb, atmp->value.bit_string)) {
-                ERR_raise(ERR_LIB_ASN1, ASN1_R_LIST_ERROR);
-                goto bad_str;
+                ERR_raise_data(ERR_LIB_ASN1, ASN1_R_LIST_ERROR,
+                    "string=%s", str);
+                goto bad_form;
             }
             no_unused = 0;
 
@@ -732,15 +742,14 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
         break;
 
     default:
-        ERR_raise(ERR_LIB_ASN1, ASN1_R_UNSUPPORTED_TYPE);
-        goto bad_str;
+        ERR_raise_data(ERR_LIB_ASN1, ASN1_R_UNSUPPORTED_TYPE,
+            "string=%s", str);
+        goto bad_form;
     }
 
     atmp->type = utype;
     return atmp;
 
-bad_str:
-    ERR_add_error_data(2, "string=", str);
 bad_form:
 
     ASN1_TYPE_free(atmp);

--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -15,6 +15,7 @@
 #include <openssl/buffer.h>
 #include <openssl/err.h>
 #include "crypto/asn1.h"
+#include "internal/err.h"
 #include "internal/numbers.h"
 #include "asn1_local.h"
 
@@ -506,11 +507,11 @@ int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
 auxerr:
     ERR_raise(ERR_LIB_ASN1, ASN1_R_AUX_ERROR);
 err:
-    if (errtt)
-        ERR_add_error_data(4, "Field=", errtt->field_name,
-            ", Type=", it->sname);
+    if (errtt != NULL)
+        ossl_err_add_error_fmt("Field=%s, Type=%s", errtt->field_name,
+            it->sname);
     else
-        ERR_add_error_data(2, "Type=", it->sname);
+        ossl_err_add_error_fmt("Type=%s", it->sname);
     return 0;
 }
 

--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -15,7 +15,7 @@
 #include <openssl/buffer.h>
 #include <openssl/err.h>
 #include "crypto/asn1.h"
-#include "internal/err.h"
+#include "crypto/err.h"
 #include "internal/numbers.h"
 #include "asn1_local.h"
 

--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -254,7 +254,8 @@ static int addr_strings(const BIO_ADDR *ap, int numeric,
             } else
 #endif
             {
-                ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, gai_strerror(ret));
+                ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, "%s",
+                    gai_strerror(ret));
             }
             return 0;
         }
@@ -749,7 +750,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
 #endif
 #ifdef EAI_MEMORY
         case EAI_MEMORY:
-            ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB,
+            ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, "%s",
                 gai_strerror(old_ret ? old_ret : gai_ret));
             break;
 #endif
@@ -765,7 +766,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 goto retry;
             }
 #endif
-            ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB,
+            ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, "%s",
                 gai_strerror(old_ret ? old_ret : gai_ret));
             break;
         }

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -39,6 +39,7 @@ static int wsa_init_done = 0;
 #include <sys/select.h>
 #endif
 #endif
+#include "internal/err.h"
 #include "internal/sockets.h" /* for openssl_fdset() */
 
 #ifndef OPENSSL_NO_DEPRECATED_1_1_0
@@ -65,7 +66,7 @@ int BIO_get_host_ip(const char *str, unsigned char *ip)
         }
         BIO_ADDRINFO_free(res);
     } else {
-        ERR_add_error_data(2, "host=", str);
+        ossl_err_add_error_fmt("host=%s", ossl_string_or_null(str));
     }
 
     return ret;
@@ -93,7 +94,7 @@ int BIO_get_port(const char *str, unsigned short *port_ptr)
         }
         BIO_ADDRINFO_free(res);
     } else {
-        ERR_add_error_data(2, "host=", str);
+        ossl_err_add_error_fmt("host=%s", str);
     }
 
     return ret;

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -39,7 +39,7 @@ static int wsa_init_done = 0;
 #include <sys/select.h>
 #endif
 #endif
-#include "internal/err.h"
+#include "crypto/err.h"
 #include "internal/sockets.h" /* for openssl_fdset() */
 
 #ifndef OPENSSL_NO_DEPRECATED_1_1_0

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 
 #include "cmp_local.h"
+#include "internal/err.h"
 #include <inttypes.h>
 
 #define IS_CREP(t) ((t) == OSSL_CMP_PKIBODY_IP || (t) == OSSL_CMP_PKIBODY_CP \
@@ -220,8 +221,8 @@ static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
     ERR_raise(ERR_LIB_CMP, bt == OSSL_CMP_PKIBODY_ERROR ? CMP_R_RECEIVED_ERROR : CMP_R_UNEXPECTED_PKIBODY); /* in next line for mkerr.pl */
 
     if (bt != OSSL_CMP_PKIBODY_ERROR) {
-        ERR_add_error_data(3, "message type is '",
-            ossl_cmp_bodytype_to_string(bt), "'");
+        ossl_err_add_error_fmt("message type is '%s'",
+            ossl_cmp_bodytype_to_string(bt));
     } else {
         OSSL_CMP_ERRORMSGCONTENT *emc = (*rep)->body->value.error;
         OSSL_CMP_PKISI *si = emc->pKIStatusInfo;
@@ -231,18 +232,16 @@ static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
             && OSSL_CMP_CTX_snprint_PKIStatus(ctx, buf,
                    sizeof(buf))
                 != NULL)
-            ERR_add_error_data(1, buf);
-        if (emc->errorCode != NULL
-            && snprintf(buf, sizeof(buf), "; errorCode: %08lX",
-                   ASN1_INTEGER_get(emc->errorCode))
-                > 0)
-            ERR_add_error_data(1, buf);
+            ossl_err_add_error_fmt("%s", buf);
+        if (emc->errorCode != NULL)
+            ossl_err_add_error_fmt("; errorCode: %08lX",
+                ASN1_INTEGER_get(emc->errorCode));
         if (emc->errorDetails != NULL) {
             char *text = ossl_sk_ASN1_UTF8STRING2text(emc->errorDetails, ", ",
                 OSSL_CMP_PKISI_BUFLEN - 1);
 
             if (text != NULL && *text != '\0')
-                ERR_add_error_data(2, "; errorDetails: ", text);
+                ossl_err_add_error_fmt("; errorDetails: %s", text);
             OPENSSL_free(text);
         }
         if (ctx->status != OSSL_CMP_PKISTATUS_rejection) {
@@ -563,7 +562,7 @@ static X509 *get1_cert_status(OSSL_CMP_CTX *ctx, int bodytype,
 
 err:
     if (OSSL_CMP_CTX_snprint_PKIStatus(ctx, buf, sizeof(buf)) != NULL)
-        ERR_add_error_data(1, buf);
+        ossl_err_add_error_fmt("%s", buf);
     return NULL;
 }
 
@@ -739,7 +738,7 @@ retry:
 
     cert = get1_cert_status(ctx, (*resp)->body->type, crep);
     if (cert == NULL) {
-        ERR_add_error_data(1, "; cannot extract certificate from response");
+        ossl_err_add_error_fmt("; cannot extract certificate from response");
         return 0;
     }
     if (!ossl_cmp_ctx_set0_newCert(ctx, cert)) {
@@ -1021,7 +1020,7 @@ int OSSL_CMP_exec_RR_ses(OSSL_CMP_CTX *ctx)
 err:
     if (ret == 0
         && OSSL_CMP_CTX_snprint_PKIStatus(ctx, buf, sizeof(buf)) != NULL)
-        ERR_add_error_data(1, buf);
+        ossl_err_add_error_fmt("%s", buf);
 
 end:
     OSSL_CMP_MSG_free(rr);

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -12,7 +12,7 @@
 #include <stdio.h>
 
 #include "cmp_local.h"
-#include "internal/err.h"
+#include "crypto/err.h"
 #include <inttypes.h>
 
 #define IS_CREP(t) ((t) == OSSL_CMP_PKIBODY_IP || (t) == OSSL_CMP_PKIBODY_CP \

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -311,11 +311,8 @@ static int poll_for_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
                 goto err;
             }
             if (check_after < 0 || (uint64_t)check_after > (sleep ? ULONG_MAX / 1000 : INT_MAX)) {
-                ERR_raise(ERR_LIB_CMP, CMP_R_CHECKAFTER_OUT_OF_RANGE);
-                if (snprintf(str, OSSL_CMP_PKISI_BUFLEN, "value = %" PRId64,
-                        check_after)
-                    >= 0)
-                    ERR_add_error_data(1, str);
+                ERR_raise_data(ERR_LIB_CMP, CMP_R_CHECKAFTER_OUT_OF_RANGE,
+                    "value = %" PRId64, check_after);
                 goto err;
             }
 

--- a/crypto/comp/c_brotli.c
+++ b/crypto/comp/c_brotli.c
@@ -533,8 +533,8 @@ static int bio_brotli_read(BIO *b, char *out, int outl)
             bret = BrotliDecoderDecompressStream(ctx->decode.state, &ctx->decode.avail_in, (const uint8_t **)&ctx->decode.next_in,
                 &ctx->decode.avail_out, &ctx->decode.next_out, NULL);
             if (bret == BROTLI_DECODER_RESULT_ERROR) {
-                ERR_raise(ERR_LIB_COMP, COMP_R_BROTLI_DECODE_ERROR);
-                ERR_add_error_data(1, BrotliDecoderErrorString(BrotliDecoderGetErrorCode(ctx->decode.state)));
+                ERR_raise_data(ERR_LIB_COMP, COMP_R_BROTLI_DECODE_ERROR, "%s",
+                    BrotliDecoderErrorString(BrotliDecoderGetErrorCode(ctx->decode.state)));
                 return 0;
             }
             /* If EOF or we've read everything then return */
@@ -633,8 +633,8 @@ static int bio_brotli_write(BIO *b, const char *in, int inl)
         brret = BrotliEncoderCompressStream(ctx->encode.state, BROTLI_OPERATION_FLUSH, &ctx->encode.avail_in, (const uint8_t **)&ctx->encode.next_in,
             &ctx->encode.avail_out, &ctx->encode.next_out, NULL);
         if (brret != BROTLI_TRUE) {
-            ERR_raise(ERR_LIB_COMP, COMP_R_BROTLI_ENCODE_ERROR);
-            ERR_add_error_data(1, "brotli encoder error");
+            ERR_raise_data(ERR_LIB_COMP, COMP_R_BROTLI_ENCODE_ERROR,
+                "brotli encoder error");
             return 0;
         }
         ctx->encode.count = ctx->encode.bufsize - ctx->encode.avail_out;
@@ -682,8 +682,8 @@ static int bio_brotli_flush(BIO *b)
         brret = BrotliEncoderCompressStream(ctx->encode.state, BROTLI_OPERATION_FINISH, &ctx->encode.avail_in,
             (const uint8_t **)&ctx->encode.next_in, &ctx->encode.avail_out, &ctx->encode.next_out, NULL);
         if (brret != BROTLI_TRUE) {
-            ERR_raise(ERR_LIB_COMP, COMP_R_BROTLI_ENCODE_ERROR);
-            ERR_add_error_data(1, "brotli encoder error");
+            ERR_raise_data(ERR_LIB_COMP, COMP_R_BROTLI_ENCODE_ERROR,
+                "brotli encoder error");
             return 0;
         }
         if (!BrotliEncoderHasMoreOutput(ctx->encode.state) && ctx->encode.avail_in == 0)

--- a/crypto/comp/c_zstd.c
+++ b/crypto/comp/c_zstd.c
@@ -601,8 +601,8 @@ static int bio_zstd_read(BIO *b, char *out, int outl)
         do {
             zret = ZSTD_decompressStream(ctx->decompress.state, &outBuf, &ctx->decompress.inbuf);
             if (ZSTD_isError(zret)) {
-                ERR_raise(ERR_LIB_COMP, COMP_R_ZSTD_DECOMPRESS_ERROR);
-                ERR_add_error_data(1, ZSTD_getErrorName(zret));
+                ERR_raise_data(ERR_LIB_COMP, COMP_R_ZSTD_DECOMPRESS_ERROR,
+                    "%s", ZSTD_getErrorName(zret));
                 return -1;
             }
             /* No more output space */
@@ -680,8 +680,8 @@ static int bio_zstd_write(BIO *b, const char *in, int inl)
         /* Compress some more */
         zret = ZSTD_compressStream2(ctx->compress.state, &ctx->compress.outbuf, &inBuf, ZSTD_e_end);
         if (ZSTD_isError(zret)) {
-            ERR_raise(ERR_LIB_COMP, COMP_R_ZSTD_COMPRESS_ERROR);
-            ERR_add_error_data(1, ZSTD_getErrorName(zret));
+            ERR_raise_data(ERR_LIB_COMP, COMP_R_ZSTD_COMPRESS_ERROR,
+                "%s", ZSTD_getErrorName(zret));
             return 0;
         } else if (zret == 0) {
             done = 1;
@@ -726,8 +726,8 @@ static int bio_zstd_flush(BIO *b)
         /* Compress some more */
         zret = ZSTD_flushStream(ctx->compress.state, &ctx->compress.outbuf);
         if (ZSTD_isError(zret)) {
-            ERR_raise(ERR_LIB_COMP, COMP_R_ZSTD_COMPRESS_ERROR);
-            ERR_add_error_data(1, ZSTD_getErrorName(zret));
+            ERR_raise_data(ERR_LIB_COMP, COMP_R_ZSTD_COMPRESS_ERROR,
+                "%s", ZSTD_getErrorName(zret));
             return 0;
         }
         if (zret == 0)

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -17,6 +17,7 @@
 #include <sys/stat.h> /* struct stat */
 #endif
 #include "internal/cryptlib.h"
+#include "internal/err.h"
 #include "internal/o_dir.h"
 #include <openssl/lhash.h>
 #include <openssl/conf.h>
@@ -214,7 +215,6 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
     int again;
     int first_call = 1;
     long eline = 0;
-    char btmp[DECIMAL_SIZE(eline) + 1];
     CONF_VALUE *v = NULL, *tv;
     CONF_VALUE *sv = NULL;
     char *section = NULL, *buf;
@@ -587,8 +587,7 @@ err:
 #endif
     if (line != NULL)
         *line = eline;
-    snprintf(btmp, sizeof(btmp), "%ld", eline);
-    ERR_add_error_data(2, "line ", btmp);
+    ossl_err_add_error_fmt("line %ld", eline);
     if (h != conf->data) {
         CONF_free(conf->data);
         conf->data = NULL;

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -17,7 +17,7 @@
 #include <sys/stat.h> /* struct stat */
 #endif
 #include "internal/cryptlib.h"
-#include "internal/err.h"
+#include "crypto/err.h"
 #include "internal/o_dir.h"
 #include <openssl/lhash.h>
 #include <openssl/conf.h>

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -13,7 +13,7 @@
 
 #include "crmf_local.h"
 #include <openssl/rand.h> /* for RAND_bytes_ex() */
-#include "internal/err.h"
+#include "crypto/err.h"
 #include "internal/sizes.h" /* for OSSL_MAX_NAME_SIZE */
 #include <openssl/err.h>
 

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -13,6 +13,7 @@
 
 #include "crmf_local.h"
 #include <openssl/rand.h> /* for RAND_bytes_ex() */
+#include "internal/err.h"
 #include "internal/sizes.h" /* for OSSL_MAX_NAME_SIZE */
 #include <openssl/err.h>
 
@@ -219,7 +220,7 @@ err:
         char buf[128];
 
         if (OBJ_obj2txt(buf, sizeof(buf), pbmp->mac->algorithm, 0))
-            ERR_add_error_data(1, buf);
+            ossl_err_add_error_fmt("%s", buf);
     }
     return 0;
 }

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -20,7 +20,7 @@
 
 #include "dso_local.h"
 #include "internal/e_os.h"
-#include "internal/err.h"
+#include "crypto/err.h"
 
 #ifdef DSO_DLFCN
 

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -20,6 +20,7 @@
 
 #include "dso_local.h"
 #include "internal/e_os.h"
+#include "internal/err.h"
 
 #ifdef DSO_DLFCN
 
@@ -428,7 +429,8 @@ static int dlfcn_pathbyaddr(void *addr, char *path, int sz)
         return len;
     }
 
-    ERR_add_error_data(2, "dlfcn_pathbyaddr(): ", dlerror());
+    ossl_err_add_error_fmt("dlfcn_pathbyaddr(): %s",
+        ossl_string_or_null(dlerror()));
 #endif
     return -1;
 }

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -852,6 +852,69 @@ void ERR_add_error_vdata(int num, va_list args)
         OPENSSL_free(str);
 }
 
+void ossl_err_add_error_fmt(const char *fmt, ...)
+{
+    ERR_STATE *es;
+    va_list args, args_copy;
+    char *str, *tmp;
+    size_t base_len, size;
+    int add_len;
+    int i;
+
+    es = ossl_err_get_state_int(1);
+    if (es == NULL)
+        return;
+    i = es->top;
+
+    /* Take the string over so that nothing we call can free it. */
+    if ((es->err_data_flags[i] & (ERR_TXT_MALLOCED | ERR_TXT_STRING))
+            == (ERR_TXT_MALLOCED | ERR_TXT_STRING)
+        && es->err_data[i] != NULL) {
+        str = es->err_data[i];
+        base_len = strlen(str);
+        /* The recorded size never overstates the allocation. */
+        size = es->err_data_size[i];
+        es->err_data[i] = NULL;
+        es->err_data_flags[i] = 0;
+    } else {
+        str = NULL;
+        base_len = 0;
+        size = 0;
+    }
+
+    va_start(args, fmt);
+
+    /* Initial allocation, grown below if the text does not fit. */
+    if (str == NULL) {
+        size = 64;
+        if ((str = OPENSSL_malloc(size)) == NULL)
+            goto err;
+    }
+
+    va_copy(args_copy, args);
+    add_len = vsnprintf(str + base_len, size - base_len, fmt, args_copy);
+    va_end(args_copy);
+    if (add_len < 0)
+        goto err;
+
+    if ((size_t)add_len >= size - base_len) {
+        size = base_len + (size_t)add_len + 1;
+        if ((tmp = OPENSSL_realloc(str, size)) == NULL)
+            goto err;
+        str = tmp;
+        if (vsnprintf(str + base_len, size - base_len, fmt, args) != add_len)
+            goto err;
+    }
+    va_end(args);
+
+    err_set_data(es, i, str, size, ERR_TXT_MALLOCED | ERR_TXT_STRING);
+    return;
+
+err:
+    va_end(args);
+    OPENSSL_free(str);
+}
+
 void err_clear_last_constant_time(int clear)
 {
     ERR_STATE *es;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -783,6 +783,9 @@ void ERR_set_error_data(char *data, int flags)
     err_set_error_data_int(data, strlen(data) + 1, flags, 1);
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_4_1
+OSSL_BEGIN_ALLOW_DEPRECATED
+
 void ERR_add_error_data(int num, ...)
 {
     va_list args;
@@ -851,6 +854,9 @@ void ERR_add_error_vdata(int num, va_list args)
     if (!err_set_error_data_int(str, size, flags, 0))
         OPENSSL_free(str);
 }
+
+OSSL_END_ALLOW_DEPRECATED
+#endif /* OPENSSL_NO_DEPRECATED_4_1 */
 
 void ossl_err_add_error_fmt(const char *fmt, ...)
 {

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
-#include "internal/err.h"
+#include "crypto/err.h"
 #include <openssl/crypto.h>
 #include <openssl/buffer.h>
 #include <openssl/err.h>

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "internal/err.h"
 #include <openssl/crypto.h>
 #include <openssl/buffer.h>
 #include <openssl/err.h>
@@ -121,7 +122,7 @@ void ERR_add_error_txt(const char *separator, const char *txt)
                 tmp = OPENSSL_strndup(txt, curr - txt);
                 if (tmp == NULL)
                     return;
-                ERR_add_error_data(2, separator, tmp);
+                ossl_err_add_error_fmt("%s%s", separator, tmp);
                 OPENSSL_free(tmp);
             }
             put_error(ERR_GET_LIB(err), func, err, file, line);
@@ -132,10 +133,10 @@ void ERR_add_error_txt(const char *separator, const char *txt)
                 if (tmp == NULL)
                     return;
                 /* output txt without the trailing separator */
-                ERR_add_error_data(2, leading_separator, tmp);
+                ossl_err_add_error_fmt("%s%s", leading_separator, tmp);
                 OPENSSL_free(tmp);
             } else {
-                ERR_add_error_data(2, leading_separator, txt);
+                ossl_err_add_error_fmt("%s%s", leading_separator, txt);
             }
             txt = next; /* finished */
         }

--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -15,6 +15,7 @@
 #include <openssl/pkcs12.h>
 #include <openssl/x509.h>
 #include "crypto/evp.h"
+#include "crypto/err.h"
 #include "evp_local.h"
 
 /* Password based encryption (PBE) functions */
@@ -125,7 +126,7 @@ int EVP_PBE_CipherInit_ex(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
         cipher = EVP_CIPHER_fetch(libctx, OBJ_nid2sn(cipher_nid), propq);
         if (cipher == NULL) {
             ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_CIPHER,
-                OBJ_nid2sn(cipher_nid));
+                "%s", ossl_string_or_null(OBJ_nid2sn(cipher_nid)));
             goto err;
         }
     }

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -23,6 +23,7 @@
 #include <openssl/trace.h>
 #include "internal/sockets.h"
 #include "internal/common.h" /* for ossl_assert() */
+#include "internal/err.h"
 
 #define HTTP_PREFIX "HTTP/"
 #define HTTP_VERSION_PATT "1." /* allow 1.x */
@@ -509,7 +510,7 @@ static int parse_http_line1(char *line, int *found_keep_alive)
             || retcode < HTTP_STATUS_CODES_NONFATAL_ERROR) {
             ERR_raise_data(ERR_LIB_HTTP, HTTP_R_STATUS_CODE_UNSUPPORTED, "code=%s", code);
             if (*reason != '\0')
-                ERR_add_error_data(2, ", reason=", reason);
+                ossl_err_add_error_fmt(", reason=%s", reason);
         } /* must return content normally if status >= 400, still tentatively raised error on 404 */
         return retcode;
     }
@@ -1228,7 +1229,6 @@ BIO *OSSL_HTTP_exchange(OSSL_HTTP_REQ_CTX *rctx, char **redirection_url)
                 /* may be NULL if out of memory: */
                 *redirection_url = OPENSSL_strdup(rctx->redirection_url);
         } else {
-            char buf[200];
             unsigned long err = ERR_peek_error();
             int lib = ERR_GET_LIB(err);
             int reason = ERR_GET_REASON(err);
@@ -1241,20 +1241,16 @@ BIO *OSSL_HTTP_exchange(OSSL_HTTP_REQ_CTX *rctx, char **redirection_url)
                     && reason == CMP_R_POTENTIALLY_INVALID_CERTIFICATE)
 #endif
             ) {
-                if (rctx->server != NULL && *rctx->server != '\0') {
-                    snprintf(buf, sizeof(buf), "server=http%s://%s%s%s",
+                if (rctx->server != NULL && *rctx->server != '\0')
+                    ossl_err_add_error_fmt("server=http%s://%s%s%s",
                         rctx->use_ssl ? "s" : "", rctx->server,
                         rctx->port != NULL ? ":" : "",
                         rctx->port != NULL ? rctx->port : "");
-                    ERR_add_error_data(1, buf);
-                }
                 if (rctx->proxy != NULL)
-                    ERR_add_error_data(2, " proxy=", rctx->proxy);
-                if (err == 0) {
-                    snprintf(buf, sizeof(buf), " peer has disconnected%s",
+                    ossl_err_add_error_fmt(" proxy=%s", rctx->proxy);
+                if (err == 0)
+                    ossl_err_add_error_fmt(" peer has disconnected%s",
                         rctx->use_ssl ? " violating the protocol" : ", likely because it requires the use of TLS");
-                    ERR_add_error_data(1, buf);
-                }
             }
         }
     }

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -23,7 +23,7 @@
 #include <openssl/trace.h>
 #include "internal/sockets.h"
 #include "internal/common.h" /* for ossl_assert() */
-#include "internal/err.h"
+#include "crypto/err.h"
 
 #define HTTP_PREFIX "HTTP/"
 #define HTTP_VERSION_PATT "1." /* allow 1.x */

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -16,7 +16,7 @@
 #include "crypto/ctype.h"
 #include <string.h>
 #include "internal/cryptlib.h"
-#include "internal/err.h"
+#include "crypto/err.h"
 #include <openssl/buffer.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -16,6 +16,7 @@
 #include "crypto/ctype.h"
 #include <string.h>
 #include "internal/cryptlib.h"
+#include "internal/err.h"
 #include <openssl/buffer.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>
@@ -253,7 +254,8 @@ static int pem_bytes_read_bio_flags(unsigned char **pdata, long *plen,
         PEM_FREE(data, flags, len);
         if (!PEM_read_bio_ex(bp, &nm, &header, &data, &len, flags)) {
             if (ERR_GET_REASON(ERR_peek_error()) == PEM_R_NO_START_LINE)
-                ERR_add_error_data(2, "Expecting: ", name);
+                ossl_err_add_error_fmt("Expecting: %s",
+                    ossl_string_or_null(name));
             return 0;
         }
     } while (!check_pem(nm, name));

--- a/crypto/x509/v3_cpols.c
+++ b/crypto/x509/v3_cpols.c
@@ -183,7 +183,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
 
             if ((pobj = OBJ_txt2obj(cnf->value, 0)) == NULL) {
                 ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_OBJECT_IDENTIFIER);
-                X509V3_conf_err(cnf);
+                ossl_X509v3_conf_err(cnf);
                 goto err;
             }
             pol->policyid = pobj;
@@ -216,14 +216,14 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
             STACK_OF(CONF_VALUE) *unot;
             if (*cnf->value != '@') {
                 ERR_raise(ERR_LIB_X509V3, X509V3_R_EXPECTED_A_SECTION_NAME);
-                X509V3_conf_err(cnf);
+                ossl_X509v3_conf_err(cnf);
                 goto err;
             }
             unot = X509V3_get_section(ctx, cnf->value + 1);
             if (!unot) {
                 ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_SECTION);
 
-                X509V3_conf_err(cnf);
+                ossl_X509v3_conf_err(cnf);
                 goto err;
             }
             qual = notice_section(ctx, unot, ia5org);
@@ -239,7 +239,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
             }
         } else {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_OPTION);
-            X509V3_conf_err(cnf);
+            ossl_X509v3_conf_err(cnf);
             goto err;
         }
     }

--- a/crypto/x509/v3_pci.c
+++ b/crypto/x509/v3_pci.c
@@ -48,6 +48,7 @@
 #include <openssl/conf.h>
 #include <openssl/x509v3.h>
 #include "ext_dat.h"
+#include "x509_local.h"
 
 #include <crypto/asn1.h>
 
@@ -100,24 +101,24 @@ static int process_pci_value(CONF_VALUE *val,
     if (strcmp(val->name, "language") == 0) {
         if (*language) {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_POLICY_LANGUAGE_ALREADY_DEFINED);
-            X509V3_conf_err(val);
+            ossl_X509v3_conf_err(val);
             return 0;
         }
         if ((*language = OBJ_txt2obj(val->value, 0)) == NULL) {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_OBJECT_IDENTIFIER);
-            X509V3_conf_err(val);
+            ossl_X509v3_conf_err(val);
             return 0;
         }
     } else if (strcmp(val->name, "pathlen") == 0) {
         if (*pathlen) {
             ERR_raise(ERR_LIB_X509V3,
                 X509V3_R_POLICY_PATH_LENGTH_ALREADY_DEFINED);
-            X509V3_conf_err(val);
+            ossl_X509v3_conf_err(val);
             return 0;
         }
         if (!X509V3_get_value_int(val, pathlen)) {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_POLICY_PATH_LENGTH);
-            X509V3_conf_err(val);
+            ossl_X509v3_conf_err(val);
             return 0;
         }
     } else if (strcmp(val->name, "policy") == 0) {
@@ -129,7 +130,7 @@ static int process_pci_value(CONF_VALUE *val,
             *policy = ASN1_OCTET_STRING_new();
             if (*policy == NULL) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
-                X509V3_conf_err(val);
+                ossl_X509v3_conf_err(val);
                 return 0;
             }
             free_policy = 1;
@@ -138,7 +139,7 @@ static int process_pci_value(CONF_VALUE *val,
             unsigned char *tmp_data2 = OPENSSL_hexstr2buf(valp, &val_len);
 
             if (!tmp_data2) {
-                X509V3_conf_err(val);
+                ossl_X509v3_conf_err(val);
                 goto err;
             }
 
@@ -159,7 +160,7 @@ static int process_pci_value(CONF_VALUE *val,
                 OPENSSL_free((*policy)->data);
                 (*policy)->data = NULL;
                 (*policy)->length = 0;
-                X509V3_conf_err(val);
+                ossl_X509v3_conf_err(val);
                 goto err;
             }
             OPENSSL_free(tmp_data2);
@@ -176,7 +177,7 @@ static int process_pci_value(CONF_VALUE *val,
             BIO *b = BIO_new_file(valp, "r");
             if (!b) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_BIO_LIB);
-                X509V3_conf_err(val);
+                ossl_X509v3_conf_err(val);
                 goto err;
             }
             while ((n = BIO_read(b, buf, sizeof(buf))) > 0
@@ -191,7 +192,7 @@ static int process_pci_value(CONF_VALUE *val,
                     OPENSSL_free((*policy)->data);
                     (*policy)->data = NULL;
                     (*policy)->length = 0;
-                    X509V3_conf_err(val);
+                    ossl_X509v3_conf_err(val);
                     BIO_free_all(b);
                     goto err;
                 }
@@ -205,7 +206,7 @@ static int process_pci_value(CONF_VALUE *val,
 
             if (n < 0) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_BIO_LIB);
-                X509V3_conf_err(val);
+                ossl_X509v3_conf_err(val);
                 goto err;
             }
         } else if (CHECK_AND_SKIP_PREFIX(valp, "text:")) {
@@ -226,16 +227,16 @@ static int process_pci_value(CONF_VALUE *val,
                 OPENSSL_free((*policy)->data);
                 (*policy)->data = NULL;
                 (*policy)->length = 0;
-                X509V3_conf_err(val);
+                ossl_X509v3_conf_err(val);
                 goto err;
             }
         } else {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_INCORRECT_POLICY_SYNTAX_TAG);
-            X509V3_conf_err(val);
+            ossl_X509v3_conf_err(val);
             goto err;
         }
         if (!tmp_data) {
-            X509V3_conf_err(val);
+            ossl_X509v3_conf_err(val);
             goto err;
         }
     }
@@ -264,7 +265,7 @@ static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
 
         if (!cnf->name || (*cnf->name != '@' && !cnf->value)) {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_PROXY_POLICY_SETTING);
-            X509V3_conf_err(cnf);
+            ossl_X509v3_conf_err(cnf);
             goto err;
         }
         if (*cnf->name == '@') {
@@ -274,7 +275,7 @@ static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
             sect = X509V3_get_section(ctx, cnf->name + 1);
             if (!sect) {
                 ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_SECTION);
-                X509V3_conf_err(cnf);
+                ossl_X509v3_conf_err(cnf);
                 goto err;
             }
             for (j = 0; success_p && j < sk_CONF_VALUE_num(sect); j++) {
@@ -286,7 +287,7 @@ static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
                 goto err;
         } else {
             if (!process_pci_value(cnf, &language, &pathlen, &policy)) {
-                X509V3_conf_err(cnf);
+                ossl_X509v3_conf_err(cnf);
                 goto err;
             }
         }

--- a/crypto/x509/x509_local.h
+++ b/crypto/x509/x509_local.h
@@ -32,6 +32,21 @@ static ossl_inline void X509V3_conf_add_error_name_value(
         ossl_string_or_null(val->value));
 }
 
+/**
+ * @brief Append the section, name and value of a config entry to the
+ * current error.
+ *
+ * @param val the config entry to report
+ */
+static ossl_inline void ossl_X509v3_conf_err(
+    const CONF_VALUE *val)
+{
+    ossl_err_add_error_fmt("section:%s,name:%s,value:%s",
+        ossl_string_or_null(val->section),
+        ossl_string_or_null(val->name),
+        ossl_string_or_null(val->value));
+}
+
 /*
  * Really all I want is CRYPTO_BUFFER from BoringSSL, but let's just do this
  * for now.

--- a/crypto/x509/x509_local.h
+++ b/crypto/x509/x509_local.h
@@ -9,16 +9,28 @@
 #if !defined(OSSL_LIBCRYPTO_X509_X509_LOCAL_H)
 #define OSSL_LIBCRYPTO_X509_X509_LOCAL_H
 
+#include <openssl/conf.h>
 #include <openssl/safestack.h>
 #include <openssl/x509_vfy.h>
 
 #include "internal/refcount.h"
 #include "internal/hashtable.h"
+#include "internal/err.h"
 
 #include <crypto/asn1.h>
 
-#define X509V3_conf_add_error_name_value(val) \
-    ERR_add_error_data(4, "name=", (val)->name, ", value=", (val)->value)
+/**
+ * @brief Append the name and value of a config entry to the current error.
+ *
+ * @param val the config entry to report
+ */
+static ossl_inline void X509V3_conf_add_error_name_value(
+    const CONF_VALUE *val)
+{
+    ossl_err_add_error_fmt("name=%s, value=%s",
+        ossl_string_or_null(val->name),
+        ossl_string_or_null(val->value));
+}
 
 /*
  * Really all I want is CRYPTO_BUFFER from BoringSSL, but let's just do this

--- a/crypto/x509/x509_local.h
+++ b/crypto/x509/x509_local.h
@@ -15,7 +15,7 @@
 
 #include "internal/refcount.h"
 #include "internal/hashtable.h"
-#include "internal/err.h"
+#include "crypto/err.h"
 
 #include <crypto/asn1.h>
 

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -16,10 +16,15 @@ ERR_add_error_txt, ERR_add_error_mem_bio
  void ERR_raise(int lib, int reason);
  void ERR_raise_data(int lib, int reason, const char *fmt, ...);
 
- void ERR_add_error_data(int num, ...);
- void ERR_add_error_vdata(int num, va_list arg);
  void ERR_add_error_txt(const char *sep, const char *txt);
  void ERR_add_error_mem_bio(const char *sep, BIO *bio);
+
+The following functions have been deprecated since OpenSSL 4.1, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
+
+ void ERR_add_error_data(int num, ...);
+ void ERR_add_error_vdata(int num, va_list arg);
 
 The following function has been deprecated since OpenSSL 3.0, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
@@ -175,6 +180,13 @@ L<ERR_load_strings(3)>, L<ERR_get_next_error_library(3)>
 
 ERR_raise, ERR_raise_data, ERR_add_error_txt() and ERR_add_error_mem_bio()
 were added in OpenSSL 3.0.
+
+ERR_add_error_data() and ERR_add_error_vdata() were deprecated in OpenSSL
+4.1.  Their B<num> argument counts the strings that follow it, and nothing
+verifies that the count is right; a value larger than the number of
+arguments actually passed reads beyond them.  Use ERR_add_error_txt() to
+append a single string, or ERR_raise_data() to raise an error carrying
+formatted text.
 
 =head1 COPYRIGHT
 

--- a/include/crypto/err.h
+++ b/include/crypto/err.h
@@ -11,6 +11,45 @@
 #define OSSL_CRYPTO_ERR_H
 #pragma once
 
+#include <stddef.h>
+
+#include <openssl/e_os2.h>
+
+/**
+ * @brief Render a string that may be NULL for a %s conversion.
+ *
+ * @param str the string to render, which may be NULL
+ * @returns str, or the string "<NULL>" if str is NULL
+ */
+static ossl_inline const char *ossl_string_or_null(const char *str)
+{
+    return str != NULL ? str : "<NULL>";
+}
+
+/**
+ * @brief Append printf(3) formatted text to the most recent error's data.
+ *
+ * The text is appended to the data that error already carries, so repeated
+ * calls accumulate; if it carries none, the text becomes its data.  Nothing
+ * is raised when the error queue is empty, and a failure to store the text
+ * is not reported.
+ *
+ * A NULL pointer passed for a %s conversion is undefined, not rendered as
+ * "<NULL>" the way ERR_add_error_data() renders it.
+ *
+ * @param fmt printf(3) style format string describing the text to append
+ * @see ERR_add_error_data(3)
+ */
+#define ossl_err__attr__(x)
+#if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__) \
+    && !defined(__APPLE__)
+#undef ossl_err__attr__
+#define ossl_err__attr__ __attribute__
+#endif
+void ossl_err_add_error_fmt(const char *fmt, ...)
+    ossl_err__attr__((__format__(__printf__, 1, 2)));
+#undef ossl_err__attr__
+
 int ossl_err_load_ERR_strings(void);
 int ossl_err_load_crypto_strings(void);
 void err_cleanup(void);

--- a/include/internal/err.h
+++ b/include/internal/err.h
@@ -11,45 +11,8 @@
 #define OSSL_INTERNAL_ERR_H
 #pragma once
 
-#include <openssl/e_os2.h>
-
 #define ERR_NUM_ERRORS 16
 
 void err_free_strings_int(void);
-
-/**
- * @brief Render a string that may be NULL for a %s conversion.
- *
- * @param str the string to render, which may be NULL
- * @returns str, or the string "<NULL>" if str is NULL
- */
-static ossl_inline const char *ossl_string_or_null(const char *str)
-{
-    return str != NULL ? str : "<NULL>";
-}
-
-/**
- * @brief Append printf(3) formatted text to the most recent error's data.
- *
- * The text is appended to the data that error already carries, so repeated
- * calls accumulate; if it carries none, the text becomes its data.  Nothing
- * is raised when the error queue is empty, and a failure to store the text
- * is not reported.
- *
- * A NULL pointer passed for a %s conversion is undefined, not rendered as
- * "<NULL>" the way ERR_add_error_data() renders it.
- *
- * @param fmt printf(3) style format string describing the text to append
- * @see ERR_add_error_data(3)
- */
-#define ossl_err__attr__(x)
-#if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__) \
-    && !defined(__APPLE__)
-#undef ossl_err__attr__
-#define ossl_err__attr__ __attribute__
-#endif
-void ossl_err_add_error_fmt(const char *fmt, ...)
-    ossl_err__attr__((__format__(__printf__, 1, 2)));
-#undef ossl_err__attr__
 
 #endif

--- a/include/internal/err.h
+++ b/include/internal/err.h
@@ -15,4 +15,28 @@
 
 void err_free_strings_int(void);
 
+/**
+ * @brief Append printf(3) formatted text to the most recent error's data.
+ *
+ * The text is appended to the data that error already carries, so repeated
+ * calls accumulate; if it carries none, the text becomes its data.  Nothing
+ * is raised when the error queue is empty, and a failure to store the text
+ * is not reported.
+ *
+ * A NULL pointer passed for a %s conversion is undefined, not rendered as
+ * "<NULL>" the way ERR_add_error_data() renders it.
+ *
+ * @param fmt printf(3) style format string describing the text to append
+ * @see ERR_add_error_data(3)
+ */
+#define ossl_err__attr__(x)
+#if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__) \
+    && !defined(__APPLE__)
+#undef ossl_err__attr__
+#define ossl_err__attr__ __attribute__
+#endif
+void ossl_err_add_error_fmt(const char *fmt, ...)
+    ossl_err__attr__((__format__(__printf__, 1, 2)));
+#undef ossl_err__attr__
+
 #endif

--- a/include/internal/err.h
+++ b/include/internal/err.h
@@ -11,9 +11,22 @@
 #define OSSL_INTERNAL_ERR_H
 #pragma once
 
+#include <openssl/e_os2.h>
+
 #define ERR_NUM_ERRORS 16
 
 void err_free_strings_int(void);
+
+/**
+ * @brief Render a string that may be NULL for a %s conversion.
+ *
+ * @param str the string to render, which may be NULL
+ * @returns str, or the string "<NULL>" if str is NULL
+ */
+static ossl_inline const char *ossl_string_or_null(const char *str)
+{
+    return str != NULL ? str : "<NULL>";
+}
 
 /**
  * @brief Append printf(3) formatted text to the most recent error's data.

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -339,8 +339,17 @@ typedef struct ERR_string_data_st {
 /* Building blocks */
 void ERR_new(void);
 void ERR_set_debug(const char *file, int line, const char *func);
-void ERR_set_error(int lib, int reason, const char *fmt, ...);
-void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
+#define ossl_err__attr__(x)
+#if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__) \
+    && !defined(__APPLE__)
+#undef ossl_err__attr__
+#define ossl_err__attr__ __attribute__
+#endif
+void ERR_set_error(int lib, int reason, const char *fmt, ...)
+    ossl_err__attr__((__format__(__printf__, 3, 4)));
+void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
+    ossl_err__attr__((__format__(__printf__, 3, 0)));
+#undef ossl_err__attr__
 
 /* Main error raising functions */
 #define ERR_raise(lib, reason) ERR_raise_data((lib), (reason), NULL)

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -421,8 +421,12 @@ void ERR_print_errors_fp(FILE *fp);
 #endif
 void ERR_print_errors(BIO *bp);
 
+#ifndef OPENSSL_NO_DEPRECATED_4_1
+OSSL_DEPRECATEDIN_4_1_FOR("use ERR_add_error_txt() or ERR_raise_data()")
 void ERR_add_error_data(int num, ...);
+OSSL_DEPRECATEDIN_4_1_FOR("use ERR_add_error_txt() or ERR_raise_data()")
 void ERR_add_error_vdata(int num, va_list args);
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 void ERR_add_error_txt(const char *sepr, const char *txt);
 void ERR_add_error_mem_bio(const char *sep, BIO *bio);
 

--- a/providers/implementations/digests/ml_dsa_mu_prov.c
+++ b/providers/implementations/digests/ml_dsa_mu_prov.c
@@ -230,7 +230,7 @@ static int mu_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             ctx->remaining = ctx->digest_len;
         else
             ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_DIGEST,
-                "%s is not supported", p.digestname->data);
+                "%s is not supported", (char *)p.digestname->data);
         return ret;
     }
     return 1;

--- a/providers/implementations/kdfs/argon2.c
+++ b/providers/implementations/kdfs/argon2.c
@@ -14,6 +14,7 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <string.h>
+#include <inttypes.h>
 #include <openssl/e_os2.h>
 #include <openssl/evp.h>
 #include <openssl/objects.h>
@@ -1068,20 +1069,20 @@ static int kdf_argon2_derive(void *vctx, unsigned char *out, size_t outlen,
     if (ctx->threads > 1) {
 #ifdef ARGON2_NO_THREADS
         ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_THREAD_POOL_SIZE,
-            "requested %u threads, single-threaded mode supported only",
+            "requested %" PRIu32 " threads, single-threaded mode supported only",
             ctx->threads);
         return 0;
 #else
         if (ctx->threads > ossl_get_avail_threads(ctx->libctx)) {
             ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_THREAD_POOL_SIZE,
-                "requested %u threads, available: %u",
+                "requested %" PRIu32 " threads, available: %" PRIu64,
                 ctx->threads, ossl_get_avail_threads(ctx->libctx));
             return 0;
         }
 #endif
         if (ctx->threads > ctx->lanes) {
             ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_THREAD_POOL_SIZE,
-                "requested more threads (%u) than lanes (%u)",
+                "requested more threads (%" PRIu32 ") than lanes (%" PRIu32 ")",
                 ctx->threads, ctx->lanes);
             return 0;
         }

--- a/providers/implementations/keymgmt/mlx_kmgmt.c
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c
@@ -186,9 +186,8 @@ static int export_sub_cb(const OSSL_PARAM *params, void *varg)
             return 0;
         if (len != sub_arg->publen) {
             ERR_raise_data(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR,
-                "Unexpected %s public key length %lu != %lu",
-                sub_arg->algorithm_name, (unsigned long)len,
-                sub_arg->publen);
+                "Unexpected %s public key length %zu != %zu",
+                sub_arg->algorithm_name, len, sub_arg->publen);
             return 0;
         }
         ++sub_arg->pubcount;

--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -856,8 +856,7 @@ static int eddsa_set_ctx_params_internal(PROV_EDDSA_CTX *peddsactx, const struct
         if (peddsactx->instance_id_preset_flag) {
             /* When the instance is preset, the caller must not try to set it */
             ERR_raise_data(ERR_LIB_PROV, PROV_R_NO_INSTANCE_ALLOWED,
-                "the EdDSA instance is preset, you may not try to specify it",
-                NULL);
+                "the EdDSA instance is preset, you may not try to specify it");
             return 0;
         }
 

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -737,7 +737,7 @@ static int rsa_sign_directly(PROV_RSA_CTX *prsactx,
         case RSA_X931_PADDING:
             if ((size_t)RSA_size(prsactx->rsa) < tbslen + 1) {
                 ERR_raise_data(ERR_LIB_PROV, PROV_R_KEY_SIZE_TOO_SMALL,
-                    "RSA key size = %d, expected minimum = %d",
+                    "RSA key size = %d, expected minimum = %zu",
                     RSA_size(prsactx->rsa), tbslen + 1);
                 return 0;
             }
@@ -980,7 +980,7 @@ static int rsa_verify_recover(void *vprsactx,
             if (rout != prsactx->tbuf) {
                 if (routsize < (size_t)ret) {
                     ERR_raise_data(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL,
-                        "buffer size is %d, should be %d",
+                        "buffer size is %zu, should be %d",
                         routsize, ret);
                     return 0;
                 }
@@ -998,7 +998,7 @@ static int rsa_verify_recover(void *vprsactx,
             }
             if (routsize < (size_t)mdsize) {
                 ERR_raise_data(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL,
-                    "buffer size is %d, should be %d",
+                    "buffer size is %zu, should be %d",
                     routsize, mdsize);
                 return 0;
             }
@@ -1021,7 +1021,7 @@ static int rsa_verify_recover(void *vprsactx,
 
         if (routsize < (size_t)rsasize) {
             ERR_raise_data(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL,
-                "buffer size is %d, should be %d",
+                "buffer size is %zu, should be %d",
                 routsize, rsasize);
             return 0;
         }
@@ -1093,7 +1093,7 @@ static int rsa_verify_directly(PROV_RSA_CTX *prsactx,
             mdsize = rsa_get_md_size(prsactx);
             if (tbslen != mdsize) {
                 ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_DIGEST_LENGTH,
-                    "Should be %d, but got %d",
+                    "Should be %zu, but got %zu",
                     mdsize, tbslen);
                 return 0;
             }

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -1670,7 +1670,7 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
             else
                 ERR_raise_data(ERR_LIB_PROV,
                     PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE,
-                    err_extra_text);
+                    "%s", err_extra_text);
             return 0;
         }
     }

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -203,7 +203,7 @@ static const char *uri_file_stat(const char *uri, struct stat *st)
             size_t len = p == NULL ? strlen(q) : (size_t)(p - q);
 
             ERR_raise_data(ERR_LIB_OSSL_STORE, OSSL_STORE_R_URI_AUTHORITY_UNSUPPORTED,
-                "%.*s", len, q);
+                "%.*s", (int)len, q);
             ERR_clear_last_mark();
             return NULL;
         }

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -6,6 +6,7 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+#include <inttypes.h>
 #include <openssl/ssl.h>
 #include "internal/recordmethod.h"
 #include "internal/quic_tls.h"
@@ -698,7 +699,7 @@ static int raise_error(QUIC_TLS *qtls, uint64_t error_code,
     ERR_new();
     ERR_set_debug(src_file, src_line, src_func);
     ERR_set_error(ERR_LIB_SSL, SSL_R_QUIC_HANDSHAKE_LAYER_ERROR,
-        "handshake layer error, error code %llu (0x%llx) (\"%s\")",
+        "handshake layer error, error code %" PRIu64 " (0x%" PRIx64 ") (\"%s\")",
         error_code, error_code, error_msg);
 
     if (qtls->args.ossl_quic) {

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <inttypes.h>
 #include "internal/common.h"
 #include "internal/quic_ssl.h"
 #include "internal/quic_reactor_wait_ctx.h"
@@ -571,7 +572,7 @@ static int poll_translate(SSL_POLL_ITEM *items,
         default:
             ERR_raise_data(ERR_LIB_SSL, SSL_R_POLL_REQUEST_NOT_SUPPORTED,
                 "SSL_poll does not support unknown poll descriptor "
-                "type %d",
+                "type %" PRIu32,
                 item->desc.type);
             FAIL_ITEM(i);
         }
@@ -785,7 +786,7 @@ static int poll_readout(SSL_POLL_ITEM *items,
         default:
             ERR_raise_data(ERR_LIB_SSL, SSL_R_POLL_REQUEST_NOT_SUPPORTED,
                 "SSL_poll does not support unknown poll descriptor "
-                "type %d",
+                "type %" PRIu32,
                 item->desc.type);
             FAIL_ITEM(i);
         }

--- a/test/build.info
+++ b/test/build.info
@@ -962,7 +962,8 @@ IF[{- !$disabled{tests} -}]
   # programs are forcibly linked with the static libraries, where all symbols
   # are always available.
   IF[1]
-    PROGRAMS{noinst}=asn1_internal_test modes_internal_test x509_internal_test \
+    PROGRAMS{noinst}=asn1_internal_test err_internal_test \
+                     modes_internal_test x509_internal_test \
                      tls13encryptiontest wpackettest ctype_internal_test \
                      rdcpu_sanitytest property_test ideatest rsa_mp_test \
                      rsa_sp800_56b_test bn_internal_test ecdsatest rsa_test \
@@ -1015,6 +1016,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[asn1_internal_test]=asn1_internal_test.c
     INCLUDE[asn1_internal_test]=.. ../include ../apps/include
     DEPEND[asn1_internal_test]=../libcrypto.a libtestutil.a
+
+    SOURCE[err_internal_test]=err_internal_test.c
+    INCLUDE[err_internal_test]=.. ../include ../apps/include
+    DEPEND[err_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[modes_internal_test]=modes_internal_test.c
     INCLUDE[modes_internal_test]=.. ../include ../apps/include

--- a/test/err_internal_test.c
+++ b/test/err_internal_test.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <openssl/err.h>
+#include "internal/err.h"
+#include "testutil.h"
+
+/* Text longer than the room ossl_err_add_error_fmt() allocates up front. */
+#define LONG_TEXT                                                   \
+    "0123456789012345678901234567890123456789012345678901234567890" \
+    "123456789012345678901234567890123456789"
+
+static const char *appended(void)
+{
+    const char *data = NULL;
+
+    ERR_peek_last_error_data(&data, NULL);
+    return data;
+}
+
+/* An error carrying no data takes the formatted text as its data. */
+static int test_add_to_error_without_data(void)
+{
+    int ok;
+
+    ERR_clear_error();
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    ossl_err_add_error_fmt("host=%s", "example.com");
+    ok = TEST_str_eq(appended(), "host=example.com");
+    ERR_clear_error();
+    return ok;
+}
+
+/* An error already carrying data has the text appended to it. */
+static int test_add_to_error_with_data(void)
+{
+    int ok;
+
+    ERR_clear_error();
+    ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR, "code=%d", 404);
+    ossl_err_add_error_fmt(", reason=%s", "gone");
+    ok = TEST_str_eq(appended(), "code=404, reason=gone");
+    ERR_clear_error();
+    return ok;
+}
+
+/* Repeated calls accumulate rather than replace. */
+static int test_appends_accumulate(void)
+{
+    int ok;
+
+    ERR_clear_error();
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    ossl_err_add_error_fmt("one");
+    ossl_err_add_error_fmt(" %s", "two");
+    ossl_err_add_error_fmt(" %d", 3);
+    ok = TEST_str_eq(appended(), "one two 3");
+    ERR_clear_error();
+    return ok;
+}
+
+/* Conversions other than %s are formatted as printf(3) would. */
+static int test_conversions(void)
+{
+    int ok;
+
+    ERR_clear_error();
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    ossl_err_add_error_fmt("%s=%d/%lu/%02x", "v", -7, 8UL, 255);
+    ok = TEST_str_eq(appended(), "v=-7/8/ff");
+    ERR_clear_error();
+    return ok;
+}
+
+/* Text too long for the initial allocation is not truncated. */
+static int test_text_longer_than_initial_room(void)
+{
+    int ok;
+
+    ERR_clear_error();
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    ossl_err_add_error_fmt("%s", LONG_TEXT);
+    ok = TEST_str_eq(appended(), LONG_TEXT)
+        && TEST_size_t_eq(strlen(appended()), strlen(LONG_TEXT));
+    ERR_clear_error();
+    return ok;
+}
+
+/* Repeated growth of one error's data. */
+static int test_repeated_growth(void)
+{
+    char expected[1024];
+    size_t pos = 0;
+    int i, ok;
+
+    ERR_clear_error();
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    for (i = 0; i < 50; i++) {
+        ossl_err_add_error_fmt("%d,", i);
+        pos += (size_t)snprintf(expected + pos, sizeof(expected) - pos,
+            "%d,", i);
+    }
+    ok = TEST_str_eq(appended(), expected);
+    ERR_clear_error();
+    return ok;
+}
+
+/* Appending nothing leaves the existing data alone. */
+static int test_empty_append(void)
+{
+    int ok;
+
+    ERR_clear_error();
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    ossl_err_add_error_fmt("kept");
+    ossl_err_add_error_fmt("%s", "");
+    ok = TEST_str_eq(appended(), "kept");
+    ERR_clear_error();
+    return ok;
+}
+
+/* Appending with nothing on the queue neither crashes nor raises. */
+static int test_add_with_empty_queue(void)
+{
+    int ok;
+
+    ERR_clear_error();
+    ossl_err_add_error_fmt("ignored=%d", 1);
+    ok = TEST_ulong_eq(ERR_peek_error(), 0);
+    ERR_clear_error();
+    return ok;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_add_to_error_without_data);
+    ADD_TEST(test_add_to_error_with_data);
+    ADD_TEST(test_appends_accumulate);
+    ADD_TEST(test_conversions);
+    ADD_TEST(test_text_longer_than_initial_room);
+    ADD_TEST(test_repeated_growth);
+    ADD_TEST(test_empty_append);
+    ADD_TEST(test_add_with_empty_queue);
+    return 1;
+}

--- a/test/err_internal_test.c
+++ b/test/err_internal_test.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <openssl/err.h>
-#include "internal/err.h"
+#include "crypto/err.h"
 #include "testutil.h"
 
 /* Text longer than the room ossl_err_add_error_fmt() allocates up front. */

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -127,14 +127,14 @@ static int preserves_system_error(void)
 #endif
 }
 
-/* Test that calls to ERR_add_error_[v]data append */
-static int vdata_appends(void)
+/* Test that calls to ERR_add_error_txt() append */
+static int txt_appends(void)
 {
     const char *data;
 
     ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
-    ERR_add_error_data(1, "hello ");
-    ERR_add_error_data(1, "world");
+    ERR_add_error_txt(NULL, "hello ");
+    ERR_add_error_txt(NULL, "world");
     ERR_peek_error_data(&data, NULL);
     return TEST_str_eq(data, "hello world");
 }
@@ -453,7 +453,7 @@ static int test_error_string(void)
 int setup_tests(void)
 {
     ADD_TEST(preserves_system_error);
-    ADD_TEST(vdata_appends);
+    ADD_TEST(txt_appends);
     ADD_TEST(raised_error);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_print_error_format);

--- a/test/recipes/03-test_internal_err.t
+++ b/test/recipes/03-test_internal_err.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test;              # get 'plan'
+use OpenSSL::Test::Simple;
+use OpenSSL::Test::Utils;
+
+setup("test_internal_err");
+
+simple_test("test_internal_err", "err_internal_test");

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -438,7 +438,11 @@ static int test_err_helper(int lib, int reason, const char *str)
 
         ERR_new();
         ERR_set_debug(e->file, e->line, e->fn);
-        ERR_set_error(ERR_GET_LIB(e->code), ERR_GET_REASON(e->code), e->data);
+        if (e->data != NULL)
+            ERR_set_error(ERR_GET_LIB(e->code), ERR_GET_REASON(e->code),
+                "%s", e->data);
+        else
+            ERR_set_error(ERR_GET_LIB(e->code), ERR_GET_REASON(e->code), NULL);
 
         OPENSSL_free(e->file);
         OPENSSL_free(e->fn);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3719,8 +3719,8 @@ ERR_reason_error_string                 3717	4_0_0	EXIST::FUNCTION:
 ERR_print_errors_cb                     3718	4_0_0	EXIST::FUNCTION:
 ERR_print_errors_fp                     3719	4_0_0	EXIST::FUNCTION:STDIO
 ERR_print_errors                        3720	4_0_0	EXIST::FUNCTION:
-ERR_add_error_data                      3721	4_0_0	EXIST::FUNCTION:
-ERR_add_error_vdata                     3722	4_0_0	EXIST::FUNCTION:
+ERR_add_error_data                      3721	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_1
+ERR_add_error_vdata                     3722	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_1
 ERR_add_error_txt                       3723	4_0_0	EXIST::FUNCTION:
 ERR_add_error_mem_bio                   3724	4_0_0	EXIST::FUNCTION:
 ERR_load_strings                        3725	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION

I really loved the 90's - the music was great, I was bulletproof, my middle name was DANGER, as
were most of the public API's in C code. 

<img width="550" height="376" alt="1990s" src="https://github.com/user-attachments/assets/7fab1f1a-2dca-4897-84fa-0514bb5c084b" />

Sadly I'm now much older and feel a lot less bulletproof and tolerant of danger.  35 years of 
C programming and surviving a head on collision does stuff to you. 

Let's mark the printf style error appenders with the printf attribute, and then fix the things
where we were sort of abusing them. This includes a large sweep at the end to catch everything
in CI I couldn't directly catch.  Of note one bug was noticed while doing this where we printed
a public key length when erroring about a private key (This was already landed separately
from this stack)

Then there is ERR_add_error_data() and ERR_add_error_vdata() - Back in the 90's
public API that that bravely walked a va_list with an integer provided length into danger without using the usual "stop at a terminating NULL" was just fine (it was the best of times). Today this just seems to be a footgun waiting to happen.

Let's deprecate these strange varargs "append a string" functions, and use an internal replacement 
that is safer since it just uses printf. I don't believe it needs to be public as external callers don't really 
need this, they can build up an error string themselves and add it with the existing public api.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
