### PR TITLE
test/recipes/70-test_tls13hrr.t: use a large MTU for DTLS subtests

### DIFF
--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -83,15 +83,26 @@ sub run_tests
     #Test 1: A client should fail if the server changes the ciphersuite between the
     #        HRR and the SH
     $proxy->clear();
+    # Use a large MTU for DTLS in these tests. With the default MTU of 1500,
+    # the IPv6/UDP overhead limits the usable datagram payload enough that
+    # the server's Certificate/CertificateVerify flight can spill into a
+    # second datagram. If a fatal alert from the client then arrives at the
+    # proxy before that second datagram, the proxy is left holding a partial
+    # fragment and dies with "Changed peer, but we still have fragment data".
+    # A large MTU keeps the whole flight in one datagram and avoids the race.
     if (disabled("ec")) {
-        $proxy->serverflags("-curves ffdhe3072");
         if ($run_test_as_dtls == 1) {
-            $proxy->clientflags("-groups ffdhe2048:ffdhe3072");
+            $proxy->serverflags("-curves ffdhe3072 -mtu 16384");
+            $proxy->clientflags("-groups ffdhe2048:ffdhe3072 -mtu 16384");
+        } else {
+            $proxy->serverflags("-curves ffdhe3072");
         }
     } else {
-        $proxy->serverflags("-curves P-256");
         if ($run_test_as_dtls == 1) {
-            $proxy->clientflags("-groups P-384:P-256");
+            $proxy->serverflags("-curves P-256 -mtu 16384");
+            $proxy->clientflags("-groups P-384:P-256 -mtu 16384");
+        } else {
+            $proxy->serverflags("-curves P-256");
         }
     }
     $testtype = CHANGE_HRR_CIPHERSUITE;
@@ -103,14 +114,18 @@ sub run_tests
     #        we end up selecting a different ciphersuite between HRR and the SH
     $proxy->clear();
     if (disabled("ec")) {
-        $proxy->serverflags("-curves ffdhe3072");
         if ($run_test_as_dtls == 1) {
-            $proxy->clientflags("-groups ffdhe2048:ffdhe3072");
+            $proxy->serverflags("-curves ffdhe3072 -mtu 16384");
+            $proxy->clientflags("-groups ffdhe2048:ffdhe3072 -mtu 16384");
+        } else {
+            $proxy->serverflags("-curves ffdhe3072");
         }
     } else {
-        $proxy->serverflags("-curves P-384");
         if ($run_test_as_dtls == 1) {
-            $proxy->clientflags("-groups P-256:P-384");
+            $proxy->serverflags("-curves P-384 -mtu 16384");
+            $proxy->clientflags("-groups P-256:P-384 -mtu 16384");
+        } else {
+            $proxy->serverflags("-curves P-384");
         }
     }
     $proxy->ciphersuitess("TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384");
@@ -123,14 +138,18 @@ sub run_tests
     $fatal_alert = 0;
     $proxy->clear();
     if (disabled("ec")) {
-        $proxy->serverflags("-curves ffdhe3072");
         if ($run_test_as_dtls == 1) {
-            $proxy->clientflags("-groups ffdhe2048:ffdhe3072");
+            $proxy->serverflags("-curves ffdhe3072 -mtu 16384");
+            $proxy->clientflags("-groups ffdhe2048:ffdhe3072 -mtu 16384");
+        } else {
+            $proxy->serverflags("-curves ffdhe3072");
         }
     } else {
-        $proxy->serverflags("-curves P-384");
         if ($run_test_as_dtls == 1) {
-            $proxy->clientflags("-groups P-256:P-384");
+            $proxy->serverflags("-curves P-384 -mtu 16384");
+            $proxy->clientflags("-groups P-256:P-384 -mtu 16384");
+        } else {
+            $proxy->serverflags("-curves P-384");
         }
     }
     $testtype = DUPLICATE_HRR;
@@ -158,8 +177,13 @@ sub run_tests
                               || ($run_test_as_dtls == 1 && disabled("dtls1_2"));
 
         $proxy->clear();
-        $proxy->clientflags("-groups P-256:brainpoolP512r1:P-521");
-        $proxy->serverflags("-groups brainpoolP512r1:P-521");
+        if ($run_test_as_dtls == 1) {
+            $proxy->clientflags("-groups P-256:brainpoolP512r1:P-521 -mtu 16384");
+            $proxy->serverflags("-groups brainpoolP512r1:P-521 -mtu 16384");
+        } else {
+            $proxy->clientflags("-groups P-256:brainpoolP512r1:P-521");
+            $proxy->serverflags("-groups brainpoolP512r1:P-521");
+        }
         $testtype = INVALID_GROUP;
         $proxy->start();
         ok(TLSProxy::Message->success(), "Invalid group with HRR");
@@ -170,9 +194,19 @@ sub run_tests
     $fatal_alert = 0;
     $proxy->clear();
     if (disabled("ec")) {
-        $proxy->serverflags("-curves ffdhe3072");
+        if ($run_test_as_dtls == 1) {
+            $proxy->serverflags("-curves ffdhe3072 -mtu 16384");
+            $proxy->clientflags("-mtu 16384");
+        } else {
+            $proxy->serverflags("-curves ffdhe3072");
+        }
     } else {
-        $proxy->serverflags("-curves P-384");
+        if ($run_test_as_dtls == 1) {
+            $proxy->serverflags("-curves P-384 -mtu 16384");
+            $proxy->clientflags("-mtu 16384");
+        } else {
+            $proxy->serverflags("-curves P-384");
+        }
     }
     $testtype = NO_SUPPORTED_VERSIONS;
     $proxy->start();


### PR DESCRIPTION
With the default DTLS MTU of 1500, IPv6/UDP overhead leaves just enough headroom that the server's Certificate/CertificateVerify flight can spill into a second datagram. If the client's fatal alert reaches the proxy before that second datagram arrives, the proxy is left holding a partial fragment and dies with "Changed peer, but we still have fragment data".

Set "-mtu 16384" on both the server and client flags for each DTLS subtest so the whole flight always fits in one datagram, removing the race. This mirrors the fix already applied in
70-test_tls13alerts.t.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
