### PR TITLE
Make X509 initialisation faster by not having a libctx dependency. 

### DIFF
--- a/Configure
+++ b/Configure
@@ -2058,8 +2058,11 @@ foreach my $what (sort keys %disabled) {
             }
         }
 
+        # siphash is used internally by libcrypto (X509 fingerprints), so
+        # no-siphash only removes the provider algorithm.
         $skipdir{"crypto/$skipdir"} = $what
-            unless $what eq 'async' || $what eq 'err' || $what eq 'dso' || $what eq 'http';
+            unless $what eq 'async' || $what eq 'err' || $what eq 'dso'
+                || $what eq 'http' || $what eq 'siphash';
     }
 }
 

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -21,6 +21,7 @@
 #include <openssl/core_names.h>
 #include "crypto/asn1.h"
 #include "crypto/evp.h"
+#include "asn1_local.h"
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 
@@ -280,6 +281,14 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
     if (!EVP_DigestSign(ctx, buf_out, &outl, buf_in, inl)) {
         outl = 0;
         ERR_raise(ERR_LIB_ASN1, ERR_R_EVP_LIB);
+        goto err;
+    }
+    /* Only a sequence item carries a cached encoding */
+    if ((it->itype == ASN1_ITYPE_SEQUENCE
+            || it->itype == ASN1_ITYPE_NDEF_SEQUENCE)
+        && !ossl_asn1_enc_save((ASN1_VALUE **)&data, buf_in, buf_len, it)) {
+        outl = 0;
+        ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
         goto err;
     }
     ASN1_STRING_set0(signature, buf_out, (int)outl);

--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -169,11 +169,14 @@ int ossl_asn1_enc_save(ASN1_VALUE **pval, const unsigned char *in, long inlen,
     if (enc == NULL)
         return 1;
 
+    /* A failure below leaves the item without a cached encoding */
     OPENSSL_free(enc->enc);
-    if (inlen <= 0) {
-        enc->enc = NULL;
+    enc->enc = NULL;
+    enc->len = 0;
+    enc->modified = 1;
+
+    if (inlen <= 0)
         return 0;
-    }
     if ((enc->enc = OPENSSL_malloc(inlen)) == NULL)
         return 0;
     memcpy(enc->enc, in, inlen);

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -518,7 +518,7 @@ static void scan_ext_flags(const X509 *x509, uint32_t *flags)
 /*
  * Cache info on various X.509v3 extensions and further derived information,
  * e.g., if cert 'x' is self-issued, in x->ex_flags and other internal fields.
- * x->sha1_hash is filled in, or else EXFLAG_NO_FINGERPRINT is set in x->flags.
+ * x->fingerprint is filled in, or else EXFLAG_NO_FINGERPRINT is set in x->flags.
  * X509_SIG_INFO_VALID is set in x->flags if x->siginf was filled successfully.
  * Set EXFLAG_INVALID and return 0 in case the certificate is invalid.
  *
@@ -537,7 +537,7 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     int i;
     int res;
     uint32_t tmp_ex_flags;
-    unsigned char tmp_sha1_hash[SHA_DIGEST_LENGTH];
+    unsigned char tmp_fingerprint[SHA_DIGEST_LENGTH];
     long tmp_ex_pathlen;
     long tmp_ex_pcpathlen;
     uint32_t tmp_ex_kusage;
@@ -570,8 +570,8 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
 
     ERR_set_mark();
 
-    /* Cache the SHA1 digest of the cert */
-    if (!X509_digest(const_x, EVP_sha1(), tmp_sha1_hash, NULL))
+    if (!ossl_x509_internal_fingerprint(ASN1_ITEM_rptr(X509), const_x,
+            tmp_fingerprint, sizeof(tmp_fingerprint)))
         tmp_ex_flags |= EXFLAG_NO_FINGERPRINT;
 
     /* V1 should mean no extensions ... */
@@ -768,7 +768,7 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     ((X509 *)const_x)->ex_pathlen = tmp_ex_pathlen;
     ((X509 *)const_x)->ex_pcpathlen = tmp_ex_pcpathlen;
     if (!(tmp_ex_flags & EXFLAG_NO_FINGERPRINT))
-        memcpy(((X509 *)const_x)->sha1_hash, tmp_sha1_hash, SHA_DIGEST_LENGTH);
+        memcpy(((X509 *)const_x)->fingerprint, tmp_fingerprint, SHA_DIGEST_LENGTH);
     if (tmp_ex_flags & EXFLAG_KUSAGE)
         ((X509 *)const_x)->ex_kusage = tmp_ex_kusage;
     ((X509 *)const_x)->ex_xkusage = tmp_ex_xkusage;

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -519,7 +519,6 @@ static void scan_ext_flags(const X509 *x509, uint32_t *flags)
  * Cache info on various X.509v3 extensions and further derived information,
  * e.g., if cert 'x' is self-issued, in x->ex_flags and other internal fields.
  * x->fingerprint is filled in, or else EXFLAG_NO_FINGERPRINT is set in x->flags.
- * X509_SIG_INFO_VALID is set in x->flags if x->siginf was filled successfully.
  * Set EXFLAG_INVALID and return 0 in case the certificate is invalid.
  *
  * This is usually called by side-effect on objects, and forces us to keep
@@ -548,7 +547,6 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     STACK_OF(GENERAL_NAME) *tmp_altname;
     NAME_CONSTRAINTS *tmp_nc;
     STACK_OF(DIST_POINT) *tmp_crldp = NULL;
-    X509_SIG_INFO tmp_siginf;
 
 #ifdef tsan_ld_acq
     /* Fast lock-free check, see end of the function for details. */
@@ -751,9 +749,6 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
 
     scan_ext_flags(const_x, &tmp_ex_flags);
 
-    /* Set x->siginf, ignoring errors due to unsupported algos */
-    (void)ossl_x509_init_sig_info(const_x, &tmp_siginf);
-
     tmp_ex_flags |= EXFLAG_SET; /* Indicate that cert has been processed */
     ERR_pop_to_mark();
 
@@ -790,7 +785,6 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     ASIdentifiers_free(((X509 *)const_x)->rfc3779_asid);
     ((X509 *)const_x)->rfc3779_asid = tmp_rfc3779_asid;
 #endif
-    ((X509 *)const_x)->siginf = tmp_siginf;
 
 #ifdef tsan_st_rel
     tsan_st_rel((TSAN_QUALIFIER int *)&const_x->ex_cached, 1);

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -518,7 +518,8 @@ static void scan_ext_flags(const X509 *x509, uint32_t *flags)
 /*
  * Cache info on various X.509v3 extensions and further derived information,
  * e.g., if cert 'x' is self-issued, in x->ex_flags and other internal fields.
- * x->fingerprint is filled in, or else EXFLAG_NO_FINGERPRINT is set in x->flags.
+ * x->fingerprint is filled in, or else EXFLAG_NO_FINGERPRINT is set in
+ * x->ex_flags.
  * Set EXFLAG_INVALID and return 0 in case the certificate is invalid.
  *
  * This is usually called by side-effect on objects, and forces us to keep
@@ -536,7 +537,7 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     int i;
     int res;
     uint32_t tmp_ex_flags;
-    unsigned char tmp_fingerprint[SHA_DIGEST_LENGTH];
+    unsigned char tmp_fingerprint[OSSL_X509_FINGERPRINT_SIZE];
     long tmp_ex_pathlen;
     long tmp_ex_pcpathlen;
     uint32_t tmp_ex_kusage;
@@ -569,7 +570,7 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     ERR_set_mark();
 
     if (!ossl_x509_internal_fingerprint(ASN1_ITEM_rptr(X509), const_x,
-            tmp_fingerprint, sizeof(tmp_fingerprint)))
+            tmp_fingerprint))
         tmp_ex_flags |= EXFLAG_NO_FINGERPRINT;
 
     /* V1 should mean no extensions ... */
@@ -763,7 +764,8 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     ((X509 *)const_x)->ex_pathlen = tmp_ex_pathlen;
     ((X509 *)const_x)->ex_pcpathlen = tmp_ex_pcpathlen;
     if (!(tmp_ex_flags & EXFLAG_NO_FINGERPRINT))
-        memcpy(((X509 *)const_x)->fingerprint, tmp_fingerprint, SHA_DIGEST_LENGTH);
+        memcpy(((X509 *)const_x)->fingerprint, tmp_fingerprint,
+            sizeof(tmp_fingerprint));
     if (tmp_ex_flags & EXFLAG_KUSAGE)
         ((X509 *)const_x)->ex_kusage = tmp_ex_kusage;
     ((X509 *)const_x)->ex_xkusage = tmp_ex_xkusage;

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -174,6 +174,13 @@ int X509_cmp(const X509 *a, const X509 *b)
             return 1;
         rv = memcmp(a->cert_info.enc.enc,
             b->cert_info.enc.enc, a->cert_info.enc.len);
+        if (rv != 0)
+            return rv < 0 ? -1 : 1;
+        /* Same TBS: the signature algorithm and signature must match too */
+        rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
+        if (rv != 0)
+            return rv < 0 ? -1 : 1;
+        rv = ASN1_STRING_cmp(&a->signature, &b->signature);
     }
     return rv < 0 ? -1 : rv > 0;
 }

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -97,7 +97,7 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 
     if ((a->flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->flags & EXFLAG_NO_FINGERPRINT) == 0)
