### PR TITLE
Fix AES-GCM tag length query and the test meant to cover it

### DIFF
--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -213,14 +213,19 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.tag != NULL) {
-        sz = p.tag->data_size;
         if (!ctx->enc || ctx->taglen == UNINITIALISED_SIZET) {
             ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
             return 0;
         }
-        if (p.tag->data != NULL && (sz > EVP_GCM_TLS_TAG_LEN || sz == 0)) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
-            return 0;
+        if (p.tag->data == NULL) {
+            /* size query: report the tag length, as for the iv above */
+            sz = ctx->taglen;
+        } else {
+            sz = p.tag->data_size;
+            if (sz > EVP_GCM_TLS_TAG_LEN || sz == 0) {
+                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
+                return 0;
+            }
         }
 
         if (!OSSL_PARAM_set_octet_string(p.tag, ctx->buf, sz)) {

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -8080,8 +8080,9 @@ static int aes_gcm_encrypt(const unsigned char *gcm_key, size_t gcm_key_s,
         || !TEST_size_t_eq(params[0].return_size, gcm_ivlen)
         || !TEST_size_t_eq(params[1].return_size, gcm_ivlen)
         || !TEST_size_t_eq(params[2].return_size, sizeof(outtag)))
+        goto err;
 
-        ret = 1;
+    ret = 1;
 err:
     EVP_CIPHER_free(cipher);
     EVP_CIPHER_CTX_free(ctx);


### PR DESCRIPTION
Querying `OSSL_CIPHER_PARAM_AEAD_TAG` with a `NULL` buffer returned a length of 0 instead of the tag length. Report `ctx->taglen` in that case, matching the IV queries.

The test had a missing `goto err`, meaning the test passed only when the assertion failed. Add the `goto`.

Both were introduced in #28232

Tagging @nhorman for review

Also tagging reviewers of the original PR @beldmit @t8m 

Assisted-by: Claude:claude-fable-5

##### Checklist
- [x] tests are added or updated
