### PR TITLE
Provider compatibility CI: Force copy of fips.so and fipsmodule.cnf [4.0-3.0]

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -256,8 +256,8 @@ jobs:
       - name: set up cross validation of FIPS from A with tree from B
         if: steps.early_exit.outputs.skip != 'true'
         run: |
-          cp providers/fips.so ../${{ matrix.tree_b }}/providers/
-          cp providers/fipsmodule.cnf ../${{ matrix.tree_b }}/providers/
+          cp -f providers/fips.so ../${{ matrix.tree_b }}/providers/
+          cp -f providers/fipsmodule.cnf ../${{ matrix.tree_b }}/providers/
         working-directory: ${{ matrix.tree_a }}
 
       - name: show module versions from cross validation

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -241,8 +241,8 @@ jobs:
       - name: set up cross validation of FIPS from A with tree from B
         if: steps.early_exit.outputs.skip != 'true'
         run: |
-          cp providers/fips.so ../${{ matrix.tree_b }}/providers/
-          cp providers/fipsmodule.cnf ../${{ matrix.tree_b }}/providers/
+          cp -f providers/fips.so ../${{ matrix.tree_b }}/providers/
+          cp -f providers/fipsmodule.cnf ../${{ matrix.tree_b }}/providers/
         working-directory: ${{ matrix.tree_a }}
 
       - name: show module versions from cross validation


### PR DESCRIPTION
If the target branch is >4.0 the destination files can be read-only.

This is urgent PR to _partially_ fix the Provider compatibility CI

There is another regression caused by #32502 which is still being investigated.