### PR TITLE
Reset verify_result for all CMS SignerInfos on verification failure

### DIFF
--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -535,8 +535,15 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
     else
         ret = n == scount; /* All must be successful */
 err:
+    /*
+     * On failure no signature must be reported as verified.  Iterate over all
+     * SignerInfos, not just the first 'scount': when we bail out early because
+     * a signer certificate could not be found, 'scount' is smaller than the
+     * number of signers and the trailing ones would otherwise keep the
+     * verify_result = 1 ("so far, fine") set in the init loop above.
+     */
     if (!ret)
-        for (i = 0; i < scount; i++)
+        for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++)
             sk_CMS_SignerInfo_value(sinfos, i)->verify_result = 0;
     if (!(flags & SMIME_BINARY) && dcont) {
         do_free_upto(cmsbio, tmpout);

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -355,8 +355,19 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
     int cadesVerify = (flags & CMS_CADES) != 0;
     const CMS_CTX *ctx = ossl_cms_get0_cmsctx(cms);
 
-    if (dcont == NULL && !check_content(cms))
+    if (dcont == NULL && !check_content(cms)) {
+        /*
+         * A CMS_ContentInfo can be verified more than once (e.g. retried
+         * with a different store).  If a previous call left verify_result
+         * == 1 ("so far, fine") on any SignerInfo, this early failure must
+         * still be reflected there instead of silently keeping the stale
+         * "verified" state from the earlier call.
+         */
+        sinfos = CMS_get0_SignerInfos(cms);
+        for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++)
+            sk_CMS_SignerInfo_value(sinfos, i)->verify_result = 0;
         return 0;
+    }
     if (dcont != NULL && !(flags & CMS_BINARY)) {
         const ASN1_OBJECT *coid = CMS_get0_eContentType(cms);
 
@@ -468,7 +479,13 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
         tmpin = (len == 0) ? dcont : BIO_new_mem_buf(ptr, len);
         if (tmpin == NULL) {
             ERR_raise(ERR_LIB_CMS, ERR_R_BIO_LIB);
-            goto err2;
+            /*
+             * goto err, not err2: cmsbio/tmpout are still NULL here, so the
+             * err-label cleanup is safe, and this must go through the
+             * verify_result reset loop at err (ret is still 0) instead of
+             * bypassing it via err2.
+             */
+            goto err;
         }
     } else {
         tmpin = dcont;

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -359,13 +359,19 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
         /*
          * A CMS_ContentInfo can be verified more than once (e.g. retried
          * with a different store).  If a previous call left verify_result
-         * == 1 ("so far, fine") on any SignerInfo, this early failure must
-         * still be reflected there instead of silently keeping the stale
-         * "verified" state from the earlier call.
+         * == 1 ("so far, fine") or any of the *_verified flags set on a
+         * SignerInfo, this early failure must still be reflected there
+         * instead of silently keeping the stale "verified" state from the
+         * earlier call.
          */
         sinfos = CMS_get0_SignerInfos(cms);
-        for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++)
-            sk_CMS_SignerInfo_value(sinfos, i)->verify_result = 0;
+        for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
+            si = sk_CMS_SignerInfo_value(sinfos, i);
+            si->verify_result = 0;
+            si->cert_verified = 0;
+            si->attr_verified = 0;
+            si->content_verified = 0;
+        }
         return 0;
     }
     if (dcont != NULL && !(flags & CMS_BINARY)) {
@@ -558,9 +564,15 @@ err:
      * number of signers and the trailing ones would otherwise keep the
      * verify_result = 1 ("so far, fine") set in the init loop above.
      */
-    if (!ret)
-        for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++)
-            sk_CMS_SignerInfo_value(sinfos, i)->verify_result = 0;
+    if (!ret) {
+        for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
+            si = sk_CMS_SignerInfo_value(sinfos, i);
+            si->verify_result = 0;
+            si->cert_verified = 0;
+            si->attr_verified = 0;
+            si->content_verified = 0;
+        }
+    }
     if (!(flags & SMIME_BINARY) && dcont) {
         do_free_upto(cmsbio, tmpout);
         if (tmpin != dcont)

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -480,10 +480,9 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
         if (tmpin == NULL) {
             ERR_raise(ERR_LIB_CMS, ERR_R_BIO_LIB);
             /*
-             * goto err, not err2: cmsbio/tmpout are still NULL here, so the
-             * err-label cleanup is safe, and this must go through the
-             * verify_result reset loop at err (ret is still 0) instead of
-             * bypassing it via err2.
+             * cmsbio/tmpout are still NULL here, so the err-label cleanup is
+             * safe, and this must go through the verify_result reset loop at
+             * err (ret is still 0) rather than skipping it.
              */
             goto err;
         }
@@ -578,7 +577,6 @@ err:
     if (out != tmpout)
         BIO_free_all(tmpout);
 
-err2:
     if (si_chains != NULL) {
         for (i = 0; i < scount; ++i)
             OSSL_STACK_OF_X509_free(si_chains[i]);

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -12,6 +12,7 @@
 #include <openssl/pem.h>
 #include <openssl/cms.h>
 #include <openssl/bio.h>
+#include <openssl/err.h>
 #include <openssl/x509.h>
 #include "../crypto/cms/cms_local.h" /* for d.signedData and d.envelopedData */
 
@@ -327,6 +328,79 @@ static int test_CMS_add1_cert(void)
         && TEST_true(CMS_add1_cert(cms, cert)); /* add cert again */
 
     CMS_ContentInfo_free(cms);
+    return ret;
+}
+
+/*
+ * Regression test for GH #32612: when CMS_verify() bails out early because a
+ * signer certificate cannot be found, every SignerInfo must report
+ * CMS_VERIFY_RESULT == 0.  A two-signer message with no embedded certificates,
+ * verified against an empty store, used to leave the trailing signer(s) at 1
+ * ("so far, fine") because the cleanup loop only reset the first 'scount'
+ * (== signers whose cert was found == 0 here) entries.
+ */
+static int test_CMS_verify_result_no_signer_cert(void)
+{
+    CMS_ContentInfo *cms = NULL, *cms2 = NULL;
+    BIO *in = NULL, *out = NULL, *der = NULL;
+    X509_STORE *store = NULL;
+    STACK_OF(CMS_SignerInfo) *sinfos;
+    const unsigned char *p;
+    unsigned char *derbuf = NULL;
+    long derlen;
+    int i, ret = 0;
+
+    if (!TEST_ptr(in = BIO_new_mem_buf("Hello World\n", -1))
+            || !TEST_ptr(out = BIO_new(BIO_s_mem()))
+            || !TEST_ptr(der = BIO_new(BIO_s_mem()))
+            || !TEST_ptr(store = X509_STORE_new()))
+        goto end;
+
+    /* two signers, neither certificate embedded */
+    if (!TEST_ptr(cms = CMS_sign(NULL, NULL, NULL, in,
+                                 CMS_BINARY | CMS_PARTIAL | CMS_NOCERTS))
+            || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
+            || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
+            || !TEST_true(CMS_final(cms, in, NULL, CMS_BINARY)))
+        goto end;
+
+    /* round-trip through DER so no in-memory signer cert pointers linger */
+    if (!TEST_true(i2d_CMS_bio(der, cms)))
+        goto end;
+    derlen = BIO_get_mem_data(der, &derbuf);
+    p = derbuf;
+    if (!TEST_ptr(cms2 = d2i_CMS_ContentInfo(NULL, &p, derlen)))
+        goto end;
+
+    ERR_clear_error();
+    if (!TEST_int_eq(CMS_verify(cms2, NULL, store, NULL, out,
+                                CMS_BINARY | CMS_VERIFY_PARTIAL), 0)
+            || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+                            CMS_R_SIGNER_CERTIFICATE_NOT_FOUND))
+        goto end;
+
+    sinfos = CMS_get0_SignerInfos(cms2);
+    if (!TEST_int_eq(sk_CMS_SignerInfo_num(sinfos), 2))
+        goto end;
+    for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
+        CMS_SignerInfo *si = sk_CMS_SignerInfo_value(sinfos, i);
+
+        if (!TEST_int_eq(CMS_SignerInfo_get_verification_result(si,
+                             CMS_VERIFY_RESULT), 0)
+                || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si,
+                                    CMS_VERIFY_CERT), 0))
+            goto end;
+    }
+
+    ret = 1;
+end:
+    ERR_clear_error();
+    CMS_ContentInfo_free(cms);
+    CMS_ContentInfo_free(cms2);
+    X509_STORE_free(store);
+    BIO_free(in);
+    BIO_free(out);
+    BIO_free(der);
     return ret;
 }
 
