### PR TITLE
[codex] Enforce TLS 1.3 AES-GCM record usage limits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,11 @@ OpenSSL 4.1
 
 ### Changes between 4.1 and 4.2 [xx XXX xxxx]
 
- * none yet
+ * Enforced the per-key AEAD usage limit for TLS 1.3 and DTLS 1.3 AES-GCM
+   write keys. OpenSSL now initiates a KeyUpdate before the limit is reached,
+   or fails safely when the active transport cannot guarantee a rekey.
+
+   *Max van Amersfort*
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1339,6 +1339,7 @@ SM2_R_INVALID_FIELD:105:invalid field
 SM2_R_INVALID_PRIVATE_KEY:113:invalid private key
 SM2_R_NO_PARAMETERS_SET:109:no parameters set
 SM2_R_USER_ID_TOO_LARGE:106:user id too large
+SSL_R_AEAD_USAGE_LIMIT_REACHED:427:aead usage limit reached
 SSL_R_APPLICATION_DATA_AFTER_CLOSE_NOTIFY:291:\
 	application data after close notify
 SSL_R_APP_DATA_IN_HANDSHAKE:100:app data in handshake

--- a/doc/man3/SSL_key_update.pod
+++ b/doc/man3/SSL_key_update.pod
@@ -43,6 +43,13 @@ operation has been scheduled but not yet performed. The type of the pending key
 update operation will be returned if there is one, or SSL_KEY_UPDATE_NONE
 otherwise.
 
+For TLS 1.3 connections using AES-GCM, OpenSSL automatically performs a key
+update before an application write would reach the per-key AEAD usage limit.
+The automatic update does not request a reciprocal update from the peer and is
+transparent to the application. If a key update is unavailable, such as while
+writing early data or with an active KTLS transmit record layer, OpenSSL fails
+the write rather than exceeding the limit.
+
 SSL_renegotiate() and SSL_renegotiate_abbreviated() should only be called for
 connections that have negotiated TLSv1.2 or less. Calling them on any other
 connection will result in an error.
@@ -120,7 +127,7 @@ OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 
-Copyright 2017-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/ssl/d1_msg.c
+++ b/ssl/d1_msg.c
@@ -13,11 +13,17 @@
 int dtls1_write_app_data_bytes(SSL *s, uint8_t type, const void *buf_,
     size_t len, size_t *written)
 {
-    int i;
+    int i, aead_limit_checked = 0;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
 
     if (sc == NULL)
         return -1;
+
+    if (!SSL_in_init(s)) {
+        if (!ossl_tls13_maybe_key_update(sc, type, len))
+            return -1;
+        aead_limit_checked = 1;
+    }
 
     /*
      * If we are supposed to be sending a KeyUpdate or NewSessionTicket then go
@@ -35,6 +41,11 @@ int dtls1_write_app_data_bytes(SSL *s, uint8_t type, const void *buf_,
             return -1;
         }
     }
+
+    /* Assess a write that entered here while another handshake was active. */
+    if (!aead_limit_checked
+        && !ossl_tls13_maybe_key_update(sc, type, len))
+        return -1;
 
     if (len > SSL3_RT_MAX_PLAIN_LENGTH) {
         ERR_raise(ERR_LIB_SSL, SSL_R_DTLS_MESSAGE_TOO_BIG);

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -1098,8 +1098,7 @@ static int dtls_get_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t *sequence)
 
 static int dtls_set_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t sequence)
 {
-    rl->sequence = sequence;
-    return 1;
+    return tls_set_sequence_number(rl, sequence);
 }
 
 static int dtls_get_epoch(OSSL_RECORD_LAYER *rl, uint64_t *epoch)

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -526,8 +526,8 @@ static int ktls_post_encryption_processing(OSSL_RECORD_LAYER *rl,
     WPACKET *thispkt,
     TLS_RL_RECORD *thiswr)
 {
-    /* The kernel does anything that is needed, so nothing to do here */
-    return 1;
+    /* Keep a userspace shadow of the sequence number used by the kernel. */
+    return tls_increment_sequence_ctr(rl);
 }
 
 static int ktls_prepare_write_bio(OSSL_RECORD_LAYER *rl, int type)
