### PR TITLE
[4.1 blocker] Fix DTLS 1.3 accepting unauthenticated plaintext alerts

### DIFF
--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -653,6 +653,18 @@ again:
     rl->rstate = SSL_ST_READ_HEADER;
 
     /*
+     * RFC 9147 permits DTLSPlaintext only in epoch 0. Silently discard it
+     * after reading the fragment so later records remain framed.
+     */
+    if (rl->version == DTLS1_3_VERSION
+        && rl->epoch != 0
+        && !DTLS13_UNI_HDR_FIX_BITS_IS_SET(rr->type)) {
+        rr->length = 0;
+        rl->packet_length = 0;
+        goto again;
+    }
+
+    /*
      * rfc9147:
      * This procedure requires the ciphertext length to be at least 16 bytes.
      * Receivers MUST reject shorter records as if they had failed deprotection

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -143,16 +143,20 @@ static int tls13_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *recs,
     }
 
     /*
-     * If we're sending an alert and ctx != NULL then we must be forcing
-     * plaintext alerts. If we're reading and ctx != NULL then we allow
-     * plaintext alerts at certain points in the handshake. If we've got this
-     * far then we have already validated that a plaintext alert is ok here.
+     * Plaintext alerts are allowed only when explicitly enabled. DTLS needs
+     * this check here because it does not run the TLS header validator.
      */
     if (rec->type == SSL3_RT_ALERT) {
+        if (!rl->allow_plain_alerts)
+            return 0;
         memmove(rec->data, rec->input, rec->length);
         rec->input = rec->data;
         return 1;
     }
+
+    /* Keyed DTLS 1.3 layers accept only unified headers. */
+    if (isdtls && !DTLS13_UNI_HDR_FIX_BITS_IS_SET(rec->type))
+        return 0;
 
     /* For integrity-only ciphers, nonce_len is same as MAC size */
     if (rl->mac_ctx != NULL) {
@@ -220,8 +224,16 @@ static int tls13_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *recs,
         addlen = 1;
     }
 