@@ -1000,6 +1074,7 @@ int setup_tests(void)
     ADD_TEST(test_short_mac_on_auth_envelope_data);
     ADD_TEST(test_CMS_add_standard_smimecap_ex);
     ADD_TEST(test_CMS_add1_cert);
+    ADD_TEST(test_CMS_verify_result_no_signer_cert);
     ADD_TEST(test_d2i_CMS_bio_NULL);
     ADD_TEST(test_CMS_set1_key_mem_leak);
     ADD_TEST(test_encrypted_data);

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -404,6 +404,167 @@ end:
     return ret;
 }
 
+/* self-signed throwaway cert for the second signer in the test below */
+static X509 *make_self_signed_cert(EVP_PKEY *pkey, const char *cn)
+{
+    X509 *newcert = NULL, *ret = NULL;
+    X509_NAME *name = NULL;
+    ASN1_INTEGER *serial = NULL;
+
+    if (!TEST_ptr(newcert = X509_new())
+            || !TEST_true(X509_set_version(newcert, X509_VERSION_3)))
+        goto err;
+
+    if (!TEST_ptr(serial = ASN1_INTEGER_new())
+            || !TEST_true(ASN1_INTEGER_set(serial, 1))
+            || !TEST_true(X509_set_serialNumber(newcert, serial)))
+        goto err;
+
+    if (!TEST_ptr(X509_gmtime_adj(X509_getm_notBefore(newcert), 0))
+            || !TEST_ptr(X509_gmtime_adj(X509_getm_notAfter(newcert),
+                                          60L * 60L * 24L * 365L)))
+        goto err;
+
+    if (!TEST_true(X509_set_pubkey(newcert, pkey)))
+        goto err;
+
+    if (!TEST_ptr(name = X509_NAME_new())
+            || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                              (const unsigned char *)cn, -1, -1, 0))
+            || !TEST_true(X509_set_subject_name(newcert, name))
+            || !TEST_true(X509_set_issuer_name(newcert, name)))
+        goto err;
+
+    if (!TEST_int_gt(X509_sign(newcert, pkey, EVP_sha256()), 0))
+        goto err;
+
+    ret = newcert;
+    newcert = NULL;
+err:
+    X509_free(newcert);
+    X509_NAME_free(name);
+    ASN1_INTEGER_free(serial);
+    return ret;
+}
+
+/*
+ * Companion to test_CMS_verify_result_no_signer_cert() above: covers the
+ * mixed case (scount == 1) that test leaves untested, per review feedback
+ * on PR #32643 (https://github.com/openssl/openssl/pull/32643) -- a
+ * two-signer message where only *one* signer's certificate is available at
+ * verification time.  Before the fix this signer's own verify_result would
+ * be reset by the >= scount cleanup loop, but the point of covering
+ * scount == 1 explicitly is to pin down that the *other*, cert-missing
+ * signer is not left at verify_result == 1 by an off-by-something in the
+ * boundary.  Also checks that supplying both certs makes CMS_verify()
+ * succeed, as requested in review.
+ */
+static int test_CMS_verify_result_partial_signer_cert(void)
+{
+    CMS_ContentInfo *cms = NULL, *cms2 = NULL;
+    BIO *in = NULL, *out = NULL, *der = NULL;
+    X509_STORE *store = NULL;
+    EVP_PKEY *pkey2 = NULL;
+    X509 *cert2 = NULL;
+    STACK_OF(X509) *both_certs = NULL;
+    STACK_OF(CMS_SignerInfo) *sinfos;
+    const unsigned char *p;
+    unsigned char *derbuf = NULL;
+    long derlen;
+    int i, found_verified = 0, found_unverified = 0, ret = 0;
+
+    if (!TEST_ptr(in = BIO_new_mem_buf("Hello World\n", -1))
+            || !TEST_ptr(out = BIO_new(BIO_s_mem()))
+            || !TEST_ptr(der = BIO_new(BIO_s_mem()))
+            || !TEST_ptr(store = X509_STORE_new())
+            || !TEST_ptr(both_certs = sk_X509_new_null()))
+        goto end;
+
+    if (!TEST_ptr(pkey2 = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", 2048))
+            || !TEST_ptr(cert2 = make_self_signed_cert(pkey2, "second-signer")))
+        goto end;
+
+    /* two signers with two *different* certs, neither embedded */
+    if (!TEST_ptr(cms = CMS_sign(NULL, NULL, NULL, in,
+                                 CMS_BINARY | CMS_PARTIAL | CMS_NOCERTS))
+            || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
+            || !TEST_ptr(CMS_add1_signer(cms, cert2, pkey2, NULL, CMS_NOCERTS))
+            || !TEST_true(CMS_final(cms, in, NULL, CMS_BINARY)))
+        goto end;
+
+    /* round-trip through DER so no in-memory signer cert pointers linger */
+    if (!TEST_true(i2d_CMS_bio(der, cms)))
+        goto end;
+    derlen = BIO_get_mem_data(der, &derbuf);
+    p = derbuf;
+    if (!TEST_ptr(cms2 = d2i_CMS_ContentInfo(NULL, &p, derlen)))
+        goto end;
+
+    /* only 'cert' (the 1st signer's) is supplied -> scount == 1, not 0 or 2 */
+    if (!TEST_int_ge(sk_X509_push(both_certs, cert), 1))
+        goto end;
+
+    ERR_clear_error();
+    if (!TEST_int_eq(CMS_verify(cms2, both_certs, store, NULL, out,
+                                CMS_BINARY | CMS_VERIFY_PARTIAL), 0)
+            || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+                            CMS_R_SIGNER_CERTIFICATE_NOT_FOUND))
+        goto end;
+
+    sinfos = CMS_get0_SignerInfos(cms2);
+    if (!TEST_int_eq(sk_CMS_SignerInfo_num(sinfos), 2))
+        goto end;
+    /*
+     * Neither signer must report success: CMS_verify() overall failed with
+     * CMS_R_SIGNER_CERTIFICATE_NOT_FOUND before any content/attr verification
+     * ran, so both entries must still be at verify_result == 0, regardless
+     * of whether that particular signer's own cert was found.
+     */
+    for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
+        CMS_SignerInfo *si = sk_CMS_SignerInfo_value(sinfos, i);
+
+        if (!TEST_int_eq(CMS_SignerInfo_get_verification_result(si,
+                             CMS_VERIFY_RESULT), 0))
+            goto end;
+    }
+
+    /* now supply both certs: verification of both signers must succeed */
+    if (!TEST_int_ge(sk_X509_push(both_certs, cert2), 1))
+        goto end;
+
+    ERR_clear_error();
+    if (!TEST_int_eq(CMS_verify(cms2, both_certs, store, NULL, out,
+                                CMS_BINARY | CMS_VERIFY_PARTIAL), 1))
+        goto end;
+
+    for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
+        CMS_SignerInfo *si = sk_CMS_SignerInfo_value(sinfos, i);
+        int r = CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_RESULT);
+
+        if (r)
+            found_verified++;
+        else
+            found_unverified++;
+    }
+    if (!TEST_int_eq(found_verified, 2) || !TEST_int_eq(found_unverified, 0))
+        goto end;
+
+    ret = 1;
+end:
+    ERR_clear_error();
+    CMS_ContentInfo_free(cms);
+    CMS_ContentInfo_free(cms2);
+    X509_STORE_free(store);
+    /* both_certs does not own cert/cert2 (no _UP_REF push), just free the stack */
+    sk_X509_free(both_certs);
+    X509_free(cert2);
+    EVP_PKEY_free(pkey2);
+    BIO_free(in);
+    BIO_free(out);
+    BIO_free(der);
+    return ret;
+}
+
 static int test_CMS_add1_signer_ed448(const EVP_MD *md, unsigned int flags,
     int expect_success)
 {
@@ -1075,6 +1236,7 @@ int setup_tests(void)
     ADD_TEST(test_CMS_add_standard_smimecap_ex);
     ADD_TEST(test_CMS_add1_cert);
     ADD_TEST(test_CMS_verify_result_no_signer_cert);
+    ADD_TEST(test_CMS_verify_result_partial_signer_cert);
     ADD_TEST(test_d2i_CMS_bio_NULL);
     ADD_TEST(test_CMS_set1_key_mem_leak);
     ADD_TEST(test_encrypted_data);

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -483,7 +483,7 @@ static int test_CMS_verify_result_partial_signer_cert(void)
         || !TEST_ptr(both_certs = sk_X509_new_null()))
         goto end;
 
