### PR TITLE
ocsp: Fail on invalid response times

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1055,6 +1055,7 @@ static int print_ocsp_summary(BIO *out, OCSP_BASICRESP *bs, OCSP_REQUEST *req,
         if (!OCSP_check_validity(thisupd, nextupd, nsec, maxage)) {
             BIO_puts(out, "WARNING: Status times invalid.\n");
             ERR_print_errors(out);
+            ret = 0;
         }
         BIO_printf(out, "%s\n"
                         "\tThis Update: ",

--- a/test/recipes/80-test_ocsp.t
+++ b/test/recipes/80-test_ocsp.t
@@ -38,14 +38,20 @@ sub test_ocsp {
     my $expected_exit = shift;
     my $nochecks = shift;
     my $opt_untrusted = shift // "-verify_other";
+    my $certfile = shift;
     my $outputfile = basename($inputfile, '.ors') . '.dat';
 
     run(app(["openssl", "base64", "-d",
              "-in", catfile($ocspdir,$inputfile),
              "-out", $outputfile]));
     my @certopt = ($opt_untrusted, catfile($ocspdir, $untrusted));
+    my @requestopt = defined($certfile)
+        ? ("-issuer", catfile($ocspdir, $CAfile),
+           "-cert", catfile($ocspdir, $certfile), "-no_nonce")
+        : ();
     with({ exit_checker => sub { return shift == $expected_exit; } },
          sub { ok(run(app(["openssl", "ocsp", "-respin", $outputfile,
+                           @requestopt,
                            "-partial_chain", @check_time,
                            "-CAfile", catfile($ocspdir, $CAfile),
                            @certopt,
@@ -54,7 +60,7 @@ sub test_ocsp {
                   $title); });
 }
 
-plan tests => 15;
+plan tests => 16;
 
 subtest "=== VALID OCSP RESPONSES ===" => sub {
     plan tests => 7;
@@ -73,6 +79,14 @@ subtest "=== VALID OCSP RESPONSES ===" => sub {
               "D2.ors", "D2_Issuer_Root.pem", "", 0, 0);
     test_ocsp("DELEGATED; Root CA -> EE",
               "D3.ors", "D3_Issuer_Root.pem", "", 0, 0);
+};
+
+subtest "=== INVALID OCSP RESPONSE TIMES ===" => sub {
+    plan tests => 1;
+
+    test_ocsp("NON-DELEGATED; expired response",
+              "ND1.ors", "ND1_Issuer_ICA.pem", "", 1, 0, undef,
+              "ND1_Cert_EE.pem");
 };
 
 subtest "=== INVALID SIGNATURE on the OCSP RESPONSE ===" => sub {


### PR DESCRIPTION
`openssl ocsp` currently prints an invalid-times warning but still exits successfully when `OCSP_check_validity()` rejects a response. This can make exit-code consumers accept stale OCSP evidence.

Propagate the existing validity failure through `print_ocsp_summary()` so `ocsp_main()` returns a nonzero status. The diagnostic output is unchanged.

The regression supplies the existing signed ND1 response with its matching issuer and certificate, reaching the per-certificate freshness check that the previous recipe skipped.

Tests:

- `make test TESTS=test_ocsp`
- `make test` (4,606 tests)
- `perl ./Configure no-shared --strict-warnings && make -j8 build_sw && make test TESTS=test_ocsp`

##### Checklist

- [x] tests are added or updated
- [x] OpenSSL ICLA v1.1 signed
