### PR TITLE
config: autodetect `mingwarm64`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -403,6 +403,10 @@ jobs:
             cc: clang
             pkgs: mingw-w64-clang-x86_64-clang
             config: mingw64
+          - arch: CLANGARM64
+            cc: clang
+            pkgs: mingw-w64-clang-aarch64-clang
+            config: mingwarm64
     runs-on: windows-latest
     env:
       CC: ${{ matrix.platform.cc }}

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -159,6 +159,7 @@ my $guess_patterns = [
     [ 'machten:.*',                 '${MACHINE}-tenon-${SYSTEM}' ],
     [ 'library:.*',                 '${MACHINE}-ncr-sysv4' ],
     [ 'ConvexOS:.*?:11\.0:.*',      '${MACHINE}-v11-${SYSTEM}' ],
+    [ 'MINGW64.*ARM64.*',           '${MACHINE}-whatever-mingwarm64' ],
     [ 'MINGW64.*?:.*?:.*?:x86_64',  '${MACHINE}-whatever-mingw64' ],
     [ 'MINGW.*',                    '${MACHINE}-whatever-mingw' ],
     [ 'CYGWIN.*',                   '${MACHINE}-pc-cygwin' ],


### PR DESCRIPTION
`uname` outputs `MINGW64_NT...-ARM64` on the `CLANGARM64` environment. That should be autodetected as `mingwarm64`.