### PR TITLE
Fix parameter name from 'lengthi' to 'length'

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -98,7 +98,7 @@ static ossl_inline int ktls_enable_tx_zerocopy_sendfile(int fd)
  * record using this control message.
  */
 static ossl_inline int ktls_send_ctrl_message(int fd,
-    unsigned char record_type, const void *data, size_t lengthi, int flags)
+    unsigned char record_type, const void *data, size_t length, int flags)
 {
     struct msghdr msg = { 0 };
     int cmsg_len = sizeof(record_type);


### PR DESCRIPTION
**### Problem**
In include/internal/ktls.h, the variable/parameter lengthi is used in Kernel TLS (KTLS) helper declarations and macros, whereas all related functions across the codebase consistently use length.
This naming inconsistency triggers static analysis warnings (including potential CWE-457 flags regarding parameter/pointer evaluation in macro expansions) and creates confusion during maintenance. The identifier lengthi appears to be an unintended typo introduced during the original KTLS interface definition.

**### Fix** 
This PR standardizes the parameter/variable name lengthi to length in include/internal/ktls.h (and associated internal call sites), unifying variable naming conventions across the KTLS module and resolving static analysis flags.

**CLA: trivial**

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
