### PR TITLE
Fix potential double-free in DSA/DH finish slots [3.6, 3.5, 3.4, 3.0]

### DIFF
--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -207,6 +207,7 @@ static int dh_init(DH *dh)
 static int dh_finish(DH *dh)
 {
     BN_MONT_CTX_free(dh->method_mont_p);
+    dh->method_mont_p = NULL;
     return 1;
 }
 

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -468,6 +468,7 @@ static int dsa_init(DSA *dsa)
 static int dsa_finish(DSA *dsa)
 {
     BN_MONT_CTX_free(dsa->method_mont_p);
+    dsa->method_mont_p = NULL;
     return 1;
 }
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4776,18 +4776,18 @@ static int test_dsa_finish_set_method(void)
     /*
      * Switch to a copy of the default method; the finish slot frees the
      * cache.  Freeing the key below calls the finish slot again.
+     * Note that the key holds a raw pointer to the method, so the method
+     * must outlive the key and is only freed in the cleanup below.
      */
     if (!TEST_ptr(method = DSA_meth_dup(DSA_get_default_method()))
         || !TEST_true(DSA_set_method(dsa, method)))
         goto err;
-    DSA_meth_free(method);
-    method = NULL;
 
     testresult = 1;
 err:
-    DSA_meth_free(method);
     DSA_SIG_free(sig);
     DSA_free(dsa);
+    DSA_meth_free(method);
     return testresult;
 }
 #endif
@@ -4829,18 +4829,18 @@ static int test_dh_finish_set_method(void)
     /*
      * Switch to a copy of the default method; the finish slot frees the
      * cache.  Freeing the key below calls the finish slot again.
+     * Note that the key holds a raw pointer to the method, so the method
+     * must outlive the key and is only freed in the cleanup below.
      */
     if (!TEST_ptr(method = DH_meth_dup(DH_get_default_method()))
         || !TEST_true(DH_set_method(dh, method)))
         goto err;
-    DH_meth_free(method);
-    method = NULL;
 
     testresult = 1;
 err:
-    DH_meth_free(method);
     OPENSSL_free(buf);
     DH_free(dh);
+    DH_meth_free(method);
     return testresult;
 }
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4734,6 +4734,116 @@ err:
     EVP_PKEY_free(remote_key);
     return ret;
 }
+
+#if !defined(OPENSSL_NO_DEPRECATED_3_0) && !defined(OPENSSL_NO_DSA)
+/*
+ * Regression test for issue 32541: the default DSA method's finish slot
+ * freed the cached Montgomery context without clearing the pointer, so
+ * warming the cache, then switching method, then freeing the key would
+ * free that cache twice.
+ */
+static int test_dsa_finish_set_method(void)
+{
+    DSA *dsa = NULL;
+    DSA_METHOD *method = NULL;
+    DSA_SIG *sig = NULL;
+    int testresult = 0;
+    unsigned char dgst[20];
+    /* Same seed as test/dsatest.c, for fast deterministic parameters */
+    static unsigned char seed[20] = {
+        0xd5, 0x01, 0x4e, 0x4b, 0x60, 0xef, 0x2b, 0xa8, 0xb6, 0x21,
+        0x1b, 0x40, 0x62, 0xba, 0x32, 0x24, 0xe0, 0x42, 0x7d, 0xd3
+    };
+
+    if (nullprov != NULL) {
+        testresult = TEST_skip("Test does not support a non-default library context");
+        goto err;
+    }
+
+    if (!TEST_ptr(dsa = DSA_new())
+        || !TEST_true(DSA_generate_parameters_ex(dsa, 512, seed, 20,
+            NULL, NULL, NULL))
+        || !TEST_true(DSA_generate_key(dsa)))
+        goto err;
+
+    /* Warm the Montgomery cache so the finish slot has something to free */
+    memset(dgst, 0, sizeof(dgst));
+    if (!TEST_ptr(sig = DSA_do_sign(dgst, sizeof(dgst), dsa)))
+        goto err;
+    DSA_SIG_free(sig);
+    sig = NULL;
+
+    /*
+     * Switch to a copy of the default method; the finish slot frees the
+     * cache.  Freeing the key below calls the finish slot again.
+     */
+    if (!TEST_ptr(method = DSA_meth_dup(DSA_get_default_method()))
+        || !TEST_true(DSA_set_method(dsa, method)))
+        goto err;
+    DSA_meth_free(method);
+    method = NULL;
+
+    testresult = 1;
+err:
+    DSA_meth_free(method);
+    DSA_SIG_free(sig);
+    DSA_free(dsa);
+    return testresult;
+}
+#endif
+
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+/*
+ * Regression test for issue 32541: the default DH method's finish slot
+ * freed the cached Montgomery context without clearing the pointer, so
+ * warming the cache, then switching method, then freeing the key would
+ * free that cache twice.
+ */
+static int test_dh_finish_set_method(void)
+{
+    DH *dh = NULL;
+    DH_METHOD *method = NULL;
+    unsigned char *buf = NULL;
+    int testresult = 0;
+
+    if (nullprov != NULL) {
+        testresult = TEST_skip("Test does not support a non-default library context");
+        goto err;
+    }
+
+    if (!TEST_ptr(dh = DH_get_2048_256())
+        || !TEST_true(DH_generate_key(dh)))
+        goto err;
+
+    /*
+     * Warm the Montgomery cache so the finish slot has something to free.
+     * Deriving against the key's own pub_key is only meant to touch the
+     * Montgomery path, not to perform a real derivation.
+     */
+    if (!TEST_ptr(buf = OPENSSL_malloc(DH_size(dh)))
+        || !TEST_int_gt(DH_compute_key(buf, DH_get0_pub_key(dh), dh), 0))
+        goto err;
+    OPENSSL_free(buf);
+    buf = NULL;
+
+    /*
+     * Switch to a copy of the default method; the finish slot frees the
+     * cache.  Freeing the key below calls the finish slot again.
+     */
+    if (!TEST_ptr(method = DH_meth_dup(DH_get_default_method()))
+        || !TEST_true(DH_set_method(dh, method)))
+        goto err;
+    DH_meth_free(method);
+    method = NULL;
+
+    testresult = 1;
+err:
+    DH_meth_free(method);
+    OPENSSL_free(buf);
+    DH_free(dh);
+    return testresult;
+}
+#endif
 #endif /* !OPENSSL_NO_DH */
 
 /*
@@ -8343,6 +8453,12 @@ int setup_tests(void)
     ADD_TEST(test_EVP_PKEY_set1_DH);
 #endif
     ADD_TEST(test_dhx_derive_rejects_bad_peer_q);
+#if !defined(OPENSSL_NO_DEPRECATED_3_0) && !defined(OPENSSL_NO_DSA)
+    ADD_TEST(test_dsa_finish_set_method);
+#endif
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+    ADD_TEST(test_dh_finish_set_method);
+#endif
 #endif
 #ifndef OPENSSL_NO_EC
     ADD_TEST(test_EC_priv_pub);


### PR DESCRIPTION
This is a backport of #32543 to 3.6, cherry-pickable from there to 3.5, 3.4 and 3.0 (verified locally).

The two fix commits cherry-pick cleanly.  The regression test is a standalone adaptation: the test_low_level_{dsa,dh}_method() family that the master test extends does not exist on these release branches (it appeared on master after the 3.6 branch point), so this branch carries self-contained tests instead.  Both tests crash (SIGSEGV on the double free) without the fix commits and pass with them.

Please see individual commit messages for details.

Link: https://github.com/openssl/openssl/pull/32543
Link: https://github.com/openssl/openssl/issues/32541