-        rv = memcmp(a->sha1_hash, b->sha1_hash, SHA_DIGEST_LENGTH);
+        rv = memcmp(a->fingerprint, b->fingerprint, SHA_DIGEST_LENGTH);
     if (rv != 0)
         return rv < 0 ? -1 : 1;
 
@@ -189,7 +189,7 @@ int X509_cmp(const X509 *a, const X509 *b)
 
     if ((a->ex_flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->ex_flags & EXFLAG_NO_FINGERPRINT) == 0)
-        rv = memcmp(a->sha1_hash, b->sha1_hash, SHA_DIGEST_LENGTH);
+        rv = memcmp(a->fingerprint, b->fingerprint, SHA_DIGEST_LENGTH);
     if (rv != 0)
         return rv < 0 ? -1 : 1;
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -88,6 +88,13 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 {
     int rv = 0;
 
+    if (a == b)
+        return 0;
+
+    /* A CRL modified since it was signed or decoded is equal only to itself */
+    if (a->crl.enc.modified || b->crl.enc.modified)
+        return a->crl.enc.modified ? 1 : -1;
+
     if ((a->flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->flags & EXFLAG_NO_FINGERPRINT) == 0)
         rv = memcmp(a->sha1_hash, b->sha1_hash, SHA_DIGEST_LENGTH);
@@ -95,20 +102,18 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
         return rv < 0 ? -1 : 1;
 
     /* Check for match against stored encoding too */
-    if (!a->crl.enc.modified && !b->crl.enc.modified) {
-        if (a->crl.enc.len < b->crl.enc.len)
-            return -1;
-        if (a->crl.enc.len > b->crl.enc.len)
-            return 1;
-        rv = memcmp(a->crl.enc.enc, b->crl.enc.enc, a->crl.enc.len);
-        if (rv != 0)
-            return rv < 0 ? -1 : 1;
-        /* Same TBS: the signature algorithm and signature must match too */
-        rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
-        if (rv != 0)
-            return rv < 0 ? -1 : 1;
-        rv = ASN1_STRING_cmp(&a->signature, &b->signature);
-    }
+    if (a->crl.enc.len < b->crl.enc.len)
+        return -1;
+    if (a->crl.enc.len > b->crl.enc.len)
+        return 1;
+    rv = memcmp(a->crl.enc.enc, b->crl.enc.enc, a->crl.enc.len);
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
+    /* Same TBS: the signature algorithm and signature must match too */
+    rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
+    rv = ASN1_STRING_cmp(&a->signature, &b->signature);
     return rv < 0 ? -1 : rv > 0;
 }
 
@@ -171,6 +176,13 @@ int X509_cmp(const X509 *a, const X509 *b)
     if (a == b) /* for efficiency */
         return 0;
 
+    /*
+     * A certificate modified since it was signed or decoded is equal only
+     * to itself
+     */
+    if (a->cert_info.enc.modified || b->cert_info.enc.modified)
+        return a->cert_info.enc.modified ? 1 : -1;
+
     /* attempt to compute cert hash */
     (void)X509_check_purpose((X509 *)a, -1, 0);
     (void)X509_check_purpose((X509 *)b, -1, 0);
@@ -182,21 +194,19 @@ int X509_cmp(const X509 *a, const X509 *b)
         return rv < 0 ? -1 : 1;
 
     /* Check for match against stored encoding too */
-    if (!a->cert_info.enc.modified && !b->cert_info.enc.modified) {
-        if (a->cert_info.enc.len < b->cert_info.enc.len)
-            return -1;
-        if (a->cert_info.enc.len > b->cert_info.enc.len)
-            return 1;
-        rv = memcmp(a->cert_info.enc.enc,
-            b->cert_info.enc.enc, a->cert_info.enc.len);
-        if (rv != 0)
-            return rv < 0 ? -1 : 1;
-        /* Same TBS: the signature algorithm and signature must match too */
-        rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
-        if (rv != 0)
-            return rv < 0 ? -1 : 1;
-        rv = ASN1_STRING_cmp(&a->signature, &b->signature);
-    }
+    if (a->cert_info.enc.len < b->cert_info.enc.len)
+        return -1;
+    if (a->cert_info.enc.len > b->cert_info.enc.len)
+        return 1;
+    rv = memcmp(a->cert_info.enc.enc,
+        b->cert_info.enc.enc, a->cert_info.enc.len);
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
+    /* Same TBS: the signature algorithm and signature must match too */
+    rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
+    rv = ASN1_STRING_cmp(&a->signature, &b->signature);
     return rv < 0 ? -1 : rv > 0;
 }
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -97,7 +97,7 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 
     if ((a->flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->flags & EXFLAG_NO_FINGERPRINT) == 0)
