### PR TITLE
mips: Declare local assembly symbols before use

### DIFF
--- a/crypto/aes/asm/aes-mips.pl
+++ b/crypto/aes/asm/aes-mips.pl
@@ -110,6 +110,12 @@ $code.=<<___;
 #include "arch/mips_arch.h"
 
 .text
+.local	_mips_AES_encrypt
+.local	_mips_AES_decrypt
+.local	_mips_AES_set_encrypt_key
+.local	AES_Te
+.local	AES_Td
+.local	AES_Te4
 #if !defined(__mips_eabi) && (!defined(__vxworks) || defined(__pic__))
 .option	pic2
 #endif

--- a/crypto/sha/asm/sha512-mips.pl
+++ b/crypto/sha/asm/sha512-mips.pl
@@ -311,6 +311,7 @@ $code.=<<___;
 #include "arch/mips_arch.h"
 
 .text
+.local	K${label}
 .set	noat
 #if !defined(__mips_eabi) && (!defined(__vxworks) || defined(__pic__))
 .option	pic2


### PR DESCRIPTION
Clang's integrated assembler expands PIC la macros as soon as they are parsed. When a local symbol is defined later, LLVM does not yet know its binding and emits a bad GOT16 relocation.

Declare the internal AES functions and AES and SHA tables local before any references to workaround this limitation.

Link: https://github.com/llvm/llvm-project/issues/65020

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

