### PR TITLE
Add a CI job to build once with Microsoft's nmake, not only jom

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -319,6 +319,52 @@ jobs:
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         jom test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
 
+  nmake:
+    # The other Windows jobs build with jom, which spawns commands
+    # differently from Microsoft's nmake.  Build once with the real
+    # nmake, in-tree as NOTES-WINDOWS.md describes, so that makefile
+    # rules nmake handles differently are exercised, including the
+    # perlasm/nasm generator rules.  Build only: the tests are covered
+    # by the jom jobs and nmake builds serially.
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: install nasm
+      if: github.repository == 'openssl/openssl'
+      run: |
+        $installer = "nasm-3.01-installer-x64.exe"
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/$installer" -OutFile $installer
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).$installer
+        $actual = (Get-FileHash $installer -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for $installer (expected $expected, got $actual)" }
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
+        "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install nasm (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        $installer = "nasm-3.01-installer-x64.exe"
+        Invoke-WebRequest -Uri "https://www.nasm.us/pub/nasm/releasebuilds/3.01/win64/$installer" -OutFile $installer
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
+        "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: config
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        perl Configure --banner=Configured --strict-warnings no-makedepend no-fips -DOSSL_WINCTX=openssl VC-WIN64A
+        perl configdata.pm --dump
+    - name: build
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        nmake /S
+    - name: check the build
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        apps\openssl.exe version -a
+
   cygwin:
     # Run a job for each of the specified target architectures:
     strategy:


### PR DESCRIPTION
Every MSVC job builds with jom, which spawns commands differently from nmake, so makefile rules that nmake handles differently were never exercised; the new GENERATE rules for crypto/objects broke under nmake while CI stayed green.  Add a build-only job that configures in-tree, as NOTES-WINDOWS.md describes, and builds with nmake, with assembly enabled so the perlasm/nasm generator rules are covered too.

This would have caught what was missed and has to be added in https://github.com/openssl/openssl/pull/32648

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