-        rv = memcmp(a->fingerprint, b->fingerprint, SHA_DIGEST_LENGTH);
+        rv = memcmp(a->fingerprint, b->fingerprint, sizeof(a->fingerprint));
     if (rv != 0)
         return rv < 0 ? -1 : 1;
 
@@ -189,7 +189,7 @@ int X509_cmp(const X509 *a, const X509 *b)
 
     if ((a->ex_flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->ex_flags & EXFLAG_NO_FINGERPRINT) == 0)
-        rv = memcmp(a->fingerprint, b->fingerprint, SHA_DIGEST_LENGTH);
+        rv = memcmp(a->fingerprint, b->fingerprint, sizeof(a->fingerprint));
     if (rv != 0)
         return rv < 0 ? -1 : 1;
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -86,14 +86,29 @@ int X509_CRL_cmp(const X509_CRL *a, const X509_CRL *b)
 
 int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 {
-    int rv;
+    int rv = 0;
 
     if ((a->flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->flags & EXFLAG_NO_FINGERPRINT) == 0)
         rv = memcmp(a->sha1_hash, b->sha1_hash, SHA_DIGEST_LENGTH);
-    else
-        return -2;
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
 
+    /* Check for match against stored encoding too */
+    if (!a->crl.enc.modified && !b->crl.enc.modified) {
+        if (a->crl.enc.len < b->crl.enc.len)
+            return -1;
+        if (a->crl.enc.len > b->crl.enc.len)
+            return 1;
+        rv = memcmp(a->crl.enc.enc, b->crl.enc.enc, a->crl.enc.len);
+        if (rv != 0)
+            return rv < 0 ? -1 : 1;
+        /* Same TBS: the signature algorithm and signature must match too */
+        rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
+        if (rv != 0)
+            return rv < 0 ? -1 : 1;
+        rv = ASN1_STRING_cmp(&a->signature, &b->signature);
+    }
     return rv < 0 ? -1 : rv > 0;
 }
 

--- a/crypto/x509/x509_ext.c
+++ b/crypto/x509/x509_ext.c
@@ -59,12 +59,20 @@ void *X509_CRL_get_ext_d2i(const X509_CRL *x, int nid, int *crit, int *idx)
 int X509_CRL_add1_ext_i2d(X509_CRL *x, int nid, void *value, int crit,
     unsigned long flags)
 {
+    /*
+     * Assume modified, sadly the underlying function does not tell us whether
+     * changes were made, or not.
+     */
+    x->crl.enc.modified = 1;
     return X509V3_add1_i2d(&x->crl.extensions, nid, value, crit, flags);
 }
 
 int X509_CRL_add_ext(X509_CRL *x, const X509_EXTENSION *ex, int loc)
 {
-    return (X509v3_add_ext(&(x->crl.extensions), ex, loc) != NULL);
+    if (X509v3_add_ext(&x->crl.extensions, ex, loc) == NULL)
+        return 0;
+    x->crl.enc.modified = 1;
+    return 1;
 }
 
 int X509_get_ext_count(const X509 *x)

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -202,13 +202,6 @@ void X509_SIG_INFO_set(X509_SIG_INFO *siginf, int mdnid, int pknid,
     siginf->flags = flags;
 }
 
-int X509_get_signature_info(const X509 *x, int *mdnid, int *pknid, int *secbits,
-    uint32_t *flags)
-{
-    X509_check_purpose(x, -1, -1);
-    return X509_SIG_INFO_get(&x->siginf, mdnid, pknid, secbits, flags);
-}
-
 /* Modify *siginf according to alg and sig. Return 1 on success, else 0. */
 static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     const ASN1_STRING *sig, const EVP_PKEY *pubkey,
@@ -312,9 +305,18 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     return 1;
 }
 
-/* Returns 1 on success, 0 on failure */
-int ossl_x509_init_sig_info(const X509 *x, X509_SIG_INFO *info)
+int X509_get_signature_info(const X509 *x, int *mdnid, int *pknid, int *secbits,
+    uint32_t *flags)
 {
-    return x509_sig_info_init(info, &x->sig_alg, &x->signature,
+    X509_SIG_INFO siginf;
+
+    if (x == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    ERR_set_mark();
+    (void)x509_sig_info_init(&siginf, &x->sig_alg, &x->signature,
         X509_PUBKEY_get0(x->cert_info.key), x->libctx, x->propq);
+    ERR_pop_to_mark();
+    return X509_SIG_INFO_get(&siginf, mdnid, pknid, secbits, flags);
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -49,8 +49,8 @@ int X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial)
     if (x == NULL)
         return 0;
     in = &x->cert_info.serialNumber;
-    if (in != serial)
-        return ASN1_STRING_copy(in, serial);
+    if (in != serial && !ASN1_STRING_copy(in, serial))
+        return 0;
     x->cert_info.enc.modified = 1;
     return 1;
 }

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -770,15 +770,6 @@ int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    if (EVP_MD_is_a(type, SN_sha1)
-        && (data->flags & EXFLAG_SET) != 0
-        && (data->flags & EXFLAG_NO_FINGERPRINT) == 0) {
-        /* Asking for SHA1; always computed in CRL d2i. */
-        if (len != NULL)
-            *len = sizeof(data->fingerprint);
-        memcpy(md, data->fingerprint, sizeof(data->fingerprint));
-        return 1;
-    }
     return ossl_asn1_item_digest_ex(ASN1_ITEM_rptr(X509_CRL), type, (char *)data,
         md, len, data->libctx, data->propq);
 }

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -30,6 +30,7 @@
 #include "crypto/x509.h"
 #include "crypto/x509_acert.h"
 #include "crypto/rsa.h"
+#include "crypto/sha.h"
 #include "x509_local.h"
 
 static void *RSA_new_thunk(void)
@@ -643,17 +644,27 @@ int X509_pubkey_digest(const X509 *data, const EVP_MD *type,
     return EVP_Digest(key->data, key->length, md, len, type, NULL);
 }
 
