### PR TITLE
Bound QUIC stream reassembly and RX buffering

### DIFF
--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -40,6 +40,9 @@ typedef struct ossl_qrx_args_st {
      */
     size_t max_deferred;
 
+    /* Maximum number of RXEs to allocate, or 0 for the default. */
+    size_t max_rxe;
+
     /* Initial reference PN used for RX. */
     QUIC_PN init_largest_pn[QUIC_PN_SPACE_NUM];
 

--- a/include/internal/quic_sf_list.h
+++ b/include/internal/quic_sf_list.h
@@ -45,6 +45,8 @@ typedef struct sframe_list_st {
     unsigned int fin;
     /* Number of stream frames in the list. */
     size_t num_frames;
+    /* Max frames allowed in the list, 0 for no limit. */
+    size_t max_frames;
     /* Offset of data not yet dropped */
     uint64_t offset;
     /* Is head locked ? */

--- a/include/internal/quic_stream.h
+++ b/include/internal/quic_stream.h
@@ -346,6 +346,12 @@ int ossl_quic_rstream_queue_data(QUIC_RSTREAM *qrs, OSSL_QRX_PKT *pkt,
     int fin);
 
 /*
+ * Returns 1 if `qrs` holds its maximum number of buffered frames, so that
+ * ossl_quic_rstream_queue_data() refuses frames that would add to them.
+ */
+int ossl_quic_rstream_at_frame_limit(const QUIC_RSTREAM *qrs);
+
+/*
  * Copies the data from the stream storage to buffer `buf` of size `size`.
  * `readbytes` is set to the number of bytes actually copied.
  * `fin` is set to 1 if all the data from the stream were read so the

--- a/include/internal/quic_stream.h
+++ b/include/internal/quic_stream.h
@@ -320,9 +320,10 @@ void ossl_quic_sstream_set_cleanse(QUIC_SSTREAM *qss, int cleanse);
  * is read by application. `statm` is queried for current rtt.
  * `rbuf_size` is the initial size of the ring buffer to be used
  * when ossl_quic_rstream_move_to_rbuf() is called.
+ * `max_frames` is the max number of buffered frames, or 0 for no limit.
  */
 QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc,
-    OSSL_STATM *statm, size_t rbuf_size);
+    OSSL_STATM *statm, size_t rbuf_size, size_t max_frames);
 
 /*
  * Frees a QUIC_RSTREAM and any associated storage.

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -142,6 +142,10 @@ static QLOG *ch_get_qlog_cb(void *arg)
 
 #define DEFAULT_STREAM_RXFC_MAX_WND_MUL 12
 
+/* Reassembly frame cap: window / STREAM_FRAME_MIN_AVG_LEN, floored. */
+#define STREAM_FRAME_MIN_AVG_LEN 384
+#define SFRAME_LIST_MAX_FRAMES_FLOOR 1024
+
 static int ch_init(QUIC_CHANNEL *ch)
 {
     OSSL_QUIC_TX_PACKETISER_ARGS txp_args = { 0 };
@@ -309,7 +313,8 @@ static int ch_init(QUIC_CHANNEL *ch)
     }
 
     for (pn_space = QUIC_PN_SPACE_INITIAL; pn_space < QUIC_PN_SPACE_NUM; ++pn_space) {
-        ch->crypto_recv[pn_space] = ossl_quic_rstream_new(NULL, NULL, 0);
+        ch->crypto_recv[pn_space] = ossl_quic_rstream_new(NULL, NULL, 0,
+            SFRAME_LIST_MAX_FRAMES_FLOOR);
         if (ch->crypto_recv[pn_space] == NULL)
             goto err;
     }