@@ -608,8 +608,8 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     tls_set_max_frag_len,
     NULL,
     tls_increment_sequence_ctr,
-    NULL,
-    NULL,
+    tls_get_sequence_number,
+    tls_set_sequence_number,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -276,6 +276,9 @@ struct ossl_record_layer_st {
     /* Sequence number for the next record */
     uint64_t sequence;
 
+    /* Maximum number of records permitted for the write key, or 0 if unset */
+    uint64_t max_sequence;
+
     /* Alert code to be used if an error occurs */
     int alert;
 
@@ -435,6 +438,8 @@ int ossl_set_tls_provider_parameters(OSSL_RECORD_LAYER *rl,
     const EVP_MD *md);
 
 int tls_increment_sequence_ctr(OSSL_RECORD_LAYER *rl);
+int tls_get_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t *sequence);
+int tls_set_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t sequence);
 int tls_alloc_buffers(OSSL_RECORD_LAYER *rl);
 int tls_free_buffers(OSSL_RECORD_LAYER *rl);
 

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1295,6 +1295,18 @@ int tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     rl->taglen = taglen;
     rl->md = md;
 
+    /*
+     * RFC 9846 section 5.5 requires TLS 1.3 implementations to update the
+     * traffic key or close the connection before the AEAD usage limit is
+     * reached. Count every record as full sized, which is conservative for
+     * shorter records.
+     */
+    if (direction == OSSL_RECORD_DIRECTION_WRITE
+        && vers == TLS1_3_VERSION && ciph != NULL
+        && (EVP_CIPHER_is_a(ciph, "AES-128-GCM")
+            || EVP_CIPHER_is_a(ciph, "AES-256-GCM")))
+        rl->max_sequence = TLS13_AES_GCM_USAGE_LIMIT;
+
     rl->alert = SSL_AD_NO_ALERT;
     rl->rstate = SSL_ST_READ_HEADER;
 
@@ -2087,6 +2099,11 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl)
             }
             return ret;
         }
+        if (BIO_get_ktls_send(rl->bio)
+            && !tls_increment_sequence_ctr(rl)) {
+            /* RLAYERfatal() already called */
+            return OSSL_RECORD_RETURN_FATAL;
+        }
         TLS_BUFFER_add_offset(thiswb, tmpwrit);
         TLS_BUFFER_sub_left(thiswb, tmpwrit);
     }
@@ -2222,12 +2239,35 @@ void tls_set_max_frag_len(OSSL_RECORD_LAYER *rl, size_t max_frag_len)
 
 int tls_increment_sequence_ctr(OSSL_RECORD_LAYER *rl)
 {
+    if (rl->max_sequence != 0 && rl->sequence >= rl->max_sequence) {
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR,
+            SSL_R_AEAD_USAGE_LIMIT_REACHED);
+        return 0;
+    }
+
     /* Increment the sequence counter */
     if (++rl->sequence == 0) {
         /* Sequence has wrapped */
         RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, SSL_R_SEQUENCE_CTR_WRAPPED);
         return 0;
     }
+    return 1;
+}
+
+int tls_get_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t *sequence)
+{
+    *sequence = rl->sequence;
+    return 1;
+}
+
+int tls_set_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t sequence)
+{
+    if (rl->max_sequence != 0 && sequence > rl->max_sequence) {
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR,
+            SSL_R_AEAD_USAGE_LIMIT_REACHED);
+        return 0;
+    }
+    rl->sequence = sequence;
     return 1;
 }
 
@@ -2320,8 +2360,8 @@ const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_set_max_frag_len,
     NULL,
     tls_increment_sequence_ctr,
