### PR TITLE
[3.6, 3.5, 3.4, 3.0] Do not advertise OPENSSL_INIT_LOAD_CONFIG in optsdone too soon

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -496,6 +496,7 @@ void OPENSSL_cleanup(void)
 int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
 {
     uint64_t tmp;
+    uint64_t optsdone_bits = opts;
     int aloaddone = 0;
 
     /* Applications depend on 0 being returned when cleanup was already done */
@@ -621,8 +622,15 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
     if (opts & OPENSSL_INIT_LOAD_CONFIG) {
         int loading = CRYPTO_THREAD_get_local(&in_init_config_local) != NULL;
 
-        /* If called recursively from OBJ_ calls, just skip it. */
-        if (!loading) {
+        /* If called recursively from OBJ_ calls during config loading,
+         * we have to mask OPENSSL_INIT_LOAD_CONFIG in optsdone to not
+         * advertise that config loading is complete, otherwise other
+         * threads may proceed, e.g., to fetching from a provider that
+         * is not yet loaded.
+         */
+        if (loading) {
+            optsdone_bits &= ~(uint64_t)OPENSSL_INIT_LOAD_CONFIG;
+        } else {
             int ret;
 
             if (!CRYPTO_THREAD_set_local(&in_init_config_local, (void *)-1))
@@ -687,7 +695,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
     }
 #endif
 
-    if (!CRYPTO_atomic_or(&optsdone, opts, &tmp, optsdone_lock))
+    if (!CRYPTO_atomic_or(&optsdone, optsdone_bits, &tmp, optsdone_lock))
         return 0;
 
     return 1;


### PR DESCRIPTION
This is a backport of #32646.

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