@@ -3837,9 +3842,26 @@ static int ch_init_new_stream(QUIC_CHANNEL *ch, QUIC_STREAM *qs,
         if ((qs->sstream = ossl_quic_sstream_new(INIT_APP_BUF_LEN)) == NULL)
             goto err;
 
-    if (can_recv)
-        if ((qs->rstream = ossl_quic_rstream_new(NULL, NULL, 0)) == NULL)
+    if (!can_recv)
+        rxfc_wnd = 0;
+    else if (is_uni)
+        rxfc_wnd = ch->tx_init_max_stream_data_uni;
+    else if (local_init)
+        rxfc_wnd = ch->tx_init_max_stream_data_bidi_local;
+    else
+        rxfc_wnd = ch->tx_init_max_stream_data_bidi_remote;
+
+    if (can_recv) {
+        size_t max_frames = (size_t)(DEFAULT_STREAM_RXFC_MAX_WND_MUL * rxfc_wnd
+            / STREAM_FRAME_MIN_AVG_LEN);
+
+        if (max_frames < SFRAME_LIST_MAX_FRAMES_FLOOR)
+            max_frames = SFRAME_LIST_MAX_FRAMES_FLOOR;
+        if ((qs->rstream = ossl_quic_rstream_new(NULL, NULL, 0,
+                 max_frames))
+            == NULL)
             goto err;
+    }
 
     /* TXFC */
     if (!ossl_quic_txfc_init(&qs->txfc, &ch->conn_txfc))
@@ -3866,15 +3888,6 @@ static int ch_init_new_stream(QUIC_CHANNEL *ch, QUIC_STREAM *qs,
     }
 
     /* RXFC */
-    if (!can_recv)
-        rxfc_wnd = 0;
-    else if (is_uni)
-        rxfc_wnd = ch->tx_init_max_stream_data_uni;
-    else if (local_init)
-        rxfc_wnd = ch->tx_init_max_stream_data_bidi_local;
-    else
-        rxfc_wnd = ch->tx_init_max_stream_data_bidi_remote;
-
     if (!ossl_quic_rxfc_init(&qs->rxfc, &ch->conn_rxfc,
             rxfc_wnd,
             DEFAULT_STREAM_RXFC_MAX_WND_MUL * rxfc_wnd,

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -78,6 +78,9 @@ struct ossl_qrx_st {
      */
     RXE_LIST rx_pending;
 
+    size_t num_rxe;
+    size_t max_rxe;
+
     /* Largest PN we have received and processed in a given PN space. */
     QUIC_PN largest_pn[QUIC_PN_SPACE_NUM];
 
@@ -161,6 +164,7 @@ OSSL_QRX *ossl_qrx_new(const OSSL_QRX_ARGS *args)
     qrx->init_key_phase_bit = args->init_key_phase_bit;
     qrx->max_deferred = args->max_deferred;
     qrx->refcount = 1;
+    qrx->max_rxe = args->max_rxe;
     return qrx;
 }
 
@@ -260,8 +264,10 @@ void ossl_qrx_inject_pkt(OSSL_QRX *qrx, OSSL_QRX_PKT *pkt)
      * to get pkt. Such packet has refcount 1.
      */
     ossl_qrx_pkt_orphan(pkt);
-    if (ossl_assert(rxe->refcount == 0))
+    if (ossl_assert(rxe->refcount == 0)) {
+        ++qrx->num_rxe;
         ossl_list_rxe_insert_tail(&qrx->rx_pending, rxe);
+    }
 }
 
 /*
@@ -523,6 +529,9 @@ static RXE *qrx_pop_pending_rxe(OSSL_QRX *qrx)
     return rxe;
 }
 
+/* Above the ~13k packets the default 15MiB connection window can pin. */
+#define QRX_MAX_RXE 16384
+
 /* Allocate a new RXE. */
 static RXE *qrx_alloc_rxe(size_t alloc_len)
 {
@@ -552,14 +561,19 @@ static RXE *qrx_alloc_rxe(size_t alloc_len)
 static RXE *qrx_ensure_free_rxe(OSSL_QRX *qrx, size_t alloc_len)
 {
     RXE *rxe;
+    size_t max_rxe = qrx->max_rxe != 0 ? qrx->max_rxe : QRX_MAX_RXE;
 
     if (ossl_list_rxe_head(&qrx->rx_free) != NULL)
         return ossl_list_rxe_head(&qrx->rx_free);
+
+    if (qrx->num_rxe >= max_rxe)
+        return NULL;
 
     rxe = qrx_alloc_rxe(alloc_len);
     if (rxe == NULL)
         return NULL;
 
+    ++qrx->num_rxe;
     ossl_list_rxe_insert_tail(&qrx->rx_free, rxe);
     return rxe;
 }

--- a/ssl/quic/quic_rstream.c
+++ b/ssl/quic/quic_rstream.c
@@ -55,6 +55,11 @@ void ossl_quic_rstream_free(QUIC_RSTREAM *qrs)
     OPENSSL_free(qrs);
 }
 
+int ossl_quic_rstream_at_frame_limit(const QUIC_RSTREAM *qrs)
+{
+    return qrs->fl.max_frames != 0 && qrs->fl.num_frames >= qrs->fl.max_frames;
+}
+
 int ossl_quic_rstream_queue_data(QUIC_RSTREAM *qrs, OSSL_QRX_PKT *pkt,
     uint64_t offset,
     const unsigned char *data, uint64_t data_len,

--- a/ssl/quic/quic_rstream.c
+++ b/ssl/quic/quic_rstream.c
@@ -22,7 +22,7 @@ struct quic_rstream_st {
 };
 
 QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc,
-    OSSL_STATM *statm, size_t rbuf_size)
+    OSSL_STATM *statm, size_t rbuf_size, size_t max_frames)
 {
     QUIC_RSTREAM *ret = OPENSSL_zalloc(sizeof(*ret));
 
@@ -36,6 +36,7 @@ QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc,
     }
 
     ossl_sframe_list_init(&ret->fl);
+    ret->fl.max_frames = max_frames;
     ret->rxfc = rxfc;
     ret->statm = statm;
     return ret;

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -325,7 +325,9 @@ static int depack_do_frame_crypto(PACKET *pkt, QUIC_CHANNEL *ch,
         ossl_quic_channel_raise_protocol_error(ch,
             OSSL_QUIC_ERR_INTERNAL_ERROR,
             OSSL_QUIC_FRAME_TYPE_CRYPTO,
-            "internal error (rstream queue)");
+            ossl_quic_rstream_at_frame_limit(rstream)
+                ? "too many buffered crypto frames"
+                : "internal error (rstream queue)");
         return 0;
     }
 