-    NULL,
-    NULL,
+    tls_get_sequence_number,
+    tls_set_sequence_number,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1298,11 +1298,12 @@ int tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     /*
      * RFC 9846 section 5.5 requires TLS 1.3 implementations to update the
      * traffic key or close the connection before the AEAD usage limit is
-     * reached. Count every record as full sized, which is conservative for
-     * shorter records.
+     * reached. RFC 9147 section 4.5.3 applies the same limit to DTLS 1.3.
+     * Count every record as full sized, which is conservative for shorter
+     * records.
      */
     if (direction == OSSL_RECORD_DIRECTION_WRITE
-        && vers == TLS1_3_VERSION && ciph != NULL
+        && (vers == TLS1_3_VERSION || vers == DTLS1_3_VERSION) && ciph != NULL
         && (EVP_CIPHER_is_a(ciph, "AES-128-GCM")
             || EVP_CIPHER_is_a(ciph, "AES-256-GCM")))
         rl->max_sequence = TLS13_AES_GCM_USAGE_LIMIT;

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -261,6 +261,94 @@ static int tls_write_check_pending(SSL_CONNECTION *s, uint8_t type,
 }
 
 /*
+ * Schedule a KeyUpdate before an application write would reach the TLS 1.3
+ * AES-GCM per-key record limit. One old-key record is reserved for the
+ * KeyUpdate message itself. If the active write record layer cannot safely
+ * change keys, fail the write before reaching the limit instead.
+ */
+int ossl_tls13_maybe_key_update(SSL_CONNECTION *s, uint8_t type, size_t len)
+{
+    const EVP_CIPHER *ciph = s->s3.tmp.new_sym_enc;
+    uint64_t sequence, records;
+    size_t fragment;
+
+    if (type != SSL3_RT_APPLICATION_DATA || len == 0
+        || !SSL_CONNECTION_IS_TLS13(s) || ciph == NULL
+        || (!EVP_CIPHER_is_a(ciph, "AES-128-GCM")
+            && !EVP_CIPHER_is_a(ciph, "AES-256-GCM"))
+        || s->rlayer.wrlmethod->get_sequence == NULL)
+        return 1;
+
+    if (!s->rlayer.wrlmethod->get_sequence(s->rlayer.wrl, &sequence)) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    fragment = ssl_get_split_send_fragment(s);
+    if (fragment == 0) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    records = 1 + (len - 1) / fragment;
+
+    if (sequence >= TLS13_AES_GCM_USAGE_LIMIT
+        || records >= TLS13_AES_GCM_USAGE_LIMIT) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+            SSL_R_AEAD_USAGE_LIMIT_REACHED);
+        return 0;
+    }
+
+    if (records >= TLS13_AES_GCM_USAGE_LIMIT - sequence
+        && s->key_update == SSL_KEY_UPDATE_NONE) {
+        if (!SSL_is_init_finished(SSL_CONNECTION_GET_SSL(s))
+            || BIO_get_ktls_send(s->wbio)) {
+            /*
+             * KeyUpdate is unavailable for early data. An active KTLS
+             * transmit layer also cannot guarantee that the kernel accepts
+             * the replacement key immediately after the old-key KeyUpdate
+             * record, so close rather than risk exceeding the usage limit.
+             */
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                SSL_R_AEAD_USAGE_LIMIT_REACHED);
+            return 0;
+        }
+        s->key_update = SSL_KEY_UPDATE_NOT_REQUESTED;
+    }
+
+    return 1;
+}
+
+/* Update the userspace sequence shadow after a direct KTLS write. */
+int ossl_tls_record_add_write_bytes(SSL_CONNECTION *s, size_t bytes)
+{
+    uint64_t sequence, records;
+    size_t fragment;
+
+    if (bytes == 0)
+        return 1;
+    if (s->rlayer.wrlmethod->get_sequence == NULL
+        || s->rlayer.wrlmethod->set_sequence == NULL
+        || !s->rlayer.wrlmethod->get_sequence(s->rlayer.wrl, &sequence)) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    fragment = ssl_get_split_send_fragment(s);
+    if (fragment == 0) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    records = 1 + (bytes - 1) / fragment;
+    if (records > UINT64_MAX - sequence) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_SEQUENCE_CTR_WRAPPED);
+        return 0;
+    }
+
+    return s->rlayer.wrlmethod->set_sequence(s->rlayer.wrl,
+        sequence + records);
+}
+
+/*
  * Call this to write data in records of type 'type' It will return <= 0 if
  * not all data has been sent or non-blocking IO.
  */
