### PR TITLE
DTLS 1.3 Enforce the RFC 9147 Section 8 sending epoch limit

### DIFF
--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -840,7 +840,7 @@ int dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
             /* We've wrapped around, so clear the buffer just in case */
             return 0;
     } else {
-        if (!SSL_CONNECTION_IS_DTLS13(s) && s->rlayer.d->w_conn_epoch == UINT16_MAX)
+        if (!SSL_CONNECTION_IS_DTLS13(s) && s->rlayer.d->w_conn_epoch == DTLS1_MAX_EPOCH)
             return 0;
 
         /*

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -843,11 +843,14 @@ int dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
         if (!SSL_CONNECTION_IS_DTLS13(s) && s->rlayer.d->w_conn_epoch == UINT16_MAX)
             return 0;
 
-        s->rlayer.d->w_conn_epoch++;
-
-        if (s->rlayer.d->w_conn_epoch == 0)
-            /* We've wrapped around, so clear the buffer just in case */
+        /*
+         * RFC 9147 Section 8: sending implementations MUST NOT allow the
+         * epoch to exceed 2^48-1.
+         */
+        if (SSL_CONNECTION_IS_DTLS13(s) && s->rlayer.d->w_conn_epoch == DTLS1_3_MAX_EPOCH)
             return 0;
+
+        s->rlayer.d->w_conn_epoch++;
     }
 
     return 1;

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -48,6 +48,13 @@ typedef struct tls_record_st {
 #endif
 } TLS_RECORD;
 