-    if (!TEST_ptr(pkey2 = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", 2048))
+    if (!TEST_ptr(pkey2 = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
         || !TEST_ptr(cert2 = make_self_signed_cert(pkey2, "second-signer")))
         goto end;
 
@@ -539,7 +539,8 @@ static int test_CMS_verify_result_partial_signer_cert(void)
 
     ERR_clear_error();
     if (!TEST_int_eq(CMS_verify(cms2, both_certs, store, NULL, out,
-                         CMS_BINARY | CMS_VERIFY_PARTIAL),
+                         CMS_BINARY | CMS_VERIFY_PARTIAL
+                               | CMS_NO_SIGNER_CERT_VERIFY),
             1))
         goto end;
 
@@ -557,7 +558,6 @@ static int test_CMS_verify_result_partial_signer_cert(void)
 
     ret = 1;
 end:
-    ERR_clear_error();
     CMS_ContentInfo_free(cms);
     CMS_ContentInfo_free(cms2);
     X509_STORE_free(store);

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -351,17 +351,17 @@ static int test_CMS_verify_result_no_signer_cert(void)
     int i, ret = 0;
 
     if (!TEST_ptr(in = BIO_new_mem_buf("Hello World\n", -1))
-            || !TEST_ptr(out = BIO_new(BIO_s_mem()))
-            || !TEST_ptr(der = BIO_new(BIO_s_mem()))
-            || !TEST_ptr(store = X509_STORE_new()))
+        || !TEST_ptr(out = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(der = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(store = X509_STORE_new()))
         goto end;
 
     /* two signers, neither certificate embedded */
     if (!TEST_ptr(cms = CMS_sign(NULL, NULL, NULL, in,
-                                 CMS_BINARY | CMS_PARTIAL | CMS_NOCERTS))
-            || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
-            || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
-            || !TEST_true(CMS_final(cms, in, NULL, CMS_BINARY)))
+                      CMS_BINARY | CMS_PARTIAL | CMS_NOCERTS))
+        || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
+        || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
+        || !TEST_true(CMS_final(cms, in, NULL, CMS_BINARY)))
         goto end;
 
     /* round-trip through DER so no in-memory signer cert pointers linger */
