### PR TITLE
Don't update the certificate in cache_extensions if we lost the race.

### DIFF
--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -543,21 +543,28 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     uint32_t tmp_ex_kusage;
     uint32_t tmp_ex_xkusage;
     uint32_t tmp_ex_nscert;
-    ASN1_OCTET_STRING *tmp_skid;
-    AUTHORITY_KEYID *tmp_akid;
-    STACK_OF(GENERAL_NAME) *tmp_altname;
-    NAME_CONSTRAINTS *tmp_nc;
+    ASN1_OCTET_STRING *tmp_skid = NULL;
+    AUTHORITY_KEYID *tmp_akid = NULL;
+    STACK_OF(GENERAL_NAME) *tmp_altname = NULL;
+    NAME_CONSTRAINTS *tmp_nc = NULL;
     STACK_OF(DIST_POINT) *tmp_crldp = NULL;
     X509_SIG_INFO tmp_siginf;
+#ifndef OPENSSL_NO_RFC3779
+    STACK_OF(IPAddressFamily) *tmp_rfc3779_addr = NULL;
+    struct ASIdentifiers_st *tmp_rfc3779_asid = NULL;
+#endif
+    int ret = 0;
 
 #ifdef tsan_ld_acq
     /* Fast lock-free check, see end of the function for details. */
-    if (tsan_ld_acq((TSAN_QUALIFIER int *)&const_x->ex_cached))
-        return (const_x->ex_flags & EXFLAG_INVALID) == 0;
+    if (tsan_ld_acq((TSAN_QUALIFIER int *)&const_x->ex_cached)) {
+        ret = (const_x->ex_flags & EXFLAG_INVALID) == 0;
+        goto done;
+    }
 #endif
 
     if (!CRYPTO_THREAD_read_lock(const_x->lock))
-        return 0;
+        goto done;
     tmp_ex_flags = const_x->ex_flags;
     tmp_ex_pcpathlen = const_x->ex_pcpathlen;
     tmp_ex_kusage = const_x->ex_kusage;
@@ -565,7 +572,8 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
 
     if ((tmp_ex_flags & EXFLAG_SET) != 0) { /* Cert has already been processed */
         CRYPTO_THREAD_unlock(const_x->lock);
-        return (tmp_ex_flags & EXFLAG_INVALID) == 0;
+        ret = (tmp_ex_flags & EXFLAG_INVALID) == 0;
+        goto done;
     }
 
     ERR_set_mark();
@@ -738,13 +746,11 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
         tmp_ex_flags |= EXFLAG_INVALID;
 
 #ifndef OPENSSL_NO_RFC3779
-    STACK_OF(IPAddressFamily) *tmp_rfc3779_addr
-        = X509_get_ext_d2i(const_x, NID_sbgp_ipAddrBlock, &i, NULL);
+    tmp_rfc3779_addr = X509_get_ext_d2i(const_x, NID_sbgp_ipAddrBlock, &i, NULL);
     if (tmp_rfc3779_addr == NULL && i != -1)
         tmp_ex_flags |= EXFLAG_INVALID;
 
-    struct ASIdentifiers_st *tmp_rfc3779_asid
-        = X509_get_ext_d2i(const_x, NID_sbgp_autonomousSysNum, &i, NULL);
+    tmp_rfc3779_asid = X509_get_ext_d2i(const_x, NID_sbgp_autonomousSysNum, &i, NULL);
     if (tmp_rfc3779_asid == NULL && i != -1)
         tmp_ex_flags |= EXFLAG_INVALID;
 #endif
@@ -763,7 +769,16 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
      * do all the updating under a write lock
      */
     if (!CRYPTO_THREAD_write_lock(const_x->lock))
-        return 0;
+        goto done;
+
+    /* See if another thread updated this certificate before we got the write lock. */
+    if ((const_x->ex_flags & EXFLAG_SET) != 0) { /* Cert has already been processed */
+        CRYPTO_THREAD_unlock(const_x->lock);
+        ret = (const_x->ex_flags & EXFLAG_INVALID) == 0;
+        goto done;
+    }
+
+    /* Otherwise, we have the lock, set the cached fields in the cert. */
     ((X509 *)const_x)->ex_flags = tmp_ex_flags;
     ((X509 *)const_x)->ex_pathlen = tmp_ex_pathlen;
     ((X509 *)const_x)->ex_pcpathlen = tmp_ex_pcpathlen;