+int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
+    unsigned char *hash, size_t hash_size)
+{
+    unsigned char *der = NULL;
+    int der_len;
+
+    if (!ossl_assert(hash_size >= SHA_DIGEST_LENGTH)) {
+        ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    der_len = ASN1_item_i2d((const ASN1_VALUE *)val, &der, it);
+    if (der_len < 0)
+        return 0;
+    ossl_sha1(der, (size_t)der_len, hash);
+    OPENSSL_free(der);
+    return 1;
+}
+
 int X509_digest(const X509 *cert, const EVP_MD *md, unsigned char *data,
     unsigned int *len)
 {
-    if (EVP_MD_is_a(md, SN_sha1) && (cert->ex_flags & EXFLAG_SET) != 0
-        && (cert->ex_flags & EXFLAG_NO_FINGERPRINT) == 0) {
-        /* Asking for SHA1 and we already computed it. */
-        if (len != NULL)
-            *len = sizeof(cert->sha1_hash);
-        memcpy(data, cert->sha1_hash, sizeof(cert->sha1_hash));
-        return 1;
-    }
     return ossl_asn1_item_digest_ex(ASN1_ITEM_rptr(X509), md, (char *)cert,
         data, len, cert->libctx, cert->propq);
 }
@@ -764,8 +775,8 @@ int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
         && (data->flags & EXFLAG_NO_FINGERPRINT) == 0) {
         /* Asking for SHA1; always computed in CRL d2i. */
         if (len != NULL)
-            *len = sizeof(data->sha1_hash);
-        memcpy(md, data->sha1_hash, sizeof(data->sha1_hash));
+            *len = sizeof(data->fingerprint);
+        memcpy(md, data->fingerprint, sizeof(data->fingerprint));
         return 1;
     }
     return ossl_asn1_item_digest_ex(ASN1_ITEM_rptr(X509_CRL), type, (char *)data,

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -30,7 +30,7 @@
 #include "crypto/x509.h"
 #include "crypto/x509_acert.h"
 #include "crypto/rsa.h"
-#include "crypto/sha.h"
+#include "crypto/siphash.h"
 #include "x509_local.h"
 
 static void *RSA_new_thunk(void)
@@ -645,19 +645,20 @@ int X509_pubkey_digest(const X509 *data, const EVP_MD *type,
 }
 
 int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
-    unsigned char *hash, size_t hash_size)
+    unsigned char *hash)
 {
+    static const unsigned char key[SIPHASH_KEY_SIZE] = { 0 };
+    SIPHASH ctx = { 0 };
     unsigned char *der = NULL;
     int der_len;
 
-    if (!ossl_assert(hash_size >= SHA_DIGEST_LENGTH)) {
-        ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
-        return 0;
-    }
     der_len = ASN1_item_i2d((const ASN1_VALUE *)val, &der, it);
     if (der_len < 0)
         return 0;
-    ossl_sha1(der, (size_t)der_len, hash);
+    (void)SipHash_set_hash_size(&ctx, OSSL_X509_FINGERPRINT_SIZE);
+    (void)SipHash_Init(&ctx, key, 0, 0);
+    SipHash_Update(&ctx, der, (size_t)der_len);
+    (void)SipHash_Final(&ctx, hash, OSSL_X509_FINGERPRINT_SIZE);
     OPENSSL_free(der);
     return 1;
 }

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -245,7 +245,7 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         break;
 
     case ASN1_OP_D2I_POST:
-        if (!X509_CRL_digest(crl, EVP_sha1(), crl->sha1_hash, NULL))
+        if (!X509_CRL_digest(crl, EVP_sha1(), crl->fingerprint, NULL))
             crl->flags |= EXFLAG_NO_FINGERPRINT;
         crl->idp = X509_CRL_get_ext_d2i(crl, NID_issuing_distribution_point, &i, NULL);
         if (crl->idp == NULL && i != -1) {

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -208,7 +208,8 @@ static int crl_set_issuers(X509_CRL *crl)
 
 /*
  * The X509_CRL structure needs a bit of customisation. Cache some extensions
- * and hash of the whole CRL or set EXFLAG_NO_FINGERPRINT if this fails.
+ * and the internal-use fingerprint of the whole CRL, or set
+ * EXFLAG_NO_FINGERPRINT if this fails.
  */
 static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     void *exarg)
@@ -245,7 +246,8 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         break;
 
     case ASN1_OP_D2I_POST:
