### PR TITLE
Make the extended tests CI jobs run on ready_for_review

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -9,6 +9,7 @@ name: Cross Compile
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'doc/**'
       - '*.md'

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -12,6 +12,7 @@ name: Provider compatibility for PRs
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'doc/**'
       - '*.md'


### PR DESCRIPTION
This allows avoiding full CI re-run by the otherwise necessary close & reopen of the PR to re-run these jobs.

With this PR it is sufficient to mark the PR as draft and then back as ready for review to re-run these CI jobs depending on extended tests label.