-    if ((isdtls && !ossl_assert(!DTLS13_UNI_HDR_CID_BIT_IS_SET(rec->type)))
-        || !WPACKET_init_static_len(&wpkt, recheader, sizeof(recheader), 0)
+    /*
+     * Reject unsupported CID before WPACKET setup so cleanup cannot touch
+     * an uninitialised packet.
+     */
+    if (isdtls && !ossl_assert(!DTLS13_UNI_HDR_CID_BIT_IS_SET(rec->type))) {
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    if (!WPACKET_init_static_len(&wpkt, recheader, sizeof(recheader), 0)
         || !WPACKET_put_bytes_u8(&wpkt, rec->type)
         || (isdtls && (sbit ? !WPACKET_put_bytes_u16(&wpkt, rl->sequence) : !WPACKET_put_bytes_u8(&wpkt, rl->sequence)))
         || (!isdtls && !WPACKET_put_bytes_u16(&wpkt, rec->rec_version))
@@ -515,6 +527,10 @@ const struct record_functions_st dtls_1_3_funcs = {
     tls_default_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    /*
+     * Keep this NULL: the TLS validator raises fatal errors, while DTLS must
+     * silently discard invalid records (RFC 9147 section 4.5.2).
+     */
     NULL,
     tls13_post_process_record,
     NULL,

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -974,6 +974,350 @@ end:
 }
 #endif /* OPENSSL_NO_DTLS */
 
+#ifndef OPENSSL_NO_DTLS1_3
+/*
+ * Keyed DTLS 1.3 epochs must silently discard DTLSPlaintext records
+ * (RFC 9147 sections 4 and 4.5.2).
+ */
+
+static size_t make_forged_plaintext_record(unsigned char *out,
+    unsigned int epoch, uint64_t seq,
+    unsigned int type,
+    const unsigned char *body,
+    size_t bodylen)
+{
+    out[0] = (unsigned char)type;
+    out[1] = 0xfe;
+    out[2] = 0xfd;
+    out[3] = (unsigned char)(epoch >> 8);
+    out[4] = (unsigned char)epoch;
+    out[5] = (unsigned char)(seq >> 40);
+    out[6] = (unsigned char)(seq >> 32);
+    out[7] = (unsigned char)(seq >> 24);
+    out[8] = (unsigned char)(seq >> 16);
+    out[9] = (unsigned char)(seq >> 8);
+    out[10] = (unsigned char)seq;
+    out[11] = (unsigned char)(bodylen >> 8);
+    out[12] = (unsigned char)bodylen;
+    memcpy(out + 13, body, bodylen);
+    return 13 + bodylen;
+}
+
+static size_t make_forged_alert(unsigned char *out, unsigned int epoch,
+    uint64_t seq, unsigned int level,
+    unsigned int descr)
+{
+    unsigned char body[2];
+
+    body[0] = (unsigned char)level;
+    body[1] = (unsigned char)descr;
+    return make_forged_plaintext_record(out, epoch, seq, SSL3_RT_ALERT,
+        body, sizeof(body));
+}
+
+static int do_dtls13_handshake(SSL *sssl, SSL *cssl)
+{
+    int i;
+
+    for (i = 0; i < 64; i++) {
+        int rc = SSL_connect(cssl);
+        int rs = SSL_accept(sssl);
+
+        if (SSL_is_init_finished(cssl) && SSL_is_init_finished(sssl))
+            return 1;
+        if (rc <= 0) {
+            int e = SSL_get_error(cssl, rc);
+
+            if (e != SSL_ERROR_WANT_READ && e != SSL_ERROR_WANT_WRITE)
+                return 0;
+        }
+        if (rs <= 0) {
+            int e = SSL_get_error(sssl, rs);
+
+            if (e != SSL_ERROR_WANT_READ && e != SSL_ERROR_WANT_WRITE)
+                return 0;
+        }
+    }
+    return 0;
+}
+
+/* Drain pending ACK and NewSessionTicket records. */
+static int drain_ssl(SSL *ssl)
+{
+    unsigned char buf[256];
+    int ret;
+
+    do {
+        ret = SSL_read(ssl, buf, sizeof(buf));
+    } while (ret > 0);
+
+    if (!TEST_int_eq(SSL_get_error(ssl, ret), SSL_ERROR_WANT_READ))
+        return 0;
+    ERR_clear_error();
+    return 1;
+}
+
+static int inject_client_datagram(SSL *cssl, const unsigned char *pkt,
+    size_t pktlen)
+{
+    BIO *bio = SSL_get_wbio(cssl);
+
+    if (!TEST_ptr(bio))
+        return 0;
+    return TEST_int_eq(mempacket_test_inject(bio, (const char *)pkt,
+                           (int)pktlen, -1,
+                           INJECT_PACKET_IGNORE_REC_SEQ),
+        (int)pktlen);
+}
+
+/* Rejected plaintext must not change state or disrupt application data. */
+static int test_dtls13_forged_plaintext_alert(int idx)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *sssl = NULL, *cssl = NULL;
+    unsigned char pkt[5 * 15];
+    size_t pktlen = 0;
+    char msg[] = { 0x00, 0x01, 0x02, 0x03 };
+    char buf[16];
+    int ret, i, testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(),
+            DTLS1_3_VERSION, DTLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        return 0;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, NULL)))
+        goto end;
+
+    if (!TEST_true(do_dtls13_handshake(sssl, cssl)))
+        goto end;
+
+    /* Consume any post-handshake ACKs and NewSessionTickets */
+    if (!TEST_true(drain_ssl(cssl)) || !TEST_true(drain_ssl(sssl)))
+        goto end;
+
+    switch (idx) {
+    case 0:
+        /* Spoofed close_notify */
+        pktlen = make_forged_alert(pkt, 3, 100, SSL3_AL_WARNING,
+            SSL3_AD_CLOSE_NOTIFY);
+        break;
+    case 1:
+        /* Spoofed fatal alert (handshake_failure) */
+        pktlen = make_forged_alert(pkt, 3, 100, SSL3_AL_FATAL,
+            SSL3_AD_HANDSHAKE_FAILURE);
+        break;
+    case 2:
+        /* user_cancelled with seq 2^48-1 (replay-window poison) */
+        pktlen = make_forged_alert(pkt, 3, (((uint64_t)1) << 48) - 1,
+            SSL3_AL_WARNING, SSL_AD_USER_CANCELLED);
+        break;
+    case 3:
+        /* Trip the warning limit while preserving record framing. */
+        for (i = 0; i < 5; i++)
+            pktlen += make_forged_alert(pkt + pktlen, 3, 10 + i,
+                SSL3_AL_WARNING,
+                SSL_AD_USER_CANCELLED);
+        break;
+    case 4:
+        /* Malformed alert body (fragment length 3) */
+        pktlen = make_forged_alert(pkt, 3, 100, SSL3_AL_FATAL,
+            SSL3_AD_HANDSHAKE_FAILURE);
+        pkt[12] = 3;
+        pkt[15] = 0xff;
+        pktlen = 16;
+        break;
+    case 5:
+        /* Alert with an overlong body (longer than content + tag) */
+        pktlen = make_forged_alert(pkt, 3, 100, SSL3_AL_WARNING,
+            SSL3_AD_CLOSE_NOTIFY);
+        pkt[11] = 0;
+        pkt[12] = 40;
+        memset(pkt + 15, 0xaa, 40 - 2);
+        pktlen = 13 + 40;
+        break;
+    case 6:
+        /* Type 22 used to reach AAD setup with an uninitialised WPACKET. */
+        {
+            unsigned char body[40];
+
+            memset(body, 0xbb, sizeof(body));
+            pktlen = make_forged_plaintext_record(pkt, 3, 100,
+                SSL3_RT_HANDSHAKE, body,
+                sizeof(body));
+        }
+        break;
+    case 7:
+        /* Same as case 6 with outer type ack(26) */
+        {
+            unsigned char body[40];
+
+            memset(body, 0xcc, sizeof(body));
+            pktlen = make_forged_plaintext_record(pkt, 3, 100,
+                SSL3_RT_ACK, body,
+                sizeof(body));
+        }
+        break;
+    default:
+        goto end;
+    }
+
+    if (!inject_client_datagram(cssl, pkt, pktlen))
+        goto end;
+
+    /* It must be silently discarded without changing shutdown state. */
+    ret = SSL_read(sssl, buf, sizeof(buf));
+    if (!TEST_int_le(ret, 0)
+        || !TEST_int_eq(SSL_get_error(sssl, ret), SSL_ERROR_WANT_READ)
+        || !TEST_int_eq(SSL_get_shutdown(sssl), 0))
+        goto end;
+    ERR_clear_error();
+
+    /* The association must still work: application data keeps flowing */
+    if (!TEST_int_eq(SSL_write(cssl, msg, sizeof(msg)), (int)sizeof(msg))
+        || !TEST_int_eq(ret = SSL_read(sssl, buf, sizeof(buf)),
+            (int)sizeof(msg))
+        || !TEST_mem_eq(buf, sizeof(msg), msg, sizeof(msg)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(cssl);
+    SSL_free(sssl);
+    SSL_CTX_free(cctx);
+    SSL_CTX_free(sctx);
+
+    return testresult;
+}
+
+/*
+ * Plant epoch 2 plaintext after ClientHello and verify that it is discarded
+ * when reparsed under epoch 2.
+ *
+ * idx 0: far ahead sequence makes Finished stale
+ * idx 1: fatal alert aborts the handshake
+ * idx 2: sequence 0 makes the first protected record look replayed
+ */
+static int test_dtls13_forged_plaintext_alert_plant(int idx)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *sssl = NULL, *cssl = NULL;
+    unsigned char pkt[15];
+    size_t pktlen = 0;
+    char msg[] = { 0x00, 0x01, 0x02, 0x03 };
+    char buf[16];
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(),
+            DTLS1_3_VERSION, DTLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        return 0;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, NULL)))
+        goto end;
+
+    /* Send flight 1: ClientHello */
+    if (!TEST_int_le(SSL_connect(cssl), 0))
+        goto end;
+
+    switch (idx) {
+    case 0:
+        pktlen = make_forged_alert(pkt, 2, (((uint64_t)1) << 48) - 1,
+            SSL3_AL_WARNING, SSL_AD_USER_CANCELLED);
+        break;
+    case 1:
+        pktlen = make_forged_alert(pkt, 2, 0, SSL3_AL_FATAL,
+            SSL3_AD_HANDSHAKE_FAILURE);
+        break;
+    case 2:
+        pktlen = make_forged_alert(pkt, 2, 0, SSL3_AL_WARNING,
+            SSL_AD_USER_CANCELLED);
+        break;
+    default:
+        goto end;
+    }
+
+    if (!inject_client_datagram(cssl, pkt, pktlen))
+        goto end;
+
+    /* The handshake must complete despite the plant */
+    if (!TEST_true(do_dtls13_handshake(sssl, cssl)))
+        goto end;
+
+    /* Application data must flow in both directions */
+    if (!TEST_int_eq(SSL_write(cssl, msg, sizeof(msg)), (int)sizeof(msg))
+        || !TEST_int_eq(SSL_read(sssl, buf, sizeof(buf)), (int)sizeof(msg))
+        || !TEST_mem_eq(buf, sizeof(msg), msg, sizeof(msg))
+        || !TEST_int_eq(SSL_write(sssl, msg, sizeof(msg)), (int)sizeof(msg))
+        || !TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg))
+        || !TEST_mem_eq(buf, sizeof(msg), msg, sizeof(msg)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(cssl);
+    SSL_free(sssl);
+    SSL_CTX_free(cctx);
+    SSL_CTX_free(sctx);
+
+    return testresult;
+}
+
+/* Epoch 0 plaintext alerts must still reach the handshake. */
+static int test_dtls13_epoch0_plaintext_alert(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *sssl = NULL, *cssl = NULL;
+    unsigned char pkt[15];
+    size_t pktlen;
+    int ret, i, testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(),
+            DTLS1_3_VERSION, DTLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        return 0;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, NULL)))
+        goto end;
+
+    /* Send flight 1: ClientHello */
+    if (!TEST_int_le(SSL_connect(cssl), 0))
+        goto end;
+
+    /* ClientHello used sequence 0, so inject the alert with sequence 1. */
+    pktlen = make_forged_alert(pkt, 0, 1, SSL3_AL_FATAL,
+        SSL3_AD_HANDSHAKE_FAILURE);
+    if (!inject_client_datagram(cssl, pkt, pktlen))
+        goto end;
+
+    /* The epoch 0 alert must fail the handshake. */
+    ret = SSL_accept(sssl);
+    for (i = 0; i < 3 && ret <= 0
+        && SSL_get_error(sssl, ret) == SSL_ERROR_WANT_READ;
+        i++)
+        ret = SSL_accept(sssl);
+    if (!TEST_int_le(ret, 0)
+        || !TEST_int_eq(SSL_get_error(sssl, ret), SSL_ERROR_SSL)
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+            SSL_AD_REASON_OFFSET + SSL3_AD_HANDSHAKE_FAILURE)
+        || !TEST_true((SSL_get_shutdown(sssl) & SSL_RECEIVED_SHUTDOWN) != 0))
+        goto end;
+    ERR_clear_error();
+
+    testresult = 1;
+end:
+    SSL_free(cssl);
+    SSL_free(sssl);
+    SSL_CTX_free(cctx);
+    SSL_CTX_free(sctx);
+
+    return testresult;
+}
+#endif /* OPENSSL_NO_DTLS1_3 */
+
 /* Confirm that we can create a connections using DTLSv1_listen() */
 #ifndef OPENSSL_NO_DTLS1_2
 static int test_listen(void)
