### PR TITLE
riscv: boost SHA-512 round throughput by interleaving the schedule

### DIFF
--- a/crypto/sha/asm/sha512-riscv64-zvkb-zvknhb.pl
+++ b/crypto/sha/asm/sha512-riscv64-zvkb-zvknhb.pl
@@ -177,117 +177,123 @@ L_round_loop_256_512:
     @{[vrev8_v $V16, $V16]}
     addi $INP, $INP, 32
 
+    # The message-schedule chain (vsha2ms on v10-16) is independent of the state
+    # chain (vsha2cl/vsha2ch on v22/v24); writing its inputs to a constant-staged
+    # scratch (V20) lets it issue in parallel for extra loop ILP.  V20 is only
+    # free here on the VLEN>128 path (the VLEN==128 loop reuses it as constant
+    # staging).  V18 feeds vsha2ch into the next round's vadd, keep a slot between
+    # them on cores that stall on tightly-coupled vector ops.
     # Quad-round 0 (+0, v10->v12->v14->v16)
     @{[vadd_vv $V18, $V2, $V10]}
+    @{[vmerge_vvm $V20, $V14, $V12, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V10, $V20, $V16]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V14, $V12, $V0]}
-    @{[vsha2ms_vv $V10, $V18, $V16]}
 
     # Quad-round 1 (+1, v12->v14->v16->v10)
     @{[vadd_vv $V18, $V3, $V12]}
+    @{[vmerge_vvm $V20, $V16, $V14, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V12, $V20, $V10]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V16, $V14, $V0]}
-    @{[vsha2ms_vv $V12, $V18, $V10]}
 
     # Quad-round 2 (+2, v14->v16->v10->v12)
     @{[vadd_vv $V18, $V4, $V14]}
+    @{[vmerge_vvm $V20, $V10, $V16, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V14, $V20, $V12]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V10, $V16, $V0]}
-    @{[vsha2ms_vv $V14, $V18, $V12]}
 
     # Quad-round 3 (+3, v16->v10->v12->v14)
     @{[vadd_vv $V18, $V5, $V16]}
+    @{[vmerge_vvm $V20, $V12, $V10, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V16, $V20, $V14]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V12, $V10, $V0]}
-    @{[vsha2ms_vv $V16, $V18, $V14]}
 
     # Quad-round 4 (+4, v10->v12->v14->v16)
     @{[vadd_vv $V18, $V6, $V10]}
+    @{[vmerge_vvm $V20, $V14, $V12, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V10, $V20, $V16]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V14, $V12, $V0]}
-    @{[vsha2ms_vv $V10, $V18, $V16]}
 
     # Quad-round 5 (+5, v12->v14->v16->v10)
     @{[vadd_vv $V18, $V7, $V12]}
+    @{[vmerge_vvm $V20, $V16, $V14, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V12, $V20, $V10]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V16, $V14, $V0]}
-    @{[vsha2ms_vv $V12, $V18, $V10]}
 
     # Quad-round 6 (+6, v14->v16->v10->v12)
     @{[vadd_vv $V18, $V8, $V14]}
+    @{[vmerge_vvm $V20, $V10, $V16, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V14, $V20, $V12]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V10, $V16, $V0]}
-    @{[vsha2ms_vv $V14, $V18, $V12]}
 
     # Quad-round 7 (+7, v16->v10->v12->v14)
     @{[vadd_vv $V18, $V9, $V16]}
+    @{[vmerge_vvm $V20, $V12, $V10, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V16, $V20, $V14]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V12, $V10, $V0]}
-    @{[vsha2ms_vv $V16, $V18, $V14]}
 
     # Quad-round 8 (+8, v10->v12->v14->v16)
     @{[vadd_vv $V18, $V11, $V10]}
+    @{[vmerge_vvm $V20, $V14, $V12, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V10, $V20, $V16]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V14, $V12, $V0]}
-    @{[vsha2ms_vv $V10, $V18, $V16]}
 
     # Quad-round 9 (+9, v12->v14->v16->v10)
     @{[vadd_vv $V18, $V13, $V12]}
