### PR TITLE
apps: print an error for a non-positive genrsa bits argument [4.0]

### DIFF
--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -153,8 +153,12 @@ int genrsa_main(int argc, char **argv)
     argv = opt_rest();
 
     if (argc == 1) {
-        if (!opt_int(argv[0], &num) || num <= 0)
+        if (!opt_int(argv[0], &num))
             goto end;
+        if (num <= 0) {
+            BIO_printf(bio_err, "%s: Invalid number of bits: %d\n", prog, num);
+            goto end;
+        }
         if (num > OPENSSL_RSA_MAX_MODULUS_BITS)
             BIO_printf(bio_err,
                 "Warning: It is not recommended to use more than %d bit for RSA keys.\n"

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -25,7 +25,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
     ($no_fips ? 0 : 5)          # Extra FIPS related tests
-    + 16;
+    + 17;
 
 # We want to know that an absurdly small number of bits isn't support
 is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
@@ -34,6 +34,8 @@ is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
            0, "genpkey 8");
 is(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', '8'])),
            0, "genrsa -3 8");
+is(run(app([ 'openssl', 'genrsa', '-out', 'genrsatest.pem', '--', '-5'])),
+           0, "genrsa with a negative number of bits should fail");
 
 # Depending on the shared library, we might have different lower limits.
 # Let's find it!  This is a simple binary search


### PR DESCRIPTION
This is a backport of the genrsa fix from #32592. Previously a negative or zero numbits argument made genrsa exit with a failure status without printing any error message. A minimal test checking the failure exit status is included.

##### Checklist
- [x] tests are added or updated