### PR TITLE
Cleanse ASN1-decoded secret material before free (EC_PRIVATEKEY, SSL_SESSION_ASN1)

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -156,12 +156,27 @@ DECLARE_ASN1_FUNCTIONS(ECPKPARAMETERS)
 DECLARE_ASN1_ENCODE_FUNCTIONS_name(ECPKPARAMETERS, ECPKPARAMETERS)
 IMPLEMENT_ASN1_FUNCTIONS(ECPKPARAMETERS)
 
-ASN1_SEQUENCE(EC_PRIVATEKEY) = {
+/* Override the default free and cleanse the key material */
+static int eckey_priv_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
+    void *exarg)
+{
+    EC_PRIVATEKEY *key;
+
+    if (operation == ASN1_OP_FREE_PRE) {
+        /* The structure is still valid during ASN1_OP_FREE_PRE */
+        key = (EC_PRIVATEKEY *)*pval;
+        if (key->privateKey != NULL)
+            OPENSSL_cleanse(key->privateKey->data, key->privateKey->length);
+    }
+    return 1;
+}
+
+ASN1_SEQUENCE_cb(EC_PRIVATEKEY, eckey_priv_cb) = {
     ASN1_EMBED(EC_PRIVATEKEY, version, INT32),
     ASN1_SIMPLE(EC_PRIVATEKEY, privateKey, ASN1_OCTET_STRING),
     ASN1_EXP_OPT(EC_PRIVATEKEY, parameters, ECPKPARAMETERS, 0),
     ASN1_EXP_OPT(EC_PRIVATEKEY, publicKey, ASN1_BIT_STRING, 1)
-} static_ASN1_SEQUENCE_END(EC_PRIVATEKEY)
+} static_ASN1_SEQUENCE_END_cb(EC_PRIVATEKEY, EC_PRIVATEKEY)
 
 DECLARE_ASN1_FUNCTIONS(EC_PRIVATEKEY)
 DECLARE_ASN1_ENCODE_FUNCTIONS_name(EC_PRIVATEKEY, EC_PRIVATEKEY)

--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -50,7 +50,22 @@ typedef struct {
     ASN1_OCTET_STRING *peer_rpk;
 } SSL_SESSION_ASN1;
 
-ASN1_SEQUENCE(SSL_SESSION_ASN1) = {
+/* Minor tweak to operation: zero master key data */
+static int ssl_session_asn1_cb(int operation, ASN1_VALUE **pval,
+    const ASN1_ITEM *it, void *exarg)
+{
+    SSL_SESSION_ASN1 *key;
+
+    if (operation == ASN1_OP_FREE_PRE) {
+        /* The structure is still valid during ASN1_OP_FREE_PRE */
+        key = (SSL_SESSION_ASN1 *)*pval;
+        if (key->master_key != NULL)
+            OPENSSL_cleanse(key->master_key->data, key->master_key->length);
+    }
+    return 1;
+}
+
+ASN1_SEQUENCE_cb(SSL_SESSION_ASN1, ssl_session_asn1_cb) = {
     ASN1_EMBED(SSL_SESSION_ASN1, version, UINT32),
     ASN1_EMBED(SSL_SESSION_ASN1, ssl_version, INT32),
     ASN1_SIMPLE(SSL_SESSION_ASN1, cipher, ASN1_OCTET_STRING),
@@ -81,7 +96,7 @@ ASN1_SEQUENCE(SSL_SESSION_ASN1) = {
     ASN1_EXP_OPT(SSL_SESSION_ASN1, ticket_appdata, ASN1_OCTET_STRING, 18),
     ASN1_EXP_OPT_EMBED(SSL_SESSION_ASN1, kex_group, UINT32, 19),
     ASN1_EXP_OPT(SSL_SESSION_ASN1, peer_rpk, ASN1_OCTET_STRING, 20)
-} static_ASN1_SEQUENCE_END(SSL_SESSION_ASN1)
+} static_ASN1_SEQUENCE_END_cb(SSL_SESSION_ASN1, SSL_SESSION_ASN1)
 
 IMPLEMENT_STATIC_ASN1_ENCODE_FUNCTIONS(SSL_SESSION_ASN1)
 


### PR DESCRIPTION
Issue : #32639

Two ASN1 templates hold secrets in plain `ASN1_OCTET_STRING` fields with no
`ASN1_OP_FREE_PRE` callback, so `ASN1_item_free()` releases those bytes through
the default, non-cleansing path. `PKCS8_PRIV_KEY_INFO` (`crypto/asn1/p8_pkey.c`)
already handles this via `pkey_cb`; both fixes mirror it.

### `EC_PRIVATEKEY` (`crypto/ec/ec_asn1.c`) — the raw private scalar

This isn't confined to the legacy `d2i_ECPrivateKey()` / `"EC PRIVATE KEY"` PEM
path: `ossl_ec_key_from_pkcs8()` (`ec_backend.c`) calls `d2i_ECPrivateKey()` to
decode the SEC1 blob nested inside a PKCS8 payload, and is wired into the
provider decoder chain (`decode_der2key.c`), so ordinary
`PEM_read_bio_PrivateKey()` / `EVP_PKEY` loading of any EC key in default PKCS8
form hits it.

Also fixes the encode side: `i2d_ECPrivateKey()` already attempted a cleanse of
the raw buffer, but it became a no-op once `ASN1_STRING_set0()` moved ownership
into `priv_key->privateKey` and the local pointer was NULLed.

### `SSL_SESSION_ASN1` (`ssl/ssl_asn1.c`) — the TLS master key, decode side only

`i2d_SSL_SESSION()` is unaffected: the struct is stack-allocated and
`master_key` is aliased to the live `SSL_SESSION`'s own buffer via
`ssl_session_oinit()`, so there's nothing to free.

In `d2i_SSL_SESSION_ex()`, `d2i_SSL_SESSION_ASN1()` heap-allocates octet strings
from untrusted input, the bytes are copied out via
`ssl_session_memcpy(ret->master_key, ...)`, and the transient object is then
released with `M_ASN1_free_of()` on both success and error paths. This fires on
every `SSL_SESSION_from_bytes()` / `d2i_SSL_SESSION()` call — distributed
session caches, session persistence across restarts. `SSL_SESSION_free()`
already cleanses the long-lived object; the gap is only the transient
decode-time copy.

### Fix

Adds `eckey_priv_cb` and `ssl_session_asn1_cb`, switches both templates to
`ASN1_SEQUENCE_cb`, and cleanses `privateKey->data` / `master_key->data` on
`ASN1_OP_FREE_PRE`. No API/ABI change. CWE-226.

### Verification

Full build, no new warnings; EC keys round-trip correctly in both SEC1 and
PKCS8 form.

- `test_ec`, `test_ecdsa`, `test_internal_ec`, `test_ecparam`, `test_genec`,
  `test_evp_extra`, `test_pkcs12`, `test_pkey_check` — 104/104
- `test_bad_dtls` (direct `d2i_SSL_SESSION` exercise), `test_dtls13sessionid`,
  `test_sslsessiontick`, `test_dtls`, `test_sslapi`, `test_ssl_ctx`,
  `test_tls13ticket`, `test_ssl_new`, `test_tls13psk` — 66/66