### PR TITLE
Fix has_stdin_waiting() treating an empty redirected pipe as ready

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -3704,6 +3704,22 @@ int has_stdin_waiting(void)
     peeked = PeekConsoleInput(inhand, &inputrec, insize, &events);
     if (!peeked) {
         /* Probably redirected input? _kbhit() does not work in this case */
+        if (GetFileType(inhand) == FILE_TYPE_PIPE) {
+            DWORD avail = 0;
+
+            /*
+             * For a pipe we must only report readiness when bytes are really
+             * buffered: the caller follows up with a blocking raw_read_stdin()
+             * and would otherwise hang until the writer sends something.
+             * Unlike ReadFile(), PeekNamedPipe() does not wait for data to
+             * arrive, and leaves in the pipe whatever it reports. If it fails
+             * we cannot tell what is buffered, so report ready and let the
+             * subsequent read report the condition.
+             */
+            if (!PeekNamedPipe(inhand, NULL, 0, NULL, &avail, NULL))
+                return 1;
+            return avail > 0;
+        }
         if (!feof(stdin)) {
             return 1;
         }


### PR DESCRIPTION

This is a fix for an issue found compiling openssl 3.5.8, 3.6.2 and master under Mingw 32-bits. 
`s_server` and `s_client` can hang indefinitely on Windows when their stdin is a pipe
rather than a console — they block on a read that never returns, before doing any of the
work they were started for. I believe this is the root cause of #24436 ("When building
openssl with mingw64, `make test` is hang up"), which was closed recently without a
diagnosis.

**This affects the test harness (make test).** Some tests where openssl s_server and s_client 
workers are started hang and won't continue until killed. See image below for an example:

<img width="1261" height="784" alt="image" src="https://github.com/user-attachments/assets/d83718e8-f0b4-4001-8f41-6fe6ad8248da" />

## What's happening

`has_stdin_waiting()` in `apps/lib/apps.c` first tries `PeekConsoleInput()`. That fails
whenever stdin has been redirected, which is the normal situation under the test harness
(and under any script that pipes into these apps). The fallback is:

```c
    peeked = PeekConsoleInput(inhand, &inputrec, insize, &events);
    if (!peeked) {
        /* Probably redirected input? _kbhit() does not work in this case */
        if (!feof(stdin)) {
            return 1;
        }
        return 0;
    }
```

The `feof(stdin)` test would be enough if the caller read stdin via C stdio layer, but 
these apps don't do that. They call `raw_read_stdin()`, which goes straight to
`ReadFile()` on the OS handle and never touches the `FILE *` that `feof()` inspects. So
`feof(stdin)` stays false forever and the function answers "ready" unconditionally,
whether or not a single byte is actually available.

In `s_server` that feeds directly into the Windows branch of the accept loop, which can't
`select()` on stdin and so polls this function instead:

```c
    i = select(width, (void *)&readfds, NULL, NULL, &timeout);
    if (has_stdin_waiting())
        read_from_terminal = 1;
```

`read_from_terminal` is therefore set on the very first iteration regardless of the
socket, and the loop falls through to a blocking `raw_read_stdin()`. Under the test
harness the write end of that pipe is open but idle, so the read never returns and the
connection is never accepted. `s_client` reaches the same function from its own
`has_stdin_waiting()` calls.

## A note on a false start

This is worth mentioning because the symptom is misleading. The test recipe where I first hit
this is `82-test_ocsp_cert_chain.t`, and a hung `s_server` on an OCSP-stapling test looks like if
stapling were code blocking mid-handshake, but that's not happening, since running the
server with `-status_verbose` shows that `cert_status_cb` never prints its entry line at
all. hence the handshake hasn't started yet, because the process is still stuck on stdin. That
check is what pointed at this function instead.

## The proposed change

The proposed solution is, in case we are working with a pipe, to test whether anything is 
actually buffered instead of trusting `feof(stdin)`:

```c
        if (GetFileType(inhand) == FILE_TYPE_PIPE) {
            DWORD avail = 0;

            if (!PeekNamedPipe(inhand, NULL, 0, NULL, &avail, NULL))
                return 1;
            return avail > 0;
        }
```

Unlike `ReadFile()`, `PeekNamedPipe()` does not wait for data to arrive, and it leaves in
the pipe whatever it reports. (It is still an I/O call: per the [documentation] it can
block on a synchronous handle in a multi-threaded application, but it never waits for
input that has not arrived, which is the property this needs.) If the peek fails we
cannot tell what is buffered, so report ready and let the following read report the
condition — which is what this path did before the change.

  [documentation]: <https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-peeknamedpipe>

Console input and non-pipe redirection (a plain file, which is always readable) keep the
existing behaviour; only the pipe case changes.

## Testing

Built 32-bit MinGW (`i686-w64-mingw32`, gcc 16.2.0, msvcrt, MSYS2 host) on Windows 10.

- `82-test_ocsp_cert_chain.t` previously hung and left a resident `s_server` holding its
  port; it now passes and the process exits.
- A full test suite run completes with no stranded `openssl.exe` processes left behind.

`apps/lib/apps.c` compiles warning-free with the `--strict-warnings` flag set, and
`clang-format` reports no changes against the in-tree `.clang-format`.

Nothing in this code path is specific to 32-bit — `has_stdin_waiting()` is guarded only by
`OPENSSL_SYS_WINDOWS` — and #24436 reports the same hang on a mingw64 build, so I'd expect
64-bit builds to be affected in the same way. I've only reproduced it on 32-bit myself.

The same code is present unchanged on `openssl-3.5` and `openssl-3.6`, so this likely
wants backporting, but I've raised it against master first.