@@ -374,9 +374,10 @@ static int test_CMS_verify_result_no_signer_cert(void)
 
     ERR_clear_error();
     if (!TEST_int_eq(CMS_verify(cms2, NULL, store, NULL, out,
-                                CMS_BINARY | CMS_VERIFY_PARTIAL), 0)
-            || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
-                            CMS_R_SIGNER_CERTIFICATE_NOT_FOUND))
+                         CMS_BINARY | CMS_VERIFY_PARTIAL),
+            0)
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+            CMS_R_SIGNER_CERTIFICATE_NOT_FOUND))
         goto end;
 
     sinfos = CMS_get0_SignerInfos(cms2);
@@ -386,9 +387,11 @@ static int test_CMS_verify_result_no_signer_cert(void)
         CMS_SignerInfo *si = sk_CMS_SignerInfo_value(sinfos, i);
 
         if (!TEST_int_eq(CMS_SignerInfo_get_verification_result(si,
-                             CMS_VERIFY_RESULT), 0)
-                || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si,
-                                    CMS_VERIFY_CERT), 0))
+                             CMS_VERIFY_RESULT),
+                0)
+            || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si,
+                                CMS_VERIFY_CERT),
+                0))
             goto end;
     }
 
@@ -412,27 +415,27 @@ static X509 *make_self_signed_cert(EVP_PKEY *pkey, const char *cn)
     ASN1_INTEGER *serial = NULL;
 
     if (!TEST_ptr(newcert = X509_new())
-            || !TEST_true(X509_set_version(newcert, X509_VERSION_3)))
+        || !TEST_true(X509_set_version(newcert, X509_VERSION_3)))
         goto err;
 
     if (!TEST_ptr(serial = ASN1_INTEGER_new())
-            || !TEST_true(ASN1_INTEGER_set(serial, 1))
-            || !TEST_true(X509_set_serialNumber(newcert, serial)))
+        || !TEST_true(ASN1_INTEGER_set(serial, 1))
+        || !TEST_true(X509_set_serialNumber(newcert, serial)))
         goto err;
 
     if (!TEST_ptr(X509_gmtime_adj(X509_getm_notBefore(newcert), 0))
-            || !TEST_ptr(X509_gmtime_adj(X509_getm_notAfter(newcert),
-                                          60L * 60L * 24L * 365L)))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notAfter(newcert),
+            60L * 60L * 24L * 365L)))
         goto err;
 
     if (!TEST_true(X509_set_pubkey(newcert, pkey)))
         goto err;
 
     if (!TEST_ptr(name = X509_NAME_new())
-            || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
-                              (const unsigned char *)cn, -1, -1, 0))
-            || !TEST_true(X509_set_subject_name(newcert, name))
-            || !TEST_true(X509_set_issuer_name(newcert, name)))
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)cn, -1, -1, 0))
+        || !TEST_true(X509_set_subject_name(newcert, name))
+        || !TEST_true(X509_set_issuer_name(newcert, name)))
         goto err;
 
     if (!TEST_int_gt(X509_sign(newcert, pkey, EVP_sha256()), 0))
