### PR TITLE
`doc/man3/EVP_PKEY_get_size.pod`: remove stray ">" from HTML table formatting

### DIFF
--- a/doc/man3/EVP_PKEY_get_size.pod
+++ b/doc/man3/EVP_PKEY_get_size.pod
@@ -143,7 +143,7 @@ _
 =begin html
 
 <table>
-<tr><th>Security Category</th><th>Attack Type</th>></tr>
+<tr><th>Security Category</th><th>Attack Type</th></tr>
 <tr><td>0</td><td>Weak</td></tr>
 <tr><td>1</td><td>Key search on a block cipher with a 128-bit key</td></tr>
 <tr><td>2</td><td>Collision search on a 256-bit hash function</td></tr>


### PR DESCRIPTION
There is a stray closing angle bracket in HTML-specific formatting of the security levels table, remove it.

Fixes: 73188a01bd99 "doc: document EVP_PKEY_get_security_category function"