### PR TITLE
Explain why -crl_download could not obtain a CRL

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -29,6 +29,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/http.h>
+#include <openssl/httperr.h>
 #include <openssl/pem.h>
 #include <openssl/store.h>
 #include <openssl/pkcs12.h>
@@ -447,6 +448,30 @@ CONF *app_load_config_modules(const char *configfile)
 #define IS_HTTP(uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTP_PREFIX))
 #define IS_HTTPS(uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTPS_PREFIX))
 
+static int is_missing_asn1_encoding(unsigned long err)
+{
+    return ERR_GET_LIB(err) == ERR_LIB_HTTP
+        && ERR_GET_REASON(err) == HTTP_R_MISSING_ASN1_ENCODING;
+}
+
+/*
+ * Report why an HTTP download of an ASN.1 object failed. A non-DER response,
+ * typically a PEM file served at the URI, is easy to miss in the raw error
+ * queue, so state it plainly.
+ */
+static void print_http_load_error(const char *desc, const char *uri)
+{
+    /* the content error gets wrapped in a generic one, so check both ends */
+    int not_der = is_missing_asn1_encoding(ERR_peek_error())
+        || is_missing_asn1_encoding(ERR_peek_last_error());
+
+    ERR_print_errors(bio_err);
+    BIO_printf(bio_err, "Unable to load %s from %s\n", desc, uri);
+    if (not_der)
+        BIO_printf(bio_err,
+            "The HTTP response was not a DER-encoded ASN.1 SEQUENCE\n");
+}
+
 X509 *load_cert_pass(const char *uri, int format, int maybe_stdin,
     const char *pass, const char *desc)
 {
@@ -458,10 +483,8 @@ X509 *load_cert_pass(const char *uri, int format, int maybe_stdin,
         BIO_printf(bio_err, "Loading %s over HTTPS is unsupported\n", desc);
     } else if (IS_HTTP(uri)) {
         cert = X509_load_http(uri, NULL, NULL, 0 /* timeout */);
-        if (cert == NULL) {
-            ERR_print_errors(bio_err);
-            BIO_printf(bio_err, "Unable to load %s from %s\n", desc, uri);
-        }
+        if (cert == NULL)
+            print_http_load_error(desc, uri);
     } else {
         (void)load_key_certs_crls(uri, format, maybe_stdin, pass, desc, 0,
             NULL, NULL, NULL, &cert, NULL, NULL, NULL, NULL);
@@ -480,10 +503,8 @@ X509_CRL *load_crl(const char *uri, int format, int maybe_stdin,
         BIO_printf(bio_err, "Loading %s over HTTPS is unsupported\n", desc);
     } else if (IS_HTTP(uri)) {
         crl = X509_CRL_load_http(uri, NULL, NULL, 0 /* timeout */);
-        if (crl == NULL) {
-            ERR_print_errors(bio_err);
-            BIO_printf(bio_err, "Unable to load %s from %s\n", desc, uri);
-        }
+        if (crl == NULL)
+            print_http_load_error(desc, uri);
     } else {
         (void)load_key_certs_crls(uri, format, maybe_stdin, NULL, desc, 0,
             NULL, NULL, NULL, NULL, NULL, &crl, NULL, NULL);
@@ -2838,12 +2859,38 @@ static char *get_dp_url(DIST_POINT *dp)
     return NULL;
 }
 
+/* List the URIs contained in a CRLDP; returns the number of URIs printed */
+static int print_dp_urls(STACK_OF(DIST_POINT) *crldp)
+{
+    int i, j, gtype, n = 0;
+
+    for (i = 0; i < sk_DIST_POINT_num(crldp); i++) {
+        DIST_POINT *dp = sk_DIST_POINT_value(crldp, i);
+        GENERAL_NAMES *gens;
+
+        if (dp->distpoint == NULL || dp->distpoint->type != 0)
+            continue;
+        gens = dp->distpoint->name.fullname;
+        for (j = 0; j < sk_GENERAL_NAME_num(gens); j++) {
+            GENERAL_NAME *gen = sk_GENERAL_NAME_value(gens, j);
+            ASN1_STRING *uri = GENERAL_NAME_get0_value(gen, &gtype);
+
+            if (gtype != GEN_URI)
+                continue;
+            BIO_printf(bio_err, "  %.*s\n", (int)ASN1_STRING_get_length(uri),
+                (const char *)ASN1_STRING_get0_data(uri));
+            n++;
+        }
+    }
+    return n;
+}
+
 /*
  * Look through a CRLDP structure and attempt to find an http URL to
  * downloads a CRL from.
  */
 
-static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp)
+static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp, const char *desc)
 {
     int i;
     char *urlptr = NULL;
@@ -2853,13 +2900,31 @@ static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp)
 
         urlptr = get_dp_url(dp);
         if (urlptr != NULL) {
-            X509_CRL *crl = load_crl(urlptr, FORMAT_UNDEF, 0, "CRL via CDP");
+            X509_CRL *crl = load_crl(urlptr, FORMAT_UNDEF, 0, desc);
 
             OPENSSL_free(urlptr);
             return crl;
         }
     }
