### PR TITLE
Reject TLS 1.2 fallback after 0-RTT attempt

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2429,6 +2429,20 @@ int ssl_choose_client_version(SSL_CONNECTION *s, int version,
         return 0;
     }
 
+    /*
+     * RFC 8446 Appendix D.3 requires a client that attempted 0-RTT to
+     * fail the connection if the ServerHello selects TLS 1.2 or older.
+     * early_data_session is retained only when the early_data extension was
+     * actually constructed, so it distinguishes a real 0-RTT attempt from
+     * one that was suppressed before the ClientHello was sent.
+     */
+    if (!SSL_CONNECTION_IS_DTLS(s) && s->ext.early_data_session != NULL
+        && s->version != TLS1_3_VERSION) {
+        s->version = origv;
+        SSLfatal(s, SSL_AD_PROTOCOL_VERSION, SSL_R_WRONG_SSL_VERSION);
+        return 0;
+    }
+
     if (s->hello_retry_request != SSL_HRR_NONE && s->version != version1_3) {
         s->version = origv;
         SSLfatal(s, SSL_AD_PROTOCOL_VERSION, SSL_R_WRONG_SSL_VERSION);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -6089,6 +6089,50 @@ end:
 
 #if !defined(OSSL_NO_USABLE_TLS1_3) && !defined(OPENSSL_NO_TLS1_2)
 /*
+ * RFC 8446 Appendix D.3 requires a client that attempted 0-RTT to abort the
+ * current connection if the ServerHello selects TLS 1.2 or older.
+ */
+static int test_early_data_tls1_2_fallback(void)
+{
+    SSL_CTX *cctx = NULL;
+    SSL *clientssl = NULL;
+    SSL_CONNECTION *clientsc = NULL;
+    RAW_EXTENSION extensions[TLSEXT_IDX_num_builtins] = { 0 };
+    int testresult = 0;
+
+    if (!TEST_ptr(cctx = SSL_CTX_new_ex(libctx, NULL, TLS_client_method()))
+        || !TEST_ptr(clientssl = SSL_new(cctx))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
+        goto end;
+
+    /* TLS 1.2 fallback remains valid when 0-RTT was not attempted. */
+    if (!TEST_true(ssl_choose_client_version(clientsc, TLS1_2_VERSION,
+            extensions))
+        || !TEST_int_eq(clientsc->version, TLS1_2_VERSION))
+        goto end;
+
+    SSL_free(clientssl);
+    clientssl = NULL;
+    if (!TEST_ptr(clientssl = SSL_new(cctx))
+        || !TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl))
+        || !TEST_ptr(clientsc->ext.early_data_session = SSL_SESSION_new()))
+        goto end;
+
+    ERR_clear_error();
+    if (!TEST_false(ssl_choose_client_version(clientsc, TLS1_2_VERSION,
+            extensions))
+        || !TEST_int_eq(ERR_GET_REASON(ERR_get_error()),
+            SSL_R_WRONG_SSL_VERSION))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(clientssl);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
  * Test that a server attempting to read early data can handle a connection
  * from a TLSv1.2 client.
  */
@@ -17019,6 +17063,7 @@ int setup_tests(void)
 #endif
 #endif /* !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3) */
 #if !defined(OSSL_NO_USABLE_TLS1_3) && !defined(OPENSSL_NO_TLS1_2)
+    ADD_TEST(test_early_data_tls1_2_fallback);
     ADD_ALL_TESTS(test_early_data_tls1_2, 3);
 #endif
 #if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3)


### PR DESCRIPTION
RFC 8446 Appendix D.3 requires a TLS 1.3 client that attempted 0-RTT to fail the current connection if the ServerHello selects TLS 1.2 or older.

This change enforces that rule in the client version-selection path. `early_data_session` is retained only after the client early-data extension is actually constructed, so ordinary TLS 1.2 fallback remains valid when 0-RTT was not attempted or was suppressed before ClientHello construction.

The regression test covers both sides of that boundary:
- TLS 1.2 version selection still succeeds without an early-data attempt.
- TLS 1.2 version selection fails with `SSL_R_WRONG_SSL_VERSION` once the early-data attempt marker is present.

Validation:
- `make test TESTS=test_sslapi` — passed
- `git diff --check origin/master...HEAD` — passed
- branch is current with upstream master and GitHub reports it automatically mergeable

Fixes #32215