### PR TITLE
quic: account anti-amplification credit per received datagram

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2359,6 +2359,18 @@ static int ch_rx(QUIC_CHANNEL *ch, int channel_only, int *notify_other_threads)
         handled_any = 1;
     }
 
+    /*
+     * RFC 9000 s. 8.1
+     * Prior to address validation we may send up to three times as many bytes
+     * as we have received, counting all payload bytes of received datagrams,
+     * including bytes from packets which were discarded or could not be
+     * processed. The QRX counts the payload bytes of every datagram routed to
+     * this channel; drain the counter and convert it to unvalidated credit.
+     * This is a no-op once the peer address has been validated.
+     */
+    ossl_quic_tx_packetiser_add_unvalidated_credit(
+        ch->txp, (size_t)ossl_qrx_get_bytes_received(ch->qrx, /*clear=*/1));
+
     ch_rx_check_forged_pkt_limit(ch);
 
     if (handled_any && notify_other_threads != NULL)

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1838,6 +1838,16 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
         goto undesirable;
 
     /*
+     * RFC 9000 s. 8.1
+     * The datagram carrying the client's first Initial packet is never
+     * processed by the channel's QRX (only the validated packet itself is
+     * injected below), so account its payload bytes towards the channel's
+     * anti-amplification credit here. This is a no-op if the peer address
+     * has already been validated via a token.
+     */
+    ossl_quic_tx_packetiser_add_unvalidated_credit(new_ch->txp, e->data_len);
+
+    /*
      * Generate a token for sending in a later NEW_TOKEN frame
      */
     if (gen_new_token == 1)

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -1380,7 +1380,13 @@ static int qrx_process_datagram(OSSL_QRX *qrx, QUIC_URXE *e,
     size_t pkt_idx = 0;
     QUIC_CONN_ID first_dcid = { 255 };
 
-    qrx->bytes_received += data_len;
+    /*
+     * A deferred datagram is processed again once decryption keys become
+     * available, so only count its bytes towards the received byte count the
+     * first time we see it.
+     */
+    if (!e->deferred)
+        qrx->bytes_received += data_len;
 
     if (!PACKET_buf_init(&pkt, data, data_len))
         return 0;

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -1462,7 +1462,6 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
     PACKET pkt;
     OSSL_ACKM_RX_PKT ackm_data;
     uint32_t enc_level;
-    size_t dgram_len = qpacket->datagram_len;
 
     if (ch == NULL)
         return 0;
@@ -1491,14 +1490,14 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
      * RFC 9000 s. 8.1
      * We can consider the connection to be validated, if we receive a packet
      * from the client protected via handshake keys, meaning that the
-     * amplification limit no longer applies (i.e. we can set it as validated.
-     * Otherwise, add the size of this packet to the unvalidated credit for
-     * the connection.
+     * amplification limit no longer applies (i.e. we can set it as validated).
+     * Unvalidated credit is accounted per received datagram in ch_rx(), as
+     * RFC 9000 s. 8.1 requires counting all payload bytes of received
+     * datagrams, including bytes from packets which cannot be processed at
+     * this layer.
      */
     if (enc_level == QUIC_ENC_LEVEL_HANDSHAKE)
         ossl_quic_tx_packetiser_set_validated(ch->txp);
-    else
-        ossl_quic_tx_packetiser_add_unvalidated_credit(ch->txp, dgram_len);
 
     /* Now that special cases are out of the way, parse frames */
     if (!PACKET_buf_init(&pkt, qpacket->hdr->data, qpacket->hdr->len)

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -478,6 +478,11 @@ void ossl_quic_tx_packetiser_set_validated(OSSL_QUIC_TX_PACKETISER *txp)
  * `SIZE_MAX - 1`. If the current unvalidated credit is already `SIZE_MAX`,
  * the function does nothing.
  *
+ * The credit is expressed in UDP payload bytes received from the unvalidated
+ * peer address, per RFC 9000 s. 8.1, and is consumed in UDP payload bytes
+ * sent, so callers must credit whole received datagrams rather than
+ * individual packets or frames.
+ *
  * @param txp    A pointer to the OSSL_QUIC_TX_PACKETISER structure to update.
  * @param credit The amount of credit to add, multiplied by 3.
  */
@@ -1002,12 +1007,23 @@ int ossl_quic_tx_packetiser_generate(OSSL_QUIC_TX_PACKETISER *txp,
             /* Nothing was generated for this EL, so skip. */
             continue;
 
+        /*
+         * RFC 9000 s. 8.1 limits the bytes we may send on an unvalidated
+         * path, counting bytes as sent on the wire, so charge the packet
+         * overhead (headers, PN, AEAD tag) as well as the payload against
+         * the credit. Note pkt_overhead may still be the conservative
+         * pre-generation estimate here if no padding pass has run, which
+         * can only overstate the charge.
+         */
         if (!ossl_quic_tx_packetiser_check_unvalidated_credit(txp,
-                pkt[enc_level].h.bytes_appended)) {
+                pkt[enc_level].h.bytes_appended
+                    + pkt[enc_level].geom.pkt_overhead)) {
             res = TXP_ERR_SPACE;
             goto out;
         }
-        ossl_quic_tx_packetiser_consume_unvalidated_credit(txp, pkt[enc_level].h.bytes_appended);
+        ossl_quic_tx_packetiser_consume_unvalidated_credit(txp,
+            pkt[enc_level].h.bytes_appended
+                + pkt[enc_level].geom.pkt_overhead);
 
         rc = txp_pkt_commit(txp, &pkt[enc_level], archetype,
             &txpim_pkt_reffed);

--- a/test/quic_record_test.c
+++ b/test/quic_record_test.c
@@ -33,6 +33,7 @@ static const QUIC_CONN_ID empty_conn_id = { 0, { 0 } };
 #define RX_TEST_OP_SET_INIT_KEY_PHASE 12 /* initial Key Phase bit value */
 #define RX_TEST_OP_CHECK_PKT_EPOCH 13 /* check read key epoch matches */
 #define RX_TEST_OP_ALLOW_1RTT 14 /* allow 1RTT packet processing */
+#define RX_TEST_OP_CHECK_BYTES_RECEIVED 15 /* check received byte counter */
 
 struct rx_test_op {
     unsigned char op;
@@ -84,6 +85,8 @@ struct rx_test_op {
     { RX_TEST_OP_CHECK_PKT_EPOCH, 0, NULL, 0, NULL, 0, 0, (expected), NULL }
 #define RX_OP_ALLOW_1RTT() \
     { RX_TEST_OP_ALLOW_1RTT, 0, NULL, 0, NULL, 0, 0, 0, NULL }
+#define RX_OP_CHECK_BYTES_RECEIVED(expected, clear) \
+    { RX_TEST_OP_CHECK_BYTES_RECEIVED, 0, NULL, 0, NULL, (clear), 0, (expected), NULL }
 
 #define RX_OP_INJECT_N(n) \
     RX_OP_INJECT(rx_script_##n##_in)
@@ -1875,6 +1878,38 @@ static const struct rx_test_op rx_script_9[] = {
     RX_OP_END
 };
 
+/*
+ * 10. Received Byte Counting Test
+ *
+ * The counter of received bytes used for anti-amplification credit
+ * (RFC 9000 s. 8.1) covers whole datagrams and counts each datagram exactly
+ * once, including datagrams which are deferred and processed again as keys
+ * become available.
+ */
+static const struct rx_test_op rx_script_10[] = {
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    /* the datagram is counted even though no keys are available yet */
+    RX_OP_INJECT_N(5),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_BYTES_RECEIVED(sizeof(rx_script_5_in), 0),
+    /* reprocessing the deferred datagram must not count it again */
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_5_c2s_init_dcid),
+    RX_OP_CHECK_PKT_N(5a),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_BYTES_RECEIVED(sizeof(rx_script_5_in), 0),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, rx_script_5_handshake_secret),
+    RX_OP_CHECK_PKT_N(5b),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, rx_script_5_1rtt_secret),
+    RX_OP_ALLOW_1RTT(),
+    RX_OP_CHECK_PKT_N(5c),
+    RX_OP_CHECK_NO_PKT(),
+    /* clearing the counter returns the old value and resets it */
+    RX_OP_CHECK_BYTES_RECEIVED(sizeof(rx_script_5_in), 1),
+    RX_OP_CHECK_BYTES_RECEIVED(0, 0),
+
+    RX_OP_END
+};
+
 static const struct rx_test_op *rx_scripts[] = {
     rx_script_1,
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
@@ -1888,7 +1923,8 @@ static const struct rx_test_op *rx_scripts[] = {
     rx_script_7,
 #endif
     rx_script_8,
-    rx_script_9
+    rx_script_9,
+    rx_script_10
 };
 
 struct rx_state {
@@ -2098,6 +2134,16 @@ static int rx_run_script(const struct rx_test_op *script)
             s.allow_1rtt = 1;
 
             if (!TEST_true(rx_state_ensure(&s)))
+                goto err;
+
+            break;
+        case RX_TEST_OP_CHECK_BYTES_RECEIVED:
+            if (!TEST_true(rx_state_ensure(&s)))
+                goto err;
+
+            if (!TEST_uint64_t_eq(ossl_qrx_get_bytes_received(s.qrx,
+                                      (int)op->enc_level),
+                    op->largest_pn))
                 goto err;
 
             break;

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -122,7 +122,7 @@ static void demux_default_handler(QUIC_URXE *e, void *arg,
     ossl_qrx_inject_urxe(h->qrx, e);
 }
 
-static int helper_init(struct helper *h)
+static int helper_init(struct helper *h, int validated)
 {
     int rc = 0;
     size_t i;
@@ -222,10 +222,12 @@ static int helper_init(struct helper *h)
         goto err;
 
     /*
-     * Our helper should always skip validation
-     * as the tests are not written to expect delayed connections
+     * Most tests are not written to expect delayed connections, so skip
+     * validation, unless a script opts out to test the anti-amplification
+     * credit gating with OP_NO_VALIDATION().
      */
-    ossl_quic_tx_packetiser_set_validated(h->txp);
+    if (validated)
+        ossl_quic_tx_packetiser_set_validated(h->txp);
 
     if (!TEST_ptr(h->demux = ossl_quic_demux_new(h->bio2, 8,
                       fake_now, NULL)))
@@ -274,6 +276,8 @@ err:
 #define OPK_STREAM_TXFC_BUMP 21 /* Bump stream TXFC CWM */
 #define OPK_HANDSHAKE_COMPLETE 22 /* Mark handshake as complete */
 #define OPK_NOP 23 /* No-op */
+#define OPK_NO_VALIDATION 24 /* Run with an unvalidated TXP (must be first op) */
+#define OPK_ADD_CREDIT 25 /* Add unvalidated path credit */
 
 struct script_op {
     uint32_t opcode;
@@ -331,6 +335,10 @@ struct script_op {
     { OPK_HANDSHAKE_COMPLETE }
 #define OP_NOP() \
     { OPK_NOP }
+#define OP_NO_VALIDATION() \
+    { OPK_NO_VALIDATION }
+#define OP_ADD_CREDIT(credit) \
+    { OPK_ADD_CREDIT, (credit) }
 
 static int schedule_handshake_done(struct helper *h)
 {
@@ -1272,6 +1280,56 @@ static const struct script_op script_18[] = {
     OP_END
 };
 
+/* 19. Initial datagram gated by anti-amplification credit */
+static int flush_qtx(struct helper *h)
+{
+    ossl_qtx_finish_dgram(h->args.qtx);
+    ossl_qtx_flush_net(h->args.qtx);
+    return 1;
+}
+
+static int check_credit_19(struct helper *h)
+{
+    /*
+     * Exactly 3 of the 1203 credit must remain after the 1200 byte datagram
+     * was charged, confirming the charge covers the wire size of the packet
+     * rather than just its payload.
+     */
+    if (!TEST_true(ossl_quic_tx_packetiser_check_unvalidated_credit(h->txp, 2))
+        || !TEST_false(ossl_quic_tx_packetiser_check_unvalidated_credit(h->txp,
+            3)))
+        return 0;
+
+    return 1;
+}
+
+static const struct script_op script_19[] = {
+    OP_NO_VALIDATION(),
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1),
+    OP_CRYPTO_SEND(QUIC_PN_SPACE_INITIAL, crypto_1),
+    /* no credit, nothing can be sent */
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(flush_qtx),
+    OP_RX_PKT_NONE(),
+    /* 3 * 400 = 1200 does not exceed the 1200 byte datagram, still blocked */
+    OP_ADD_CREDIT(400),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(flush_qtx),
+    OP_RX_PKT_NONE(),
+    /* 3 * 401 = 1203 covers the whole datagram including packet overhead */
+    OP_ADD_CREDIT(1),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(1200, 1200),
+    OP_CHECK(check_credit_19),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CRYPTO),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
+};
+
 static const struct script_op *const scripts[] = {
     script_1,
     script_2,
@@ -1290,7 +1348,8 @@ static const struct script_op *const scripts[] = {
     script_15,
     script_16,
     script_17,
-    script_18
+    script_18,
+    script_19
 };
 
 static void skip_padding(struct helper *h)
@@ -1312,7 +1371,7 @@ static int run_script(int script_idx, const struct script_op *script)
     const struct script_op *op;
     size_t opn = 0;
 
-    if (!helper_init(&h))
+    if (!helper_init(&h, script->opcode != OPK_NO_VALIDATION))
         goto err;
 
     have_helper = 1;
@@ -1593,6 +1652,13 @@ static int run_script(int script_idx, const struct script_op *script)
             ossl_quic_tx_packetiser_notify_handshake_complete(h.txp);
             break;
         case OPK_NOP:
+            break;
+        case OPK_NO_VALIDATION:
+            /* Handled by run_script() when initialising the helper. */
+            break;
+        case OPK_ADD_CREDIT:
+            ossl_quic_tx_packetiser_add_unvalidated_credit(h.txp,
+                (size_t)op->arg0);
             break;
         default:
             TEST_error("bad opcode");


### PR DESCRIPTION
Previously the server added unvalidated credit from the depacketiser, once per decrypted packet, using the length of the containing datagram. For a datagram carrying N decryptable packets this granted N times the intended credit, and bytes from packets which never reached the depacketiser (undecryptable packets and padding) were either over-counted or not counted at all depending on the rest of the datagram.

RFC 9000 s. 8.1 requires servers to count all payload bytes of received datagrams towards the anti-amplification limit, including bytes from packets which are discarded or cannot be processed. Move the accounting to datagram granularity by draining the existing, previously unused QRX byte counter in ch_rx(). Datagrams deferred while waiting for keys are processed twice, so count them only on first sight. The datagram carrying the client's first Initial packet never passes through the channel's QRX, only the validated packet itself is injected, so credit it explicitly when the channel is bound.

On the consuming side, charge the packet overhead (headers, packet number, AEAD tag) as well as the payload against the credit, since the limit applies to bytes sent on the wire. Previously only payload bytes were charged, which allowed the server to exceed three times the received byte count.

Add a QRX test checking that the received byte counter counts whole datagrams exactly once, including datagrams deferred and reprocessed repeatedly as keys for further encryption levels arrive, and a TXP test running with an unvalidated path, checking that an Initial datagram is withheld until the credit covers its full wire size and that sending charges exactly the wire size of the datagram against the credit. Both tests fail against the previous accounting.

This is alternative solution that #32308 tries to address but it has got limitations.