+    if (sk_DIST_POINT_num(crldp) > 0) {
+        BIO_printf(bio_err,
+            "No http:// URI among the distribution points to load the %s from\n",
+            desc);
+        if (print_dp_urls(crldp) == 0)
+            BIO_printf(bio_err, "  (the distribution points contain no URI)\n");
+    }
     return NULL;
+}
+
+/* Warn if a downloaded CRL is unusable because it was issued by another CA */
+static void check_crl_issuer(const X509_CRL *crl, const X509_NAME *nm,
+    const char *desc)
+{
+    if (nm == NULL || X509_NAME_cmp(X509_CRL_get_issuer(crl), nm) == 0)
+        return;
+    BIO_printf(bio_err, "The %s was issued by a different CA\n", desc);
+    print_name(bio_err, "  CRL issuer:      ", X509_CRL_get_issuer(crl));
+    print_name(bio_err, "  expected issuer: ", nm);
 }
 
 /*
@@ -2880,19 +2945,27 @@ static STACK_OF(X509_CRL) *crls_http_cb(const X509_STORE_CTX *ctx,
         return NULL;
     x = X509_STORE_CTX_get_current_cert(ctx);
     crldp = X509_get_ext_d2i(x, NID_crl_distribution_points, NULL, NULL);
-    crl = load_crl_crldp(crldp);
+    if (crldp == NULL)
+        print_name(bio_err,
+            "Cannot download CRL: no distribution point in cert with subject=",
+            X509_get_subject_name(x));
+    crl = load_crl_crldp(crldp, "CRL via CDP");
     sk_DIST_POINT_pop_free(crldp, DIST_POINT_free);
 
     if (crl == NULL || !sk_X509_CRL_push(crls, crl))
         goto error;
+    check_crl_issuer(crl, nm, "CRL via CDP");
 
     /* Try to download delta CRL */
     crldp = X509_get_ext_d2i(x, NID_freshest_crl, NULL, NULL);
-    crl = load_crl_crldp(crldp);
+    crl = load_crl_crldp(crldp, "delta CRL via CDP");
     sk_DIST_POINT_pop_free(crldp, DIST_POINT_free);
 
-    if (crl != NULL && !sk_X509_CRL_push(crls, crl))
-        goto error;
+    if (crl != NULL) {
+        if (!sk_X509_CRL_push(crls, crl))
+            goto error;
+        check_crl_issuer(crl, nm, "delta CRL via CDP");
+    }
 
     return crls;
 

--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -70,7 +70,7 @@ EOF
              "-out", $crl]));
 }
 
