### PR TITLE
Fix AES-CBC-HMAC multiblock output validation

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1093,8 +1093,15 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     case EVP_CTRL_TLS1_1_MULTIBLOCK_ENCRYPT: {
         EVP_CTRL_TLS1_1_MULTIBLOCK_PARAM *p = (EVP_CTRL_TLS1_1_MULTIBLOCK_PARAM *)ptr;
 
+        params[0] = OSSL_PARAM_construct_size_t(
+            OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_AAD_PACKLEN, &sz);
+        params[1] = OSSL_PARAM_construct_end();
+        ret = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
+        if (ret <= 0)
+            return ret;
+
         params[0] = OSSL_PARAM_construct_octet_string(
-            OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC, p->out, p->len);
+            OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC, p->out, sz);
 
         params[1] = OSSL_PARAM_construct_octet_string(
             OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC_IN, (void *)p->inp,

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -158,8 +158,10 @@ static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             || p.enc_in->data_type != OSSL_PARAM_OCTET_STRING
             || p.enc_in->data == NULL
             || p.enc_in->data_size == 0
-            || p.enc->data_size != p.enc_in->data_size
+            || ctx->multiblock_aad_packlen == 0
+            || p.enc->data_size < ctx->multiblock_aad_packlen
             || !aes_get_multiblock_interleave(p.ileave, &mb_param.interleave)
+            || mb_param.interleave != ctx->multiblock_interleave
             || p.enc_in->data_size
                 > (size_t)SSL3_RT_MAX_PLAIN_LENGTH * mb_param.interleave) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -7962,6 +7962,117 @@ static int test_aes_cbc_hmac_sha_large_multiblock_aad(void)
 
     return test_aes_cbc_hmac_sha_reject_multiblock_params(params);
 }
