### PR TITLE
apps: cover the genrsa, gendsa and genpkey error cases

### DIFF
--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -153,8 +153,12 @@ int genrsa_main(int argc, char **argv)
     argv = opt_rest();
 
     if (argc == 1) {
-        if (!opt_int(argv[0], &num) || num <= 0)
+        if (!opt_int(argv[0], &num))
             goto end;
+        if (num <= 0) {
+            BIO_printf(bio_err, "%s: Invalid number of bits: %d\n", prog, num);
+            goto end;
+        }
         if (num > OPENSSL_RSA_MAX_MODULUS_BITS)
             BIO_printf(bio_err,
                 "Warning: It is not recommended to use more than %d bit for RSA keys.\n"

--- a/test/recipes/15-test_gendsa.t
+++ b/test/recipes/15-test_gendsa.t
@@ -11,7 +11,8 @@ use strict;
 use warnings;
 
 use File::Spec;
-use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir bldtop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir bldtop_file
+                     app_fails slurp_file/;
 use OpenSSL::Test::Utils;
 
 BEGIN {
@@ -28,7 +29,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
     ($no_fips ? 0 : 2)          # FIPS related tests
-    + 18;
+    + 19;
 
 ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-algorithm', 'DSA',
@@ -107,13 +108,62 @@ ok(!run(app([ 'openssl', 'genpkey',
               '-algorithm', 'DSA'])),
    "genpkey DSA with no params should fail");
 
-ok(run(app(["openssl", "gendsa", "-verbose",
-            'dsagen.pem'])),
-    "gendsa with -verbose option and dsagen parameter");
+subtest "gendsa verbose mode" => sub {
+    plan tests => 4;
+
+    my $stderr_file = "gendsa_verbose.txt";
+
+    ok(run(app(['openssl', 'gendsa', '-verbose',
+                '-out', 'gendsatest-verbose.pem', 'dsagen.pem'],
+               stderr => $stderr_file)),
+       "gendsa -verbose generates a key");
+    my $err = slurp_file($stderr_file);
+    ok($err =~ qr/Generating DSA key with \d+ bits/,
+       "-verbose reports the key generation");
+
+    ok(run(app(['openssl', 'gendsa', '-quiet',
+                '-out', 'gendsatest-quiet.pem', 'dsagen.pem'],
+               stderr => $stderr_file)),
+       "gendsa -quiet generates a key");
+    $err = slurp_file($stderr_file);
+    ok($err !~ qr/Generating DSA key/,
+       "-quiet does not report the key generation");
+    unlink($stderr_file) if -f $stderr_file;
+};
 
 ok(!run(app(["openssl", "gendsa",
              'dsagen.pem', "-verbose"])),
    "gendsa with extra parameter (at end) should fail");
+
+subtest "gendsa error cases" => sub {
+    plan tests => 14;
+
+    app_fails('gendsa', "missing params file argument should fail",
+              qr/Missing argument: params file/);
+    app_fails('gendsa', "extra positional argument should fail",
+              qr/Extra argument after params file: "extra"/,
+              'dsagen.pem', 'extra');
+    app_fails('gendsa', "unknown cipher option should fail",
+              qr/Unknown option or cipher: badcipher/,
+              '-badcipher', 'dsagen.pem');
+    app_fails('gendsa', "invalid passout argument should fail",
+              qr/Error getting password/,
+              '-passout', 'bad:pass', 'dsagen.pem');
+    app_fails('gendsa', "nonexistent params file should fail",
+              qr/Could not open file or uri for loading key parameters/,
+              'nonexistent.pem');
+
+    my $garbage = "garbage.pem";
+    open(my $fh, '>', $garbage) or die "Cannot write $garbage: $!";
+    print $fh "not a valid DSA params file\n";
+    close($fh);
+    app_fails('gendsa', "garbage params file should fail",
+              qr/Could not find or decode key parameters/,
+              $garbage);
+    app_fails('gendsa', "non-DSA params file should fail",
+              qr/Could not find or decode key parameters of DSA parameters/,
+              srctop_file("test", "testrsa.pem"));
+};
 
 # test key generation with dsaparam tool
 ok(run(app([ 'openssl', 'dsaparam',

--- a/test/recipes/15-test_genpkey.t
+++ b/test/recipes/15-test_genpkey.t
@@ -9,7 +9,7 @@
 use strict;
 use warnings;
 
-use OpenSSL::Test qw/:DEFAULT with/;
+use OpenSSL::Test qw/:DEFAULT with app_fails slurp_file/;
 use OpenSSL::Test::Utils;
 
 setup("test_genpkey");
@@ -22,7 +22,7 @@ push @algs, qw(EC) unless disabled("ec");
 push @algs, qw(X25519 X448) unless disabled("ecx");
 push @algs, qw(SM2) unless disabled("sm2");
 
-plan tests => scalar(@algs) + 2;
+plan tests => scalar(@algs) + 4;
 
 foreach (@algs) {
     my $alg = $_;
@@ -67,3 +67,67 @@ SKIP: {
                "Cannot use a cipher with -genparam");
         });
 }
+
+subtest "genpkey error cases" => sub {
+    plan tests => 20;
+
+    app_fails('genpkey', "no algorithm or parameter file should fail",
+              qr/Use -help for summary/);
+    app_fails('genpkey', "extra positional argument should fail",
+              qr/Extra option: "extra"/,
+              '-algorithm', 'RSA', 'extra');
+    app_fails('genpkey', "invalid output format should fail",
+              qr/Invalid format "BAD" for option -outform/,
+              '-outform', 'BAD', '-algorithm', 'RSA');
+    app_fails('genpkey', "parameter file with -genparam should fail",
+              qr/Use -help for summary/,
+              '-genparam', '-paramfile', 'dsagen.pem');
+    app_fails('genpkey', "unknown algorithm should fail",
+              qr/Error initializing FOO context/,
+              '-algorithm', 'FOO');
+    app_fails('genpkey', "unknown key option should fail",
+              qr/Error setting bad:1 parameter/,
+              '-algorithm', 'RSA', '-pkeyopt', 'bad:1');
+    app_fails('genpkey', "unknown cipher option should fail",
+              qr/Unknown option or cipher: badcipher/,
+              '-algorithm', 'RSA', '-badcipher');
+    app_fails('genpkey', "invalid pass argument should fail",
+              qr/Error getting password/,
+              '-algorithm', 'RSA', '-pass', 'bad:secret');
+    app_fails('genpkey', "nonexistent parameter file should fail",
+              qr/Can't open parameter file/,
+              '-paramfile', 'nonexistent.pem');
+
+    my $garbage = "garbage.pem";
+    open(my $fh, '>', $garbage) or die "Cannot write $garbage: $!";
+    print $fh "not a valid params file\n";
+    close($fh);
+    app_fails('genpkey', "garbage parameter file should fail",
+              qr/Error reading parameter file/,
+              '-paramfile', $garbage);
+};
+
+subtest "genpkey verbose mode" => sub {
+    plan tests => 4;
+
+    my $stderr_file = "genpkey_verbose.txt";
+
+    ok(run(app(['openssl', 'genpkey', '-verbose', '-algorithm', 'RSA',
+                '-pkeyopt', 'rsa_keygen_bits:2048',
+                '-out', 'genpkey-verbose.pem'],
+               stderr => $stderr_file)),
+       "genpkey -verbose generates a key");
+    my $err = slurp_file($stderr_file);
+    ok($err =~ qr/Generating RSA key/,
+       "-verbose reports the key generation");
+
+    ok(run(app(['openssl', 'genpkey', '-quiet', '-algorithm', 'RSA',
+                '-pkeyopt', 'rsa_keygen_bits:2048',
+                '-out', 'genpkey-quiet.pem'],
+               stderr => $stderr_file)),
+       "genpkey -quiet generates a key");
+    $err = slurp_file($stderr_file);
+    ok($err !~ qr/Generating RSA key/,
+       "-quiet does not report the key generation");
+    unlink($stderr_file) if -f $stderr_file;
+};

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -11,7 +11,8 @@ use strict;
 use warnings;
 
 use File::Spec;
-use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir bldtop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir bldtop_file
+                     app_fails slurp_file/;
 use OpenSSL::Test::Utils;
 
 BEGIN {
@@ -25,7 +26,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
     ($no_fips ? 0 : 5)          # Extra FIPS related tests
-    + 16;
+    + 18;
 
 # We want to know that an absurdly small number of bits isn't support
 is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
@@ -115,6 +116,58 @@ ok(run(app(([ 'openssl', 'asn1parse',
    "Check the default size of the PBKDF2 PARAM 'salt length' is 16");
 ok(run(app([ 'openssl', 'rsa', '-in', 'genrsatest-enc.pem', '-passin', 'pass:x' ])),
    "rsa decrypt");
+
+subtest "genrsa error cases" => sub {
+    plan tests => 14;
+
+    app_fails('genrsa', "unknown cipher option should fail",
+              qr/Unknown option or cipher: badcipher/,
+              '-badcipher');
+    app_fails('genrsa', "non-numeric primes argument should fail",
+              qr/Can't parse "abc" as a number/,
+              '-primes', 'abc', $good);
+    app_fails('genrsa', "too small number of primes should fail",
+              qr/Error generating RSA key/,
+              '-primes', '1', $good);
+    app_fails('genrsa', "too large number of primes should fail",
+              qr/Error generating RSA key/,
+              '-primes', '100', $good);
+    app_fails('genrsa', "invalid passout argument should fail",
+              qr/Error getting password/,
+              '-passout', 'bad:pass', $good);
+    app_fails('genrsa', "non-numeric bits argument should fail",
+              qr/Can't parse "abc" as a number/,
+              'abc');
+    app_fails('genrsa', "negative bits argument should fail",
+              qr/Invalid number of bits: -5/,
+              '--', '-5');
+};
+
+subtest "genrsa verbose mode" => sub {
+    plan tests => 6;
+
+    my $stderr_file = "genrsa_verbose.txt";
+
+    ok(run(app(['openssl', 'genrsa', '-verbose', '-f4',
+                '-out', 'genrsatest-verbose.pem', $good],
+               stderr => $stderr_file)),
+       "genrsa -verbose generates a key");
+    my $err = slurp_file($stderr_file);
+    ok($err =~ qr/Generating RSA key with $good bits/,
+       "-verbose reports the key generation");
+    ok($err =~ qr/e is 65537 \(0x010001\)/,
+       "-verbose reports the public exponent");
+
+    ok(run(app(['openssl', 'genrsa', '-quiet', '-f4',
+                '-out', 'genrsatest-quiet.pem', $good],
+               stderr => $stderr_file)),
+       "genrsa -quiet generates a key");
+    $err = slurp_file($stderr_file);
+    ok($err !~ qr/Generating RSA key/,
+       "-quiet does not report the key generation");
+    ok($err !~ qr/e is/, "-quiet does not report the public exponent");
+    unlink($stderr_file) if -f $stderr_file;
+};
 
 unless ($no_fips) {
     my $provconf = srctop_file("test", "fips-and-base.cnf");

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -23,7 +23,8 @@ $VERSION = "1.0";
                                          srctop_dir srctop_file
                                          data_file data_dir
                                          result_file result_dir
-                                         pipe with cmdstr
+                                         pipe with cmdstr app_fails
+                                         slurp_file
                                          openssl_versions
                                          ok_nofips is_nofips isnt_nofips));
 
@@ -833,6 +834,60 @@ sub with {
     foreach (keys %saved_hooks) {
         $hooks{$_} = $saved_hooks{$_};
     }
+}
+
+=over 4
+
+=item B<slurp_file FILENAME>
+
+C<slurp_file> reads back the whole file FILENAME, usually an output
+captured with the C<stdout> or C<stderr> option of C<cmd> and its
+derivatives, and returns its content as a single string.  If the file
+cannot be opened, an empty string is returned.
+
+=back
+
+=cut
+
+sub slurp_file {
+    my ($file) = @_;
+    my $content = '';
+
+    if (open(my $fh, '<', $file)) {
+        $content = do { local $/; <$fh> };
+        close($fh);
+    }
+    return $content;
+}
+
+=over 4
+
+=item B<app_fails APPNAME, TEST_NAME, REGEXP, LIST>
+
+C<app_fails> runs the C<openssl> sub-command B<APPNAME> with the command
+line arguments in LIST, expecting a non-zero (failure) exit status, as a
+test named B<TEST_NAME>.  If REGEXP is defined, it additionally checks, as
+a second test, that the stderr output of the command matches it.
+
+=back
+
+=cut
+
+sub app_fails {
+    my ($appname, $testtext, $re, @args) = @_;
+
+    my $stderr_file = "app_fails_stderr.txt";
+
+    with({ exit_checker => sub { return shift != 0; } },
+        sub {
+            ok(run(app(['openssl', $appname, @args], stderr => $stderr_file)),
+               $testtext);
+        });
+
+    if (defined $re) {
+        ok(slurp_file($stderr_file) =~ $re, "$testtext: stderr matches");
+    }
+    unlink($stderr_file) if -f $stderr_file;
 }
 
 =over 4


### PR DESCRIPTION
This extends the genrsa, gendsa and genpkey test recipes to cover the previously unexercised error paths: unknown cipher options, invalid primes, bits and password arguments, missing and extra positional arguments, an unknown algorithm, an invalid key option and loading of nonexistent, invalid or non-DSA parameter files. The stderr output is verified against the expected error messages. The recipes also newly cover the -verbose progress output and check that -quiet suppresses it.

Since this would repeat the same failure checking helper that already exists in several recipes, the first commit adds a shared app_fails function to OpenSSL::Test so the new recipes and future ones do not need to duplicate it.

While adding the tests it turned out that genrsa exits with a failure status without printing any error message when the numbits argument is negative or zero. The second commit fixes that so the test can verify the error output.

##### Checklist
- [x] tests are added or updated