+    @{[vmerge_vvm $V20, $V16, $V14, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V12, $V20, $V10]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V16, $V14, $V0]}
-    @{[vsha2ms_vv $V12, $V18, $V10]}
 
     # Quad-round 10 (+10, v14->v16->v10->v12)
     @{[vadd_vv $V18, $V15, $V14]}
+    @{[vmerge_vvm $V20, $V10, $V16, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V14, $V20, $V12]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V10, $V16, $V0]}
-    @{[vsha2ms_vv $V14, $V18, $V12]}
 
     # Quad-round 11 (+11, v16->v10->v12->v14)
     @{[vadd_vv $V18, $V17, $V16]}
+    @{[vmerge_vvm $V20, $V12, $V10, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V16, $V20, $V14]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V12, $V10, $V0]}
-    @{[vsha2ms_vv $V16, $V18, $V14]}
 
     # Quad-round 12 (+12, v10->v12->v14->v16)
     @{[vadd_vv $V18, $V19, $V10]}
+    @{[vmerge_vvm $V20, $V14, $V12, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V10, $V20, $V16]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V14, $V12, $V0]}
-    @{[vsha2ms_vv $V10, $V18, $V16]}
 
     # Quad-round 13 (+13, v12->v14->v16->v10)
     @{[vadd_vv $V18, $V21, $V12]}
+    @{[vmerge_vvm $V20, $V16, $V14, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V12, $V20, $V10]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V16, $V14, $V0]}
-    @{[vsha2ms_vv $V12, $V18, $V10]}
 
     # Quad-round 14 (+14, v14->v16->v10->v12)
     @{[vadd_vv $V18, $V23, $V14]}
+    @{[vmerge_vvm $V20, $V10, $V16, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V14, $V20, $V12]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V10, $V16, $V0]}
-    @{[vsha2ms_vv $V14, $V18, $V12]}
 
     # Quad-round 15 (+15, v16->v10->v12->v14)
     @{[vadd_vv $V18, $V25, $V16]}
+    @{[vmerge_vvm $V20, $V12, $V10, $V0]}
     @{[vsha2cl_vv $V24, $V22, $V18]}
+    @{[vsha2ms_vv $V16, $V20, $V14]}
     @{[vsha2ch_vv $V22, $V24, $V18]}
-    @{[vmerge_vvm $V18, $V12, $V10, $V0]}
-    @{[vsha2ms_vv $V16, $V18, $V14]}
 
     # Quad-round 16 (+0, v10->v12->v14->v16)
     # Note that we stop generating new message schedule words (Wt, v10-16)


### PR DESCRIPTION
The Zvknha/Zvknhb SHA-512 round loop keeps the message-schedule chain (vsha2ms on v10/v12/v14/v16) independent of the serial state chain (vsha2cl/vsha2ch on v22/v24).  The loop previously used one register (v18) to carry both the add-result feeding the state round and the vmerge input feeding the message schedule, so a schedule word could not be produced and consumed until the corresponding state round had issued, limiting ILP.

Stage the vmerge input in a scratch vector on the VLEN>128 path (v20) and issue vsha2ms ahead of the state pair, letting the two independent chains co-issue throughout the 64-iteration round loop.  v20 is only touched in this mutually exclusive VLEN branch (the VLEN==128 loop reuses it as constant staging), so no extra vector registers are required and the VLEN==128 path is left unchanged.  The VLEN>128 tail rounds (16-19) and the state-accumulate epilogue also keep their original schedule.

Hardware (SpacemiT K3, riscv64 rv64gcv, GCC 15.2) verification data, baseline 2924476b5591:

| EVP SHA-384           | Baseline  | Optimized | Improvement |
| --------------------- | --------- | --------- | ----------- |
| -bytes 16384          | 664 MB/s  | 906 MB/s  | +36.45%     |
| -bytes 8192           | 645 MB/s  | 874 MB/s  | +35.36%     |
| -bytes 64             |  96 MB/s  | 104 MB/s  |  +8.42%     |

Official functional suite: make-test, 385 files / 4966 tests, PASS.

Assisted-by: YuanSheng:DeepSeek-V4-Flash

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