@@ -776,19 +791,26 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
         ((X509 *)const_x)->ex_nscert = tmp_ex_nscert;
     ASN1_OCTET_STRING_free(((X509 *)const_x)->skid);
     ((X509 *)const_x)->skid = tmp_skid;
+    tmp_skid = NULL;
     AUTHORITY_KEYID_free(((X509 *)const_x)->akid);
     ((X509 *)const_x)->akid = tmp_akid;
+    tmp_akid = NULL;
     sk_GENERAL_NAME_pop_free(((X509 *)const_x)->altname, GENERAL_NAME_free);
     ((X509 *)const_x)->altname = tmp_altname;
+    tmp_altname = NULL;
     NAME_CONSTRAINTS_free(((X509 *)const_x)->nc);
     ((X509 *)const_x)->nc = tmp_nc;
+    tmp_nc = NULL;
     sk_DIST_POINT_pop_free(((X509 *)const_x)->crldp, DIST_POINT_free);
     ((X509 *)const_x)->crldp = tmp_crldp;
+    tmp_crldp = NULL;
 #ifndef OPENSSL_NO_RFC3779
     sk_IPAddressFamily_pop_free(((X509 *)const_x)->rfc3779_addr, IPAddressFamily_free);
     ((X509 *)const_x)->rfc3779_addr = tmp_rfc3779_addr;
+    tmp_rfc3779_addr = NULL;
     ASIdentifiers_free(((X509 *)const_x)->rfc3779_asid);
     ((X509 *)const_x)->rfc3779_asid = tmp_rfc3779_asid;
+    tmp_rfc3779_asid = NULL;
 #endif
     ((X509 *)const_x)->siginf = tmp_siginf;
 
@@ -803,9 +825,22 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     CRYPTO_THREAD_unlock(const_x->lock);
     if (tmp_ex_flags & EXFLAG_INVALID) {
         ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_CERTIFICATE);
-        return 0;
+        goto done;
     }