@@ -474,22 +477,22 @@ static int test_CMS_verify_result_partial_signer_cert(void)
     int i, found_verified = 0, found_unverified = 0, ret = 0;
 
     if (!TEST_ptr(in = BIO_new_mem_buf("Hello World\n", -1))
-            || !TEST_ptr(out = BIO_new(BIO_s_mem()))
-            || !TEST_ptr(der = BIO_new(BIO_s_mem()))
-            || !TEST_ptr(store = X509_STORE_new())
-            || !TEST_ptr(both_certs = sk_X509_new_null()))
+        || !TEST_ptr(out = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(der = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(store = X509_STORE_new())
+        || !TEST_ptr(both_certs = sk_X509_new_null()))
         goto end;
 
     if (!TEST_ptr(pkey2 = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", 2048))
-            || !TEST_ptr(cert2 = make_self_signed_cert(pkey2, "second-signer")))
+        || !TEST_ptr(cert2 = make_self_signed_cert(pkey2, "second-signer")))
         goto end;
 
     /* two signers with two *different* certs, neither embedded */
     if (!TEST_ptr(cms = CMS_sign(NULL, NULL, NULL, in,
-                                 CMS_BINARY | CMS_PARTIAL | CMS_NOCERTS))
-            || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
-            || !TEST_ptr(CMS_add1_signer(cms, cert2, pkey2, NULL, CMS_NOCERTS))
-            || !TEST_true(CMS_final(cms, in, NULL, CMS_BINARY)))
+                      CMS_BINARY | CMS_PARTIAL | CMS_NOCERTS))
+        || !TEST_ptr(CMS_add1_signer(cms, cert, privkey, NULL, CMS_NOCERTS))
+        || !TEST_ptr(CMS_add1_signer(cms, cert2, pkey2, NULL, CMS_NOCERTS))
+        || !TEST_true(CMS_final(cms, in, NULL, CMS_BINARY)))
         goto end;
 
     /* round-trip through DER so no in-memory signer cert pointers linger */
@@ -506,9 +509,10 @@ static int test_CMS_verify_result_partial_signer_cert(void)
 
     ERR_clear_error();
     if (!TEST_int_eq(CMS_verify(cms2, both_certs, store, NULL, out,
-                                CMS_BINARY | CMS_VERIFY_PARTIAL), 0)
-            || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
-                            CMS_R_SIGNER_CERTIFICATE_NOT_FOUND))
+                         CMS_BINARY | CMS_VERIFY_PARTIAL),
+            0)
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+            CMS_R_SIGNER_CERTIFICATE_NOT_FOUND))
         goto end;
 
     sinfos = CMS_get0_SignerInfos(cms2);
@@ -524,7 +528,8 @@ static int test_CMS_verify_result_partial_signer_cert(void)
         CMS_SignerInfo *si = sk_CMS_SignerInfo_value(sinfos, i);
 
         if (!TEST_int_eq(CMS_SignerInfo_get_verification_result(si,
-                             CMS_VERIFY_RESULT), 0))
+                             CMS_VERIFY_RESULT),
+                0))
             goto end;
     }
 
@@ -534,7 +539,8 @@ static int test_CMS_verify_result_partial_signer_cert(void)
 
     ERR_clear_error();
     if (!TEST_int_eq(CMS_verify(cms2, both_certs, store, NULL, out,
-                                CMS_BINARY | CMS_VERIFY_PARTIAL), 1))
+                         CMS_BINARY | CMS_VERIFY_PARTIAL),
+            1))
         goto end;
 
     for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -571,6 +571,97 @@ end:
     return ret;
 }
 
