### PR TITLE
Fix CRYPTO_atomic_* aborting on a NULL lock on 32-bit Windows

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -183,8 +183,8 @@ void ossl_rcu_lock_free(CRYPTO_RCU_LOCK *lock)
 /* Read side acquisition of the current qp */
 static ossl_inline struct rcu_qp *get_hold_current_qp(CRYPTO_RCU_LOCK *lock)
 {
-    uint32_t qp_idx;
-    uint32_t tmp;
+    uint32_t qp_idx = 0;
+    uint32_t tmp = 0;
     uint64_t tmp64;
 
     /* get the current qp index */
@@ -273,7 +273,7 @@ void ossl_rcu_read_unlock(CRYPTO_RCU_LOCK *lock)
 {
     struct rcu_thr_data *data = CRYPTO_THREAD_get_local_ex(CRYPTO_THREAD_LOCAL_RCU_KEY, lock->ctx);
     int i;
-    LONG64 ret;
+    LONG64 ret = 0;
 
     assert(data != NULL);
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -611,8 +611,7 @@ int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b)
 int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 {
 #if (!defined(OSSL_USE_INTERLOCKEDOR64))
-    OPENSSL_assert(lock != NULL);
-    if (!CRYPTO_THREAD_write_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val += amount;
     *ret = *val;
@@ -632,8 +631,7 @@ int CRYPTO_atomic_add64(uint64_t *val, uint64_t op, uint64_t *ret,
     CRYPTO_RWLOCK *lock)
 {
 #if (!defined(OSSL_USE_INTERLOCKEDOR64))
-    OPENSSL_assert(lock != NULL);
-    if (!CRYPTO_THREAD_write_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val += op;
     *ret = *val;
@@ -652,8 +650,7 @@ int CRYPTO_atomic_and(uint64_t *val, uint64_t op, uint64_t *ret,
     CRYPTO_RWLOCK *lock)
 {
 #if (!defined(OSSL_USE_INTERLOCKEDOR64))
-    OPENSSL_assert(lock != NULL);
-    if (!CRYPTO_THREAD_write_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val &= op;
     *ret = *val;
@@ -672,8 +669,7 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
     CRYPTO_RWLOCK *lock)
 {
 #if (!defined(OSSL_USE_INTERLOCKEDOR64))
-    OPENSSL_assert(lock != NULL);
-    if (!CRYPTO_THREAD_write_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val |= op;
     *ret = *val;
@@ -691,8 +687,7 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
 int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
 {
 #if (!defined(OSSL_USE_INTERLOCKEDOR64))
-    OPENSSL_assert(lock != NULL);
-    if (!CRYPTO_THREAD_read_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
         return 0;
     *ret = *val;
     if (!CRYPTO_THREAD_unlock(lock))
@@ -708,8 +703,7 @@ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock)
 {
 #if (!defined(OSSL_USE_INTERLOCKEDOR64))
-    OPENSSL_assert(lock != NULL);
-    if (!CRYPTO_THREAD_read_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
         return 0;
     *dst = val;
     if (!CRYPTO_THREAD_unlock(lock))
@@ -725,8 +719,7 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock)
 {
 #if (!defined(OSSL_USE_INTERLOCKEDOR64))
-    OPENSSL_assert(lock != NULL);
-    if (!CRYPTO_THREAD_read_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
         return 0;
     *ret = *val;
     if (!CRYPTO_THREAD_unlock(lock))
@@ -743,8 +736,7 @@ int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_store_int(int *dst, int val, CRYPTO_RWLOCK *lock)
 {
 #if (!defined(OSSL_USE_INTERLOCKEDOR64))
-    OPENSSL_assert(lock != NULL);
-    if (!CRYPTO_THREAD_read_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
         return 0;
     *dst = val;
     if (!CRYPTO_THREAD_unlock(lock))


### PR DESCRIPTION
On a 32-bit MinGW build of current master, every binary aborts as soon as it touches
libcrypto:

```
$ ./apps/openssl.exe version
crypto/threads_win.c:694: OpenSSL internal error: assertion failed: lock != NULL
```

Nothing else is printed. `openssl version` is about the simplest call into the library
there is, so in practice nothing on this target runs at all — including the whole test
suite.

## What's happening

`crypto/threads_win.c` provides two implementations of the `CRYPTO_atomic_*` family: a
lock-free one using the `Interlocked*` intrinsics, and a fallback that takes a
`CRYPTO_RWLOCK`. The fallback is selected when `OSSL_USE_INTERLOCKEDOR64` is not defined,
which per `include/internal/threads_common.h` means MSVC 2010 and earlier on x86, or any
MinGW build that isn't `__MINGW64__` — i.e. 32-bit MinGW. The comment at
`crypto/threads_win.c:110` names exactly those two cases.

Eight functions in that fallback path currently start with:

```c
    OPENSSL_assert(lock != NULL);
```

The intent makes sense — if you're on the locking path, a caller that passes no lock has
made a mistake. But there is one caller in the tree (crypto/init.c) that passes `NULL` 
deliberately, and it documents why:

```c
    /*
     * We ignore failures from this function. It is probably because we are
     * on a platform that doesn't support lockless atomic loads (we may not
     * have created optsdone_lock yet so we can't use it). This is just an
     * optimisation to skip the full checks in this function if we don't need
     * to, so we carry on regardless in the event of failure.
     ...
     */
    if (ossl_likely(CRYPTO_atomic_load(&optsdone, &tmp, NULL))) {
```

That's function `OPENSSL_init_crypto()` in `init.c:373`. It can't pass a lock, because
`optsdone_lock` doesn't exist yet at that point — the call is a fast path that is
*expected* to fail on platforms without lockless atomics, and the failure is meant to be
ignored. Since `OPENSSL_init_crypto()` runs on essentially the first use of the library in
any process, the assert fires immediately on the affected targets.

The pthread backend has the same function and handles this case the way `init.c` expects
(`crypto/threads_pthread.c`):

```c
    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
        return 0;
```

so the difference in behaviour is specific to the Windows backend rather than a real
invariant of the API.

## The change

This PR restores the graceful `lock == NULL` check in the eight affected functions
(`CRYPTO_atomic_add`, `add64`, `and`, `or`, `load`, `store`, `load_int`, `store_int`),
matching what `threads_pthread.c` already does. Behaviour when a lock *is* supplied is
unchanged.

It comes in two commits. The first is a prerequisite: the RCU code ignores the return
value of some of these atomics, so once they gain a visible early return the compiler
reports `qp_idx`, `tmp` and `ret` as possibly uninitialised. That commit gives the three
locals initialisers; the second removes the assertions.

## Testing

Built 32-bit MinGW (`i686-w64-mingw32`, gcc 16.2.0, msvcrt, MSYS2 host), shared, on
Windows 10. Before the change all of these abort with no output; after it:

- `openssl version -a` — prints normally
- `openssl rand -hex 16` — works
- `openssl speed aes-128-cbc` — completes and reports throughput
- `test/threadstest -test test_atomic` — `ok 11 - test_atomic`

The full test suite also runs to completion afterwards, which it could not do before.

`crypto/threads_win.c` compiles warning-free with the `--strict-warnings` flag set at
both commits, so the series is clean at every point, and `clang-format` reports no
changes against the in-tree `.clang-format`.

Only master is affected — `openssl-3.5`, `openssl-3.6` and `openssl-4.0` don't carry the
commit and are fine.