@@ -625,7 +627,9 @@ static int depack_do_frame_stream(PACKET *pkt, QUIC_CHANNEL *ch,
         ossl_quic_channel_raise_protocol_error(ch,
             OSSL_QUIC_ERR_INTERNAL_ERROR,
             frame_type,
-            "internal error (rstream queue)");
+            ossl_quic_rstream_at_frame_limit(stream->rstream)
+                ? "too many buffered stream frames"
+                : "internal error (rstream queue)");
         return 0;
     }
 

--- a/ssl/quic/quic_sf_list.c
+++ b/ssl/quic/quic_sf_list.c
@@ -66,6 +66,9 @@ static int append_frame(SFRAME_LIST *fl, UINT_RANGE *range,
 {
     STREAM_FRAME *new_frame;
 
+    if (fl->max_frames != 0 && fl->num_frames >= fl->max_frames)
+        return 0;
+
     if ((new_frame = stream_frame_new(range, pkt, data)) == NULL)
         return 0;
     new_frame->prev = fl->tail;
@@ -150,17 +153,23 @@ int ossl_sframe_list_insert(SFRAME_LIST *fl, UINT_RANGE *range,
         stream_frame_free(fl, drop_frame);
     }
 
-    if (next_frame != NULL) {
-        /* check whether the new_frame is redundant because there is no gap */
-        if (prev_frame != NULL
-            && next_frame->range.start <= prev_frame->range.end) {
-            stream_frame_free(fl, new_frame);
-            goto end;
-        }
-        next_frame->prev = new_frame;
-    } else {
-        fl->tail = new_frame;
+    /* the new_frame is redundant if there is no gap */
+    if (next_frame != NULL && prev_frame != NULL
+        && next_frame->range.start <= prev_frame->range.end) {
+        stream_frame_free(fl, new_frame);
+        goto end;
     }
+
+    /* new_frame grows the list; enforce the cap */
+    if (fl->max_frames != 0 && fl->num_frames >= fl->max_frames) {
+        stream_frame_free(fl, new_frame);
+        return 0;
+    }
+
+    if (next_frame != NULL)
+        next_frame->prev = new_frame;
+    else
+        fl->tail = new_frame;
 
     new_frame->next = next_frame;
     new_frame->prev = prev_frame;

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -5008,6 +5008,77 @@ static const struct script_op script_106[] = {
     OP_END
 };
 
+/* Inject a run of tiny out-of-order CRYPTO frames into each 1-RTT packet. */
+static int script_107_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
+    unsigned char *buf, size_t len)
+{
+    int ok = 0;
+    unsigned char frame_buf[800];
+    size_t written, i;
+    WPACKET wpkt;
+
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
+        return 1;
+
+    if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
+            sizeof(frame_buf), 0)))
+        return 0;
+
+    /* 160 frames of 5 bytes: type, 2-byte offset, length 1, one data byte. */
+    for (i = 0; i < 160; ++i) {
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, OSSL_QUIC_FRAME_TYPE_CRYPTO))
+            || !TEST_true(WPACKET_quic_write_vlint(&wpkt, h->inject_word1))
+            || !TEST_true(WPACKET_quic_write_vlint(&wpkt, 1))
+            || !TEST_true(WPACKET_put_bytes_u8(&wpkt, 0x42)))
+            goto err;
+        /* Leave a gap after every frame so none can be merged or read. */
+        h->inject_word1 += 2;
+    }
+
+    if (!TEST_true(WPACKET_get_total_written(&wpkt, &written)))
+        goto err;
+
+    if (!qtest_fault_prepend_frame(h->qtf, frame_buf, written))
+        goto err;
+
+    ok = 1;
+err:
+    if (ok)
+        WPACKET_finish(&wpkt);
+    else
+        WPACKET_cleanup(&wpkt);
+    return ok;
+}
+
+/*
+ * 107. Fault injection - CRYPTO reassembly frame limit. The crypto stream
+ * cap is 1024 frames; 7 packets of 160 exceed it. Offsets start well past
+ * any post-handshake CRYPTO data and stay inside the 16KiB crypto window.
+ */
+static const struct script_op script_107[] = {
+    OP_S_SET_INJECT_PLAIN(script_107_inject_plain),
+    OP_C_SET_ALPN("ossltest"),
+    OP_C_CONNECT_WAIT(),
+
+    OP_C_WRITE(DEFAULT, "apple", 5),
+    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
+    OP_S_READ_EXPECT(a, "apple", 5),
+
+    OP_SET_INJECT_WORD(1, 8000),
+
+    OP_S_WRITE(a, "1", 1),
+    OP_S_WRITE(a, "2", 1),
+    OP_S_WRITE(a, "3", 1),
+    OP_S_WRITE(a, "4", 1),
+    OP_S_WRITE(a, "5", 1),
+    OP_S_WRITE(a, "6", 1),
+    OP_S_WRITE(a, "7", 1),
+
+    OP_C_EXPECT_CONN_CLOSE_INFO(OSSL_QUIC_ERR_INTERNAL_ERROR, 0, 0),
+
+    OP_END
+};
+
 static const struct script_op *const scripts[] = {
     script_1,
     script_2,
@@ -5115,6 +5186,7 @@ static const struct script_op *const scripts[] = {
     script_104,
     script_105,
     script_106,
+    script_107,
 };
 
 static int test_script(int idx)

--- a/test/quic_record_test.c
+++ b/test/quic_record_test.c
@@ -3914,6 +3914,49 @@ err:
     return testresult;
 }
 
