### PR TITLE
tdes: restore query parameters

### DIFF
--- a/providers/implementations/ciphers/cipher_tdes.inc.in
+++ b/providers/implementations/ciphers/cipher_tdes.inc.in
@@ -16,8 +16,12 @@ use OpenSSL::paramnames qw(produce_param_decoder);
                           ['OSSL_CIPHER_PARAM_KEYLEN',           'common.keylen', 'size_t'],
                           ['OSSL_CIPHER_PARAM_IVLEN',            'common.ivlen',  'size_t'],
                           ['OSSL_CIPHER_PARAM_BLOCK_SIZE',       'common.bsize',  'size_t'],
+                          ['OSSL_CIPHER_PARAM_AEAD',             'common.aead',   'int' ],
                           ['OSSL_CIPHER_PARAM_CUSTOM_IV',        'common.custiv', 'int'],
+                          ['OSSL_CIPHER_PARAM_CTS',              'common.cts',    'int' ],
+                          ['OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK',  'common.mb',     'int' ],
                           ['OSSL_CIPHER_PARAM_HAS_RAND_KEY',     'common.rand',   'int'],
+                          ['OSSL_CIPHER_PARAM_ENCRYPT_THEN_MAC', 'common.etm',    'int' ],
                           ['OSSL_CIPHER_PARAM_DECRYPT_ONLY',     'decrypt',       'int'],
                          )); -}
 


### PR DESCRIPTION
TDES doesn't do anything with these parameters but they do default via the common cipher code and return zero (false). Removing them could thus be considered an API break.

Refer: https://github.com/openssl/openssl/pull/32536#issuecomment-5519823897

- [ ] documentation is added or updated
- [ ] tests are added or updated
