### PR TITLE
apps: cover the ca extension options in the test recipe

### DIFF
--- a/test/ca-and-certs.cnf
+++ b/test/ca-and-certs.cnf
@@ -99,6 +99,9 @@ organizationalUnitName	= optional
 commonName		= supplied
 emailAddress		= optional
 
+[ crl_ext ]
+authorityKeyIdentifier	= keyid:always
+
 [ v3_ca ]
 subjectKeyIdentifier	= hash
 authorityKeyIdentifier	= keyid:nonss,issuer:nonss

--- a/test/recipes/80-test_ca.t
+++ b/test/recipes/80-test_ca.t
@@ -29,7 +29,7 @@ sub src_file {
 
 rmtree("demoCA", { safe => 0 });
 
-plan tests => 20;
+plan tests => 28;
 
 require_ok(srctop_file("test", "recipes", "tconversion.pl"));
 
@@ -87,6 +87,12 @@ has_version($v3_cert, 3);
 has_SKID($v3_cert, 1);
 has_AKID($v3_cert, 1);
 
+# Sign with X509v3 extensions from a separate -extfile, once using its
+# default section and once with a section selected via -extensions.
+test_extfile('extfile_default', [], qr/Digital Signature/);
+test_extfile('extfile_section', ['-extensions', 'alt_ext'],
+             qr/Key Encipherment/);
+
 test_revoke('notimes', {
     should_succeed => 1,
 });
@@ -124,6 +130,45 @@ test_revoke('both_generalizedtime', {
     nextupdate     => '20990908123456Z',
     should_succeed => 1,
 });
+
+sub test_extfile {
+    my ($filename, $ca_opts, $keyusage_re) = @_;
+
+    $ENV{CN2} = $filename;
+    ok(
+        run(app(['openssl',
+                 'req',
+                 '-config',  $cnf,
+                 '-new',
+                 '-key',     data_file('revoked.key'),
+                 '-out',     "$filename-req.pem",
+                 '-section', 'userreq',
+        ])),
+        "Generate CSR: $filename"
+    );
+    delete $ENV{CN2};
+
+    ok(
+        run(app(['openssl',
+                 'ca',
+                 '-batch',
+                 '-config',  $cnf,
+                 '-extfile', data_file('extensions.cnf'),
+                 @$ca_opts,
+                 '-in',      "$filename-req.pem",
+                 '-out',     "$filename-cert.pem",
+        ])),
+        "Sign CSR with -extfile: $filename"
+    );
+
+    has_version("$filename-cert.pem", 3);
+
+    my $keyusage = join('',
+        run(app(['openssl', 'x509', '-in', "$filename-cert.pem",
+                 '-noout', '-ext', 'keyUsage']), capture => 1));
+    ok($keyusage =~ $keyusage_re,
+       "keyUsage taken from the extfile: $filename");
+}
 
 sub test_revoke {
     my ($filename, $opts) = @_;

--- a/test/recipes/80-test_ca.t
+++ b/test/recipes/80-test_ca.t
@@ -29,7 +29,7 @@ sub src_file {
 
 rmtree("demoCA", { safe => 0 });
 
-plan tests => 28;
+plan tests => 31;
 
 require_ok(srctop_file("test", "recipes", "tconversion.pl"));
 
@@ -92,6 +92,16 @@ has_AKID($v3_cert, 1);
 test_extfile('extfile_default', [], qr/Digital Signature/);
 test_extfile('extfile_section', ['-extensions', 'alt_ext'],
              qr/Key Encipherment/);
+
+# Generate a CRL with extensions from the config section named by -crlexts
+ok(run(app(['openssl', 'ca', '-config', $cnf, '-gencrl', '-crlsec', '60',
+            '-crlexts', 'crl_ext', '-out', 'crlexts-crl.pem'])),
+   'Generate CRL with -crlexts');
+my $crlexts_text = join('',
+    run(app(['openssl', 'crl', '-in', 'crlexts-crl.pem',
+             '-noout', '-text']), capture => 1));
+ok($crlexts_text =~ qr/Version 2/, 'CRL with extensions is version 2');
+ok($crlexts_text =~ qr/Authority Key Identifier/, 'CRL contains AKID');
 
 test_revoke('notimes', {
     should_succeed => 1,

--- a/test/recipes/80-test_ca_data/extensions.cnf
+++ b/test/recipes/80-test_ca_data/extensions.cnf
@@ -1,0 +1,10 @@
+extensions = default_ext
+
+[ default_ext ]
+basicConstraints = CA:false
+subjectKeyIdentifier = hash
+keyUsage = digitalSignature
+
+[ alt_ext ]
+basicConstraints = CA:false
+keyUsage = keyEncipherment


### PR DESCRIPTION
The extension handling of the ca app was so far untested. Sign requests taking the X509v3 extensions from a separate extension file given with the -extfile option, both via its default section and with a section explicitly selected using the -extensions option, and check that the extensions from the chosen section end up in the certificate.

Also generate a CRL taking its extensions from a dedicated section of the configuration file given with the -crlexts option and check that the CRL is version 2 and carries the requested extension.