### PR TITLE
Let TLSProxy tests set the expected NewSessionTicket count

### DIFF
--- a/test/recipes/70-test_dtls13sessionid.t
+++ b/test/recipes/70-test_dtls13sessionid.t
@@ -76,6 +76,9 @@ $proxy->clientflags("$clientflags -sess_in $session");
 $proxy->serverflags($serverflags);
 $proxy->sessionfile($session);
 $proxy->filter(\&inject_session_id_filter);
+# The server sends at most one NewSessionTicket after a resumption, so the
+# proxy must not wait for the default two to be acked.
+$proxy->expected_tickets(1);
 TLSProxy::Message->successondata(1);
 $proxy->start();
 ok(TLSProxy::Message->success() && !server_sent_certificate(),

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -117,6 +117,7 @@ sub init
         serverconnects => 1,
         reneg => 0,
         sessionfile => undef,
+        expected_tickets => 2,
 
         #Public read
         isdtls => $isdtls,
@@ -164,6 +165,7 @@ sub clearClient
     $self->{seen_msgseq} = {};
     $self->{clientflags} = "";
     $self->{sessionfile} = undef;
+    $self->{expected_tickets} = 2;
     $self->{clientpid} = 0;
     $self->{clientexit} = 0;
     $is_tls13 = 0;
@@ -773,7 +775,7 @@ sub process_packet
                 foreach my $record (@{$message->{records}}) {
                     if (@{$self->{session_ticket_seq}} == 0) {
                         push @{$self->{session_ticket_seq}}, TLSProxy::RecordNumber->new($record->epoch, $record->seq);
-                    } elsif (scalar(@{$self->{session_ticket_seq}}) != 2) {
+                    } elsif (scalar(@{$self->{session_ticket_seq}}) != $self->{expected_tickets}) {
                         my $match = $self->find_session_ticket_ack($record->epoch, $record->seq);
                         if ($match == -1) {
                             push @{$self->{session_ticket_seq}}, TLSProxy::RecordNumber->new($record->epoch, $record->seq);
@@ -820,7 +822,8 @@ sub seen_session_ticket_ack
     my $record = shift;
 
     my $ack_hash = $self->{saw_session_ticket_ack};
-    return if !$self->{saw_session_ticket} || scalar(keys %{$ack_hash}) == 2;
+    return if !$self->{saw_session_ticket}
+              || scalar(keys %{$ack_hash}) == $self->{expected_tickets};
     return if $record->content_type() != TLSProxy::Record::RT_ACK;
 
     my @record_numbers = ();
@@ -838,7 +841,7 @@ sub seen_session_ticket_ack
         if ($match != -1) {
             my $session_ticket = splice(@{$ticket_seq}, $match, 1);
             $ack_hash->{$key} = $session_ticket;
-            last if scalar(keys %{$ack_hash}) == 2;
+            last if scalar(keys %{$ack_hash}) == $self->{expected_tickets};
         }
     }
 }
@@ -867,8 +870,9 @@ sub handshake_complete
     my $res = 0;
 
     if ($self->{isdtls} && $self->is_tls13() && defined($self->{sessionfile})) {
-        # We need to wait for the second ack message for the handshake to be complete
-        if (scalar(keys %{$self->{saw_session_ticket_ack}}) == 2) {
+        # The handshake is complete once every expected NewSessionTicket
+        # (2 by default, but only 1 follows a resumption) has been acked
+        if (scalar(keys %{$self->{saw_session_ticket_ack}}) == $self->{expected_tickets}) {
             $res = 1;
         }
     } else {
@@ -1077,6 +1081,14 @@ sub sessionfile
         TLSProxy::Message->successondata(1);
     }
     return $self->{sessionfile};
+}
+sub expected_tickets
+{
+    my $self = shift;
+    if (@_) {
+        $self->{expected_tickets} = shift;
+    }
+    return $self->{expected_tickets};
 }
 
 sub ciphersuite


### PR DESCRIPTION
The DTLS 1.3 handshake-complete check waited for two ticket acks, but a server sends at most one ticket after a resumption, so the resuming connection in 70-test_dtls13sessionid.t stalled until the proxy killed s_server. Add a per-connection expected_tickets setting (default two) and set it to one there.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