-        if (!X509_CRL_digest(crl, EVP_sha1(), crl->fingerprint, NULL))
+        if (!ossl_x509_internal_fingerprint(ASN1_ITEM_rptr(X509_CRL), crl,
+                crl->fingerprint, sizeof(crl->fingerprint)))
             crl->flags |= EXFLAG_NO_FINGERPRINT;
         crl->idp = X509_CRL_get_ext_d2i(crl, NID_issuing_distribution_point, &i, NULL);
         if (crl->idp == NULL && i != -1) {

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -247,7 +247,7 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 
     case ASN1_OP_D2I_POST:
         if (!ossl_x509_internal_fingerprint(ASN1_ITEM_rptr(X509_CRL), crl,
-                crl->fingerprint, sizeof(crl->fingerprint)))
+                crl->fingerprint))
             crl->flags |= EXFLAG_NO_FINGERPRINT;
         crl->idp = X509_CRL_get_ext_d2i(crl, NID_issuing_distribution_point, &i, NULL);
         if (crl->idp == NULL && i != -1) {

--- a/doc/internal/man3/x509v3_cache_extensions.pod
+++ b/doc/internal/man3/x509v3_cache_extensions.pod
@@ -16,9 +16,9 @@ x509v3_cache_extensions
 This function processes any X509v3 extensions present in an X509 object I<x>
 and caches the result of that processing as well as further derived info,
 for instance whether the certificate is self-issued or has version X.509v1.
-It computes an internal-use SHA1 fingerprint of the certificate, used only by
-L<X509_cmp(3)> and never exposed to callers, with the built-in SHA1
-implementation, independent of any library context or property query string,
+It computes an internal-use fingerprint of the certificate, used only by
+L<X509_cmp(3)> and never exposed to callers,
+independent of any library context or property query string,
 and stores the result in x->fingerprint;
 on failure (the certificate cannot be DER encoded, for instance because it is
 still under construction, or memory allocation failed) it sets

--- a/doc/internal/man3/x509v3_cache_extensions.pod
+++ b/doc/internal/man3/x509v3_cache_extensions.pod
@@ -23,8 +23,6 @@ and stores the result in x->fingerprint;
 on failure (the certificate cannot be DER encoded, for instance because it is
 still under construction, or memory allocation failed) it sets
 B<EXFLAG_NO_FINGERPRINT> in x->flags instead.
-It sets B<X509_SIG_INFO_VALID> in x->flags if x->siginf was filled successfully,
-which may not be possible if a referenced algorithm is unknown or not available.
 Many OpenSSL functions that use an X509 object call this function implicitly.
 
 =head1 RETURN VALUES

--- a/doc/internal/man3/x509v3_cache_extensions.pod
+++ b/doc/internal/man3/x509v3_cache_extensions.pod
@@ -16,9 +16,13 @@ x509v3_cache_extensions
 This function processes any X509v3 extensions present in an X509 object I<x>
 and caches the result of that processing as well as further derived info,
 for instance whether the certificate is self-issued or has version X.509v1.
-It computes the SHA1 digest of the certificate using the default library context
-and property query string and stores the result in x->sha1_hash,
-or on failure sets B<EXFLAG_NO_FINGERPRINT> in x->flags.
+It computes an internal-use SHA1 fingerprint of the certificate, used only by
+L<X509_cmp(3)> and never exposed to callers, with the built-in SHA1
+implementation, independent of any library context or property query string,
+and stores the result in x->fingerprint;
+on failure (the certificate cannot be DER encoded, for instance because it is
+still under construction, or memory allocation failed) it sets
+B<EXFLAG_NO_FINGERPRINT> in x->flags instead.
 It sets B<X509_SIG_INFO_VALID> in x->flags if x->siginf was filled successfully,
 which may not be possible if a referenced algorithm is unknown or not available.
 Many OpenSSL functions that use an X509 object call this function implicitly.

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -28,8 +28,7 @@ The X509_cmp() function compares two B<X509> objects indicated by parameters
 I<a> and I<b>. The comparison is based on the B<memcmp> result of the hash
 values of two B<X509> objects and the canonical (DER) encoding values.
 A certificate that has been modified since it was signed or decoded, and
-not signed again, compares equal only to itself, and sorts after any
-certificate that has not been modified.
+not signed again, compares equal only to itself.
 
 The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
 parameters I<a> and I<b>, any of which may be NULL.
@@ -52,8 +51,7 @@ objects, respectively.
 The X509_CRL_match() function compares two B<X509_CRL> objects. Unlike the
 X509_CRL_cmp() function, this function compares the whole CRL content instead
 of just the issuer name. A CRL that has been modified since it was signed or
-decoded, and not signed again, compares equal only to itself, and sorts after
-any CRL that has not been modified.
+decoded, and not signed again, compares equal only to itself.
 
 =head1 RETURN VALUES
 
@@ -70,8 +68,11 @@ to indicate an error, and callers should still be prepared to receive it.
 
 These functions in fact utilize the underlying B<memcmp> of the C library to do
 the comparison job. Data to be compared varies from DER encoding data, hash
-value or B<ASN1_STRING>. The sign of the comparison can be used to order the
-objects but it does not have a special meaning in some cases.
+value or B<ASN1_STRING>. The sign of the result of X509_cmp() and
+X509_CRL_match() orders objects consistently only while none of them has been
+modified since it was signed or decoded, and the internal hash of each could
+be computed. A modified object compares unequal to every other object, but
+two modified objects are not ordered with respect to each other.
 
 X509_NAME_cmp() and wrappers utilize the value B<-2> to indicate errors in some
 circumstances, which could cause confusion for the applications.

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -56,8 +56,10 @@ The B<X509> comparison functions return B<-1>, B<0>, or B<1> if object I<a> is
 found to be less than, to match, or be greater than object I<b>, respectively.
 
 X509_NAME_cmp(), X509_issuer_and_serial_cmp(), X509_issuer_name_cmp(),
-X509_subject_name_cmp(), X509_CRL_cmp(), and X509_CRL_match()
+X509_subject_name_cmp(), and X509_CRL_cmp()
 may return B<-2> to indicate an error.
+X509_CRL_match() no longer returns B<-2>, but did so in earlier versions
+to indicate an error, and callers should still be prepared to receive it.
 
 =head1 NOTES
 

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -27,6 +27,9 @@ certificates, X509 CRL objects and various values in an X509 certificate.
 The X509_cmp() function compares two B<X509> objects indicated by parameters
 I<a> and I<b>. The comparison is based on the B<memcmp> result of the hash
 values of two B<X509> objects and the canonical (DER) encoding values.
+A certificate that has been modified since it was signed or decoded, and
+not signed again, compares equal only to itself, and sorts after any
+certificate that has not been modified.
 
 The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
 parameters I<a> and I<b>, any of which may be NULL.
@@ -48,7 +51,9 @@ objects, respectively.
 
 The X509_CRL_match() function compares two B<X509_CRL> objects. Unlike the
 X509_CRL_cmp() function, this function compares the whole CRL content instead
-of just the issuer name.
+of just the issuer name. A CRL that has been modified since it was signed or
+decoded, and not signed again, compares equal only to itself, and sorts after
+any CRL that has not been modified.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/X509_get_extension_flags.pod
+++ b/doc/man3/X509_get_extension_flags.pod
@@ -86,8 +86,9 @@ ASN1 object itself.
 
 =item B<EXFLAG_NO_FINGERPRINT>
 
-Failed to compute the internal SHA1 hash value of the certificate or CRL.
-This may be due to malloc failure or because no SHA1 implementation was found.
+Failed to compute the internal fingerprint of the certificate or CRL,
+because it could not be DER encoded (for instance a certificate still under
+construction) or on memory allocation failure.
 
 =item B<EXFLAG_INVALID_POLICY>
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -19,6 +19,19 @@
 #include "crypto/types.h"
 
 #include <crypto/asn1.h>
+#include <crypto/siphash.h>
+
+/*
+ * Size in bytes of the internal X509 / X509_CRL fingerprint, see
+ * ossl_x509_internal_fingerprint(). The fingerprint only short-circuits
+ * X509_cmp() and X509_CRL_match(), which compare the encodings on a match,
+ * so a collision costs one extra memcmp. With 64 bits a collision among
+ * n objects has probability about n^2 / 2^65: one in 10^12 for 10,000
+ * certificates, and even odds only at around 2^32 of them. The SipHash key
+ * is fixed, so an attacker can craft certificates that collide, but gains
+ * only that memcmp per colliding pair on certificates they had to supply.
+ */
+#define OSSL_X509_FINGERPRINT_SIZE SIPHASH_MIN_DIGEST_SIZE
 
 /* Internal X509 structures and functions: not for application use */
 
@@ -119,8 +132,12 @@ struct X509_crl_st {
     ASN1_INTEGER *crl_number;
     ASN1_INTEGER *base_crl_number;
     STACK_OF(GENERAL_NAMES) *issuers;
-    /* internal-use fingerprint for X509_CRL_match(), see ossl_x509_internal_fingerprint() */
-    unsigned char fingerprint[SHA_DIGEST_LENGTH];
+    /*
+     * Internal-use fingerprint for X509_CRL_match(), see
+     * ossl_x509_internal_fingerprint(). Not cryptographically secure and
+     * not collision free: a match is confirmed by comparing the CRLs.
+     */
+    unsigned char fingerprint[OSSL_X509_FINGERPRINT_SIZE];
     /* alternative method to handle this CRL */
     const X509_CRL_METHOD *meth;
     void *meth_data;
@@ -197,8 +214,12 @@ struct x509_st {
     STACK_OF(IPAddressFamily) *rfc3779_addr;
     struct ASIdentifiers_st *rfc3779_asid;
 #endif
-    /* internal-use fingerprint for X509_cmp(), see ossl_x509_internal_fingerprint() */
-    unsigned char fingerprint[SHA_DIGEST_LENGTH];
+    /*
+     * Internal-use fingerprint for X509_cmp(), see
+     * ossl_x509_internal_fingerprint(). Not cryptographically secure and
+     * not collision free: a match is confirmed by comparing the certificates.
+     */
+    unsigned char fingerprint[OSSL_X509_FINGERPRINT_SIZE];
     X509_CERT_AUX *aux;
     CRYPTO_RWLOCK *lock;
     volatile int ex_cached;
@@ -324,22 +345,23 @@ int ossl_x509v3_cache_extensions(const X509 *x);
  * The fingerprint is cached in X509 / X509_CRL fingerprint and used only for
  * internal identity comparison (X509_cmp(), X509_CRL_match()); it is never
  * returned to callers, so the algorithm is an implementation detail
- * (currently SHA-1). It uses the built-in implementation directly rather
- * than fetching one, so the result depends on neither the library context
- * nor the property query string of the object and stays valid if the object
- * is moved to another library context. It fails only if the object cannot be
+ * (currently SipHash-2-4 with a fixed key and 64-bit output; a collision
+ * only costs the callers a fall through to their encoding comparison).
+ * Callers hash the whole signed object (X509, X509_CRL). No algorithm
+ * is fetched, so the result depends on neither the library context nor the
+ * property query string of the object and stays valid if the object is
+ * moved to another library context. It fails only if the object cannot be
  * DER encoded, for instance a certificate still under construction, or on
  * an allocation failure in the encoder.
  *
  * @param it the ASN1_ITEM describing @p val
  * @param val the object to encode and hash
- * @param hash output buffer for the fingerprint
- * @param hash_size size in bytes of @p hash, must be at least
- *                  SHA_DIGEST_LENGTH
+ * @param hash output buffer for the fingerprint, OSSL_X509_FINGERPRINT_SIZE
+ *             bytes
  * @returns 1 on success, 0 on failure
  */
 int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
-    unsigned char *hash, size_t hash_size);
+    unsigned char *hash);
 
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
 int ossl_x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx,

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -178,7 +178,6 @@ struct x509_st {
     X509_CINF cert_info;
     X509_ALGOR sig_alg;
     ASN1_BIT_STRING signature;
-    X509_SIG_INFO siginf;
     CRYPTO_REF_COUNT references;
     CRYPTO_EX_DATA ex_data;
     /* These contain copies of various extension values */
@@ -318,7 +317,6 @@ int ossl_a2i_ipadd(unsigned char *ipout, const char *ipasc);
 int ossl_x509_set1_time(int *modified, ASN1_TIME **ptm, const ASN1_TIME *tm);
 int ossl_x509_print_ex_brief(BIO *bio, const X509 *cert, unsigned long neg_cflags);
 int ossl_x509v3_cache_extensions(const X509 *x);
-int ossl_x509_init_sig_info(const X509 *x, X509_SIG_INFO *info);
 
 /**
  * @brief Compute the internal-use fingerprint of a DER-encodable object.

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -119,8 +119,8 @@ struct X509_crl_st {
     ASN1_INTEGER *crl_number;
     ASN1_INTEGER *base_crl_number;
     STACK_OF(GENERAL_NAMES) *issuers;
-    /* hash of CRL */
-    unsigned char sha1_hash[SHA_DIGEST_LENGTH];
+    /* internal-use fingerprint for X509_CRL_match(), see ossl_x509_internal_fingerprint() */
+    unsigned char fingerprint[SHA_DIGEST_LENGTH];
     /* alternative method to handle this CRL */
     const X509_CRL_METHOD *meth;
     void *meth_data;
@@ -198,7 +198,8 @@ struct x509_st {
     STACK_OF(IPAddressFamily) *rfc3779_addr;
     struct ASIdentifiers_st *rfc3779_asid;
 #endif
-    unsigned char sha1_hash[SHA_DIGEST_LENGTH];
+    /* internal-use fingerprint for X509_cmp(), see ossl_x509_internal_fingerprint() */
+    unsigned char fingerprint[SHA_DIGEST_LENGTH];
     X509_CERT_AUX *aux;
     CRYPTO_RWLOCK *lock;
     volatile int ex_cached;
@@ -318,6 +319,29 @@ int ossl_x509_set1_time(int *modified, ASN1_TIME **ptm, const ASN1_TIME *tm);
 int ossl_x509_print_ex_brief(BIO *bio, const X509 *cert, unsigned long neg_cflags);
 int ossl_x509v3_cache_extensions(const X509 *x);
 int ossl_x509_init_sig_info(const X509 *x, X509_SIG_INFO *info);
+
+/**
+ * @brief Compute the internal-use fingerprint of a DER-encodable object.
+ *
+ * The fingerprint is cached in X509 / X509_CRL fingerprint and used only for
+ * internal identity comparison (X509_cmp(), X509_CRL_match()); it is never
+ * returned to callers, so the algorithm is an implementation detail
+ * (currently SHA-1). It uses the built-in implementation directly rather
+ * than fetching one, so the result depends on neither the library context
+ * nor the property query string of the object and stays valid if the object
+ * is moved to another library context. It fails only if the object cannot be
+ * DER encoded, for instance a certificate still under construction, or on
+ * an allocation failure in the encoder.
+ *
+ * @param it the ASN1_ITEM describing @p val
+ * @param val the object to encode and hash
+ * @param hash output buffer for the fingerprint
+ * @param hash_size size in bytes of @p hash, must be at least
+ *                  SHA_DIGEST_LENGTH
+ * @returns 1 on success, 0 on failure
+ */
+int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
+    unsigned char *hash, size_t hash_size);
 
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
 int ossl_x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx,

--- a/ssl/build.info
+++ b/ssl/build.info
@@ -52,11 +52,7 @@ ENDIF
 # siphash.c is needed by dtls_conn_lookup.c (DTLS) and quic_lcidm.c (QUIC)
 # for hash-flooding resistant connection lookup
 IF[{- !$disabled{dtls} || !$disabled{quic} -}]
-  IF[{- $disabled{siphash} -}]
-    SOURCE[../libssl]=../crypto/siphash/siphash.c
-  ELSE
-    SHARED_SOURCE[../libssl]=../crypto/siphash/siphash.c
-  ENDIF
+  SHARED_SOURCE[../libssl]=../crypto/siphash/siphash.c
 ENDIF
 
 IF[{- $target{needs_c99_snprintf_compat} -}]

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -1273,8 +1273,91 @@ err:
     return ret;
 }
 
+/*
+ * Signing leaves the cached encoding of the signed part current and equal
+ * to the decoded one; modifying the object afterwards marks it stale.
+ */
+static int test_sign_caches_encoding(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509_NAME *name = NULL;
+    X509 *cert = NULL, *cert_copy = NULL;
+    X509_CRL *crl = NULL, *crl_copy = NULL;
+    X509_REQ *req = NULL, *req_copy = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)"sign test", -1, -1, 0)))
+        goto err;
+
+    /* Certificate */
+    if (!TEST_ptr(cert = X509_new())
+        || !TEST_true(cert->cert_info.enc.modified)
+        || !TEST_true(X509_set_subject_name(cert, name))
+        || !TEST_true(X509_set_issuer_name(cert, name))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notBefore(cert), 0))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notAfter(cert), 3600))
+        || !TEST_true(X509_set_pubkey(cert, pkey))
+        || !TEST_int_gt(X509_sign(cert, pkey, EVP_sha256()), 0)
+        || !TEST_false(cert->cert_info.enc.modified)
+        || !TEST_ptr(cert_copy = X509_dup(cert))
+        || !TEST_false(cert_copy->cert_info.enc.modified)
+        || !TEST_mem_eq(cert->cert_info.enc.enc,
+            (size_t)cert->cert_info.enc.len,
+            cert_copy->cert_info.enc.enc,
+            (size_t)cert_copy->cert_info.enc.len)
+        || !TEST_int_eq(X509_cmp(cert, cert_copy), 0)
+        || !TEST_true(X509_set_version(cert, X509_VERSION_2))
+        || !TEST_true(cert->cert_info.enc.modified)
+        || !TEST_int_gt(X509_sign(cert, pkey, EVP_sha256()), 0)
+        || !TEST_false(cert->cert_info.enc.modified)
+        || !TEST_int_ne(X509_cmp(cert, cert_copy), 0))
+        goto err;
+
+    /* CRL */
+    if (!TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(crl->crl.enc.modified)
+        || !TEST_true(X509_CRL_set_issuer_name(crl, name))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, X509_getm_notBefore(cert)))
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
+        || !TEST_false(crl->crl.enc.modified)
+        || !TEST_ptr(crl_copy = X509_CRL_dup(crl))
+        || !TEST_false(crl_copy->crl.enc.modified)
+        || !TEST_mem_eq(crl->crl.enc.enc, (size_t)crl->crl.enc.len,
+            crl_copy->crl.enc.enc, (size_t)crl_copy->crl.enc.len))
+        goto err;
+
+    /* Request */
+    if (!TEST_ptr(req = X509_REQ_new())
+        || !TEST_true(req->req_info.enc.modified)
+        || !TEST_true(X509_REQ_set_subject_name(req, name))
+        || !TEST_true(X509_REQ_set_pubkey(req, pkey))
+        || !TEST_int_gt(X509_REQ_sign(req, pkey, EVP_sha256()), 0)
+        || !TEST_false(req->req_info.enc.modified)
+        || !TEST_ptr(req_copy = X509_REQ_dup(req))
+        || !TEST_false(req_copy->req_info.enc.modified)
+        || !TEST_mem_eq(req->req_info.enc.enc, (size_t)req->req_info.enc.len,
+            req_copy->req_info.enc.enc, (size_t)req_copy->req_info.enc.len))
+        goto err;
+
+    ret = 1;
+err:
+    X509_REQ_free(req_copy);
+    X509_REQ_free(req);
+    X509_CRL_free(crl_copy);
+    X509_CRL_free(crl);
+    X509_free(cert_copy);
+    X509_free(cert);
+    X509_NAME_free(name);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
 int setup_tests(void)
 {
+    ADD_TEST(test_sign_caches_encoding);
     ADD_TEST(test_standard_exts);
     ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     ADD_ALL_TESTS(test_ipaddr_to_asc, OSSL_NELEM(ipaddr_to_asc_tests));

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -20,6 +20,7 @@
 #include "internal/nelem.h"
 #include "crypto/x509.h"
 #include "crypto/evp.h"
+#include "../crypto/asn1/asn1_local.h"
 
 /**********************************************************************
  *
@@ -279,6 +280,61 @@ err:
     X509_CRL_free(copy);
     X509_CRL_free(crl);
     ASN1_INTEGER_free(num);
+    ASN1_TIME_free(tm);
+    X509_NAME_free(name);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
+/*
+ * A failed encoding save discards the cached encoding, and the item is
+ * encoded from its fields afterwards.
+ */
+static int test_enc_save_failure(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509_NAME *name = NULL;
+    X509_CRL *crl = NULL, *copy = NULL;
+    X509_CRL_INFO *info = NULL;
+    ASN1_TIME *tm = NULL;
+    unsigned char *der = NULL, *der_copy = NULL;
+    unsigned char buf[1] = { 0 };
+    int len, len_copy, ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)"enc save test", -1, -1, 0))
+        || !TEST_ptr(tm = ASN1_TIME_set(NULL, 0))
+        || !TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(X509_CRL_set_issuer_name(crl, name))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, tm))
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
+        || !TEST_ptr(copy = X509_CRL_dup(crl))
+        || !TEST_false(copy->crl.enc.modified)
+        || !TEST_ptr(copy->crl.enc.enc))
+        goto err;
+
+    /* A zero input length is a failure */
+    info = &copy->crl;
+    if (!TEST_false(ossl_asn1_enc_save((ASN1_VALUE **)&info, buf, 0,
+            ASN1_ITEM_rptr(X509_CRL_INFO)))
+        || !TEST_ptr_null(copy->crl.enc.enc)
+        || !TEST_int_eq(copy->crl.enc.len, 0)
+        || !TEST_true(copy->crl.enc.modified))
+        goto err;
+
+    if (!TEST_int_gt(len = i2d_X509_CRL(crl, &der), 0)
+        || !TEST_int_gt(len_copy = i2d_X509_CRL(copy, &der_copy), 0)
+        || !TEST_mem_eq(der, (size_t)len, der_copy, (size_t)len_copy))
+        goto err;
+
+    ret = 1;
+err:
+    OPENSSL_free(der_copy);
+    OPENSSL_free(der);
+    X509_CRL_free(copy);
+    X509_CRL_free(crl);
     ASN1_TIME_free(tm);
     X509_NAME_free(name);
     EVP_PKEY_free(pkey);