+static int test_qrx_rxe_limit(void)
+{
+    int testresult = 0;
+    struct rx_state s = { 0 };
+    OSSL_QRX_PKT *pkt = NULL;
+
+    s.args.short_conn_id_len = 0;
+    s.args.max_rxe = 1;
+
+    if (!TEST_true(rx_state_ensure(&s)))
+        goto err;
+
+    s.rx_dcid = empty_conn_id;
+
+    /* Provide both secrets so the second coalesced packet would otherwise decode. */
+    if (!TEST_true(ossl_quic_provide_initial_secret(NULL, NULL,
+            &rx_script_5_c2s_init_dcid, 0, s.qrx, NULL))
+        || !TEST_true(ossl_qrx_provide_secret(s.qrx, QUIC_ENC_LEVEL_HANDSHAKE,
+            QRL_SUITE_AES128GCM, NULL, rx_script_5_handshake_secret,
+            sizeof(rx_script_5_handshake_secret))))
+        goto err;
+
+    if (!TEST_true(ossl_quic_demux_inject(s.demux, rx_script_5_in,
+            sizeof(rx_script_5_in), NULL, NULL)))
+        goto err;
+
+    /* First packet fits under the cap; the rest of the datagram is dropped. */
+    if (!TEST_true(ossl_qrx_read_pkt(s.qrx, &pkt))
+        || !TEST_ptr(pkt))
+        goto err;
+    ossl_qrx_pkt_release(pkt);
+    pkt = NULL;
+
+    if (!TEST_false(ossl_qrx_read_pkt(s.qrx, &pkt)))
+        goto err;
+
+    testresult = 1;
+err:
+    ossl_qrx_pkt_release(pkt);
+    rx_state_teardown(&s);
+    return testresult;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_rx_script, OSSL_NELEM(rx_scripts));
@@ -3929,5 +3972,6 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_wire_pkt_hdr, NUM_WIRE_PKT_HDR_TESTS + 1);
     ADD_ALL_TESTS(test_tx_script, OSSL_NELEM(tx_scripts));
     ADD_MFAIL_NO_CHECK_TEST(test_qrx_multipkt_alloc_failure);