@@ -270,7 +358,7 @@ int ssl3_write_bytes(SSL *ssl, uint8_t type, const void *buf_, size_t len,
     const unsigned char *buf = buf_;
     size_t tot;
     size_t n, max_send_fragment, split_send_fragment, maxpipes;
-    int i;
+    int i, aead_limit_checked = 0;
     SSL_CONNECTION *s = SSL_CONNECTION_FROM_SSL_ONLY(ssl);
     OSSL_RECORD_TEMPLATE tmpls[SSL_MAX_PIPELINES];
     unsigned int recversion;
@@ -304,6 +392,12 @@ int ssl3_write_bytes(SSL *ssl, uint8_t type, const void *buf_, size_t len,
 
     s->rlayer.wnum = 0;
 
+    if (s->rlayer.wpend_tot == 0 && !SSL_in_init(ssl)) {
+        if (!ossl_tls13_maybe_key_update(s, type, len - tot))
+            return -1;
+        aead_limit_checked = 1;
+    }
+
     /*
      * If we are supposed to be sending a KeyUpdate or NewSessionTicket then go
      * into init unless we have writes pending - in which case we should finish
@@ -327,6 +421,15 @@ int ssl3_write_bytes(SSL *ssl, uint8_t type, const void *buf_, size_t len,
             return -1;
         }
     }
+
+    /*
+     * If a handshake (including a previous nonblocking KeyUpdate) was already
+     * in progress, let it finish before assessing the application write under
+     * the resulting write key.
+     */
+    if (s->rlayer.wpend_tot == 0 && !aead_limit_checked
+        && !ossl_tls13_maybe_key_update(s, type, len - tot))
+        return -1;
 
     i = tls_write_check_pending(s, type, buf, len);
     if (i < 0) {

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -261,10 +261,10 @@ static int tls_write_check_pending(SSL_CONNECTION *s, uint8_t type,
 }
 
 /*
- * Schedule a KeyUpdate before an application write would reach the TLS 1.3
- * AES-GCM per-key record limit. One old-key record is reserved for the
- * KeyUpdate message itself. If the active write record layer cannot safely
- * change keys, fail the write before reaching the limit instead.
+ * Schedule a KeyUpdate before an application write would reach the TLS 1.3 or
+ * DTLS 1.3 AES-GCM per-key record limit. One old-key record is reserved for
+ * the KeyUpdate message itself. If the active write record layer cannot
+ * safely change keys, fail the write before reaching the limit instead.
  */
 int ossl_tls13_maybe_key_update(SSL_CONNECTION *s, uint8_t type, size_t len)
 {
@@ -273,7 +273,8 @@ int ossl_tls13_maybe_key_update(SSL_CONNECTION *s, uint8_t type, size_t len)
     size_t fragment;
 
     if (type != SSL3_RT_APPLICATION_DATA || len == 0
-        || !SSL_CONNECTION_IS_TLS13(s) || ciph == NULL
+        || (!SSL_CONNECTION_IS_TLS13(s) && !SSL_CONNECTION_IS_DTLS13(s))
+        || ciph == NULL
         || (!EVP_CIPHER_is_a(ciph, "AES-128-GCM")
             && !EVP_CIPHER_is_a(ciph, "AES-256-GCM"))
         || s->rlayer.wrlmethod->get_sequence == NULL)

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -24,6 +24,9 @@
 
 #define SEQ_NUM_SIZE 8
 
+/* floor(2^24.5), the TLS 1.3 AES-GCM per-key record limit from RFC 9846 */
+#define TLS13_AES_GCM_USAGE_LIMIT UINT64_C(23726566)
+
 typedef struct tls_record_st {
     void *rechandle;
     int version;
@@ -185,6 +188,9 @@ int ssl_release_record(SSL_CONNECTION *s, TLS_RECORD *rr, size_t length);
 
 int ossl_tls_handle_rlayer_return(SSL_CONNECTION *s, int writing, int ret,
     char *file, int line);
+
+int ossl_tls13_maybe_key_update(SSL_CONNECTION *s, uint8_t type, size_t len);
+int ossl_tls_record_add_write_bytes(SSL_CONNECTION *s, size_t bytes);
 
 int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     int direction, int level,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2876,6 +2876,22 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
         return -1;
     }
 
+    if (sc->rlayer.wpend_tot == 0
+        && !ossl_tls13_maybe_key_update(sc, SSL3_RT_APPLICATION_DATA, size)) {
+        ssl_update_error_state(sc);
+        return -1;
+    }
+    if (sc->key_update != SSL_KEY_UPDATE_NONE)
+        ossl_statem_set_in_init(sc, 1);
+    if (SSL_in_init(s) && !ossl_statem_get_in_handshake(sc)) {
+        ret = sc->handshake_func(s);
+        ssl_update_error_state(sc);
+        if (ret < 0)
+            return ret;
+        if (ret == 0)
+            return -1;
+    }
+
     /* If we have an alert to send, lets send it */
     if (sc->s3.alert_dispatch != SSL_ALERT_DISPATCH_NONE) {
         ret = (ossl_ssize_t)s->method->ssl_dispatch_alert(s);
@@ -2906,6 +2922,11 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
     return -1;
 #else
     ret = ktls_sendfile(SSL_get_wfd(s), fd, offset, size, &sbytes, flags);
+    if (sbytes > 0
+        && !ossl_tls_record_add_write_bytes(sc, (size_t)sbytes)) {
+        ssl_update_error_state(sc);
+        return -1;
+    }
     ssl_update_error_state(sc);
     BIO_clear_retry_flags(sc->wbio);
     if (ret < 0) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1338,25 +1338,10 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl)
     if (!TEST_mem_eq(cbuf, sizeof(cbuf), sbuf, sizeof(sbuf)))
         goto end;
 
-    /*
-     * If ktls is used then kernel sequences are used instead of
-     * OpenSSL sequences
-     */
-    if (!BIO_get_ktls_send(clientsc->wbio)) {
-        if (!TEST_uint64_t_ne(crec_wseq_before, crec_wseq_after))
-            goto end;
-    } else {
-        if (!TEST_uint64_t_eq(crec_wseq_before, crec_wseq_after))
-            goto end;
-    }
-
-    if (!BIO_get_ktls_send(serversc->wbio)) {
-        if (!TEST_uint64_t_ne(srec_wseq_before, srec_wseq_after))
-            goto end;
-    } else {
-        if (!TEST_uint64_t_eq(srec_wseq_before, srec_wseq_after))
-            goto end;
-    }
+    /* KTLS write sequence numbers are shadowed in userspace. */
+    if (!TEST_uint64_t_ne(crec_wseq_before, crec_wseq_after)
+        || !TEST_uint64_t_ne(srec_wseq_before, srec_wseq_after))
+        goto end;
 
     if (!BIO_get_ktls_recv(clientsc->wbio)) {
         if (!TEST_uint64_t_ne(crec_rseq_before, crec_rseq_after))
@@ -1562,6 +1547,8 @@ static int execute_test_ktls_sendfile(int tls_version, const char *cipher,
     ssize_t chunk_size = 0;
     off_t chunk_off = 0;
     int testresult = 0;
+    int test_usage_limit;
+    uint64_t wseq_before, wseq_after;
     FILE *ffdp;
     SSL_CONNECTION *serversc;
 
@@ -1625,6 +1612,11 @@ static int execute_test_ktls_sendfile(int tls_version, const char *cipher,
         goto end;
     }
 
+    test_usage_limit = tls_version == TLS1_3_VERSION
+        && strstr(cipher, "_AES_") != NULL
+        && strstr(cipher, "_GCM_") != NULL;
+    wseq_before = serversc->rlayer.wrl->sequence;
+
     if (!TEST_int_gt(RAND_bytes_ex(libctx, buf, SENDFILE_SZ, 0), 0))
         goto end;
 
@@ -1668,6 +1660,29 @@ static int execute_test_ktls_sendfile(int tls_version, const char *cipher,
             goto end;
 
         chunk_off += chunk_size;
+    }
+
+    wseq_after = serversc->rlayer.wrl->sequence;
+    if (!TEST_uint64_t_eq(wseq_after - wseq_before,
+            SENDFILE_SZ / SENDFILE_CHUNK)) {
+        goto end;
+    }
+
+    /*
+     * A KTLS backend may be unable to install a transmit rekey immediately
+     * after the old-key KeyUpdate record. Verify that OpenSSL refuses another
+     * AES-GCM application record instead of crossing the usage limit.
+     */
+    if (test_usage_limit) {
+        serversc->rlayer.wrl->sequence = TLS13_AES_GCM_USAGE_LIMIT - 1;
+        ERR_clear_error();
+        err = SSL_sendfile(serverssl, ffd, 0, SENDFILE_CHUNK, 0);
+        if (!TEST_int_eq(err, -1)
+            || !TEST_int_eq(SSL_get_error(serverssl, err), SSL_ERROR_SSL)
+            || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+                SSL_R_AEAD_USAGE_LIMIT_REACHED))
+            goto end;
+        ERR_clear_error();
     }
 
     testresult = 1;
@@ -8751,6 +8766,141 @@ end:
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
 
+    return testresult;
+}
+
+static const struct {
+    const char *ciphersuite;
+    int expect_update;
+} tls13_aead_usage_limit_tests[] = {
+    { "TLS_AES_128_GCM_SHA256", 1 },
+    { "TLS_AES_256_GCM_SHA384", 1 },
+    { "TLS_CHACHA20_POLY1305_SHA256", 0 },
+};
+
+/*
+ * Test that TLS 1.3 proactively updates AES-GCM traffic keys before the
+ * per-key record usage limit is reached, without applying the AES-GCM limit
+ * to another AEAD.
+ */
+static int test_tls13_aead_usage_limit(int idx)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *clientsc = NULL, *serversc = NULL;
+    int testresult = 0;
+    int expect_update = tls13_aead_usage_limit_tests[idx].expect_update;
+    static const char mess[] = "A test message";
+    char buf[sizeof(mess)];
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_3_VERSION, TLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
+            tls13_aead_usage_limit_tests[idx].ciphersuite))
+        || !TEST_true(SSL_CTX_set_ciphersuites(cctx,
+            tls13_aead_usage_limit_tests[idx].ciphersuite))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl))
+        || !TEST_ptr(serversc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl)))
+        goto end;
+
+    clientsc->rlayer.wrl->sequence = TLS13_AES_GCM_USAGE_LIMIT
+        - (expect_update ? 2 : 1);
+    serversc->rlayer.rrl->sequence = clientsc->rlayer.wrl->sequence;
+
+    if (!TEST_int_eq(SSL_write(clientssl, mess, sizeof(mess)), sizeof(mess))
+        || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)), sizeof(buf))
+        || !TEST_mem_eq(buf, sizeof(buf), mess, sizeof(mess))
+        || !TEST_uint64_t_eq(clientsc->rlayer.wrl->sequence,
+            TLS13_AES_GCM_USAGE_LIMIT - (expect_update ? 1 : 0))
+        || !TEST_uint64_t_eq(serversc->rlayer.rrl->sequence,
+            TLS13_AES_GCM_USAGE_LIMIT - (expect_update ? 1 : 0)))
+        goto end;
+
+    if (expect_update
+        && (!TEST_int_eq(SSL_write(clientssl, mess, sizeof(mess)),
+                sizeof(mess))
+            || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)), sizeof(buf))
+            || !TEST_mem_eq(buf, sizeof(buf), mess, sizeof(mess))
+            /* KeyUpdate uses the old key; application data starts at seq 0. */
+            || !TEST_uint64_t_eq(clientsc->rlayer.wrl->sequence, 1)
+            || !TEST_uint64_t_eq(serversc->rlayer.rrl->sequence, 1)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/* Test retrying an automatic KeyUpdate after a nonblocking write stalls. */
+static int test_tls13_aead_usage_limit_retry(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *clientsc = NULL, *serversc = NULL;
+    BIO *bretry = BIO_new(bio_s_always_retry());
+    BIO *tmp = NULL;
+    int testresult = 0;
+    static const char mess[] = "A test message";
+    char buf[sizeof(mess)];
+
+    if (!TEST_ptr(bretry)
+        || !TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_3_VERSION, TLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
+            "TLS_AES_128_GCM_SHA256"))
+        || !TEST_true(SSL_CTX_set_ciphersuites(cctx,
+            "TLS_AES_128_GCM_SHA256"))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl))
+        || !TEST_ptr(serversc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl)))
+        goto end;
+
+    clientsc->rlayer.wrl->sequence = TLS13_AES_GCM_USAGE_LIMIT - 1;
+    serversc->rlayer.rrl->sequence = TLS13_AES_GCM_USAGE_LIMIT - 1;
+
+    tmp = SSL_get_wbio(clientssl);
+    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
+        tmp = NULL;
+        goto end;
+    }
+    SSL_set0_wbio(clientssl, bretry);
+    bretry = NULL;
+
+    if (!TEST_int_eq(SSL_write(clientssl, mess, sizeof(mess)), -1)
+        || !TEST_int_eq(SSL_get_error(clientssl, -1), SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    SSL_set0_wbio(clientssl, tmp);
+    tmp = NULL;
+
+    if (!TEST_int_eq(SSL_write(clientssl, mess, sizeof(mess)), sizeof(mess))
+        || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)), sizeof(buf))
+        || !TEST_mem_eq(buf, sizeof(buf), mess, sizeof(mess))
+        || !TEST_uint64_t_eq(clientsc->rlayer.wrl->sequence, 1)
+        || !TEST_uint64_t_eq(serversc->rlayer.rrl->sequence, 1))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    BIO_free(bretry);
+    BIO_free(tmp);
     return testresult;
 }
 
