### PR TITLE
CONF: reject a NUL list separator

### DIFF
--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -695,6 +695,11 @@ int CONF_parse_list(const char *list_, int sep, int nospc,
         ERR_raise(ERR_LIB_CONF, CONF_R_LIST_CANNOT_BE_NULL);
         return 0;
     }
+    /* strchr() converts sep to unsigned char, so reject every NUL alias. */
+    if ((unsigned char)sep == '\0') {
+        ERR_raise(ERR_LIB_CONF, ERR_R_PASSED_INVALID_ARGUMENT);
+        return 0;
+    }
 
     lstart = list_;
     for (;;) {

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -695,7 +695,7 @@ int CONF_parse_list(const char *list_, int sep, int nospc,
         ERR_raise(ERR_LIB_CONF, CONF_R_LIST_CANNOT_BE_NULL);
         return 0;
     }
-    /* strchr() converts sep to unsigned char, so reject every NUL alias. */
+    /* Reject separators whose byte value is NUL. */
     if ((unsigned char)sep == '\0') {
         ERR_raise(ERR_LIB_CONF, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;

--- a/test/build.info
+++ b/test/build.info
@@ -52,7 +52,7 @@ IF[{- !$disabled{tests} -}]
           evp_fetch_prov_test evp_libctx_test ossl_store_test \
           v3nametest v3ext byteorder_test punycode_test evp_byname_test \
           crltest danetest bad_dtls_test lhash_test sparse_array_test \
-          conf_include_test params_api_test params_conversion_test \
+          conf_include_test conf_parse_list_test params_api_test params_conversion_test \
           constant_time_test crypto_memcmp_test ct_validation_helpers_test \
           safe_math_test verify_extra_test clienthellotest \
           packettest asynctest secmemtest srptest memleaktest stack_test \
@@ -901,6 +901,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[conf_include_test]=conf_include_test.c
   INCLUDE[conf_include_test]=../include ../apps/include
   DEPEND[conf_include_test]=../libcrypto libtestutil.a
+
+  SOURCE[conf_parse_list_test]=conf_parse_list_test.c
+  INCLUDE[conf_parse_list_test]=../include ../apps/include
+  DEPEND[conf_parse_list_test]=../libcrypto libtestutil.a
 
   IF[{- !$disabled{cmp} -}]
     PROGRAMS{noinst}=cmp_asn_test cmp_ctx_test cmp_status_test cmp_hdr_test \

--- a/test/conf_parse_list_test.c
+++ b/test/conf_parse_list_test.c
@@ -8,6 +8,7 @@
  */
 
 #include <limits.h>
+#include <string.h>
 
 #include <openssl/conf.h>
 #include <openssl/err.h>
@@ -26,6 +27,32 @@ static int list_cb(const char *elem, int len, void *arg)
     return 1;
 }
 
+static int count_and_stop_cb(const char *elem, int len, void *arg)
+{
+    (void)list_cb(elem, len, arg);
+    return 0;
+}
+
+static const char *expected[] = { "one", "two" };
+
+static int check_list_cb(const char *elem, int len, void *arg)
+{
+    int *idx = arg;
+    size_t expected_len;
+
+    if (!TEST_int_lt(*idx, (int)OSSL_NELEM(expected)))
+        return 0;
+
+    expected_len = strlen(expected[*idx]);
+    if (!TEST_ptr(elem)
+        || !TEST_int_eq(len, (int)expected_len)
+        || !TEST_mem_eq(elem, expected_len, expected[*idx], expected_len))
+        return 0;
+
+    (*idx)++;
+    return 1;
+}
+
 static int test_invalid_separator(int sep)
 {
     unsigned long err;
@@ -33,7 +60,7 @@ static int test_invalid_separator(int sep)
 
     ERR_clear_error();
     callback_count = 0;
-    if (!TEST_false(CONF_parse_list("entry", sep, 0, list_cb, NULL))
+    if (!TEST_false(CONF_parse_list("entry", sep, 0, count_and_stop_cb, NULL))
         || !TEST_int_eq(callback_count, 0))
         goto end;
 
@@ -51,11 +78,12 @@ end:
 
 static int test_valid_separator(void)
 {
-    ERR_clear_error();
-    callback_count = 0;
+    int idx = 0;
 
-    return TEST_true(CONF_parse_list("one,two", ',', 0, list_cb, NULL))
-        && TEST_int_eq(callback_count, 2)
+    ERR_clear_error();
+
+    return TEST_true(CONF_parse_list("one,two", ',', 0, check_list_cb, &idx))
+        && TEST_int_eq(idx, (int)OSSL_NELEM(expected))
         && TEST_ulong_eq(ERR_get_error(), 0);
 }
 

--- a/test/conf_parse_list_test.c
+++ b/test/conf_parse_list_test.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <limits.h>
+
+#include <openssl/conf.h>
+#include <openssl/err.h>
+
+#include "testutil.h"
+
+static int callback_count;
+
+static int list_cb(const char *elem, int len, void *arg)
+{
+    (void)elem;
+    (void)len;
+    (void)arg;
+
+    callback_count++;
+    return 1;
+}
+
+static int test_invalid_separator(int sep)
+{
+    unsigned long err;
+    int ret = 0;
+
+    ERR_clear_error();
+    callback_count = 0;
+    if (!TEST_false(CONF_parse_list("entry", sep, 0, list_cb, NULL))
+        || !TEST_int_eq(callback_count, 0))
+        goto end;
+
+    err = ERR_get_error();
+    if (!TEST_int_eq(ERR_GET_LIB(err), ERR_LIB_CONF)
+        || !TEST_int_eq(ERR_GET_REASON(err), ERR_R_PASSED_INVALID_ARGUMENT)
+        || !TEST_ulong_eq(ERR_get_error(), 0))
+        goto end;
+
+    ret = 1;
+end:
+    ERR_clear_error();
+    return ret;
+}
+
+static int test_valid_separator(void)
+{
+    ERR_clear_error();
+    callback_count = 0;
+
+    return TEST_true(CONF_parse_list("one,two", ',', 0, list_cb, NULL))
+        && TEST_int_eq(callback_count, 2)
+        && TEST_ulong_eq(ERR_get_error(), 0);
+}
+
+static int test_nul_separator(void)
+{
+    int ret = test_invalid_separator('\0');
+
+#if UCHAR_MAX < INT_MAX
+    ret &= test_invalid_separator(UCHAR_MAX + 1);
+    ret &= test_invalid_separator(-(UCHAR_MAX + 1));
+#endif
+    return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_valid_separator);
+    ADD_TEST(test_nul_separator);
+    return 1;
+}

--- a/test/recipes/02-test_conf_parse_list.t
+++ b/test/recipes/02-test_conf_parse_list.t
@@ -1,0 +1,11 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_conf_parse_list", "conf_parse_list_test");


### PR DESCRIPTION
Fixes #32667.

`CONF_parse_list()` accepts an `int` separator, while `strchr()` converts it to `char`. A separator value that converts to NUL therefore matches the string terminator. After processing that final element, the parser advances beyond the input and searches from the invalid pointer on the next iteration.

Reject every NUL-equivalent separator before parsing and raise `ERR_R_PASSED_INVALID_ARGUMENT`. The regression verifies the direct NUL value and positive/negative integer aliases, confirms that no callback is invoked, checks the error queue, and preserves normal comma-separated parsing.

The original issue and reproducer were reported by @x-ray-z, who is credited in the commit.

Verification:

- Baseline two-byte heap harness: reproduced a one-byte ASan heap-buffer-overflow read in `CONF_parse_list()`
- Patched direct test under ASan/UBSan: passed
- `make run_tests TESTS=test_conf_parse_list`: passed
- `git diff --check`: passed