+/*
+ * Regression test for the stale cert_verified/attr_verified/content_verified
+ * flags raised in review on PR #32643
+ * (https://github.com/openssl/openssl/pull/32643): a CMS_ContentInfo that
+ * verified successfully once (all four per-SignerInfo fields left at 1) must
+ * not keep reporting that state if it is verified again and that second
+ * call fails via the early check_content() path at the top of CMS_verify()
+ * -- reached when the content turns out to be missing and dcont is NULL.
+ */
+static int test_CMS_verify_reused_after_check_content_failure(void)
+{
+    CMS_ContentInfo *cms = NULL;
+    BIO *in = NULL, *out = NULL;
+    X509_STORE *store = NULL;
+    EVP_PKEY *pkey2 = NULL;
+    X509 *cert2 = NULL;
+    CMS_SignerInfo *si;
+    STACK_OF(CMS_SignerInfo) *sinfos;
+    ASN1_OCTET_STRING *saved_econtent = NULL;
+    int ret = 0;
+
+    /*
+     * Self-signed cert added directly to the store: chain building succeeds
+     * trivially, so the first CMS_verify() below genuinely sets
+     * cert_verified (unlike the other two tests above, which use
+     * CMS_NO_SIGNER_CERT_VERIFY and never actually exercise that field).
+     */
+    if (!TEST_ptr(in = BIO_new_mem_buf("Hello World\n", -1))
+        || !TEST_ptr(out = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(store = X509_STORE_new())
+        || !TEST_ptr(pkey2 = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(cert2 = make_self_signed_cert(pkey2, "reused-cms-signer"))
+        || !TEST_true(X509_STORE_add_cert(store, cert2)))
+        goto end;
+
+    /* one signer, cert embedded, content embedded (not detached) */
+    if (!TEST_ptr(cms = CMS_sign(cert2, pkey2, NULL, in, CMS_BINARY)))
+        goto end;
+
+    /*
+     * First verification succeeds on this exact in-memory CMS_ContentInfo
+     * (no DER round-trip): 'cert' is directly in the trust store, so
+     * verify_result, cert_verified, attr_verified and content_verified all
+     * land on 1 for the single signer.
+     */
+    ERR_clear_error();
+    if (!TEST_int_eq(CMS_verify(cms, NULL, store, NULL, out, CMS_BINARY), 1))
+        goto end;
+
+    sinfos = CMS_get0_SignerInfos(cms);
+    if (!TEST_int_eq(sk_CMS_SignerInfo_num(sinfos), 1))
+        goto end;
+    si = sk_CMS_SignerInfo_value(sinfos, 0);
+    if (!TEST_int_eq(CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_RESULT), 1)
+        || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_CERT), 1)
+        || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_ATTR), 1)
+        || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_CONTENT), 1))
+        goto end;
+
+    /*
+     * Corrupt the embedded content in place on the same, still-"verified"
+     * object so the next call takes the check_content() early-return path
+     * (dcont == NULL and no eContent) instead of the main body / err label.
+     */
+    saved_econtent = cms->d.signedData->encapContentInfo->eContent;
+    cms->d.signedData->encapContentInfo->eContent = NULL;
+
+    ERR_clear_error();
+    if (!TEST_int_eq(CMS_verify(cms, NULL, store, NULL, out, CMS_BINARY), 0))
+        goto end;
+
+    if (!TEST_int_eq(CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_RESULT), 0)
+        || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_CERT), 0)
+        || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_ATTR), 0)
+        || !TEST_int_eq(CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_CONTENT), 0))
+        goto end;
+
+    ret = 1;
+end:
+    /* put the real content back so CMS_ContentInfo_free() doesn't leak it */
+    if (cms != NULL && saved_econtent != NULL)
+        cms->d.signedData->encapContentInfo->eContent = saved_econtent;
+    CMS_ContentInfo_free(cms);
+    X509_STORE_free(store);
+    X509_free(cert2);
+    EVP_PKEY_free(pkey2);
+    BIO_free(in);
+    BIO_free(out);
+    return ret;
+}
+
 static int test_CMS_add1_signer_ed448(const EVP_MD *md, unsigned int flags,
     int expect_success)
 {
@@ -1243,6 +1334,7 @@ int setup_tests(void)
     ADD_TEST(test_CMS_add1_cert);
     ADD_TEST(test_CMS_verify_result_no_signer_cert);
     ADD_TEST(test_CMS_verify_result_partial_signer_cert);
+    ADD_TEST(test_CMS_verify_reused_after_check_content_failure);
     ADD_TEST(test_d2i_CMS_bio_NULL);
     ADD_TEST(test_CMS_set1_key_mem_leak);
     ADD_TEST(test_encrypted_data);


### PR DESCRIPTION
Fixes #32612

### Problem

After a failed `CMS_verify()` where no signer certificate could be found
(`CMS_R_SIGNER_CERTIFICATE_NOT_FOUND`), `CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_RESULT)`
still returns `1` for the signers past `scount`, telling the caller a signature
verified when it never did.

### Root cause

The cleanup at the `err:` label in `CMS_verify()` only resets `verify_result`
for the first `scount` `SignerInfo`s, where `scount` is the number of signers
whose certificate was found. On the early exit at
`CMS_R_SIGNER_CERTIFICATE_NOT_FOUND`, `scount < sk_CMS_SignerInfo_num(sinfos)`
(in the two-signer / `-nocerts` / empty-store case `scount == 0`), so the
trailing signers keep the `verify_result = 1` ("so far, fine") set in the init
loop. Every other `goto err` reaches this loop with
`scount == sk_CMS_SignerInfo_num(sinfos)`, so this is the only affected path.

Introduced by the result-reporting changes in #27604; only affects the master
branch (4.1 dev) — released branches don't have `CMS_VERIFY_PARTIAL` /
`CMS_SignerInfo_get_verification_result`, so no `CHANGES.md` entry.

### Fix

Iterate over all `SignerInfo`s in the failure cleanup. No-op for the
`NO_SIGNERS` / NULL `sinfos` paths where `sk_CMS_SignerInfo_num()` is `<= 0`.

### Test

New `test_CMS_verify_result_no_signer_cert` in `test/cmsapitest.c`: a two-signer
CMS with no embedded certificates, verified against an empty store with
`CMS_VERIFY_PARTIAL`, asserts `CMS_VERIFY_RESULT == 0` for every signer. It
fails before this change (result is `1`) and passes after. `test_cms` and
`test_cmsapi` both pass.

Thanks to @idrassi for the report and for confirming this was open to pick up.

---

Checklist:
- [x] documentation is added or updated — n/a, behaviour was never released
- [x] tests are added or updated