### PR TITLE
test/dtlsssllistenertest.c: fix flaky zero-wait handshake loops

### DIFF
--- a/test/dtlsssllistenertest.c
+++ b/test/dtlsssllistenertest.c
@@ -4185,7 +4185,7 @@ static int test_dtls_listener_max_dgram_size_functional(void)
 
     SSL_set_connect_state(clientssl);
     while (serverssl == NULL) {
-        if (++abortctr > 100) {
+        if (++abortctr > 200) {
             TEST_error("connection did not converge (oversized ClientHello)");
             goto end;
         }
@@ -4213,6 +4213,9 @@ static int test_dtls_listener_max_dgram_size_functional(void)
         if (poll_result > 0 && (poll_item.revents & SSL_POLL_EVENT_IC) != 0)
             serverssl = SSL_accept_connection(listener,
                 SSL_ACCEPT_CONNECTION_NO_BLOCK);
+
+        /* Loopback delivery can lag and a lost datagram needs a retransmit */
+        OSSL_sleep(10);
     }
 
     if (!TEST_ptr(serverssl))
@@ -5007,7 +5010,7 @@ static int test_dtls_notifier_signalled_on_accept_queue_push(void)
     poll_timeout.tv_usec = 0;
 
     SSL_set_connect_state(clientssl);
-    for (abortctr = 0; abortctr < 100; abortctr++) {
+    for (abortctr = 0; abortctr < 200; abortctr++) {
         retc = SSL_connect(clientssl);
         err_code = SSL_get_error(clientssl, retc);
         if (retc <= 0
@@ -5040,6 +5043,9 @@ static int test_dtls_notifier_signalled_on_accept_queue_push(void)
 
         if ((poll_item.revents & SSL_POLL_EVENT_IC) != 0)
             break;
+
+        /* Loopback delivery can lag and a lost datagram needs a retransmit */
+        OSSL_sleep(10);
     }
 
     if (!TEST_size_t_gt(SSL_get_accept_connection_queue_len(listener), 0))


### PR DESCRIPTION
test_dtls_listener_max_dgram_size_functional() and test_dtls_notifier_signalled_on_accept_queue_push() drive a real loopback UDP handshake in a fixed 100-iteration loop that polls with a zero timeout and never sleeps between attempts. If loopback delivery lags - as it does intermittently on macOS CI runners - the loop can exhaust its budget before a datagram becomes readable and the test fails with "did not converge", even though the listener is working correctly.

This is the same bug fixed in drive_until_connection_queued() by 271222650b ("dtls: fix flaky cookie exchange loop in listener test"). Apply the same treatment here: sleep 10ms between iterations so a delayed datagram has time to arrive, and raise the iteration cap to 200 so the budget still covers the client's 1s initial retransmit timer if a datagram is lost outright.

Every other real-socket convergence loop in the file already waits on the SSL_poll() call itself (poll_timeout.tv_usec = 100000) rather than busy-spinning, and the remaining zero-timeout loops are backed by an in-memory dgram BIO pair with synchronous delivery, so neither needed this fix.

Assisted-by: Claude:claude-sonnet-5

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