+/*
+ * RFC 9147 Section 8: sending implementations MUST NOT allow the epoch to
+ * exceed 2^48-1. This margin (rather than the 2^64-1 wire/representation
+ * ceiling of Section 6.1) is what actually bounds w_conn_epoch for DTLS 1.3.
+ */
+#define DTLS1_3_MAX_EPOCH ((uint64_t)0xFFFFFFFFFFFFULL)
+
 typedef struct dtls_record_layer_st {
     /*
      * The current data and handshake epoch. This is initially

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -54,6 +54,7 @@ typedef struct tls_record_st {
  * ceiling of Section 6.1) is what actually bounds w_conn_epoch for DTLS 1.3.
  */
 #define DTLS1_3_MAX_EPOCH ((uint64_t)0xFFFFFFFFFFFFULL)
+#define DTLS1_MAX_EPOCH UINT16_MAX
 
 typedef struct dtls_record_layer_st {
     /*

--- a/test/build.info
+++ b/test/build.info
@@ -797,7 +797,7 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[pemtest]=../include ../apps/include
   DEPEND[pemtest]=../libcrypto libtestutil.a
 
-  SOURCE[dtls13_internal_test]=dtls13_internal_test.c
+  SOURCE[dtls13_internal_test]=dtls13_internal_test.c helpers/ssltestlib.c
   INCLUDE[dtls13_internal_test]=.. ../include ../apps/include
   DEPEND[dtls13_internal_test]=../libssl.a ../libcrypto.a libtestutil.a
 

--- a/test/dtls13_internal_test.c
+++ b/test/dtls13_internal_test.c
@@ -8,8 +8,15 @@
  */
 
 #include "../ssl/record/methods/recmethod_local.h"
+#include "../ssl/ssl_local.h"
+#include "internal/ssl_unwrap.h"
+#include "helpers/ssltestlib.h"
 #include "testutil.h"
 #include <openssl/evp.h>
+#include <openssl/ssl.h>
+
+static char *cert = NULL;
+static char *privkey = NULL;
 
 static const char *cipher_names[] = {
     "aes-128-ecb",
@@ -72,8 +79,82 @@ err:
     return 0;
 }
 
+#ifndef OPENSSL_NO_DTLS1_3
+/*
+ * Test that dtls1_increment_epoch() enforces the RFC 9147 Section 8 limit
+ * on the write (sending) epoch for DTLS 1.3: "sending implementations MUST
+ * NOT allow the epoch to exceed 2^48-1". This is stricter than the 2^64-1
+ * wrap-around ceiling in Section 6.1, and applies only to the write side
+ * and only for DTLS 1.3 -- DTLS 1.2 keeps its existing UINT16_MAX limit.
+ *
+ * There's no way to actually drive 2^48 real KeyUpdates in a test, so this
+ * drives one real DTLS 1.3 handshake to get a genuinely-typed connection
+ * (SSL_CONNECTION_IS_DTLS13() depends on the negotiated method, not
+ * anything that can be poked directly), then writes w_conn_epoch directly
+ * to one below the limit before calling the real increment function at and
+ * past the boundary.
+ */
+static int test_dtls13_increment_epoch_max(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    SSL_CONNECTION *sc = NULL;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(),
+            DTLS1_3_VERSION, DTLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_int_eq(SSL_version(serverssl), DTLS1_3_VERSION))
+        goto end;
+
+    if (!TEST_ptr(sc = SSL_CONNECTION_FROM_SSL(serverssl)))
+        goto end;
+
+    if (!TEST_true(SSL_CONNECTION_IS_DTLS13(sc)))
+        goto end;
+
+    /* One below the Section 8 limit: incrementing must still succeed. */
+    sc->rlayer.d->w_conn_epoch = DTLS1_3_MAX_EPOCH - 1;
+    if (!TEST_true(dtls1_increment_epoch(sc, SSL3_CC_WRITE)))
+        goto end;
+    if (!TEST_uint64_t_eq(sc->rlayer.d->w_conn_epoch, DTLS1_3_MAX_EPOCH))
+        goto end;
+
+    /* Already at the limit: incrementing further must be rejected. */
+    if (!TEST_false(dtls1_increment_epoch(sc, SSL3_CC_WRITE)))
+        goto end;
+    if (!TEST_uint64_t_eq(sc->rlayer.d->w_conn_epoch, DTLS1_3_MAX_EPOCH))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+#endif /* OPENSSL_NO_DTLS1_3 */
+
 int setup_tests(void)
 {
+    if (!TEST_ptr(cert = test_get_argument(0))
+        || !TEST_ptr(privkey = test_get_argument(1)))
+        return 0;
+
     ADD_ALL_TESTS(test_dtls_crypt_sequence_number, OSSL_NELEM(cipher_names));
+#ifndef OPENSSL_NO_DTLS1_3
+    ADD_TEST(test_dtls13_increment_epoch_max);
+#endif
     return 1;
 }

--- a/test/recipes/60-test_dtls13_internal.t
+++ b/test/recipes/60-test_dtls13_internal.t
@@ -7,6 +7,11 @@
 # https://www.openssl.org/source/license.html
 
 
-use OpenSSL::Test::Simple;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
-simple_test("test_dtls13_internal", "dtls13_internal_test");
+setup("test_dtls13_internal");
+
+plan tests => 1;
+
+ok(run(test(["dtls13_internal_test", srctop_file("apps", "server.pem"),
+             srctop_file("apps", "server.pem")])), "running dtls13_internal_test");


### PR DESCRIPTION
dtls1_increment_epoch() capped the read/write epoch at UINT16_MAX for DTLS 1.2, but skipped that check entirely for DTLS 1.3, relying only on the full 64-bit wrap as a backstop. RFC 9147 Section 8 requires a much tighter bound for senders: "sending implementations MUST NOT allow the epoch to exceed 2^48-1", motivated by AES-128's 128-bit key giving a non-negligible key-reuse probability at anything near 2^64 rekeys. Receivers are held to the looser Section 6.1 ceiling instead, so this is intentionally a write-side-only, DTLS-1.3-only check.

Add DTLS1_3_MAX_EPOCH (2^48-1) and enforce it in the write branch of dtls1_increment_epoch() before the increment, mirroring the existing UINT16_MAX guard's pre-increment style. With both the DTLS 1.2 and DTLS 1.3 write-side ceilings now always intercepting w_conn_epoch well below UINT64_MAX, the post-increment wrap-to-zero check on that path can no longer be reached, so it is removed.

Add test_dtls13_increment_epoch_max() to test/dtls13_internal_test.c, which negotiates a real DTLS 1.3 connection (SSL_CONNECTION_IS_DTLS13() depends on the negotiated method and can't be forced directly), then writes w_conn_epoch to one below the limit and calls the real increment function at and past the boundary.

Fixes: https://github.com/openssl/openssl/issues/32511
Assisted-by: Claude:claude-sonnet-5

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ x] tests are added or updated