+    ADD_TEST(test_qrx_rxe_limit);
     return 1;
 }

--- a/test/quic_stream_test.c
+++ b/test/quic_stream_test.c
@@ -425,7 +425,7 @@ static int test_rstream_simple(int idx)
         if (!TEST_ptr(pkt[i] = pkt_test_new(1200)))
             goto err;
 
-    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 0)))
         goto err;
 
     if (!TEST_true(ossl_quic_rstream_queue_data(rstream, pkt[0], 5,
@@ -535,7 +535,7 @@ static int test_rstream_random(int idx)
     if (!TEST_ptr(bulk_data = OPENSSL_malloc(data_size))
         || !TEST_ptr(read_buf = OPENSSL_malloc(data_size))
         || !TEST_ptr(pkts = OPENSSL_zalloc(sizeof(*pkts) * max_pkts))
-        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 0)))
         goto err;
 
     if (idx % 3 == 0)
@@ -684,7 +684,7 @@ static int test_rstream_pkt(void)
     if (!TEST_ptr(pkt_a = pkt_test_new(1200))
         || !TEST_ptr(pkt_b = pkt_test_new(1200))
         || !TEST_ptr(pkt_c = pkt_test_new(1200))
-        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 0)))
         goto err;
 
     /* A buffered frame holds a reference to its packet */
@@ -758,7 +758,7 @@ static int test_rstream_pkt(void)
      * data, leaving the surrounding bytes intact.
      */
     memset(cbuf, 0xAA, sizeof(cbuf));
-    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 0)))
         goto err;
     ossl_quic_rstream_set_cleanse(rstream, 1);
     if (!TEST_true(ossl_quic_rstream_queue_data(rstream, pkt_a, 0,
@@ -804,7 +804,7 @@ static int test_rstream_pkt_overhead(void)
     if (!TEST_ptr(data = OPENSSL_malloc(total))
         || !TEST_ptr(buf = OPENSSL_malloc(total))
         || !TEST_ptr(pkt = OPENSSL_zalloc(nframes * sizeof(*pkt)))
-        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 0)))
         goto err;
 
     for (i = 0; i < total; ++i)
@@ -886,7 +886,7 @@ static int test_rstream_reorder(int idx)
         || !TEST_ptr(arena = OPENSSL_malloc(3 * data_size))
         || !TEST_ptr(order = OPENSSL_malloc(nframes * sizeof(*order)))
         || !TEST_ptr(pkts = OPENSSL_zalloc(2 * nframes * sizeof(*pkts)))
-        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0)))
+        || !TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 0)))
         goto err;
 
     if (cleanse)

--- a/test/quic_stream_test.c
+++ b/test/quic_stream_test.c
@@ -518,6 +518,114 @@ err:
     return ret;
 }
 
+static int test_rstream_frame_limit(void)
+{
+    QUIC_RSTREAM *rstream = NULL;
+    int ret = 0, fin = 0;
+    unsigned char buf[16];
+    size_t readbytes = 0;
+
+    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 4)))
+        goto err;
+
+    /* Four disjoint frames fill the list to the cap. */
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 0,
+            simple_data, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 4,
+            simple_data + 4, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 8,
+            simple_data + 8, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 12,
+            simple_data + 12, 2, 0))
+        /* A further frame past the tail is refused. */
+        || !TEST_false(ossl_quic_rstream_queue_data(rstream, NULL, 16,
+            simple_data + 16, 2, 0))
+        /* A further frame in a gap is refused. */
+        || !TEST_false(ossl_quic_rstream_queue_data(rstream, NULL, 6,
+            simple_data + 6, 2, 0))
+        /* A frame covering the whole list drops frames, so is accepted. */
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 0,
+            simple_data, 14, 0))
+        || !TEST_true(ossl_quic_rstream_read(rstream, buf, sizeof(buf),
+            &readbytes, &fin))
+        || !TEST_size_t_eq(readbytes, 14)
+        || !TEST_mem_eq(buf, 14, simple_data, 14))
+        goto err;
+
+    ret = 1;
+
+err:
+    ossl_quic_rstream_free(rstream);
+    return ret;
+}
+
+/* Unread in-order frames count towards the cap; reading makes room. */
+static int test_rstream_frame_limit_unread(void)
+{
+    QUIC_RSTREAM *rstream = NULL;
+    int ret = 0, fin = 0;
+    unsigned char buf[16];
+    size_t readbytes = 0;
+
+    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 4)))
+        goto err;
+
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 0,
+            simple_data, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 2,
+            simple_data + 2, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 4,
+            simple_data + 4, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 6,
+            simple_data + 6, 2, 0))
+        || !TEST_false(ossl_quic_rstream_queue_data(rstream, NULL, 8,
+            simple_data + 8, 2, 0))
+        || !TEST_true(ossl_quic_rstream_read(rstream, buf, sizeof(buf),
+            &readbytes, &fin))
+        || !TEST_size_t_eq(readbytes, 8)
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 8,
+            simple_data + 8, 2, 0))
+        || !TEST_true(ossl_quic_rstream_read(rstream, buf, sizeof(buf),
+            &readbytes, &fin))
+        || !TEST_size_t_eq(readbytes, 2)
+        || !TEST_mem_eq(buf, 2, simple_data + 8, 2))
+        goto err;
+
+    ret = 1;
+
+err:
+    ossl_quic_rstream_free(rstream);
+    return ret;
+}
+
+/* A lost first frame is not exempt: its retransmit is refused at the cap. */
+static int test_rstream_frame_limit_lost(void)
+{
+    QUIC_RSTREAM *rstream = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(rstream = ossl_quic_rstream_new(NULL, NULL, 0, 4)))
+        goto err;
+
+    if (!TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 2,
+            simple_data + 2, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 4,
+            simple_data + 4, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 6,
+            simple_data + 6, 2, 0))
+        || !TEST_true(ossl_quic_rstream_queue_data(rstream, NULL, 8,
+            simple_data + 8, 2, 0))
+        || !TEST_false(ossl_quic_rstream_queue_data(rstream, NULL, 0,
+            simple_data, 2, 0)))
+        goto err;
+
+    ret = 1;
+
+err:
+    ossl_quic_rstream_free(rstream);
+    return ret;
+}
+
 static int test_rstream_random(int idx)
 {
     unsigned char *bulk_data = NULL;
@@ -979,6 +1087,9 @@ int setup_tests(void)
     ADD_TEST(test_sstream_simple);
     ADD_ALL_TESTS(test_sstream_bulk, 100);
     ADD_ALL_TESTS(test_rstream_simple, 4);
+    ADD_TEST(test_rstream_frame_limit);
+    ADD_TEST(test_rstream_frame_limit_unread);
+    ADD_TEST(test_rstream_frame_limit_lost);
     ADD_ALL_TESTS(test_rstream_random, 100);
     ADD_TEST(test_rstream_pkt);
     ADD_TEST(test_rstream_pkt_overhead);

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -1508,7 +1508,7 @@ static int run_script(int script_idx, const struct script_op *script)
                     16 * 1024 * 1024,
                     fake_now, NULL))
                 || !TEST_ptr(s->rstream = ossl_quic_rstream_new(&s->rxfc,
-                                 NULL, 1024))) {
+                                 NULL, 1024, 0))) {
                 ossl_quic_sstream_free(s->sstream);
                 ossl_quic_stream_map_release(h.args.qsm, s);
                 goto err;


### PR DESCRIPTION
Minimal fixes for two QUIC receive-path DoS issues: quadratic CPU from
many small out-of-order STREAM/CRYPTO fragments, and unbounded memory
when the resulting delay lets decrypted packets pile up in the QRX.

Rather than rework reassembly, this keeps the existing O(n) list and
caps n. Reassembly *should* be reworked going forward.

Compromises:

- A receive stream buffers at most window / 384 frames (floor 1024,
  16384 at the default window). Any frame that would grow the list past
  that, including a retransmit of a lost frame, closes the connection
  with INTERNAL_ERROR. Unread in-order data counts too, so a stalled
  reader plus a peer sending sub-384-byte frames is disconnected where
  it used to stall on flow control.

- The cap scales with the configured window with no ceiling, so a
  large window buys proportionally more attacker CPU per packet.

- The QRX allocates at most 16384 packet buffers per connection;
  datagrams arriving with none free are dropped as lost. Buffers are
  pinned by unread data, so a stalled reader with a full 15MiB window
  of sub-1KB packets pins all of them and the connection cannot decode
  anything, including ACKs and CONNECTION_CLOSE, until the application
  reads; stalled past the idle timeout, it is lost.

Reaching either limit needs a sender using unusually small frames or
packets (a full default window of MTU-sized frames is ~5000 nodes)
combined with an application that stops reading for an entire window.
Compliant peers with typical frame sizes cannot reach it.

The final reason-string commit is cosmetic and could be dropped.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