-    return 1;
+
+    ret = 1;
+
+done:
+    ASN1_OCTET_STRING_free(tmp_skid);
+    AUTHORITY_KEYID_free(tmp_akid);
+    sk_GENERAL_NAME_pop_free(tmp_altname, GENERAL_NAME_free);
+    NAME_CONSTRAINTS_free(tmp_nc);
+    sk_DIST_POINT_pop_free(tmp_crldp, DIST_POINT_free);
+#ifndef OPENSSL_NO_RFC3779
+    sk_IPAddressFamily_pop_free(tmp_rfc3779_addr, IPAddressFamily_free);
+    ASIdentifiers_free(tmp_rfc3779_asid);
+#endif
+    return ret;
 }
 
 /*-

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -1395,6 +1395,83 @@ err:
     return ret;
 }
 
+/* Self-signed "Root CA" certificate, the same as in the test store. */
+static const char *kSelfSignedRootCA[] = {
+    "-----BEGIN CERTIFICATE-----\n",
+    "MIIDFjCCAf6gAwIBAgIBATANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdSb290\n",
+    "IENBMCAXDTIwMTIxMjIwMTEzN1oYDzIxMjAxMjEzMjAxMTM3WjASMRAwDgYDVQQD\n",
+    "DAdSb290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4eYA9Qa8\n",
+    "oEY4eQ8/HnEZE20C3yubdmv8rLAh7daRCEI7pWM17FJboKJKxdYAlAOXWj25ZyjS\n",
+    "feMhXKTtxjyNjoTRnVTDPdl0opZ2Z3H5xhpQd7P9eO5b4OOMiSPCmiLsPtQ3ngfN\n",
+    "wCtVERc6NEIcaQ06GLDtFZRexv2eh8Yc55QaksBfBcFzQ+UD3gmRySTO2I6Lfi7g\n",
+    "MUjRhipqVSZ66As2Tpex4KTJ2lxpSwOACFaDox+yKrjBTP7FsU3UwAGq7b7OJb3u\n",
+    "aa32B81uK6GJVPVo65gJ7clgZsszYkoDsGjWDqtfwTVVfv1G7rrr3Laio+2Ff3ff\n",
+    "tWgiQ35mJCOvxQIDAQABo3UwczAPBgNVHRMBAf8EBTADAQH/MAsGA1UdDwQEAwIB\n",
+    "BjAdBgNVHQ4EFgQUjvUlrx6ba4Q9fICayVOcTXL3o1IwHwYDVR0jBBgwFoAUjvUl\n",
+    "rx6ba4Q9fICayVOcTXL3o1IwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDQYJKoZIhvcN\n",
+    "AQELBQADggEBABWUjaqtkdRDhVAJZTxkJVgohjRrBwp86Y0JZWdCDua/sErmEaGu\n",
+    "nQVxWWFWIgu6sb8tyQo3/7dBIQl3Rpij9bsgKhToO1OzoG3Oi3d0+zRDHfY6xNrj\n",
+    "TUE00FeLHGNWsgZSIvu99DrGApT/+uPdWfJgMu5szillqW+4hcCUPLjG9ekVNt1s\n",
+    "KhdEklo6PrP6eMbm6s22EIVUxqGE6xxAmrvyhlY1zJH9BJ23Ps+xabjG6OeMRZzT\n",
+    "0F/fU7XIFieSO7rqUcjgo1eYc3ghsDxNUJ6TPBgv5z4SPnstoOBj59rjpJ7Qkpyd\n",
+    "L17VfEadezat37Cpeha7vGDduCsyMfN4kiw=\n",
+    "-----END CERTIFICATE-----\n",
+    NULL
+};
+
+/*
+ * A certificate shared by the threads of test_x509_self_signed(), and a
+ * lock the main thread holds for writing until every worker has started,
+ * so that the workers all reach the certificate at the same time.
+ */
+static X509 *shared_cert = NULL;
+static CRYPTO_RWLOCK *shared_cert_start = NULL;
+
+static void test_x509_self_signed_worker(void)
+{
+    /* Block until the main thread releases the start lock. */
+    if (!TEST_true(CRYPTO_THREAD_read_lock(shared_cert_start))) {
+        multi_set_success(0);
+        return;
+    }
+    CRYPTO_THREAD_unlock(shared_cert_start);
+
+    if (!TEST_int_eq(X509_self_signed(shared_cert, 0), 1))
+        multi_set_success(0);
+}
+
+static void test_x509_self_signed_start(void)
+{
+    CRYPTO_THREAD_unlock(shared_cert_start);
+}
+
+/*
+ * Test that concurrent first use of a certificate's cached extension data
+ * is safe. Every thread calls X509_self_signed() on the same unprocessed
+ * certificate, so they race in ossl_x509v3_cache_extensions() to compute
+ * and install the cache. Under TSAN this detects one thread installing the
+ * cache while another reads it.
+ */
+static int test_x509_self_signed(void)
+{
+    int ret = 0;
+
+    if (!TEST_ptr(shared_cert = X509_from_strings(kSelfSignedRootCA))
+        || !TEST_ptr(shared_cert_start = CRYPTO_THREAD_lock_new())
+        || !TEST_true(CRYPTO_THREAD_write_lock(shared_cert_start)))
+        goto err;
+
+    ret = thread_run_test(&test_x509_self_signed_start, MAXIMUM_THREADS,
+        &test_x509_self_signed_worker, 0, NULL);
+
+err:
+    CRYPTO_THREAD_lock_free(shared_cert_start);
+    shared_cert_start = NULL;
+    X509_free(shared_cert);
+    shared_cert = NULL;
+    return ret;
+}
+
 /* Test using OBJ_create in multiple threads */
 static void test_obj_create_worker(void)
 {
@@ -1521,6 +1598,7 @@ int setup_tests(void)
 #endif
     ADD_TEST(test_pem_read);
     ADD_TEST(test_x509_store);
+    ADD_TEST(test_x509_self_signed);
     ADD_TEST(test_obj_stress);
     return 1;
 }


### PR DESCRIPTION
ossl_x509v3_cache_extensions() checks for an unprocessed cert under
a read lock, computes the cached values, then takes a write lock to
install them. Re-check EXFLAG_SET after acquiring the write lock in
case another thread has updated the certificate in the meantime, and
if so, do not install our values over theirs.
    
Since losing the race requires freeing the temporary objects, convert
the function to a single exit that frees whatever was not installed.
This also fixes a pre-existing leak of the temporaries when acquiring
the write lock failed.

Fixes: https://github.com/openssl/openssl/issues/32609
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