@@ -17131,6 +17281,9 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_key_update_local_in_write, 4);
 #endif
 #if !defined(OSSL_NO_USABLE_TLS1_3)
+    ADD_ALL_TESTS(test_tls13_aead_usage_limit,
+        OSSL_NELEM(tls13_aead_usage_limit_tests));
+    ADD_TEST(test_tls13_aead_usage_limit_retry);
     ADD_ALL_TESTS(test_key_update_local_in_read, 2);
 #endif
     ADD_ALL_TESTS(test_ssl_clear, 8);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8840,6 +8840,84 @@ end:
     return testresult;
 }
 
+/*
+ * Test that DTLS 1.3 applies the same AES-GCM per-key record limit as TLS
+ * 1.3. The DTLS replay window is moved close to the limit together with the
+ * sender sequence number so the boundary records can be exchanged normally.
+ */
+static int test_dtls13_aead_usage_limit(int idx)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *clientsc = NULL, *serversc = NULL;
+    uint64_t sequence, write_epoch;
+    int testresult = 0;
+    int expect_update = tls13_aead_usage_limit_tests[idx].expect_update;
+    static const char mess[] = "A test message";
+    char buf[sizeof(mess)];
+
+#if defined(OSSL_NO_USABLE_DTLS1_3)
+    return TEST_skip("No usable DTLSv1.3");
+#endif
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, DTLS_server_method(),
+            DTLS_client_method(), DTLS1_3_VERSION, 0,
+            &sctx, &cctx, cert, privkey))
+        || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
+            tls13_aead_usage_limit_tests[idx].ciphersuite))
+        || !TEST_true(SSL_CTX_set_ciphersuites(cctx,
+            tls13_aead_usage_limit_tests[idx].ciphersuite))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl))
+        || !TEST_ptr(serversc = SSL_CONNECTION_FROM_SSL_ONLY(serverssl))
+        || !TEST_uint64_t_eq(clientsc->rlayer.wrl->max_sequence,
+            expect_update ? TLS13_AES_GCM_USAGE_LIMIT : 0))
+        goto end;
+
+    sequence = TLS13_AES_GCM_USAGE_LIMIT - (expect_update ? 2 : 1);
+    clientsc->rlayer.wrl->sequence = sequence;
+    serversc->rlayer.rrl->sequence = sequence;
+    serversc->rlayer.rrl->bitmap.max_seq_num = sequence - 1;
+    serversc->rlayer.rrl->bitmap.map = 1;
+    write_epoch = clientsc->rlayer.d->w_conn_epoch;
+
+    if (!TEST_int_eq(SSL_write(clientssl, mess, sizeof(mess)), sizeof(mess))
+        || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)), sizeof(buf))
+        || !TEST_mem_eq(buf, sizeof(buf), mess, sizeof(mess))
+        || !TEST_uint64_t_eq(clientsc->rlayer.wrl->sequence,
+            TLS13_AES_GCM_USAGE_LIMIT - (expect_update ? 1 : 0)))
+        goto end;
+
+    if (expect_update) {
+        if (!TEST_int_eq(SSL_write(clientssl, mess, sizeof(mess)), -1)
+            || !TEST_uint64_t_eq(clientsc->rlayer.d->w_conn_epoch,
+                write_epoch + 1)
+            || !TEST_uint64_t_eq(clientsc->rlayer.wrl->sequence, 0))
+            goto end;
+
+        /* Process the KeyUpdate and its ACK, then retry the application write. */
+        if (!TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)), -1)
+            || !TEST_int_eq(SSL_read(clientssl, buf, sizeof(buf)), -1)
+            || !TEST_int_eq(SSL_write(clientssl, mess, sizeof(mess)),
+                sizeof(mess))
+            || !TEST_int_eq(SSL_read(serverssl, buf, sizeof(buf)), sizeof(buf))
+            || !TEST_mem_eq(buf, sizeof(buf), mess, sizeof(mess))
+            || !TEST_uint64_t_eq(clientsc->rlayer.wrl->sequence, 1))
+            goto end;
+    }
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 /* Test retrying an automatic KeyUpdate after a nonblocking write stalls. */
 static int test_tls13_aead_usage_limit_retry(void)
 {
@@ -17285,6 +17363,10 @@ int setup_tests(void)
         OSSL_NELEM(tls13_aead_usage_limit_tests));
     ADD_TEST(test_tls13_aead_usage_limit_retry);
     ADD_ALL_TESTS(test_key_update_local_in_read, 2);