@@ -1223,6 +1279,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     ADD_ALL_TESTS(test_ipaddr_to_asc, OSSL_NELEM(ipaddr_to_asc_tests));
     ADD_TEST(test_crl_add_ext_modifies);
+    ADD_TEST(test_enc_save_failure);
     ADD_TEST(tests_X509_PURPOSE);
     ADD_TEST(tests_X509_check_time);
     ADD_TEST(tests_X509_check_crypto);

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -1355,9 +1355,76 @@ err:
     return ret;
 }
 
+/* A modified, unsigned certificate or CRL is equal only to itself */
+static int test_cmp_modified(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509_NAME *name = NULL;
+    X509 *cert = NULL, *copy = NULL;
+    X509_CRL *crl = NULL, *crl_copy = NULL;
+    ASN1_INTEGER *serial = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)"cmp test", -1, -1, 0))
+        || !TEST_ptr(serial = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(serial, 2)))
+        goto err;
+
+    if (!TEST_ptr(cert = X509_new())
+        || !TEST_true(X509_set_subject_name(cert, name))
+        || !TEST_true(X509_set_issuer_name(cert, name))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notBefore(cert), 0))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notAfter(cert), 3600))
+        || !TEST_true(X509_set_pubkey(cert, pkey))
+        || !TEST_int_gt(X509_sign(cert, pkey, EVP_sha256()), 0)
+        || !TEST_ptr(copy = X509_dup(cert))
+        || !TEST_int_eq(X509_cmp(cert, copy), 0)
+        || !TEST_int_eq(X509_cmp(cert, cert), 0)
+        /* The copy is modified but still equal to itself */
+        || !TEST_true(X509_set_serialNumber(copy, serial))
+        || !TEST_int_eq(X509_cmp(copy, copy), 0)
+        || !TEST_int_eq(X509_cmp(cert, copy), -1)
+        || !TEST_int_eq(X509_cmp(copy, cert), 1)
+        /* Both modified: unequal */
+        || !TEST_true(X509_set_serialNumber(cert, serial))
+        || !TEST_int_ne(X509_cmp(cert, copy), 0)
+        /* Signing again makes them comparable and equal */
+        || !TEST_int_gt(X509_sign(cert, pkey, EVP_sha256()), 0)
+        || !TEST_int_gt(X509_sign(copy, pkey, EVP_sha256()), 0)
+        || !TEST_int_eq(X509_cmp(cert, copy), 0))
+        goto err;
+
+    if (!TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(X509_CRL_set_issuer_name(crl, name))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, X509_getm_notBefore(cert)))
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
+        || !TEST_ptr(crl_copy = X509_CRL_dup(crl))
+        || !TEST_int_eq(X509_CRL_match(crl, crl), 0)
+        || !TEST_true(X509_CRL_set_version(crl_copy, X509_CRL_VERSION_2))
+        || !TEST_int_eq(X509_CRL_match(crl_copy, crl_copy), 0)
+        || !TEST_int_eq(X509_CRL_match(crl, crl_copy), -1)
+        || !TEST_int_eq(X509_CRL_match(crl_copy, crl), 1))
+        goto err;
+
+    ret = 1;
+err:
+    X509_CRL_free(crl_copy);
+    X509_CRL_free(crl);
+    X509_free(copy);
+    X509_free(cert);
+    ASN1_INTEGER_free(serial);
+    X509_NAME_free(name);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_sign_caches_encoding);
+    ADD_TEST(test_cmp_modified);
     ADD_TEST(test_standard_exts);
     ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     ADD_ALL_TESTS(test_ipaddr_to_asc, OSSL_NELEM(ipaddr_to_asc_tests));

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -232,6 +232,59 @@ static int test_ipaddr_to_asc(int idx)
     return good;
 }
 
