### PR TITLE
fix MSVC 2013 builds in shared mode

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -114,12 +114,21 @@ jobs:
       run: docker pull %IMAGE%
     - name: config
       run: |
-        $config = @(
+        if [ "${{ matrix.target }}" == "VC-WIN64A-MSVC2013" ]
+        then
+          $config = @(
           'no-makedepend'
-          'no-shared'
           'enable-fips'
           '-DOSSL_WINCTX=openssl'
-        ) -join ' '
+          ) -join ' '
+         else
+          $config = @(
+            'no-makedepend'
+            'enable-fips'
+            'no-shared'
+            '-DOSSL_WINCTX=openssl'
+            ) -join ' '
+         fi
         $chain = @(
           # 'call', not a bare invocation: cmd does not necessarily return from a
           # batch file run without it, which would skip the rest of the chain.

--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -96,8 +96,10 @@ jobs:
         include:
           - arch: amd64
             target: VC-WIN64A-MSVC2013
+            config: no-makedepend no-shared enable-fips -DOSSL_WINCTX=openssl
           - arch: x86
             target: VC-WIN32-MSVC2013
+            config: no-makedepend enable-fips -DOSSL_WINCTX=openssl
     runs-on: windows-2022
     env:
       IMAGE: ghcr.io/openssl/openssl-vs2013:latest
@@ -114,28 +116,13 @@ jobs:
       run: docker pull %IMAGE%
     - name: config
       run: |
-        if [ "${{ matrix.target }}" == "VC-WIN64A-MSVC2013" ]
-        then
-          $config = @(
-          'no-makedepend'
-          'enable-fips'
-          '-DOSSL_WINCTX=openssl'
-          ) -join ' '
-         else
-          $config = @(
-            'no-makedepend'
-            'enable-fips'
-            'no-shared'
-            '-DOSSL_WINCTX=openssl'
-            ) -join ' '
-         fi
         $chain = @(
           # 'call', not a bare invocation: cmd does not necessarily return from a
           # batch file run without it, which would skip the rest of the chain.
           "call $env:VCVARS"
           'mkdir _build'
           'cd _build'
-          "perl ..\Configure ${{ matrix.target }} --banner=Configured $config"
+          "perl ..\Configure ${{ matrix.target }} --banner=Configured ${{ matrix.config }}"
           'perl configdata.pm --dump'
         ) -join ' && '
         docker run --rm --isolation=process -v "${env:GITHUB_WORKSPACE}:C:\src" `

--- a/test/build.info
+++ b/test/build.info
@@ -37,6 +37,9 @@ IF[{- !$disabled{tests} -}]
           testutil/options.c testutil/test_options.c testutil/provider.c \
           testutil/apps_shims.c testutil/random.c testutil/helper.c \
           testutil/compare.c mfail/mfail.c $LIBAPPSSRC
+  IF[{- $target{needs_c99_snprintf_compat} -}]
+    SOURCE[libtestutil.a]=../crypto/msvc2013_snprintf.c
+  ENDIF
   INCLUDE[libtestutil.a]=../include ../apps/include .. mfail
   DEPEND[libtestutil.a]=../libcrypto
 


### PR DESCRIPTION
MSVC is running ok with static linking at the moment, but shared builds still fail, because all of our dynamically linked tests include libtestutil.a, which references vsnprintf.

Fix it by including the msvc2013 printf code in libstestutil.a

While we're at it, mix up the 2013 test a bit, so that one of the builds compiles a static library, and the other does a shared library

