### PR TITLE
Add design document for C509 certificates

### DIFF
--- a/doc/designs/c509.md
+++ b/doc/designs/c509.md
@@ -1,0 +1,360 @@
+C509 Certificate Design
+=======================
+
+[C509] specifies a CBOR encoding of X.509 certificates. The resulting
+certificates are called C509 certificates. They are substantially smaller than
+the DER-encoded originals, which matters for constrained devices and
+low-bandwidth links, and they can be parsed without an ASN.1 decoder.
+
+This design proposes the use of a new opaque type to represent C509
+certificates in libcrypto, together with an internal CBOR codec. It does not
+propose reusing `X509`; the reasons are given under
+[Why not decode into X509](#why-not-decode-into-x509).
+
+At the time of writing, [C509] has been approved by the IESG (2026-07-20,
+intended status Proposed Standard) and is in the RFC Editor queue. It is not
+yet an RFC and no number has been assigned. Two consequences are called out
+where they affect the design: the IANA registrations are not final, and the
+wire-format constants may still change.
+
+  [C509]: https://datatracker.ietf.org/doc/draft-ietf-cose-cbor-encoded-cert/
+
+Scope
+-----
+
+This design covers Section 3 of [C509] — the certificate format — and nothing
+else. The following parts of the specification are deliberately excluded from
+this work:
+
+| Excluded | [C509] section |
+| --- | --- |
+| C509 certification requests (CSRs) | 4 |
+| C509 private key structures | 3.6 |
+| C509 COSE header parameters | 3.4, 3.5 |
+| C509 Name in TLS and DTLS | 3.8 |
+| TLSA selectors, EDHOC credential types | 8.21, 8.22 |
+
+TLS use of C509 certificates is not part of this design either, but it is the
+intended second phase and a sketch is given under
+[Future work: TLS](#future-work-tls) so that the shape of the eventual
+integration is visible now.
+
+Certificate types
+-----------------
+
+The first element of a C509 `TBSCertificate` is `c509CertificateType`. It is
+not a translation of the X.509 `version` field. It records **which bytes the
+signature covers**:
+
+| Value | Meaning | Signature computed over |
+| --- | --- | --- |
+| 2 | Natively signed C509 certificate, X.509 v3 semantics | the CBOR sequence `TBSCertificate` |
+| 3 | CBOR re-encoding of a DER-encoded X.509 v3 certificate | the original **DER** encoding |
+
+This distinction drives the rest of the design. A type 3 certificate is only
+verifiable if the original DER encoding can be reproduced exactly, so the
+re-encoding must be a bijection rather than a semantic equivalence. [C509]
+achieves this with transforms that have no X.509 counterpart — for example the
+octets `0xfe` and `0xfd` are used in place of the SECG `0x02` and `0x03` point
+prefixes to record that the original DER carried an uncompressed EC point, so
+that compression can be undone on the way back.
+
+Why not decode into X509
+------------------------
+
+An obvious alternative is an `OSSL_DECODER` implementation that turns C509
+input into an ordinary `X509` and leaves everything else unchanged. It was
+considered and rejected.
+
+`X509` has nowhere to record `c509CertificateType`. Without it, a relying party
+cannot know whether the signature covers DER or CBOR, and therefore cannot
+verify the certificate at all. The loss is not a missing accessor; decoding
+discards a precondition of verification.
+
+The other objection is that the approach does not deliver what the format is
+for. Producing an `X509` requires the whole ASN.1 machinery, so neither the
+code-size argument nor the attack-surface argument survives.
+
+Object model
+------------
+
+A single opaque type represents both certificate types:
+
+```c
+typedef struct c509_st C509;
+```
+
+Types 2 and 3 have the same field set — both follow X.509 v3 — and differ only
+in what the signature covers. Modelling them as two types would duplicate the
+entire accessor surface to express one integer.
+
+A `C509` created by decoding a DER certificate, or by decoding a type 3 C509
+certificate, retains the DER encoding it was derived from. This mirrors the
+`ASN1_ENCODING enc` member that `X509_CINF` already carries for the same
+reason: signature verification must use the bytes as received, not a
+re-serialisation of the parsed structure. When the DER encoding is not
+available — a type 3 certificate constructed field by field — verification
+requires the encoder to regenerate it, and fails cleanly if it cannot.
+
+Accessors reuse the library's existing vocabulary. This design introduces a new
+certificate type, not a parallel ecosystem of names, times and keys:
+
+```c
+int C509_get_type(const C509 *cert);
+const ASN1_INTEGER *C509_get0_serialNumber(const C509 *cert);
+X509_NAME *C509_get_issuer_name(const C509 *cert);
+X509_NAME *C509_get_subject_name(const C509 *cert);
+const ASN1_TIME *C509_get0_notBefore(const C509 *cert);
+const ASN1_TIME *C509_get0_notAfter(const C509 *cert);
+EVP_PKEY *C509_get0_pubkey(const C509 *cert);
+const STACK_OF(X509_EXTENSION) *C509_get0_extensions(const C509 *cert);
+```
+
+Two C509 constructs have no X.509 counterpart and are exposed directly:
+
+```c
+/*
+ * In a self-signed certificate the issuer is encoded as CBOR null and
+ * C509_get_issuer_name() returns the subject. This reports the encoding.
+ */
+int C509_issuer_is_absent(const C509 *cert);
+
+/*
+ * notAfter is encoded as CBOR null when the certificate does not expire.
+ * C509_get0_notAfter() then reports 99991231235959Z, per RFC 5280.
+ */
+int C509_has_no_expiry(const C509 *cert);
+```
+
+Public API
+----------
+
+Lifecycle follows the conventions used elsewhere in libcrypto:
+
+```c
+C509 *C509_new(void);
+C509 *C509_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
+void C509_free(C509 *cert);
+C509 *C509_dup(const C509 *cert);
+int C509_up_ref(C509 *cert);
+```
+
+Encoding and decoding. The object is a C509 certificate, so `encode` and
+`decode` are unambiguous; the `d2i_`/`i2d_` prefixes are reserved for DER and
+are deliberately not used:
+
+```c
+C509 *C509_decode(OSSL_LIB_CTX *libctx, const char *propq,
+                  const unsigned char *in, size_t in_len);
+int C509_encode(const C509 *cert, unsigned char **out, size_t *out_len);
+
+C509 *C509_decode_bio(OSSL_LIB_CTX *libctx, const char *propq, BIO *bp);
+int C509_encode_bio(const C509 *cert, BIO *bp);
+```
+
+Signing and signature verification. Which bytes are covered is decided from
+the certificate type, so callers do not need to know:
+
+```c
+/*
+ * Signs the CBOR sequence TBSCertificate, producing a type 2 certificate.
+ * A type 3 certificate cannot be signed here: its signature is over DER
+ * produced elsewhere, and this call fails on one.
+ */
+int C509_sign(C509 *cert, EVP_PKEY *pkey, const EVP_MD *md);
+
+int C509_verify(C509 *cert, EVP_PKEY *pkey);
+int C509_get_signature_nid(const C509 *cert);
+```
+
+Field-by-field construction, printing and stack handling are deliberately not
+specified here. They mirror existing spellings — `X509_set1_*`,
+`X509_print_ex()`, `STACK_OF(X509)` — and settle no question this document
+needs to answer, while the form they take follows from one it cannot: whether
+a new certificate type belongs in libcrypto at all or is better expressed as a
+provider, where there is no public header to declare them in. `STACK_OF(C509)`
+additionally waits on [Chain verification](#chain-verification), since what a
+chain is made of depends on how one is checked. They are left to the API
+review that accompanies the implementation.
+
+Conversion to and from `X509`:
+
+```c
+/*
+ * Always succeeds for type 3: the bijection guarantees the original DER can
+ * be reproduced. For type 2 the field values convert, but the resulting X509
+ * carries a signature that is not valid over its DER encoding; callers that
+ * verify must use C509_verify() on the original object. See Chain
+ * verification below.
+ */
+X509 *C509_to_X509(const C509 *cert);
+
+/*
+ * Produces a type 3 certificate. Not total: see Encoding failures.
+ */
+C509 *C509_from_X509(const X509 *x);
+
+/*
+ * The DER encoding this object was derived from, if it retains one.
+ * Returns 0 and sets *der to NULL otherwise.
+ */
+int C509_get0_der(const C509 *cert, const unsigned char **der, size_t *der_len);
+```
+
+Chain verification
+------------------
+
+The first version does not perform chain verification. This is the largest open
+question in the design and the part most in need of review.
+
+`X509_STORE` and `X509_verify_cert()` are built around `X509` throughout, and
+they are among the most security-sensitive code in the library. Extending them
+is not something this design proposes to do speculatively. What the first
+version provides is single-certificate signature verification against a
+supplied key, which is enough to be useful and enough to be reviewed.
+
+Two candidate designs for the next step, neither yet chosen:
+
+**Convert and delegate.** `C509_to_X509()` followed by the existing
+`X509_verify_cert()`. For type 3 this is sound, because the conversion
+reproduces the original DER and the existing signature check operates on the
+bytes the signature actually covers. For type 2 it is not: the reconstructed
+DER was never signed. Making this work would require `X509_STORE` to accept a
+certificate whose signature has been verified by other means, which is a
+change to the verification core, not to C509.
+
+**A parallel store.** `C509_STORE` and `C509_verify_cert()`, duplicating path
+building, name constraints, policy processing and revocation. Correct in
+principle and a maintenance liability in practice: it doubles the code that has
+to be right.
+
+The first is far cheaper and is the more likely answer, but it needs a decision
+on how a store may accept an externally verified signature. That decision
+belongs to the OTC rather than to this document.
+
+Encoding failures
+-----------------
+
+Conversion from X.509 to C509 is not a total function. [C509] declares several
+X.509 constructs unsupported, and an encoder that silently produced something
+else would be worse than one that refuses. Each case gets its own reason code
+so that failures are diagnosable:
+
+| X.509 construct | [C509] | Reason code |
+| --- | --- | --- |
+| `issuerUniqueID` present | 3.1.8 | `C509_R_ISSUER_UNIQUE_ID_UNSUPPORTED` |
+| `subjectUniqueID` present | 3.1.9 | `C509_R_SUBJECT_UNIQUE_ID_UNSUPPORTED` |
+| RDN with more than one `AttributeTypeAndValue` | 3.1.4 | `C509_R_MULTI_VALUED_RDN` |
+| `TeletexString`, `UniversalString` or `BMPString` value | 3.1.4 | `C509_R_UNSUPPORTED_STRING_TYPE` |
+| Validity time `23:59:60` | 3.1.5 | `C509_R_LEAP_SECOND` |
+| Outer `signatureAlgorithm` differs from inner `signature` | 3.1.11 | `C509_R_SIGNATURE_ALGORITHM_MISMATCH` |
+| `BIT STRING` with non-zero unused bits | 3.1.7, 3.1.12 | `C509_R_UNUSED_BITS` |
+| Negative `serialNumber` | 3.1.2 | `C509_R_NEGATIVE_SERIAL_NUMBER` |
+
+The last is already forbidden by RFC 5280, but `ASN1_INTEGER` can hold one and
+certificates in the wild do.
+
+CBOR codec
+----------
+
+There is no CBOR support in the tree today, so one has to be written. It is
+proposed as a separate internal module, `crypto/cbor/`, with its interface in
+`include/crypto/cbor.h` and **no public API**.
+
+Keeping it separate costs nothing in compatibility terms precisely because it
+is internal, and it buys two things: it can be fuzzed and unit-tested against
+[RFC8949] independently of any C509 logic, and the parts of [C509] that are out
+of scope here — CSRs, private key structures, COSE header parameters — will
+need the same codec if they are implemented later.
+
+Only the subset [C509] requires is implemented:
+
+| Supported | |
+| --- | --- |
+| Major types | 0, 1, 2, 3, 4, and 7 restricted to the simple value `null` |
+| Tags | 1 (epoch time), 2 (unsigned bignum), 48 (MAC address, [RFC9542]), 111 (OID, [RFC9090]), 55799 (self-describe, [RFC9277]) |
+
+Maps, floating point and indefinite-length encoding are not accepted. The
+last is excluded by the deterministic encoding requirement in Section 3.7 of
+[C509] rather than by choice.
+
+The decoder enforces a hard nesting depth limit. Unbounded recursion over
+nested arrays is the classic failure mode for this kind of parser.
+
+Deterministic encoding has a consequence worth stating explicitly, because it
+shows up in the API: the encoder and decoder do not accept the same set of
+inputs. Natively signed certificates must use the specific CBOR encoding
+wherever one is defined, but a decoder has to accept the generic encoding as
+well, since a certificate may predate the registration of a specific one.
+
+  [RFC8949]: https://www.rfc-editor.org/rfc/rfc8949
+  [RFC9090]: https://www.rfc-editor.org/rfc/rfc9090
+  [RFC9277]: https://www.rfc-editor.org/rfc/rfc9277
+  [RFC9542]: https://www.rfc-editor.org/rfc/rfc9542
+
+File and transport encoding
+---------------------------
+
+[C509] defines no base64 armor. Certificates are carried as binary CBOR,
+identified by the `application/cose-c509-cert+cbor` media type, and stored
+files use the self-describing envelope of [RFC9277] Section 2.2 — CBOR tag
+55799 followed by a Content-Format number.
+
+No `-----BEGIN C509 CERTIFICATE-----` equivalent is introduced here. Inventing
+one would be a deviation from the specification dressed up as a convenience,
+and it would have to be un-invented if the working group ever defines a text
+form of its own. `C509_decode_bio()` and `C509_encode_bio()` therefore read and
+write binary CBOR, accepting and emitting the [RFC9277] envelope when present.
+
+The `C509PEM` structure in Section 3.6 of [C509] is unrelated despite the name.
+It is a CBOR array pairing a private key with an optional certificate, not a
+text encoding, and Section 3.6 is out of scope here in any case.
+
+Registry codepoints
+-------------------
+
+[C509] replaces OIDs and extension identifiers with small integers drawn from
+ten IANA registries (Sections 8.6 to 8.15). Those registrations are not yet
+final — the IANA state is still open — so the codepoints may move.
+
+All registry constants are therefore held in a single generated table rather
+than being spread through the codec, so that a registry change is one edit and
+not an audit. Test vectors are generated from
+[C509-test-vectors] by a script rather than being embedded in C source, for the
+same reason.
+
+  [C509-test-vectors]: https://datatracker.ietf.org/doc/draft-ietf-cose-c509-test-vectors/
+
+Configuration
+-------------
+
+The feature is disablable with `no-c509`, guarded by `OPENSSL_NO_C509`. A
+format whose stated purpose is to reduce footprint on constrained devices
+should not itself be unconditional.
+
+Future work: TLS
+----------------
+
+Nothing in this design touches libssl, but the intended second phase is TLS
+authentication with C509 certificates, and it is worth recording that this does
+not require protocol design work.
+
+Section 8.20 of [C509] negotiates C509 with the existing [RFC7250]
+`client_certificate_type` and `server_certificate_type` extensions, which
+OpenSSL already implements — `TLSEXT_TYPE_client_cert_type` and the certificate
+type codepoint table are in `include/openssl/tls1.h`, and the raw public key
+(`rpk`) support added for [RFC7250] is a working blueprint, complete with
+per-certificate-type branches in the state machine, tests and documentation.
+
+What a TLS phase needs is a new codepoint, a `CertificateEntry` case in TLS 1.3
+([RFC8446] Section 4.4.2), and the same branch points `rpk` already
+established. The `certificate_authorities` extension needs no change at all:
+Section 3.8 of [C509] carries a C509 Name inside an ordinary X.501
+distinguished name with a single attribute.
+
+This phase is blocked on IANA rather than on engineering. The TLS certificate
+type codepoint and the OID arc for the Name attribute are both unassigned.
+Without them there is nothing to interoperate with.
+
+  [RFC7250]: https://www.rfc-editor.org/rfc/rfc7250
+  [RFC8446]: https://www.rfc-editor.org/rfc/rfc8446

--- a/doc/designs/c509.md
+++ b/doc/designs/c509.md
@@ -34,10 +34,11 @@ this work:
 | C509 Name in TLS and DTLS | 3.8 |
 | TLSA selectors, EDHOC credential types | 8.21, 8.22 |
 
-TLS use of C509 certificates is not part of this design either, but it is the
-intended second phase and a sketch is given under
-[Future work: TLS](#future-work-tls) so that the shape of the eventual
-integration is visible now.
+Two things outside that list are not part of this design either, but are
+sketched so that the shape of the eventual result is visible now: how a
+certificate gets loaded and read from the command line, under
+[Loading and the command line](#loading-and-the-command-line), and TLS
+authentication, under [Future work: TLS](#future-work-tls).
 
 Certificate types
 -----------------
@@ -309,6 +310,38 @@ write binary CBOR, accepting and emitting the [RFC9277] envelope when present.
 The `C509PEM` structure in Section 3.6 of [C509] is unrelated despite the name.
 It is a CBOR array pairing a private key with an optional certificate, not a
 text encoding, and Section 3.6 is out of scope here in any case.
+
+Loading and the command line
+----------------------------
+
+A certificate format nobody can load is not useful, so the intended shape of
+that is recorded here even though it belongs to the phase after this one.
+Unlike the exclusions under [Scope](#scope), which are sections of [C509] with
+specifications of their own, none of this is specified by [C509] at all — it is
+OpenSSL-side usability, and the design is free to choose.
+
+**A new `openssl c509` command rather than an extension of `openssl x509`.**
+Certificate type is a property `X509` has no counterpart for, and options such
+as those selecting what to print or re-encode would have to mean different
+things depending on which format the input turned out to be; a separate command
+keeps each option's meaning fixed. The wiring cost is one source file:
+`apps/build.info` generates the command table with `progs.pl`, which discovers
+commands by scanning the `apps/` sources for a `<name>_main(int argc, ...)`
+definition, so adding `apps/c509.c` registers the command without editing a
+registry.
+
+**`OSSL_STORE` and `X509_LOOKUP` for loading by URI or directory.** A store
+loader would let `OSSL_STORE_load()` return a `C509`, and the three lookup
+methods in `crypto/x509` — `by_file.c`, `by_dir.c`, `by_store.c` — are where a
+certificate store would learn to supply one. Both depend on the answer to the
+question in [Chain verification](#chain-verification): there is little point
+teaching a store to supply a certificate type it cannot then verify, so neither
+is proposed until that is settled.
+
+None of this is part of the first version. The object model and the codec are
+what need agreement first, and a pull request that also rewrote the loading
+paths would be harder to review without adding any confidence in the parts that
+matter.
 
 Registry codepoints
 -------------------


### PR DESCRIPTION
This adds `doc/designs/c509.md`, a design document for supporting C509
certificates ([draft-ietf-cose-cbor-encoded-cert][C509]) in libcrypto.  It is a
document only — no implementation is proposed for merge here.

Opening it as a design document rather than as code because new public API is a
decision for the OTC, and because `doc/designs/ech-api.md` set the precedent
that a standalone design PR is a legitimate way to start that conversation.

The underlying request is [#13925][issue], open since 2021 and currently first
on the [large feature requests][triage] list.

  [C509]: https://datatracker.ietf.org/doc/draft-ietf-cose-cbor-encoded-cert/
  [issue]: https://github.com/openssl/openssl/issues/13925
  [triage]: https://github.com/openssl/project/issues/2053

##### What the document proposes

A new opaque type in libcrypto to represent C509 certificates, with an internal
CBOR codec under `crypto/cbor/` and no public API of its own.  Scope is
Section 3 of the specification — the certificate format — and the document
states explicitly what is excluded: certification requests (§4), private key
structures (§3.6), COSE header parameters (§3.4/§3.5), and C509 Name in TLS
(§3.8).

##### The two questions most likely to be contested

**Why not decode C509 into an ordinary `X509` via `OSSL_DECODER`?**  This was
@beldmit's suggestion on the issue, and the document answers it rather than
skirting it.  The first field of a C509 certificate records *which bytes the
signature covers*: type 2 is signed over the CBOR sequence, type 3 over the
original DER.  `X509` has nowhere to put that, so decoding into one discards a
precondition of verification — the loss is not a missing accessor.  Separately,
producing an `X509` requires the whole ASN.1 machinery, so neither the code-size
nor the attack-surface argument survives.

**How does chain verification work?**  The honest answer is that the first
version does not do it, and the document says so.  `X509_STORE` and
`X509_verify_cert()` are `X509`-centric throughout and among the most
security-sensitive code in the library; extending them speculatively is not
proposed.  Two candidate designs are set out with their costs, and the choice is
flagged as belonging to the OTC rather than to this document.  This is the part
most in need of review.

##### On specification status

[C509] was approved by the IESG on 2026-07-20 (intended status Proposed
Standard) and is in the RFC Editor queue.  It is not an RFC yet and no number
has been assigned — "come back when it is an RFC" remains a fair answer, and the
document is written so that the answer can be given cheaply.

Two consequences are called out where they affect the design.  The IANA
registrations are not final, so all registry codepoints are proposed to live in
a single generated table rather than spread through the codec; and the
conformance vectors come from the companion WG draft
[draft-ietf-cose-c509-test-vectors][vectors] via a regeneration script rather
than being embedded in C source, so a codepoint change is one edit and not an
audit.

  [vectors]: https://datatracker.ietf.org/doc/draft-ietf-cose-c509-test-vectors/

##### Is it implementable?

The CBOR codec the design depends on has been written and tested against
RFC 8949 Appendix A — 81 vectors, clean under ASAN and UBSAN, and building in
both the default and `no-c509` configurations.  It is deliberately **not** part
of this pull request; it is mentioned only because "would this actually work"
is a reasonable thing to ask of a design document, and because writing it
already corrected two points in an earlier draft of the document.

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated
