### PR TITLE
Do not advertise OPENSSL_INIT_LOAD_CONFIG in optsdone too soon

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -348,6 +348,7 @@ void ossl_cleanup_destructor(void)
 int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
 {
     uint64_t tmp;
+    uint64_t optsdone_bits = opts;
     int aloaddone = 0;
 
     /* Applications depend on 0 being returned when cleanup was already done */
@@ -453,8 +454,15 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
     if (opts & OPENSSL_INIT_LOAD_CONFIG) {
         int loading = CRYPTO_THREAD_get_local(&in_init_config_local) != NULL;
 
-        /* If called recursively from OBJ_ calls, just skip it. */
-        if (!loading) {
+        /* If called recursively from OBJ_ calls during config loading,
+         * we have to mask OPENSSL_INIT_LOAD_CONFIG in optsdone to not
+         * advertise that config loading is complete, otherwise other
+         * threads may proceed, e.g., to fetching from a provider that
+         * is not yet loaded.
+         */
+        if (loading) {
+            optsdone_bits &= ~(uint64_t)OPENSSL_INIT_LOAD_CONFIG;
+        } else {
             int ret;
 
             if (!CRYPTO_THREAD_set_local(&in_init_config_local, (void *)-1))
@@ -480,7 +488,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         && !RUN_ONCE(&async, ossl_init_async))
         return 0;
 
-    if (!CRYPTO_atomic_or(&optsdone, opts, &tmp, optsdone_lock))
+    if (!CRYPTO_atomic_or(&optsdone, optsdone_bits, &tmp, optsdone_lock))
         return 0;
 
     return 1;


### PR DESCRIPTION
Details in the commit message.

We've encountered this in libssh CI running on RHEL in FIPS mode. One thread would be loading the FIPS provider from the config, and other threads would try to fetch from the provider before the config loading was complete.

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