@@ -1055,6 +1399,9 @@ int setup_tests(void)
 #endif
 #ifndef OPENSSL_NO_DTLS1_3
     ADD_TEST(test_duplicate_app_data_dtls13);
+    ADD_ALL_TESTS(test_dtls13_forged_plaintext_alert, 8);
+    ADD_ALL_TESTS(test_dtls13_forged_plaintext_alert_plant, 3);
+    ADD_TEST(test_dtls13_epoch0_plaintext_alert);
 #endif
 
     return 1;

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -980,6 +980,28 @@ end:
  * (RFC 9147 sections 4 and 4.5.2).
  */
 
+/*
+ * RFC 9147 section 6.1 assigns epoch 2 to handshake traffic and epoch 3 to
+ * the first application traffic keys.
+ */
+#define DTLS13_HANDSHAKE_EPOCH 2
+#define DTLS13_APPLICATION_EPOCH 3
+
+/*
+ * Genuine sequence numbers are close to zero in these tests. A sequence
+ * number of 100 is beyond the 64 record replay window, so accepting it would
+ * make the next genuine record stale.
+ */
+#define DTLS13_FAR_AHEAD_SEQUENCE 100
+
+/*
+ * DTLSPlaintext has a 48 bit sequence number. Its maximum moves the replay
+ * window as far forward as the record format permits. Sequence zero is the
+ * first protected record in a newly installed epoch.
+ */
+#define DTLS13_MAX_PLAINTEXT_SEQUENCE ((((uint64_t)1) << 48) - 1)
+#define DTLS13_FIRST_PROTECTED_SEQUENCE 0
+
 static size_t make_forged_plaintext_record(unsigned char *out,
     unsigned int epoch, uint64_t seq,
     unsigned int type,
@@ -1019,6 +1041,11 @@ static int do_dtls13_handshake(SSL *sssl, SSL *cssl)
 {
     int i;
 
+    /*
+     * An in memory DTLS 1.3 handshake completes in far fewer than 64 calls,
+     * even when its flights are fragmented. This isn't a protocol limit: it
+     * leaves ample room while making a stalled handshake fail promptly.
+     */
     for (i = 0; i < 64; i++) {
         int rc = SSL_connect(cssl);
         int rs = SSL_accept(sssl);
@@ -1100,29 +1127,33 @@ static int test_dtls13_forged_plaintext_alert(int idx)
     switch (idx) {
     case 0:
         /* Spoofed close_notify */
-        pktlen = make_forged_alert(pkt, 3, 100, SSL3_AL_WARNING,
+        pktlen = make_forged_alert(pkt, DTLS13_APPLICATION_EPOCH,
+            DTLS13_FAR_AHEAD_SEQUENCE, SSL3_AL_WARNING,
             SSL3_AD_CLOSE_NOTIFY);
         break;
     case 1:
         /* Spoofed fatal alert (handshake_failure) */
-        pktlen = make_forged_alert(pkt, 3, 100, SSL3_AL_FATAL,
+        pktlen = make_forged_alert(pkt, DTLS13_APPLICATION_EPOCH,
+            DTLS13_FAR_AHEAD_SEQUENCE, SSL3_AL_FATAL,
             SSL3_AD_HANDSHAKE_FAILURE);
         break;
     case 2:
         /* user_cancelled with seq 2^48-1 (replay-window poison) */
-        pktlen = make_forged_alert(pkt, 3, (((uint64_t)1) << 48) - 1,
-            SSL3_AL_WARNING, SSL_AD_USER_CANCELLED);
+        pktlen = make_forged_alert(pkt, DTLS13_APPLICATION_EPOCH,
+            DTLS13_MAX_PLAINTEXT_SEQUENCE, SSL3_AL_WARNING,
+            SSL_AD_USER_CANCELLED);
         break;
     case 3:
         /* Trip the warning limit while preserving record framing. */
         for (i = 0; i < 5; i++)
-            pktlen += make_forged_alert(pkt + pktlen, 3, 10 + i,
-                SSL3_AL_WARNING,
+            pktlen += make_forged_alert(pkt + pktlen,
+                DTLS13_APPLICATION_EPOCH, 10 + i, SSL3_AL_WARNING,
                 SSL_AD_USER_CANCELLED);
         break;
     case 4:
         /* Malformed alert body (fragment length 3) */
-        pktlen = make_forged_alert(pkt, 3, 100, SSL3_AL_FATAL,
+        pktlen = make_forged_alert(pkt, DTLS13_APPLICATION_EPOCH,
+            DTLS13_FAR_AHEAD_SEQUENCE, SSL3_AL_FATAL,
             SSL3_AD_HANDSHAKE_FAILURE);
         pkt[12] = 3;
         pkt[15] = 0xff;
@@ -1130,7 +1161,8 @@ static int test_dtls13_forged_plaintext_alert(int idx)
         break;
     case 5:
         /* Alert with an overlong body (longer than content + tag) */
-        pktlen = make_forged_alert(pkt, 3, 100, SSL3_AL_WARNING,
+        pktlen = make_forged_alert(pkt, DTLS13_APPLICATION_EPOCH,
+            DTLS13_FAR_AHEAD_SEQUENCE, SSL3_AL_WARNING,
             SSL3_AD_CLOSE_NOTIFY);
         pkt[11] = 0;
         pkt[12] = 40;
@@ -1143,9 +1175,9 @@ static int test_dtls13_forged_plaintext_alert(int idx)
             unsigned char body[40];
 
             memset(body, 0xbb, sizeof(body));
-            pktlen = make_forged_plaintext_record(pkt, 3, 100,
-                SSL3_RT_HANDSHAKE, body,
-                sizeof(body));
+            pktlen = make_forged_plaintext_record(pkt,
+                DTLS13_APPLICATION_EPOCH, DTLS13_FAR_AHEAD_SEQUENCE,
+                SSL3_RT_HANDSHAKE, body, sizeof(body));
         }
         break;
     case 7:
@@ -1154,9 +1186,9 @@ static int test_dtls13_forged_plaintext_alert(int idx)
             unsigned char body[40];
 
             memset(body, 0xcc, sizeof(body));
-            pktlen = make_forged_plaintext_record(pkt, 3, 100,
-                SSL3_RT_ACK, body,
-                sizeof(body));
+            pktlen = make_forged_plaintext_record(pkt,
+                DTLS13_APPLICATION_EPOCH, DTLS13_FAR_AHEAD_SEQUENCE,
+                SSL3_RT_ACK, body, sizeof(body));
         }
         break;
     default:
@@ -1224,15 +1256,18 @@ static int test_dtls13_forged_plaintext_alert_plant(int idx)
 
     switch (idx) {
     case 0:
-        pktlen = make_forged_alert(pkt, 2, (((uint64_t)1) << 48) - 1,
-            SSL3_AL_WARNING, SSL_AD_USER_CANCELLED);
+        pktlen = make_forged_alert(pkt, DTLS13_HANDSHAKE_EPOCH,
+            DTLS13_MAX_PLAINTEXT_SEQUENCE, SSL3_AL_WARNING,
+            SSL_AD_USER_CANCELLED);
         break;
     case 1:
-        pktlen = make_forged_alert(pkt, 2, 0, SSL3_AL_FATAL,
+        pktlen = make_forged_alert(pkt, DTLS13_HANDSHAKE_EPOCH,
+            DTLS13_FIRST_PROTECTED_SEQUENCE, SSL3_AL_FATAL,
             SSL3_AD_HANDSHAKE_FAILURE);
         break;
     case 2:
-        pktlen = make_forged_alert(pkt, 2, 0, SSL3_AL_WARNING,
+        pktlen = make_forged_alert(pkt, DTLS13_HANDSHAKE_EPOCH,
+            DTLS13_FIRST_PROTECTED_SEQUENCE, SSL3_AL_WARNING,
             SSL_AD_USER_CANCELLED);
         break;
     default:
@@ -1268,6 +1303,11 @@ end:
 /* Epoch 0 plaintext alerts must still reach the handshake. */
 static int test_dtls13_epoch0_plaintext_alert(void)
 {
+#ifdef OPENSSL_NO_EC
+    const char *group = "ffdhe3072";
+#else
+    const char *group = "P-256";
+#endif
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *sssl = NULL, *cssl = NULL;
     unsigned char pkt[15];
@@ -1279,6 +1319,11 @@ static int test_dtls13_epoch0_plaintext_alert(void)
             DTLS1_3_VERSION, DTLS1_3_VERSION,
             &sctx, &cctx, cert, privkey)))
         return 0;
+
+    /* Keep ClientHello in one record so sequence number 1 remains unused. */
+    if (!TEST_true(SSL_CTX_set1_groups_list(sctx, group))
+        || !TEST_true(SSL_CTX_set1_groups_list(cctx, group)))
+        goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, NULL)))
         goto end;

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -668,32 +668,38 @@ sub construct_alert_message
     die "construct_alert_message only valid for DTLSv1.3 tests\n"
         if !$self->{isdtls} || !$self->is_tls13();
 
-    my $seqhi = ($sequence_number >> 32) & 0xffff;
-    my $seqmi = ($sequence_number >> 16) & 0xffff;
-    my $seqlo = ($sequence_number >> 0) & 0xffff;
-
-    # DTLS Record Layer Header
-    my $content_type = pack("C", 21);              # Alert (21)
-    my $legacy_version = pack("n", 0xFEFD);        # DTLS 1.2 (0xFEFD)
-    my $epoch_bytes = pack("n", $epoch);           # 2 bytes
-    my $sequence_bytes = pack('nnn', $seqhi, $seqmi, $seqlo);
-
-    my $length = pack("n", 2);                     # 2 bytes for alert payload
-
-    # Alert Message
     my $alert_level = pack("C", 1);                # Warning (1)
     my $alert_description = pack("C", 0);          # close_notify (0)
+    my $alert_payload = $alert_level.$alert_description;
 
-    # Combine all parts
-    my $packet = $content_type.
-                 $legacy_version.
-                 $epoch_bytes.
-                 $sequence_bytes.
-                 $length.
-                 $alert_level.
-                 $alert_description;
+    if ($epoch == 0) {
+        # Epoch 0 uses DTLSPlaintext.
+        my $seqhi = ($sequence_number >> 32) & 0xffff;
+        my $seqmi = ($sequence_number >> 16) & 0xffff;
+        my $seqlo = ($sequence_number >> 0) & 0xffff;
 
-    return $packet;
+        return pack("C", 21).                 # Alert (21)
+               pack("n", 0xFEFD).             # legacy version DTLS 1.2
+               pack("n", $epoch).
+               pack('nnn', $seqhi, $seqmi, $seqlo).
+               pack("n", length($alert_payload)).
+               $alert_payload;
+    }
+
+    # Keyed epochs use DTLSCiphertext. The p_ossltest cipher leaves the
+    # payload unchanged and does not verify the tag. The inner plaintext
+    # holds close_notify and its content type; a zero tag follows.
+    # The header uses a 16 bit sequence number and a length field. Mask the
+    # sequence number with the first two payload bytes, as in Record.pm.
+    my $payload = $alert_payload.pack("C", 21).("\x00" x 16);
+    my $maskhi = unpack("n", substr($payload, 0, 2));
+    my $seqlo = ($sequence_number & 0xffff) ^ $maskhi;
+    my $first = 0x20 | 0x08 | 0x04 | ($epoch & 0x03);
+
+    return pack("C", $first).
+           pack("n", $seqlo).
+           pack("n", length($payload)).
+           $payload;
 }
 
 sub process_packet


### PR DESCRIPTION
I hit this while looking at #32584, the DTLS 1.3 sequence number bug. It's a separate hole that's already present on master, and for me it's a release blocker for 4.1.

With `DTLS_method` on current master, a keyed DTLS 1.3 read epoch still accepts a DTLSPlaintext alert (21) whose epoch field matches the read epoch. The record has no AEAD protection, yet `tls13_cipher` passes it through because it never checks `allow_plain_alerts`. The DTLS read path doesn't call the TLS 1.3 header validator because `dtls_1_3_funcs.validate_record_header` is NULL.

RFC 9147 section 4.1 says that a record starting with 21 is DTLSPlaintext. The same parsing rule applies to 22 and 26. That's packet demux, not permission to accept the record after keys are installed. From epoch 1 onward, alerts belong inside DTLSCiphertext.

## Why this needs to land before 4.1

An attacker on the path needs one UDP payload only 15 bytes long. Source spoofing works too if the UDP addresses and ports are known. Wrong epoch guesses disappear without a reply, so cycling through epochs 0 to 16 is cheap. This can start as early as the ClientHello: an epoch 2 plaintext alert may be buffered by the epoch 0 layer and parsed once handshake keys are installed.

What that datagram can do:

* A spoofed `close_notify` makes `SSL_read` return 0 with `SSL_ERROR_ZERO_RETURN` and sets `SSL_RECEIVED_SHUTDOWN`, so the application believes that the peer closed cleanly. This defeats the truncation check that `close_notify` provides (RFC 8446 section 6.1 and RFC 9147 section 5.10). An application that reads until shutdown may accept truncation chosen by an attacker as a complete message.

* A spoofed fatal alert tears down the association. `handshake_failure` is enough, and `SSL_CTX_remove_session` evicts the session. The next connection needs a full handshake.

* A `user_cancelled` alert with sequence number 2^48-1 pushes the replay window's right edge far ahead. Later records from the real peer fail to deprotect. On a blocking socket, `SSL_read` waits forever. A nonblocking socket keeps returning `SSL_ERROR_WANT_READ` without reporting an error. Even a peer `KeyUpdate` can't recover the poisoned epoch.

* Five `user_cancelled` records in one datagram trip `MAX_WARN_ALERT_COUNT` and kill the connection without relying on replay window arithmetic. They fit in a single UDP packet.

* A record that looks like an alert but whose body isn't exactly 2 bytes long raises `SSL_R_INVALID_ALERT` after the replay bitmap has already moved.

There's a worse path. A plaintext handshake record (22) or ACK (26) isn't an alert, so it enters the normal AEAD path in `tls13_cipher`. Both byte values have the unified header CID bit set. The CID test comes before `WPACKET_init_static_len` in the same short circuit expression. When that test succeeds, initialisation is skipped but cleanup still runs on a stack `WPACKET` that was never initialised.

In a debug build, `ossl_assert` stops the process. With `NDEBUG`, cleanup can pass a stale pointer to `free`. I have seen this double free the connection BIO; other runs crashed somewhere else as the stack layout changed. One unauthenticated datagram is still enough.

This doesn't break AEAD for genuine ciphertext records. It doesn't involve nonce reuse or a decryption oracle. The problem is that unauthenticated plaintext is treated as control traffic for a keyed epoch. With outer type 22 or 26, it can also reach memory corruption.

QUIC uses another stack, so this path is specific to DTLS 1.3. The TLS 1.3 read path runs its validator, while DTLS 1.2 doesn't accept this record as an alert.

## The fix

`dtls_get_more_records` now drops DTLSPlaintext on any DTLS 1.3 read layer whose epoch isn't 0. The check runs after the fragment has been read, which keeps a later record in the same datagram correctly framed.

Its position matters. The check runs before `dtls_get_bitmap`, so an injected plaintext record can't move the replay bitmap or become the reference used to reconstruct truncated sequence numbers under RFC 9147 section 4.2.2. This is where the fix touches #32584, though the bugs are separate.

At the cipher layer, `tls13_cipher` now uses the plaintext alert shortcut only when `allow_plain_alerts` is set. For any other DTLS record whose first byte isn't a unified header, it returns 0, which DTLS already treats as a silent discard.

I also separated the CID test from `WPACKET_init_static_len`, so cleanup can't run unless the packet was initialised.

I have left `dtls_1_3_funcs.validate_record_header` NULL deliberately. Calling the TLS validator would turn these datagrams into unauthenticated fatal errors, but DTLS must silently discard them under RFC 9147 section 4.5.2. `allow_plain_alerts` isn't set on a protected DTLS read layer. It's enabled only while the layer remains at epoch 0, which still uses `tls_any_cipher`. Legitimate plaintext alerts during the unprotected handshake continue to work.

## Tests

`dtlstest` covers spoofed closure and fatal alerts. Another case moves the replay window with `user_cancelled` at sequence number 2^48-1. It also checks malformed alert bodies and several warnings in one datagram. Plaintext records with outer types 22 and 26 exercise the uninitialised `WPACKET` path. Every record sent to a keyed epoch must disappear without changing SSL state; application data proves that the connection remains usable.

A separate test plants an epoch 2 alert just after the ClientHello, before the read layer advances. The handshake must finish, with data flowing in both directions.

The epoch 0 control keeps us honest. It sends a valid plaintext fatal alert and expects the handshake to stop with the alert reason.

I also had to change `TLSProxy::Proxy` teardown. Its DTLS 1.3 recipes used a plaintext `close_notify` at a keyed epoch because UDP has no FIN. Once the record layer correctly discards that alert, the recipes hang. The helper now sends DTLSCiphertext through the `p_ossltest` passthrough cipher, which lets both endpoints deprotect it.

All new `dtlstest` attack cases fail without the record layer change. The epoch 0 control passes before and after it.

## Checklist

- [x] tests are added or updated