### PR TITLE
Fix up windows paths in the build. 

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -691,10 +691,26 @@ EOF
   # (in the build tree), but quotes paths of non-generated dependencies (in the
   # source tree). This is a workaround for a limitation of C++Builder's make.exe
   # in handling quoted paths: https://quality.embarcadero.com/browse/RSP-31756
+  # Configure runs the generator script itself through cleanfile(), which
+  # yields native (backslash) paths on Windows, but the remaining generator
+  # arguments are carried over verbatim from build.info.  Arguments written
+  # as $(SRCDIR)/... or $(BLDDIR)/... therefore arrive with forward slashes;
+  # convert those to backslashes and quote them so a path containing spaces
+  # survives the shell.  Anything else is a flag or a bare file name and is
+  # left alone.
+  sub generatearg {
+      my $arg = shift;
+      if ($arg =~ /\$\((?:SRCDIR|BLDDIR)\)/) {
+          $arg =~ s|/|\\|g;
+          return "\"$arg\"";
+      }
+      return $arg;
+  }
+
   sub generatesrc {
       my %args = @_;
       my $gen0 = $args{generator}->[0];
-      my $gen_args = join('', map { " $_" }
+      my $gen_args = join('', map { " ".generatearg($_) }
                               @{$args{generator}}[1..$#{$args{generator}}]);
       my $gen_incs = join("", map { " -I\"$_\"" } @{$args{generator_incs}});
       my $incs = join("", map { " -I\"$_\"" } @{$args{incs}});

--- a/util/perl/OpenSSL/copyright.pm
+++ b/util/perl/OpenSSL/copyright.pm
@@ -8,6 +8,7 @@
 
 use strict;
 use warnings;
+use File::Spec;
 
 package OpenSSL::copyright;
 
@@ -27,8 +28,9 @@ sub year_of {
     my $YEAR = [localtime()]->[5] + 1900;
 
     # See if git's available
+    my $devnull = File::Spec->devnull();
     open my $FH,
-       "git log -1 --date=short --format=format:%cd $file 2>/dev/null|"
+       "git log -1 --date=short --format=format:%cd $file 2>$devnull|"
            or return $YEAR;
     my $LINE = <$FH> // '';
     close $FH;


### PR DESCRIPTION
Fix the args to the generator scripts to use windows slashes - apparently jom as used in CI handles this for us
but nmake (at least old versions) does not.

Use the right devnull in the git detection for copyright.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