+/* Adding an extension to a CRL marks its cached encoding stale */
+static int test_crl_add_ext_modifies(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509_NAME *name = NULL;
+    X509_CRL *crl = NULL, *copy = NULL;
+    ASN1_TIME *tm = NULL;
+    ASN1_INTEGER *num = NULL;
+    X509_EXTENSION *ext = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)"crl ext test", -1, -1, 0))
+        || !TEST_ptr(tm = ASN1_TIME_set(NULL, 0))
+        || !TEST_ptr(num = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(num, 1))
+        || !TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(X509_CRL_set_issuer_name(crl, name))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, tm))
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0))
+        goto err;
+
+    /* X509_CRL_add1_ext_i2d() on a decoded copy */
+    if (!TEST_ptr(copy = X509_CRL_dup(crl))
+        || !TEST_false(copy->crl.enc.modified)
+        || !TEST_true(X509_CRL_add1_ext_i2d(copy, NID_crl_number, num, 0, 0))
+        || !TEST_true(copy->crl.enc.modified))
+        goto err;
+    X509_CRL_free(copy);
+    copy = NULL;
+
+    /* X509_CRL_add_ext() on a decoded copy */
+    if (!TEST_ptr(ext = X509V3_EXT_i2d(NID_crl_number, 0, num))
+        || !TEST_ptr(copy = X509_CRL_dup(crl))
+        || !TEST_false(copy->crl.enc.modified)
+        || !TEST_true(X509_CRL_add_ext(copy, ext, -1))
+        || !TEST_true(copy->crl.enc.modified))
+        goto err;
+
+    ret = 1;
+err:
+    X509_EXTENSION_free(ext);
+    X509_CRL_free(copy);
+    X509_CRL_free(crl);
+    ASN1_INTEGER_free(num);
+    ASN1_TIME_free(tm);
+    X509_NAME_free(name);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
 static int ck_purp(ossl_unused const X509_PURPOSE *purpose,
     ossl_unused const X509 *x, int ca)
 {
@@ -1169,6 +1222,7 @@ int setup_tests(void)
     ADD_TEST(test_standard_exts);
     ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     ADD_ALL_TESTS(test_ipaddr_to_asc, OSSL_NELEM(ipaddr_to_asc_tests));
+    ADD_TEST(test_crl_add_ext_modifies);
     ADD_TEST(tests_X509_PURPOSE);
     ADD_TEST(tests_X509_check_time);
     ADD_TEST(tests_X509_check_crypto);


### PR DESCRIPTION
X509 initialisation (extension caching) currently has a libctx dependency for two reasons of very dubious value:

1. When you ask for the hash of a certificate, if you happen to be asking for
   SHA-1 — the same hash we use internally — we just hand you the (really
   should be private) value out of the v3 cache.

2. When you ask for the certificate's signature info, we do the same.

The first is of dubious value: caching a SHA-1 for you saves no meaningful
compute, but it means your libctx could have a different SHA-1, or none at
all. It also triggers the blind "OMG IT'S SHA-1, IT'S BROKEN, YOU HAVE TO
CHANGE IT" — and the only reason we'd ever need to is that we give this hash
out publicly from a function the caller *might* use somewhere the
cryptographic security of the hash matters.

Internally we don't need a cryptographic hash (arguably SHA-1 hasn't been one
for a while). X509_cmp() already fell back to comparing the TBS encoding when
the hashes were equal; we extend that to also compare the signature algorithm
and signature value, and give X509_CRL_match() the same fallback, which it
lacked before.