+
+static int test_aes_cbc_hmac_sha_multiblock_output_size(void)
+{
+    static const unsigned char key[16] = { 0 };
+    static const unsigned char iv[16] = { 0 };
+    static const unsigned char mac_key[16] = { 0 };
+    static const size_t input_len = 4096;
+    unsigned char aad[EVP_AEAD_TLS1_AAD_LEN] = { 0 };
+    unsigned char *in = NULL, *out = NULL;
+    unsigned int interleave = 4, packlen = 0;
+    size_t encrypt_len = 0;
+    OSSL_PARAM init_params[] = {
+        OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_MAC_KEY,
+            (void *)mac_key, sizeof(mac_key)),
+        OSSL_PARAM_END
+    };
+    OSSL_PARAM aad_params[] = {
+        OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_AAD, aad,
+            sizeof(aad)),
+        OSSL_PARAM_uint(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_INTERLEAVE,
+            &interleave),
+        OSSL_PARAM_END
+    };
+    OSSL_PARAM get_params[] = {
+        OSSL_PARAM_uint(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_AAD_PACKLEN,
+            &packlen),
+        OSSL_PARAM_uint(OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_INTERLEAVE,
+            &interleave),
+        OSSL_PARAM_END
+    };
+    OSSL_PARAM encrypt_params[4];
+    EVP_CTRL_TLS1_1_MULTIBLOCK_PARAM mb_param;
+    EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER_CTX *ctx = NULL;
+    int ctrl_packlen, ret = 0;
+
+    aad[8] = SSL3_RT_APPLICATION_DATA;
+    aad[9] = (unsigned char)(TLS1_2_VERSION >> 8);
+    aad[10] = (unsigned char)TLS1_2_VERSION;
+    aad[11] = (unsigned char)(input_len >> 8);
+    aad[12] = (unsigned char)input_len;
+
+    cipher = EVP_CIPHER_fetch(testctx, "AES-128-CBC-HMAC-SHA256",
+        "provider=default");
+    if (cipher == NULL) {
+        ERR_clear_error();
+        return TEST_skip("AES-CBC-HMAC-SHA multiblock cipher is not available");
+    }
+    if (!TEST_ptr(in = OPENSSL_zalloc(input_len))
+        || !TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_true(EVP_EncryptInit_ex2(ctx, cipher, key, iv, init_params))
+        || !TEST_true(EVP_CIPHER_CTX_set_params(ctx, aad_params))
+        || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, get_params))
+        || !TEST_size_t_gt(packlen, input_len)
+        || !TEST_ptr(out = OPENSSL_zalloc(packlen)))
+        goto end;
+
+    encrypt_params[0] = OSSL_PARAM_construct_octet_string(
+        OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC, out, input_len);
+    encrypt_params[1] = OSSL_PARAM_construct_octet_string(
+        OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC_IN, in, input_len);
+    encrypt_params[2] = OSSL_PARAM_construct_uint(
+        OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_INTERLEAVE, &interleave);
+    encrypt_params[3] = OSSL_PARAM_construct_end();
+    if (!TEST_false(EVP_CIPHER_CTX_set_params(ctx, encrypt_params)))
+        goto end;
+    ERR_clear_error();
+
+    encrypt_params[0] = OSSL_PARAM_construct_octet_string(
+        OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC, out, packlen);
+    if (!TEST_true(EVP_CIPHER_CTX_set_params(ctx, encrypt_params)))
+        goto end;
+    get_params[0] = OSSL_PARAM_construct_size_t(
+        OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC_LEN, &encrypt_len);
+    get_params[1] = OSSL_PARAM_construct_end();
+    if (!TEST_true(EVP_CIPHER_CTX_get_params(ctx, get_params))
+        || !TEST_size_t_eq(encrypt_len, packlen))
+        goto end;
+
+    EVP_CIPHER_CTX_free(ctx);
+    ctx = NULL;
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_true(EVP_EncryptInit_ex2(ctx, cipher, key, iv, init_params)))
+        goto end;
+
+    mb_param.out = NULL;
+    mb_param.inp = aad;
+    mb_param.len = input_len;
+    mb_param.interleave = 4;
+    ctrl_packlen = EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_TLS1_1_MULTIBLOCK_AAD,
+        sizeof(mb_param), &mb_param);
+    if (!TEST_int_eq(ctrl_packlen, (int)packlen))
+        goto end;
+
+    mb_param.out = out;
+    mb_param.inp = in;
+    mb_param.len = input_len;
+    if (!TEST_int_eq(EVP_CIPHER_CTX_ctrl(ctx,
+                         EVP_CTRL_TLS1_1_MULTIBLOCK_ENCRYPT,
+                         sizeof(mb_param), &mb_param),
+            ctrl_packlen))
+        goto end;
+
+    ret = 1;
+end:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    OPENSSL_free(out);
+    OPENSSL_free(in);
+    return ret;
+}
 #endif
 
 #ifndef OPENSSL_NO_ECX
@@ -10115,6 +10226,7 @@ int setup_tests(void)
 #if !defined(OPENSSL_NO_MULTIBLOCK)
     ADD_TEST(test_aes_cbc_hmac_sha_short_multiblock_aad);
     ADD_TEST(test_aes_cbc_hmac_sha_large_multiblock_aad);
+    ADD_TEST(test_aes_cbc_hmac_sha_multiblock_output_size);
 #endif
 
 #ifndef OPENSSL_NO_ECX


### PR DESCRIPTION
Fix the AES-CBC-HMAC TLS multiblock output handling exposed by the generated OSSL_PARAM decoder conversion.

The provider now:

- validates the output buffer against the packed TLS record length established by the AAD operation;
- requires initialized multiblock state; and
- requires the encryption interleave to match the AAD interleave.

The legacy EVP control bridge supplies the packed output length instead of the plaintext input length. `EVP_CTRL_TLS1_1_MULTIBLOCK_PARAM::len` describes the plaintext, while the provider output parameter describes the larger packed TLS record buffer.

Regression coverage checks rejection of an undersized output buffer, successful direct parameter use, and the legacy EVP control path.

Refer: https://github.com/openssl/openssl/pull/32536#issuecomment-5519823897