### PR TITLE
Add CRL distribution point URI output to x509 command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,10 @@ OpenSSL 4.1
 
 ### Changes between 4.1 and 4.2 [xx XXX xxxx]
 
- * none yet
+ * Added the `-crl_uri` option to `openssl x509` for printing URIs from a
+   certificate's CRL distribution points.
+
+   *Sai Kiran Taduri*
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -38,6 +38,7 @@ static ASN1_INTEGER *x509_load_serial(const char *CAfile,
     const char *serialfile, int create);
 static int purpose_print(BIO *bio, X509 *cert, X509_PURPOSE *pt);
 static int print_x509v3_exts(BIO *bio, X509 *x, const char *ext_names);
+static int print_crl_uris(BIO *bio, const X509 *cert);
 
 typedef enum OPTION_choice {
     OPT_COMMON,
@@ -73,6 +74,7 @@ typedef enum OPTION_choice {
     OPT_NAMEOPT,
     OPT_EMAIL,
     OPT_OCSP_URI,
+    OPT_CRL_URI,
     OPT_SERIAL,
     OPT_NEXT_SERIAL,
     OPT_MODULUS,
@@ -175,6 +177,7 @@ const OPTIONS x509_options[] = {
     { "ocspid", OPT_OCSPID, '-',
         "Print OCSP hash values for the subject name and public key" },
     { "ocsp_uri", OPT_OCSP_URI, '-', "Print OCSP Responder URL(s)" },
+    { "crl_uri", OPT_CRL_URI, '-', "Print CRL distribution point URI(s)" },
     { "purpose", OPT_PURPOSE, '-', "Print out certificate purposes" },
     { "pubkey", OPT_PUBKEY, '-', "Print the public key in PEM format" },
     { "modulus", OPT_MODULUS, '-', "Print the RSA key modulus" },
@@ -398,7 +401,8 @@ int x509_main(int argc, char **argv)
     int informat = FORMAT_UNDEF, outformat = FORMAT_PEM, keyformat = FORMAT_UNDEF;
     int next_serial = 0, subject_hash = 0, issuer_hash = 0, ocspid = 0;
     int noout = 0, CA_createserial = 0, email = 0;
-    int ocsp_uri = 0, trustout = 0, clrtrust = 0, clrreject = 0, aliasout = 0;
+    int ocsp_uri = 0, crl_uri = 0, trustout = 0, clrtrust = 0, clrreject = 0;
+    int aliasout = 0;
     int ret = 1, i, j, k = 0, num = 0, badsig = 0, clrext = 0, nocert = 0;
     int text = 0, serial = 0, subject = 0, issuer = 0, startdate = 0, ext = 0;
     int enddate = 0;
@@ -576,6 +580,9 @@ int x509_main(int argc, char **argv)
             break;
         case OPT_OCSP_URI:
             ocsp_uri = ++num;
+            break;
+        case OPT_CRL_URI:
+            crl_uri = ++num;
             break;
         case OPT_SERIAL:
             serial = ++num;
@@ -1112,6 +1119,9 @@ cert_loop:
             for (j = 0; j < sk_OPENSSL_STRING_num(emlst); j++)
                 BIO_printf(out, "%s\n", sk_OPENSSL_STRING_value(emlst, j));
             X509_email_free(emlst);
+        } else if (i == crl_uri) {
+            if (!print_crl_uris(out, x))
+                goto err;
         } else if (i == aliasout) {
             const unsigned char *alstr = X509_alias_get0(x, NULL);
 
@@ -1405,6 +1415,51 @@ static int parse_ext_names(char *names, const char **result)
     }
 
     return cnt;
+}
+
+static int print_crl_uris(BIO *bio, const X509 *cert)
+{
+    CRL_DIST_POINTS *crldps = NULL;
+    int crit = -1, i, j, ret = 0;
+
+    crldps = X509_get_ext_d2i(cert, NID_crl_distribution_points, &crit, NULL);
+    if (crldps == NULL) {
+        if (crit == -1)
+            return 1;
+        BIO_puts(bio_err, "Unable to decode CRL distribution points\n");
+        return 0;
+    }
+
+    for (i = 0; i < sk_DIST_POINT_num(crldps); i++) {
+        DIST_POINT *dp = sk_DIST_POINT_value(crldps, i);
+        GENERAL_NAMES *names;
+
+        if (dp->distpoint == NULL || dp->distpoint->type != 0)
+            continue;
+        names = dp->distpoint->name.fullname;
+        for (j = 0; j < sk_GENERAL_NAME_num(names); j++) {
+            GENERAL_NAME *name = sk_GENERAL_NAME_value(names, j);
+            ASN1_IA5STRING *uri;
+            const unsigned char *data;
+            size_t length, written;
+
+            if (name->type != GEN_URI)
+                continue;
+            uri = name->d.uniformResourceIdentifier;
+            data = ASN1_STRING_get0_data(uri);
+            length = ASN1_STRING_get_length(uri);
+            if (data == NULL || length == 0 || memchr(data, 0, length) != NULL)
+                continue;
+            if (!BIO_write_ex(bio, data, length, &written)
+                || written != length || BIO_puts(bio, "\n") <= 0)
+                goto end;
+        }
+    }
+    ret = 1;
+
+end:
+    CRL_DIST_POINTS_free(crldps);
+    return ret;
 }
 
 static int print_x509v3_exts(BIO *bio, X509 *x, const char *ext_names)

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -45,6 +45,7 @@ B<openssl> B<x509>
 [B<-ext> I<extensions>]
 [B<-ocspid>]
 [B<-ocsp_uri>]
+[B<-crl_uri>]
 [B<-purpose>]
 [B<-pubkey>]
 [B<-modulus>]
@@ -331,6 +332,10 @@ Prints the OCSP hash values for the subject name and public key.
 =item B<-ocsp_uri>
 
 Prints the OCSP responder address(es) if any.
+
+=item B<-crl_uri>
+
+Prints the URI(s) from the certificate's CRL distribution points, if any.
 
 =item B<-purpose>
 
@@ -898,6 +903,8 @@ See B<-extfile> above for details.
 As of OpenSSL 4.0, the B<x509> utility no longer has specialised built-in logic
 to add the SKID or AKID extensions, they are handled through configuration
 files and command-line options just like any other extension.
+
+The B<-crl_uri> option was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -904,7 +904,7 @@ As of OpenSSL 4.0, the B<x509> utility no longer has specialised built-in logic
 to add the SKID or AKID extensions, they are handled through configuration
 files and command-line options just like any other extension.
 
-The B<-crl_uri> option was added in OpenSSL 4.1.
+The B<-crl_uri> option was added in OpenSSL 4.2.
 
 =head1 COPYRIGHT
 

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -598,6 +598,45 @@ ok(!run(app(["openssl", "x509", "-req", "-in", $in_csr, "-signkey", $in_key,
             "-out", File::Spec->devnull(), "-days", "3650" , "-extensions", "ext",
             "-extfile", $invextfile])));
 
+subtest "printing CRL distribution point URIs" => sub {
+    plan tests => 7;
+
+    my $cert = "crl-uri-cert.pem";
+    my $malformed_cert = "malformed-crl-uri-cert.pem";
+    my $extfile = srctop_file("test", "recipes", "25-test_x509_data",
+                              "crl_uri.cnf");
+
+    ok(run(app(["openssl", "x509", "-req", "-in", $in_csr,
+                "-signkey", $in_key, "-extfile", $extfile,
+                "-extensions", "extensions", "-out", $cert])),
+       "create certificate with CRL distribution points");
+
+    my @uris = run(app(["openssl", "x509", "-in", $cert, "-noout",
+                        "-crl_uri"]), capture => 1, statusvar => \my $ok);
+    ok($ok, "print CRL distribution point URIs");
+    s/\r?\n\z// for @uris;
+    is_deeply(\@uris,
+              ["http://primary.example/crl.pem",
+               "ldap://directory.example/crl"],
+              "print URI names and ignore other name types");
+
+    @uris = run(app(["openssl", "x509", "-in",
+                     srctop_file(@certs, "ca-cert.pem"), "-noout",
+                     "-crl_uri"]), capture => 1, statusvar => \$ok);
+    ok($ok, "handle certificate without CRL distribution points");
+    is(join("", @uris), "", "certificate without CRL URIs prints nothing");
+
+    ok(run(app(["openssl", "x509", "-req", "-in", $in_csr,
+                "-signkey", $in_key, "-extfile", $extfile,
+                "-extensions", "malformed_extensions",
+                "-out", $malformed_cert])),
+       "create certificate with malformed CRL distribution points");
+
+    run(app(["openssl", "x509", "-in", $malformed_cert, "-noout",
+             "-crl_uri"]), capture => 1, statusvar => \$ok);
+    ok(!$ok, "reject malformed CRL distribution points");
+};
+
 # Tests for issue #16080 (fixed in 1.1.1o)
 my $b_key = "b-key.pem";
 my $b_csr = "b-cert.csr";

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -17,7 +17,7 @@ use File::Compare qw/compare_text/;
 
 setup("test_x509");
 
-plan tests => 156;
+plan tests => 157;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't

--- a/test/recipes/25-test_x509_data/crl_uri.cnf
+++ b/test/recipes/25-test_x509_data/crl_uri.cnf
@@ -1,0 +1,5 @@
+[extensions]
+crlDistributionPoints = URI:http://primary.example/crl.pem, DNS:not-a-uri.example, URI:ldap://directory.example/crl
+
+[malformed_extensions]
+2.5.29.31 = DER:01:01:FF


### PR DESCRIPTION
`openssl x509` can print OCSP responder URIs with `-ocsp_uri`, but it has no equivalent for CRL distribution points. This adds `-crl_uri`, which prints each URI GeneralName from the certificate's CRLDistributionPoints extension on its own line. Non-URI names are ignored, certificates without the extension produce no output, and malformed extensions are reported as errors.

The command help and `openssl-x509(1)` documentation are updated, including the HISTORY section. The x509 test recipe covers HTTP and LDAP URIs, filtering a non-URI GeneralName, missing and malformed extensions, command status, and CRLF-neutral output comparison.

Validated after rebasing onto current `master` (`859aea422b`) with:

- `./config --strict-warnings -g -O0`
- `make -j8`
- `make test TESTS=test_x509` (157 tests)
- `make test HARNESS_JOBS=4` (402 files, 3,599 tests)
- `make doc-nits`
- `make check-format`
- `git diff --check origin/master...HEAD`

Fixes #32123

##### Checklist

- [x] documentation is added or updated
- [x] tests are added or updated
