### PR TITLE
test: use the portable null device in Perl recipes

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -26,6 +26,8 @@ plan skip_all => "Test is disabled on NonStop" if config('target') =~ m|^nonstop
 plan skip_all => "Test is disabled on MacOS" if config('target') =~ m|^darwin|;
 # AIX reports symbol names differently
 plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
+plan skip_all => "This is unsupported on native Windows"
+    if $^O eq 'MSWin32';
 plan skip_all => "This is unsupported on platforms that don't have 'nm'"
     unless IPC::Cmd::can_run('nm');
 
@@ -65,9 +67,10 @@ plan tests => $testcount;
 my %stsymbols;                  # Static library symbols
 my %shsymbols;                  # Shared library symbols
 my %defsymbols;                 # Symbols taken from ordinals
+my $null_device = devnull();
 foreach (sort keys %stlibname) {
-    my $stlib_cmd = "nm -Pg $stlibpath{$_} 2> /dev/null";
-    my $shlib_cmd = "nm -DPg $shlibpath{$_} 2> /dev/null";
+    my $stlib_cmd = "nm -Pg $stlibpath{$_} 2> $null_device";
+    my $shlib_cmd = "nm -DPg $shlibpath{$_} 2> $null_device";
     my @stlib_lines;
     my @shlib_lines;
     *OSTDERR = *STDERR;
@@ -97,7 +100,7 @@ foreach (sort keys %stlibname) {
         indir $bldtop => sub {
             my $mkdefpath = srctop_file("util", "mkdef.pl");
             my $def_path = srctop_file("util", "lib$_.num");
-            my $def_cmd = "$^X $mkdefpath --ordinals $def_path --name $_ --OS linux 2> /dev/null";
+            my $def_cmd = "$^X $mkdefpath --ordinals $def_path --name $_ --OS linux 2> $null_device";
             @def_lines = map { s|\R$||; $_ } `$def_cmd`;
             if ($? != 0) {
                 note "running 'cd $bldtop; $def_cmd' => $?";

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -595,7 +595,7 @@ my $in_key = srctop_file('test', 'certs', 'x509-check-key.pem');
 my $invextfile = srctop_file('test', 'invalid-x509.cnf');
 # Test that invalid extensions settings fail
 ok(!run(app(["openssl", "x509", "-req", "-in", $in_csr, "-signkey", $in_key,
-            "-out", "/dev/null", "-days", "3650" , "-extensions", "ext",
+            "-out", File::Spec->devnull(), "-days", "3650" , "-extensions", "ext",
             "-extfile", $invextfile])));
 
 # Tests for issue #16080 (fixed in 1.1.1o)


### PR DESCRIPTION
I ran into this while analyzing https://github.com/openssl/openssl/issues/32585 and https://github.com/openssl/openssl/pull/32597, because my checkout lives under `C:\dev`, and I happen to have a real `C:\dev\null` file. With `cmd.exe`, `/dev/null` resolves to that path. When `\dev` isn't present, redirection fails before `nm` starts.

This means the symbol presence recipe can collect no symbols and still let its duplicate symbol check pass.

The X.509 recipe has a similar trap. If invalid extension handling ever regresses, failure to open `/dev/null` can still satisfy the negative assertion.

This change asks `File::Spec` for the platform null device in both recipes. Windows gets `nul`, while Unix keeps `/dev/null`.

Once redirection works, GNU `nm` reports mergeable COFF definitions like ordinary duplicates. It also can't read dynamic symbols from Microsoft DLLs. The symbol presence recipe isn't reliable with native Windows Perl, so this change makes that limitation explicit and skips the recipe instead of allowing it to pass with empty input.

I confirmed the symbol recipe is reported as skipped under native Windows Perl.

I checked the updated X.509 command on Windows. It used `nul` and failed with the expected invalid extension error.

##### Checklist

- [x] tests are added or updated