### PR TITLE
crypto/http/http_client.c: fix busy-loop in OSSL_HTTP_proxy_connect on EOF

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -1550,6 +1550,12 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
          */
         read_len = BIO_gets(fbio, mbuf, BUF_SIZE);
         /* the BIO may not block, so we must wait for the 1st line to come in */
+        if (read_len <= 0 && !BIO_should_retry(fbio)) {
+            ERR_raise(ERR_LIB_HTTP, HTTP_R_FAILED_READING_DATA);
+            BIO_printf(bio_err, "%s: HTTP CONNECT failed, error reading data\n",
+                prog);
+            goto end;
+        }
         if (read_len < (int)HTTP_LINE1_MINLEN)
             continue;
 


### PR DESCRIPTION
The proxy CONNECT first-line read loop in `OSSL_HTTP_proxy_connect()`
treats a closed connection like a short read: `BIO_gets()` returns 0 at
EOF, `0 < HTTP_LINE1_MINLEN`, so the loop hits `continue`. With
`timeout <= 0` (the `openssl s_client -proxy` default) `BIO_wait()`
returns immediately, so once the peer closes the socket the loop spins
at 100% CPU and never returns.

This breaks out of the loop on EOF / non-retryable error, mirroring the
handling already done by `OSSL_HTTP_REQ_CTX_nbio()`.

Verified before/after on a real libcrypto build: a proxy that answers
CONNECT with a short response then closes hangs the client at 100% CPU
before this change and returns cleanly after it.

CLA: trivial