+#endif
+#if !defined(OSSL_NO_USABLE_DTLS1_3)
+    ADD_ALL_TESTS(test_dtls13_aead_usage_limit,
+        OSSL_NELEM(tls13_aead_usage_limit_tests));
 #endif
     ADD_ALL_TESTS(test_ssl_clear, 8);
     ADD_ALL_TESTS(test_max_fragment_len_ext, OSSL_NELEM(max_fragment_len_test));


### PR DESCRIPTION
## Summary

- enforce the RFC 9846 section 5.5 per-key record usage bound for TLS 1.3 AES-GCM write keys
- schedule a non-requesting KeyUpdate before an application write would consume the final permitted old-key record
- keep outgoing sequence accounting consistent for userspace TLS, KTLS, partial retries, and direct `SSL_sendfile()` writes
- fail safely before the bound for early data or an active KTLS transmit layer where an immediate rekey cannot be guaranteed

## Motivation

TLS 1.3 AES-GCM traffic keys have a usage bound of floor(2^24.5) full-size records. The existing record layer enforces the protocol sequence-number ceiling but does not proactively rotate traffic keys at the lower AEAD bound. A sufficiently long-lived AES-GCM connection can therefore continue writing with the same key beyond the limit analyzed by RFC 9846.

This change conservatively counts every outgoing record as full-sized. It reserves one old-key record for the KeyUpdate message and performs the update before accepting application data that would exhaust the remaining allowance. Receiver-side enforcement is intentionally omitted, as recommended by the RFC.

For KTLS, OpenSSL now retains a userspace shadow of the transmit sequence number, including direct `SSL_sendfile()` traffic. Linux KTLS may reject immediate TLS 1.3 transmit rekey installation after the old-key KeyUpdate record, so the KTLS path closes safely at the boundary instead of risking use beyond the limit.

## User impact

Long-lived TLS 1.3 AES-128-GCM and AES-256-GCM connections automatically rotate write traffic keys before reaching the per-key usage bound. ChaCha20-Poly1305 behavior is unchanged. Nonblocking KeyUpdate retries resume the original application write under the new key.

## Validation

- `./Configure --strict-warnings enable-ktls`
- `make -j2`
- `SRCTOP=. BLDTOP=. HARNESS_VERBOSE=-1 HARNESS_JOBS=1 perl test/run_tests.pl test_sslapi`
- `make update`
- `make doc-nits`
- `git diff --check`

Fixes #32219

##### Checklist

- [x] documentation is added or updated
- [x] tests are added or updated