So the answer is simple: stop handing out the cached value when the caller
happens to ask for the MD we think matches it, and just compute what was
asked for, in the correct context. And since we no longer return the private
value, use a faster hash (SipHash) that makes it abundantly clear we are
*NOT* using this as a cryptographically secure hash, that it does *NOT* need
converting to your favourite new hotness, and that there is nothing to argue
about regarding which libctx it was computed in. SipHash is considerably
faster, and provides the added benefit of shrinking the X509 object.

For the second, computing the signature info is cheap, so stop handing out
the cached value and compute it at request time, so it always comes from the
correct context. On my machine this costs 225 ns on an RSA/SHA-256
certificate  versus 21 µs for one RSA-2048 signature verification on the same build
A TLS handshake makes 2–4 such calls against at least two signature verifications, 
so the added cost is negligible.

This also fixes several latent bugs in master, each in its own commit.
They are not incidental: X509_cmp() and X509_CRL_match() have always
treated the cached hash as a shortcut and fallen back to comparing the
objects themselves, and that fallback has been wrong all along. A
freshly signed certificate, CRL or request was marked "modified" for
life, so the encoding comparison never ran for it; X509_set_serialNumber()
never marked the encoding stale at all; a modified copy of a certificate
or CRL compared equal to the original on the strength of a hash that
modification does not refresh; and the signature was never compared, so
identical TBS with different signatures were equal.

With that, X509 exposes nothing that depends on the context, which enables
future work to simplify the really awkward "re-associating" of an X509 with a
libctx — which is probably more costly in itself than anything ever saved by
caching these context-sensitive values to hand out again.

https://github.com/openssl/openssl/pull/32690 is stacked on top of this
(along with some other things on top of it)

Supersedes #32147.
Relates to: https://github.com/openssl/openssl/issues/30162

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
