### PR TITLE
Build for the right targets on msvc2013 in compiler zoo CI

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -95,9 +95,9 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            target: VC-WIN64A
+            target: VC-WIN64A-MSVC2013
           - arch: x86
-            target: VC-WIN32
+            target: VC-WIN32-MSVC2013
     runs-on: windows-2022
     env:
       IMAGE: ghcr.io/openssl/openssl-vs2013:latest

--- a/providers/build.info
+++ b/providers/build.info
@@ -67,6 +67,10 @@ SOURCE[$LIBFIPS]=$LIBCOMMON
 DEPEND[$LIBLEGACY]=$LIBCOMMON
 DEPEND[$LIBDEFAULT]=$LIBCOMMON
 
+IF[{- $target{needs_c99_snprintf_compat} -}]
+  SOURCE[$LIBFIPS]=../crypto/msvc2013_snprintf.c
+ENDIF
+
 #
 # Default provider stuff
 #


### PR DESCRIPTION
We need to build for the MSVC2013 targets when building with MSVC2013, so that we pull in our home rolled version of snprintf