-plan tests => 222;
+plan tests => 223;
 
 # Canonical success
 ok(verify("ee-cert", "sslserver", ["root-cert"], ["ca-cert"]),
@@ -717,6 +717,18 @@ ok(!run(app(["openssl", "verify", "-auth_level", "1",
                <$fh>
            }),
    "Delta CRL with onlySomeReasons is not accepted as complete CRL");
+
+# -crl_download must say why no CRL could be obtained
+my $no_cdp_stderr = "crl-download-no-cdp.err";
+ok(!run(app(["openssl", "verify", "-auth_level", "1",
+             "-trusted", srctop_file(@certspath, "root-cert.pem"),
+             "-untrusted", srctop_file(@certspath, "ca-cert.pem"),
+             "-crl_check", "-crl_download",
+             srctop_file(@certspath, "ee-cert.pem")],
+            stderr => $no_cdp_stderr))
+   && grep(/no distribution point/,
+           do { open my $fh, '<', $no_cdp_stderr; <$fh> }),
+   "-crl_download reports missing CRL distribution point");
 
 # CAstore option
 my $rootcertname = "root-cert";


### PR DESCRIPTION
Fixes #8581

When `openssl verify -crl_check -crl_download` cannot get a CRL, the only output today is `error 3 at 0 depth lookup: unable to get certificate CRL`, which gives the user nothing to act on. The original report was caused by a CDP serving a PEM-encoded CRL; a later comment on the issue adds the case of a CRL whose issuer does not match the certificate's issuer.

This makes the apps' `lookup_crls` callback report the reason:

* the certificate carries no CRL distribution point at all;
* none of the distribution points offers an `http://` URI — the URIs that *are* present are listed, so an `ldap://` or `https://` CDP becomes visible;
* the downloaded CRL was issued by a different CA than the certificate, so the verifier silently discards it (both names are printed);
* the response body does not begin with an ASN.1 SEQUENCE tag, so it cannot be a DER-encoded CRL or certificate. This is what happens when a CDP serves a PEM CRL, or when a proxy returns an HTML error page with a 200 status. Previously it surfaced only as `missing asn1 encoding` buried in an error dump.

### Before

```
$ openssl verify -crl_check -crl_download -CAfile ca.pem leaf.pem
...:error:1E80006E:HTTP routines:OSSL_HTTP_REQ_CTX_nbio:missing asn1 encoding:...
...:error:1E800067:HTTP routines:OSSL_HTTP_REQ_CTX_exchange:error receiving:...
Unable to load CRL via CDP from http://127.0.0.1:18581/crl
CN=leaf-with-cdp
error 3 at 0 depth lookup: unable to get certificate CRL
error leaf.pem: verification failed
```

and in the other three cases below, nothing at all beyond the `unable to get certificate CRL` line.

### After

PEM CRL at the CDP:

```
...:error:1E80006E:HTTP routines:OSSL_HTTP_REQ_CTX_nbio:missing asn1 encoding:...
...:error:1E800067:HTTP routines:OSSL_HTTP_REQ_CTX_exchange:error receiving:...
Unable to load CRL via CDP from http://127.0.0.1:18581/crl
The HTTP response was not a DER-encoded ASN.1 SEQUENCE
```

CRL issued by a different CA:

```
The CRL via CDP was issued by a different CA
  CRL issuer:      CN=Other Root CA
  expected issuer: CN=Test Root CA
```

No CDP in the certificate:

```
Cannot download CRL: no distribution point in cert with subject=CN=leaf-with-cdp
```

Only a non-HTTP CDP:

```
No http:// URI among the distribution points to load the CRL via CDP from
  ldap://ldap.example.com/cn=deltacrl
```

### Testing

`make test` passes in full (394 files, 4639 tests). A regression test for the missing-CDP diagnostic is added to `25-test_verify.t`; it needs no network. The other four cases above were verified by hand against a throwaway PKI and a local HTTP server, since exercising them in the test suite would need a CRL-serving HTTP server.

### Not addressed here

While testing this I found a separate pre-existing problem: if the CDP host refuses the connection, `openssl verify -crl_download` hangs forever instead of failing. `BIO_do_connect_retry()` treats `BIO_R_CONNECT_ERROR` as retryable, and with `timeout == 0` (what the apps pass for CRL/cert downloads) `bio_wait()` does not actually wait, so it becomes a tight retry loop. This reproduces on 3.5.7 as well. It felt like a distinct change from the diagnostics work here, so I left it out — happy to open a separate issue or PR for it if that is useful.

### Checklist
- [ ] documentation is added or updated
- [x] tests are added or updated

---

Written by Claude (Anthropic's Claude Opus 5) via Claude Code, reviewed and tested by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)