### PR TITLE
Remove the library context from X509 and X509_REQ

### DIFF
--- a/Configure
+++ b/Configure
@@ -2058,8 +2058,11 @@ foreach my $what (sort keys %disabled) {
             }
         }
 
+        # siphash is used internally by libcrypto (X509 fingerprints), so
+        # no-siphash only removes the provider algorithm.
         $skipdir{"crypto/$skipdir"} = $what
-            unless $what eq 'async' || $what eq 'err' || $what eq 'dso' || $what eq 'http';
+            unless $what eq 'async' || $what eq 'err' || $what eq 'dso'
+                || $what eq 'http' || $what eq 'siphash';
     }
 }
 

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -21,6 +21,7 @@
 #include <openssl/core_names.h>
 #include "crypto/asn1.h"
 #include "crypto/evp.h"
+#include "asn1_local.h"
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 
@@ -280,6 +281,14 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
     if (!EVP_DigestSign(ctx, buf_out, &outl, buf_in, inl)) {
         outl = 0;
         ERR_raise(ERR_LIB_ASN1, ERR_R_EVP_LIB);
+        goto err;
+    }
+    /* Only a sequence item carries a cached encoding */
+    if ((it->itype == ASN1_ITYPE_SEQUENCE
+            || it->itype == ASN1_ITYPE_NDEF_SEQUENCE)
+        && !ossl_asn1_enc_save((ASN1_VALUE **)&data, buf_in, buf_len, it)) {
+        outl = 0;
+        ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
         goto err;
     }
     ASN1_STRING_set0(signature, buf_out, (int)outl);

--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -169,11 +169,14 @@ int ossl_asn1_enc_save(ASN1_VALUE **pval, const unsigned char *in, long inlen,
     if (enc == NULL)
         return 1;
 
+    /* A failure below leaves the item without a cached encoding */
     OPENSSL_free(enc->enc);
-    if (inlen <= 0) {
-        enc->enc = NULL;
+    enc->enc = NULL;
+    enc->len = 0;
+    enc->modified = 1;
+
+    if (inlen <= 0)
         return 0;
-    }
     if ((enc->enc = OPENSSL_malloc(inlen)) == NULL)
         return 0;
     memcpy(enc->enc, in, inlen);

--- a/crypto/cmp/cmp_http.c
+++ b/crypto/cmp/cmp_http.c
@@ -89,8 +89,13 @@ OSSL_CMP_MSG *OSSL_CMP_MSG_http_perform(OSSL_CMP_CTX *ctx,
         ctx->msg_timeout,
         keep_alive(ctx->keep_alive, req->body->type, bios));
     BIO_free(req_mem);
-    res = (OSSL_CMP_MSG *)ASN1_item_d2i_bio(it, rsp, NULL);
+    res = (OSSL_CMP_MSG *)ASN1_item_d2i_bio_ex(it, rsp, NULL,
+        ctx->libctx, ctx->propq);
     BIO_free(rsp);
+    if (res != NULL && !ossl_cmp_msg_set0_libctx(res, ctx->libctx, ctx->propq)) {
+        OSSL_CMP_MSG_free(res);
+        res = NULL;
+    }
 
     if (ctx->http_ctx == NULL)
         ossl_cmp_debug(ctx, "disconnected from CMP server");

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -1178,8 +1178,6 @@ X509 *ossl_cmp_certresponse_get1_cert(const OSSL_CMP_CTX *ctx, const OSSL_CMP_CE
     }
     if (crt == NULL)
         ERR_raise(ERR_LIB_CMP, CMP_R_CERTIFICATE_NOT_FOUND);
-    else
-        (void)ossl_x509_set0_libctx(crt, ctx->libctx, ctx->propq);
     return crt;
 }
 

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -900,7 +900,9 @@ OSSL_CMP_MSG *ossl_cmp_certConf_new(OSSL_CMP_CTX *ctx, int certReqId,
      * as is used to create and verify the certificate signature.
      * If not available, a fallback hash algorithm is used.
      */
-    if ((certHash = X509_digest_sig(ctx->newCert, &md, &is_fallback)) == NULL)
+    if ((certHash = ossl_x509_digest_sig_ex(ctx->newCert, &md, &is_fallback,
+             ctx->libctx, ctx->propq))
+        == NULL)
         goto err;
     if (is_fallback) {
         if (!ossl_cmp_hdr_set_pvno(msg->header, OSSL_CMP_PVNO_3))

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -205,9 +205,6 @@ void ossl_cms_RecipientInfos_set_cmsctx(CMS_ContentInfo *cms)
                 break;
             case CMS_RECIPINFO_TRANS:
                 ri->d.ktri->cms_ctx = ctx;
-                ossl_x509_set0_libctx(ri->d.ktri->recip,
-                    ossl_cms_ctx_get0_libctx(ctx),
-                    ossl_cms_ctx_get0_propq(ctx));
                 break;
             case CMS_RECIPINFO_KEK:
                 ri->d.kekri->cms_ctx = ctx;

--- a/crypto/cms/cms_io.c
+++ b/crypto/cms/cms_io.c
@@ -50,7 +50,7 @@ CMS_ContentInfo *d2i_CMS_bio(BIO *bp, CMS_ContentInfo **cms)
         ossl_cms_ctx_get0_propq(ctx));
     if (ci != NULL) {
         ERR_set_mark();
-        ossl_cms_resolve_libctx(ci);
+        ossl_cms_infos_set_cmsctx(ci);
         ERR_pop_to_mark();
     }
     return ci;
@@ -116,7 +116,7 @@ CMS_ContentInfo *SMIME_read_CMS_ex(BIO *bio, int flags, BIO **bcont,
         ossl_cms_ctx_get0_propq(ctx));
     if (ci != NULL) {
         ERR_set_mark();
-        ossl_cms_resolve_libctx(ci);
+        ossl_cms_infos_set_cmsctx(ci);
         ERR_pop_to_mark();
     }
     return ci;

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -40,7 +40,7 @@ CMS_ContentInfo *d2i_CMS_ContentInfo(CMS_ContentInfo **a,
         ossl_cms_ctx_get0_propq(ctx));
     if (ci != NULL) {
         ERR_set_mark();
-        ossl_cms_resolve_libctx(ci);
+        ossl_cms_infos_set_cmsctx(ci);
         ERR_pop_to_mark();
     }
     return ci;
@@ -86,7 +86,7 @@ const char *ossl_cms_ctx_get0_propq(const CMS_CTX *ctx)
     return ctx != NULL ? ctx->propq : NULL;
 }
 
-void ossl_cms_resolve_libctx(CMS_ContentInfo *ci)
+void ossl_cms_infos_set_cmsctx(CMS_ContentInfo *ci)
 {
     ossl_cms_SignerInfos_set_cmsctx(ci);
     ossl_cms_RecipientInfos_set_cmsctx(ci);

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -88,24 +88,8 @@ const char *ossl_cms_ctx_get0_propq(const CMS_CTX *ctx)
 
 void ossl_cms_resolve_libctx(CMS_ContentInfo *ci)
 {
-    int i;
-    CMS_CertificateChoices *cch;
-    STACK_OF(CMS_CertificateChoices) **pcerts;
-    const CMS_CTX *ctx = ossl_cms_get0_cmsctx(ci);
-    OSSL_LIB_CTX *libctx = ossl_cms_ctx_get0_libctx(ctx);
-    const char *propq = ossl_cms_ctx_get0_propq(ctx);
-
     ossl_cms_SignerInfos_set_cmsctx(ci);
     ossl_cms_RecipientInfos_set_cmsctx(ci);
-
-    pcerts = cms_get0_certificate_choices(ci);
-    if (pcerts != NULL) {
-        for (i = 0; i < sk_CMS_CertificateChoices_num(*pcerts); i++) {
-            cch = sk_CMS_CertificateChoices_value(*pcerts, i);
-            if (cch->type == CMS_CERTCHOICE_CERT)
-                ossl_x509_set0_libctx(cch->d.certificate, libctx, propq);
-        }
-    }
 }
 
 const ASN1_OBJECT *CMS_get0_type(const CMS_ContentInfo *cms)

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -441,7 +441,7 @@ BIO *ossl_cms_content_bio(CMS_ContentInfo *cms);
 const CMS_CTX *ossl_cms_get0_cmsctx(const CMS_ContentInfo *cms);
 OSSL_LIB_CTX *ossl_cms_ctx_get0_libctx(const CMS_CTX *ctx);
 const char *ossl_cms_ctx_get0_propq(const CMS_CTX *ctx);
-void ossl_cms_resolve_libctx(CMS_ContentInfo *ci);
+void ossl_cms_infos_set_cmsctx(CMS_ContentInfo *ci);
 
 CMS_ContentInfo *ossl_cms_Data_create(OSSL_LIB_CTX *ctx, const char *propq);
 int ossl_cms_DataFinal(CMS_ContentInfo *cms, BIO *cmsbio, BIO *data,

--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -73,6 +73,9 @@ int OCSP_request_sign(OCSP_REQUEST *req,
     const EVP_MD *dgst,
     const STACK_OF(X509) *certs, unsigned long flags)
 {
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
+
     if (!OCSP_request_set1_name(req, X509_get_subject_name(signer)))
         goto err;
 
@@ -84,7 +87,8 @@ int OCSP_request_sign(OCSP_REQUEST *req,
                 OCSP_R_PRIVATE_KEY_DOES_NOT_MATCH_CERTIFICATE);
             goto err;
         }
-        if (!OCSP_REQUEST_sign(req, key, dgst, signer->libctx, signer->propq))
+        ossl_x509_get0_libctx(signer, &libctx, &propq);
+        if (!OCSP_REQUEST_sign(req, key, dgst, libctx, propq))
             goto err;
     }
 

--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -216,13 +216,16 @@ int OCSP_basic_sign(OCSP_BASICRESP *brsp,
 {
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
     EVP_PKEY_CTX *pkctx = NULL;
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
     int i;
 
     if (ctx == NULL)
         return 0;
 
+    ossl_x509_get0_libctx(signer, &libctx, &propq);
     if (!EVP_DigestSignInit_ex(ctx, &pkctx, EVP_MD_get0_name(dgst),
-            signer->libctx, signer->propq, key, NULL)) {
+            libctx, propq, key, NULL)) {
         EVP_MD_CTX_free(ctx);
         return 0;
     }
@@ -276,9 +279,13 @@ err:
 
 int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert)
 {
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
+
     if (cert == NULL)
         return 0;
-    return OCSP_RESPID_set_by_key_ex(respid, cert, cert->libctx, cert->propq);
+    ossl_x509_get0_libctx(cert, &libctx, &propq);
+    return OCSP_RESPID_set_by_key_ex(respid, cert, libctx, propq);
 }
 
 int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OSSL_LIB_CTX *libctx,
@@ -321,7 +328,11 @@ err:
 
 int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert)
 {
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
+
     if (cert == NULL)
         return 0;
-    return OCSP_RESPID_match_ex(respid, cert, cert->libctx, cert->propq);
+    ossl_x509_get0_libctx(cert, &libctx, &propq);
+    return OCSP_RESPID_match_ex(respid, cert, libctx, propq);
 }

--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -77,6 +77,8 @@ static int ocsp_verify(OCSP_REQUEST *req, OCSP_BASICRESP *bs,
     X509 *signer, unsigned long flags)
 {
     EVP_PKEY *skey;
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
     int ret = 1;
 
     if ((flags & OCSP_NOSIGS) == 0) {
@@ -84,10 +86,11 @@ static int ocsp_verify(OCSP_REQUEST *req, OCSP_BASICRESP *bs,
             ERR_raise(ERR_LIB_OCSP, OCSP_R_NO_SIGNER_KEY);
             return -1;
         }
+        ossl_x509_get0_libctx(signer, &libctx, &propq);
         if (req != NULL)
-            ret = OCSP_REQUEST_verify(req, skey, signer->libctx, signer->propq);
+            ret = OCSP_REQUEST_verify(req, skey, libctx, propq);
         else
-            ret = OCSP_BASICRESP_verify(bs, skey, signer->libctx, signer->propq);
+            ret = OCSP_BASICRESP_verify(bs, skey, libctx, propq);
         if (ret <= 0)
             ERR_raise(ERR_LIB_OCSP, OCSP_R_SIGNATURE_FAILURE);
     }
@@ -191,6 +194,8 @@ static X509 *ocsp_find_signer_sk(const STACK_OF(X509) *certs, OCSP_RESPID *id)
     unsigned char tmphash[SHA_DIGEST_LENGTH], *keyhash;
     EVP_MD *md;
     X509 *x;
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
 
     /* Easy if lookup by name */
     if (id->type == V_OCSP_RESPID_NAME)
@@ -205,7 +210,8 @@ static X509 *ocsp_find_signer_sk(const STACK_OF(X509) *certs, OCSP_RESPID *id)
     /* Calculate hash of each key and compare */
     for (i = 0; i < sk_X509_num(certs); i++) {
         if ((x = sk_X509_value(certs, i)) != NULL) {
-            if ((md = EVP_MD_fetch(x->libctx, SN_sha1, x->propq)) == NULL)
+            ossl_x509_get0_libctx(x, &libctx, &propq);
+            if ((md = EVP_MD_fetch(libctx, SN_sha1, propq)) == NULL)
                 break;
             r = X509_pubkey_digest(x, md, tmphash, NULL);
             EVP_MD_free(md);

--- a/crypto/pkcs12/p12_sbag.c
+++ b/crypto/pkcs12/p12_sbag.c
@@ -114,19 +114,12 @@ X509_CRL *PKCS12_SAFEBAG_get1_crl(const PKCS12_SAFEBAG *bag)
 X509 *PKCS12_SAFEBAG_get1_cert_ex(const PKCS12_SAFEBAG *bag,
     OSSL_LIB_CTX *libctx, const char *propq)
 {
-    X509 *ret = NULL;
-
     if (PKCS12_SAFEBAG_get_nid(bag) != NID_certBag)
         return NULL;
     if (OBJ_obj2nid(bag->value.bag->type) != NID_x509Certificate)
         return NULL;
-    ret = ASN1_item_unpack_ex(bag->value.bag->value.octet,
+    return ASN1_item_unpack_ex(bag->value.bag->value.octet,
         ASN1_ITEM_rptr(X509), libctx, propq);
-    if (!ossl_x509_set0_libctx(ret, libctx, propq)) {
-        X509_free(ret);
-        return NULL;
-    }
-    return ret;
 }
 
 X509_CRL *PKCS12_SAFEBAG_get1_crl_ex(const PKCS12_SAFEBAG *bag,

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -82,7 +82,7 @@ PKCS7 *d2i_PKCS7(PKCS7 **a, const unsigned char **in, long len)
     ret = (PKCS7 *)ASN1_item_d2i_ex((ASN1_VALUE **)a, in, len, ASN1_ITEM_rptr(PKCS7),
         libctx, propq);
     if (ret != NULL)
-        ossl_pkcs7_resolve_libctx(ret);
+        ossl_pkcs7_SignerInfos_set_ctx(ret);
     return ret;
 }
 

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -432,46 +432,17 @@ STACK_OF(X509) *pkcs7_get0_certificates(const PKCS7 *p7)
     return NULL;
 }
 
-static STACK_OF(PKCS7_RECIP_INFO) *pkcs7_get_recipient_info(const PKCS7 *p7)
-{
-    if (p7->d.ptr == NULL)
-        return NULL;
-    if (PKCS7_type_is_signedAndEnveloped(p7))
-        return p7->d.signed_and_enveloped->recipientinfo;
-    if (PKCS7_type_is_enveloped(p7))
-        return p7->d.enveloped->recipientinfo;
-    return NULL;
-}
-
-/*
- * Set up the library context into any loaded structure that needs it.
- * i.e loaded X509 objects.
- */
+/* Set up the library context into any loaded structure that needs it. */
 void ossl_pkcs7_resolve_libctx(PKCS7 *p7)
 {
     int i;
     const PKCS7_CTX *ctx = ossl_pkcs7_get0_ctx(p7);
-    OSSL_LIB_CTX *libctx = ossl_pkcs7_ctx_get0_libctx(ctx);
-    const char *propq = ossl_pkcs7_ctx_get0_propq(ctx);
-    STACK_OF(PKCS7_RECIP_INFO) *rinfos;
     STACK_OF(PKCS7_SIGNER_INFO) *sinfos;
-    STACK_OF(X509) *certs;
 
     if (ctx == NULL || p7->d.ptr == NULL)
         return;
 
-    rinfos = pkcs7_get_recipient_info(p7);
     sinfos = PKCS7_get_signer_info(p7);
-    certs = pkcs7_get0_certificates(p7);
-
-    for (i = 0; i < sk_X509_num(certs); i++)
-        ossl_x509_set0_libctx(sk_X509_value(certs, i), libctx, propq);
-
-    for (i = 0; i < sk_PKCS7_RECIP_INFO_num(rinfos); i++) {
-        PKCS7_RECIP_INFO *ri = sk_PKCS7_RECIP_INFO_value(rinfos, i);
-
-        ossl_x509_set0_libctx(ri->cert, libctx, propq);
-    }
 
     for (i = 0; i < sk_PKCS7_SIGNER_INFO_num(sinfos); i++) {
         PKCS7_SIGNER_INFO *si = sk_PKCS7_SIGNER_INFO_value(sinfos, i);

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -432,8 +432,8 @@ STACK_OF(X509) *pkcs7_get0_certificates(const PKCS7 *p7)
     return NULL;
 }
 
-/* Set up the library context into any loaded structure that needs it. */
-void ossl_pkcs7_resolve_libctx(PKCS7 *p7)
+/* Point the signer infos of a PKCS7 at its context */
+void ossl_pkcs7_SignerInfos_set_ctx(PKCS7 *p7)
 {
     int i;
     const PKCS7_CTX *ctx = ossl_pkcs7_get0_ctx(p7);
@@ -482,7 +482,7 @@ int ossl_pkcs7_ctx_propagate(const PKCS7 *from, PKCS7 *to)
     if (!ossl_pkcs7_set1_propq(to, from->ctx.propq))
         return 0;
 
-    ossl_pkcs7_resolve_libctx(to);
+    ossl_pkcs7_SignerInfos_set_ctx(to);
     return 1;
 }
 

--- a/crypto/pkcs7/pk7_mime.c
+++ b/crypto/pkcs7/pk7_mime.c
@@ -63,7 +63,7 @@ PKCS7 *SMIME_read_PKCS7_ex(BIO *bio, BIO **bcont, PKCS7 **p7)
     ret = (PKCS7 *)SMIME_read_ASN1_ex(bio, 0, bcont, ASN1_ITEM_rptr(PKCS7),
         (ASN1_VALUE **)p7, libctx, propq);
     if (ret != NULL)
-        ossl_pkcs7_resolve_libctx(ret);
+        ossl_pkcs7_SignerInfos_set_ctx(ret);
     return ret;
 }
 

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -203,6 +203,8 @@ int X509_ocspid_print(BIO *bp, const X509 *x)
     const ASN1_BIT_STRING *keybstr;
     const X509_NAME *subj;
     EVP_MD *md = NULL;
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
 
     if (x == NULL || bp == NULL)
         return 0;
@@ -220,7 +222,8 @@ int X509_ocspid_print(BIO *bp, const X509 *x)
     if (i2d_X509_NAME(subj, &dertmp) < 0)
         goto err;
 
-    md = EVP_MD_fetch(x->libctx, SN_sha1, x->propq);
+    ossl_x509_get0_libctx(x, &libctx, &propq);
+    md = EVP_MD_fetch(libctx, SN_sha1, propq);
     if (md == NULL)
         goto err;
     if (!EVP_Digest(der, derlen, SHA1md, NULL, md, NULL))

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -518,7 +518,7 @@ static void scan_ext_flags(const X509 *x509, uint32_t *flags)
 /*
  * Cache info on various X.509v3 extensions and further derived information,
  * e.g., if cert 'x' is self-issued, in x->ex_flags and other internal fields.
- * x->sha1_hash is filled in, or else EXFLAG_NO_FINGERPRINT is set in x->flags.
+ * x->fingerprint is filled in, or else EXFLAG_NO_FINGERPRINT is set in x->flags.
  * X509_SIG_INFO_VALID is set in x->flags if x->siginf was filled successfully.
  * Set EXFLAG_INVALID and return 0 in case the certificate is invalid.
  *
@@ -537,7 +537,7 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     int i;
     int res;
     uint32_t tmp_ex_flags;
-    unsigned char tmp_sha1_hash[SHA_DIGEST_LENGTH];
+    unsigned char tmp_fingerprint[SHA_DIGEST_LENGTH];
     long tmp_ex_pathlen;
     long tmp_ex_pcpathlen;
     uint32_t tmp_ex_kusage;
@@ -570,8 +570,8 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
 
     ERR_set_mark();
 
-    /* Cache the SHA1 digest of the cert */
-    if (!X509_digest(const_x, EVP_sha1(), tmp_sha1_hash, NULL))
+    if (!ossl_x509_internal_fingerprint(ASN1_ITEM_rptr(X509), const_x,
+            tmp_fingerprint, sizeof(tmp_fingerprint)))
         tmp_ex_flags |= EXFLAG_NO_FINGERPRINT;
 
     /* V1 should mean no extensions ... */
@@ -768,7 +768,7 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     ((X509 *)const_x)->ex_pathlen = tmp_ex_pathlen;
     ((X509 *)const_x)->ex_pcpathlen = tmp_ex_pcpathlen;
     if (!(tmp_ex_flags & EXFLAG_NO_FINGERPRINT))
-        memcpy(((X509 *)const_x)->sha1_hash, tmp_sha1_hash, SHA_DIGEST_LENGTH);
+        memcpy(((X509 *)const_x)->fingerprint, tmp_fingerprint, SHA_DIGEST_LENGTH);
     if (tmp_ex_flags & EXFLAG_KUSAGE)
         ((X509 *)const_x)->ex_kusage = tmp_ex_kusage;
     ((X509 *)const_x)->ex_xkusage = tmp_ex_xkusage;

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -519,7 +519,6 @@ static void scan_ext_flags(const X509 *x509, uint32_t *flags)
  * Cache info on various X.509v3 extensions and further derived information,
  * e.g., if cert 'x' is self-issued, in x->ex_flags and other internal fields.
  * x->fingerprint is filled in, or else EXFLAG_NO_FINGERPRINT is set in x->flags.
- * X509_SIG_INFO_VALID is set in x->flags if x->siginf was filled successfully.
  * Set EXFLAG_INVALID and return 0 in case the certificate is invalid.
  *
  * This is usually called by side-effect on objects, and forces us to keep
@@ -548,7 +547,6 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     STACK_OF(GENERAL_NAME) *tmp_altname;
     NAME_CONSTRAINTS *tmp_nc;
     STACK_OF(DIST_POINT) *tmp_crldp = NULL;
-    X509_SIG_INFO tmp_siginf;
 
 #ifdef tsan_ld_acq
     /* Fast lock-free check, see end of the function for details. */
@@ -751,9 +749,6 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
 
     scan_ext_flags(const_x, &tmp_ex_flags);
 
-    /* Set x->siginf, ignoring errors due to unsupported algos */
-    (void)ossl_x509_init_sig_info(const_x, &tmp_siginf);
-
     tmp_ex_flags |= EXFLAG_SET; /* Indicate that cert has been processed */
     ERR_pop_to_mark();
 
@@ -790,7 +785,6 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     ASIdentifiers_free(((X509 *)const_x)->rfc3779_asid);
     ((X509 *)const_x)->rfc3779_asid = tmp_rfc3779_asid;
 #endif
-    ((X509 *)const_x)->siginf = tmp_siginf;
 
 #ifdef tsan_st_rel
     tsan_st_rel((TSAN_QUALIFIER int *)&const_x->ex_cached, 1);

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -518,7 +518,8 @@ static void scan_ext_flags(const X509 *x509, uint32_t *flags)
 /*
  * Cache info on various X.509v3 extensions and further derived information,
  * e.g., if cert 'x' is self-issued, in x->ex_flags and other internal fields.
- * x->fingerprint is filled in, or else EXFLAG_NO_FINGERPRINT is set in x->flags.
+ * x->fingerprint is filled in, or else EXFLAG_NO_FINGERPRINT is set in
+ * x->ex_flags.
  * Set EXFLAG_INVALID and return 0 in case the certificate is invalid.
  *
  * This is usually called by side-effect on objects, and forces us to keep
@@ -536,7 +537,7 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     int i;
     int res;
     uint32_t tmp_ex_flags;
-    unsigned char tmp_fingerprint[SHA_DIGEST_LENGTH];
+    unsigned char tmp_fingerprint[OSSL_X509_FINGERPRINT_SIZE];
     long tmp_ex_pathlen;
     long tmp_ex_pcpathlen;
     uint32_t tmp_ex_kusage;
@@ -569,7 +570,7 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     ERR_set_mark();
 
     if (!ossl_x509_internal_fingerprint(ASN1_ITEM_rptr(X509), const_x,
-            tmp_fingerprint, sizeof(tmp_fingerprint)))
+            tmp_fingerprint))
         tmp_ex_flags |= EXFLAG_NO_FINGERPRINT;
 
     /* V1 should mean no extensions ... */
@@ -763,7 +764,8 @@ int ossl_x509v3_cache_extensions(const X509 *const_x)
     ((X509 *)const_x)->ex_pathlen = tmp_ex_pathlen;
     ((X509 *)const_x)->ex_pcpathlen = tmp_ex_pcpathlen;
     if (!(tmp_ex_flags & EXFLAG_NO_FINGERPRINT))
-        memcpy(((X509 *)const_x)->fingerprint, tmp_fingerprint, SHA_DIGEST_LENGTH);
+        memcpy(((X509 *)const_x)->fingerprint, tmp_fingerprint,
+            sizeof(tmp_fingerprint));
     if (tmp_ex_flags & EXFLAG_KUSAGE)
         ((X509 *)const_x)->ex_kusage = tmp_ex_kusage;
     ((X509 *)const_x)->ex_xkusage = tmp_ex_xkusage;

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -174,6 +174,13 @@ int X509_cmp(const X509 *a, const X509 *b)
             return 1;
         rv = memcmp(a->cert_info.enc.enc,
             b->cert_info.enc.enc, a->cert_info.enc.len);
+        if (rv != 0)
+            return rv < 0 ? -1 : 1;
+        /* Same TBS: the signature algorithm and signature must match too */
+        rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
+        if (rv != 0)
+            return rv < 0 ? -1 : 1;
+        rv = ASN1_STRING_cmp(&a->signature, &b->signature);
     }
     return rv < 0 ? -1 : rv > 0;
 }

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -97,7 +97,7 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 
     if ((a->flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->flags & EXFLAG_NO_FINGERPRINT) == 0)
-        rv = memcmp(a->sha1_hash, b->sha1_hash, SHA_DIGEST_LENGTH);
+        rv = memcmp(a->fingerprint, b->fingerprint, SHA_DIGEST_LENGTH);
     if (rv != 0)
         return rv < 0 ? -1 : 1;
 
@@ -189,7 +189,7 @@ int X509_cmp(const X509 *a, const X509 *b)
 
     if ((a->ex_flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->ex_flags & EXFLAG_NO_FINGERPRINT) == 0)
-        rv = memcmp(a->sha1_hash, b->sha1_hash, SHA_DIGEST_LENGTH);
+        rv = memcmp(a->fingerprint, b->fingerprint, SHA_DIGEST_LENGTH);
     if (rv != 0)
         return rv < 0 ? -1 : 1;
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -41,13 +41,16 @@ unsigned long X509_issuer_and_serial_hash(const X509 *a)
     unsigned char md[16];
     char *f = NULL;
     EVP_MD *digest = NULL;
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
 
     if (ctx == NULL)
         goto err;
     f = X509_NAME_oneline(a->cert_info.issuer, NULL, 0);
     if (f == NULL)
         goto err;
-    digest = EVP_MD_fetch(a->libctx, SN_md5, a->propq);
+    ossl_x509_get0_libctx(a, &libctx, &propq);
+    digest = EVP_MD_fetch(libctx, SN_md5, propq);
     if (digest == NULL)
         goto err;
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -88,6 +88,13 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 {
     int rv = 0;
 
+    if (a == b)
+        return 0;
+
+    /* A CRL modified since it was signed or decoded is equal only to itself */
+    if (a->crl.enc.modified || b->crl.enc.modified)
+        return a->crl.enc.modified ? 1 : -1;
+
     if ((a->flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->flags & EXFLAG_NO_FINGERPRINT) == 0)
         rv = memcmp(a->sha1_hash, b->sha1_hash, SHA_DIGEST_LENGTH);
@@ -95,20 +102,18 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
         return rv < 0 ? -1 : 1;
 
     /* Check for match against stored encoding too */
-    if (!a->crl.enc.modified && !b->crl.enc.modified) {
-        if (a->crl.enc.len < b->crl.enc.len)
-            return -1;
-        if (a->crl.enc.len > b->crl.enc.len)
-            return 1;
-        rv = memcmp(a->crl.enc.enc, b->crl.enc.enc, a->crl.enc.len);
-        if (rv != 0)
-            return rv < 0 ? -1 : 1;
-        /* Same TBS: the signature algorithm and signature must match too */
-        rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
-        if (rv != 0)
-            return rv < 0 ? -1 : 1;
-        rv = ASN1_STRING_cmp(&a->signature, &b->signature);
-    }
+    if (a->crl.enc.len < b->crl.enc.len)
+        return -1;
+    if (a->crl.enc.len > b->crl.enc.len)
+        return 1;
+    rv = memcmp(a->crl.enc.enc, b->crl.enc.enc, a->crl.enc.len);
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
+    /* Same TBS: the signature algorithm and signature must match too */
+    rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
+    rv = ASN1_STRING_cmp(&a->signature, &b->signature);
     return rv < 0 ? -1 : rv > 0;
 }
 
@@ -171,6 +176,13 @@ int X509_cmp(const X509 *a, const X509 *b)
     if (a == b) /* for efficiency */
         return 0;
 
+    /*
+     * A certificate modified since it was signed or decoded is equal only
+     * to itself
+     */
+    if (a->cert_info.enc.modified || b->cert_info.enc.modified)
+        return a->cert_info.enc.modified ? 1 : -1;
+
     /* attempt to compute cert hash */
     (void)X509_check_purpose((X509 *)a, -1, 0);
     (void)X509_check_purpose((X509 *)b, -1, 0);
@@ -182,21 +194,19 @@ int X509_cmp(const X509 *a, const X509 *b)
         return rv < 0 ? -1 : 1;
 
     /* Check for match against stored encoding too */
-    if (!a->cert_info.enc.modified && !b->cert_info.enc.modified) {
-        if (a->cert_info.enc.len < b->cert_info.enc.len)
-            return -1;
-        if (a->cert_info.enc.len > b->cert_info.enc.len)
-            return 1;
-        rv = memcmp(a->cert_info.enc.enc,
-            b->cert_info.enc.enc, a->cert_info.enc.len);
-        if (rv != 0)
-            return rv < 0 ? -1 : 1;
-        /* Same TBS: the signature algorithm and signature must match too */
-        rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
-        if (rv != 0)
-            return rv < 0 ? -1 : 1;
-        rv = ASN1_STRING_cmp(&a->signature, &b->signature);
-    }
+    if (a->cert_info.enc.len < b->cert_info.enc.len)
+        return -1;
+    if (a->cert_info.enc.len > b->cert_info.enc.len)
+        return 1;
+    rv = memcmp(a->cert_info.enc.enc,
+        b->cert_info.enc.enc, a->cert_info.enc.len);
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
+    /* Same TBS: the signature algorithm and signature must match too */
+    rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
+    rv = ASN1_STRING_cmp(&a->signature, &b->signature);
     return rv < 0 ? -1 : rv > 0;
 }
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -97,7 +97,7 @@ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 
     if ((a->flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->flags & EXFLAG_NO_FINGERPRINT) == 0)
-        rv = memcmp(a->fingerprint, b->fingerprint, SHA_DIGEST_LENGTH);
+        rv = memcmp(a->fingerprint, b->fingerprint, sizeof(a->fingerprint));
     if (rv != 0)
         return rv < 0 ? -1 : 1;
 
@@ -189,7 +189,7 @@ int X509_cmp(const X509 *a, const X509 *b)
 
     if ((a->ex_flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->ex_flags & EXFLAG_NO_FINGERPRINT) == 0)
-        rv = memcmp(a->fingerprint, b->fingerprint, SHA_DIGEST_LENGTH);
+        rv = memcmp(a->fingerprint, b->fingerprint, sizeof(a->fingerprint));
     if (rv != 0)
         return rv < 0 ? -1 : 1;
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -86,14 +86,29 @@ int X509_CRL_cmp(const X509_CRL *a, const X509_CRL *b)
 
 int X509_CRL_match(const X509_CRL *a, const X509_CRL *b)
 {
-    int rv;
+    int rv = 0;
 
     if ((a->flags & EXFLAG_NO_FINGERPRINT) == 0
         && (b->flags & EXFLAG_NO_FINGERPRINT) == 0)
         rv = memcmp(a->sha1_hash, b->sha1_hash, SHA_DIGEST_LENGTH);
-    else
-        return -2;
+    if (rv != 0)
+        return rv < 0 ? -1 : 1;
 
+    /* Check for match against stored encoding too */
+    if (!a->crl.enc.modified && !b->crl.enc.modified) {
+        if (a->crl.enc.len < b->crl.enc.len)
+            return -1;
+        if (a->crl.enc.len > b->crl.enc.len)
+            return 1;
+        rv = memcmp(a->crl.enc.enc, b->crl.enc.enc, a->crl.enc.len);
+        if (rv != 0)
+            return rv < 0 ? -1 : 1;
+        /* Same TBS: the signature algorithm and signature must match too */
+        rv = X509_ALGOR_cmp(&a->sig_alg, &b->sig_alg);
+        if (rv != 0)
+            return rv < 0 ? -1 : 1;
+        rv = ASN1_STRING_cmp(&a->signature, &b->signature);
+    }
     return rv < 0 ? -1 : rv > 0;
 }
 

--- a/crypto/x509/x509_ext.c
+++ b/crypto/x509/x509_ext.c
@@ -59,12 +59,20 @@ void *X509_CRL_get_ext_d2i(const X509_CRL *x, int nid, int *crit, int *idx)
 int X509_CRL_add1_ext_i2d(X509_CRL *x, int nid, void *value, int crit,
     unsigned long flags)
 {
+    /*
+     * Assume modified, sadly the underlying function does not tell us whether
+     * changes were made, or not.
+     */
+    x->crl.enc.modified = 1;
     return X509V3_add1_i2d(&x->crl.extensions, nid, value, crit, flags);
 }
 
 int X509_CRL_add_ext(X509_CRL *x, const X509_EXTENSION *ex, int loc)
 {
-    return (X509v3_add_ext(&(x->crl.extensions), ex, loc) != NULL);
+    if (X509v3_add_ext(&x->crl.extensions, ex, loc) == NULL)
+        return 0;
+    x->crl.enc.modified = 1;
+    return 1;
 }
 
 int X509_get_ext_count(const X509 *x)

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -25,8 +25,11 @@ X509_REQ *X509_to_X509_REQ(const X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
     X509_REQ_INFO *ri;
     int i;
     EVP_PKEY *pktmp;
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
 
-    ret = X509_REQ_new_ex(x->libctx, x->propq);
+    ossl_x509_get0_libctx(x, &libctx, &propq);
+    ret = X509_REQ_new_ex(libctx, propq);
     if (ret == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
         goto err;

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -202,13 +202,6 @@ void X509_SIG_INFO_set(X509_SIG_INFO *siginf, int mdnid, int pknid,
     siginf->flags = flags;
 }
 
-int X509_get_signature_info(const X509 *x, int *mdnid, int *pknid, int *secbits,
-    uint32_t *flags)
-{
-    X509_check_purpose(x, -1, -1);
-    return X509_SIG_INFO_get(&x->siginf, mdnid, pknid, secbits, flags);
-}
-
 /* Modify *siginf according to alg and sig. Return 1 on success, else 0. */
 static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     const ASN1_STRING *sig, const EVP_PKEY *pubkey,
@@ -312,9 +305,18 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     return 1;
 }
 
-/* Returns 1 on success, 0 on failure */
-int ossl_x509_init_sig_info(const X509 *x, X509_SIG_INFO *info)
+int X509_get_signature_info(const X509 *x, int *mdnid, int *pknid, int *secbits,
+    uint32_t *flags)
 {
-    return x509_sig_info_init(info, &x->sig_alg, &x->signature,
+    X509_SIG_INFO siginf;
+
+    if (x == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    ERR_set_mark();
+    (void)x509_sig_info_init(&siginf, &x->sig_alg, &x->signature,
         X509_PUBKEY_get0(x->cert_info.key), x->libctx, x->propq);
+    ERR_pop_to_mark();
+    return X509_SIG_INFO_get(&siginf, mdnid, pknid, secbits, flags);
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -49,8 +49,8 @@ int X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial)
     if (x == NULL)
         return 0;
     in = &x->cert_info.serialNumber;
-    if (in != serial)
-        return ASN1_STRING_copy(in, serial);
+    if (in != serial && !ASN1_STRING_copy(in, serial))
+        return 0;
     x->cert_info.enc.modified = 1;
     return 1;
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -305,18 +305,25 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     return 1;
 }
 
-int X509_get_signature_info(const X509 *x, int *mdnid, int *pknid, int *secbits,
-    uint32_t *flags)
+int ossl_x509_get_signature_info_ex(const X509 *x, int *mdnid, int *pknid,
+    int *secbits, uint32_t *flags, OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509_SIG_INFO siginf;
 
+    ERR_set_mark();
+    (void)x509_sig_info_init(&siginf, &x->sig_alg, &x->signature,
+        X509_PUBKEY_get0(x->cert_info.key), libctx, propq);
+    ERR_pop_to_mark();
+    return X509_SIG_INFO_get(&siginf, mdnid, pknid, secbits, flags);
+}
+
+int X509_get_signature_info(const X509 *x, int *mdnid, int *pknid, int *secbits,
+    uint32_t *flags)
+{
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    ERR_set_mark();
-    (void)x509_sig_info_init(&siginf, &x->sig_alg, &x->signature,
-        X509_PUBKEY_get0(x->cert_info.key), x->libctx, x->propq);
-    ERR_pop_to_mark();
-    return X509_SIG_INFO_get(&siginf, mdnid, pknid, secbits, flags);
+    return ossl_x509_get_signature_info_ex(x, mdnid, pknid, secbits, flags,
+        x->libctx, x->propq);
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -320,10 +320,14 @@ int ossl_x509_get_signature_info_ex(const X509 *x, int *mdnid, int *pknid,
 int X509_get_signature_info(const X509 *x, int *mdnid, int *pknid, int *secbits,
     uint32_t *flags)
 {
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
+
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
+    ossl_x509_get0_libctx(x, &libctx, &propq);
     return ossl_x509_get_signature_info_ex(x, mdnid, pknid, secbits, flags,
-        x->libctx, x->propq);
+        libctx, propq);
 }

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2132,7 +2132,8 @@ static int check_crl(X509_STORE_CTX *ctx, X509_CRL *crl)
         if (rv != X509_V_OK && !verify_cb_crl(ctx, rv))
             return 0;
         /* Verify CRL signature */
-        if (X509_CRL_verify(crl, ikey) <= 0 && !verify_cb_crl(ctx, X509_V_ERR_CRL_SIGNATURE_FAILURE))
+        if (ossl_x509_crl_verify_ex(crl, ikey, ctx->libctx, ctx->propq) <= 0
+            && !verify_cb_crl(ctx, X509_V_ERR_CRL_SIGNATURE_FAILURE))
             return 0;
     }
     return 1;
@@ -2452,7 +2453,9 @@ static int internal_verify(X509_STORE_CTX *ctx)
                 CB_FAIL_IF(1, ctx, xi, issuer_depth,
                     X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY);
             } else {
-                CB_FAIL_IF(X509_verify(xs, pkey) <= 0,
+                CB_FAIL_IF(ossl_x509_verify_ex(xs, pkey, ctx->libctx,
+                               ctx->propq)
+                        <= 0,
                     ctx, xs, n, X509_V_ERR_CERT_SIGNATURE_FAILURE);
             }
         }
@@ -3522,7 +3525,10 @@ static int check_dane_pkeys(X509_STORE_CTX *ctx)
 
     for (i = 0; i < recnum; ++i) {
         t = sk_danetls_record_value(dane->trecs, i);
-        if (t->usage != DANETLS_USAGE_DANE_TA || t->selector != DANETLS_SELECTOR_SPKI || t->mtype != DANETLS_MATCHING_FULL || X509_verify(cert, t->spki) <= 0)
+        if (t->usage != DANETLS_USAGE_DANE_TA
+            || t->selector != DANETLS_SELECTOR_SPKI
+            || t->mtype != DANETLS_MATCHING_FULL
+            || ossl_x509_verify_ex(cert, t->spki, ctx->libctx, ctx->propq) <= 0)
             continue;
 
         /* Clear any PKIX-?? matches that failed to extend to a full chain */
@@ -4201,7 +4207,8 @@ static int check_sig_level(X509_STORE_CTX *ctx, X509 *cert)
     if (level > NUM_AUTH_LEVELS)
         level = NUM_AUTH_LEVELS;
 
-    if (!X509_get_signature_info(cert, NULL, NULL, &secbits, NULL))
+    if (!ossl_x509_get_signature_info_ex(cert, NULL, NULL, &secbits, NULL,
+            ctx->libctx, ctx->propq))
         return 0;
 
     return secbits >= minbits_table[level - 1];

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -275,6 +275,8 @@ X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout)
 int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
     STACK_OF(X509_EXTENSION) *exts;
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
     int bad = 0;
 
     if (x == NULL) {
@@ -287,9 +289,10 @@ int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md)
     if (bad)
         return 0;
     x->req_info.enc.modified = 1;
+    ossl_x509_req_get0_libctx(x, &libctx, &propq);
     return ASN1_item_sign_ex(ASN1_ITEM_rptr(X509_REQ_INFO), &x->sig_alg, NULL,
         x->signature, &x->req_info, NULL,
-        pkey, md, x->libctx, x->propq);
+        pkey, md, libctx, propq);
 }
 
 int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx)
@@ -470,10 +473,8 @@ X509_REQ *d2i_X509_REQ_bio(BIO *bp, X509_REQ **req)
     OSSL_LIB_CTX *libctx = NULL;
     const char *propq = NULL;
 
-    if (req != NULL && *req != NULL) {
-        libctx = (*req)->libctx;
-        propq = (*req)->propq;
-    }
+    if (req != NULL && *req != NULL)
+        ossl_x509_req_get0_libctx(*req, &libctx, &propq);
 
     return ASN1_item_d2i_bio_ex(ASN1_ITEM_rptr(X509_REQ), bp, req, libctx, propq);
 }
@@ -809,8 +810,12 @@ int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
 int X509_REQ_digest(const X509_REQ *data, const EVP_MD *type,
     unsigned char *md, unsigned int *len)
 {
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
+
+    ossl_x509_req_get0_libctx(data, &libctx, &propq);
     return ossl_asn1_item_digest_ex(ASN1_ITEM_rptr(X509_REQ), type, (char *)data,
-        md, len, data->libctx, data->propq);
+        md, len, libctx, propq);
 }
 
 int X509_NAME_digest(const X509_NAME *data, const EVP_MD *type,

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -770,15 +770,6 @@ int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    if (EVP_MD_is_a(type, SN_sha1)
-        && (data->flags & EXFLAG_SET) != 0
-        && (data->flags & EXFLAG_NO_FINGERPRINT) == 0) {
-        /* Asking for SHA1; always computed in CRL d2i. */
-        if (len != NULL)
-            *len = sizeof(data->fingerprint);
-        memcpy(md, data->fingerprint, sizeof(data->fingerprint));
-        return 1;
-    }
     return ossl_asn1_item_digest_ex(ASN1_ITEM_rptr(X509_CRL), type, (char *)data,
         md, len, data->libctx, data->propq);
 }

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -424,7 +424,7 @@ PKCS7 *d2i_PKCS7_fp(FILE *fp, PKCS7 **p7)
 
     ret = ASN1_item_d2i_fp_ex(ASN1_ITEM_rptr(PKCS7), fp, p7, libctx, propq);
     if (ret != NULL)
-        ossl_pkcs7_resolve_libctx(ret);
+        ossl_pkcs7_SignerInfos_set_ctx(ret);
     return ret;
 }
 
@@ -447,7 +447,7 @@ PKCS7 *d2i_PKCS7_bio(BIO *bp, PKCS7 **p7)
 
     ret = ASN1_item_d2i_bio_ex(ASN1_ITEM_rptr(PKCS7), bp, p7, libctx, propq);
     if (ret != NULL)
-        ossl_pkcs7_resolve_libctx(ret);
+        ossl_pkcs7_SignerInfos_set_ctx(ret);
     return ret;
 }
 

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -30,6 +30,7 @@
 #include "crypto/x509.h"
 #include "crypto/x509_acert.h"
 #include "crypto/rsa.h"
+#include "crypto/sha.h"
 #include "x509_local.h"
 
 static void *RSA_new_thunk(void)
@@ -643,17 +644,27 @@ int X509_pubkey_digest(const X509 *data, const EVP_MD *type,
     return EVP_Digest(key->data, key->length, md, len, type, NULL);
 }
 
+int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
+    unsigned char *hash, size_t hash_size)
+{
+    unsigned char *der = NULL;
+    int der_len;
+
+    if (!ossl_assert(hash_size >= SHA_DIGEST_LENGTH)) {
+        ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    der_len = ASN1_item_i2d((const ASN1_VALUE *)val, &der, it);
+    if (der_len < 0)
+        return 0;
+    ossl_sha1(der, (size_t)der_len, hash);
+    OPENSSL_free(der);
+    return 1;
+}
+
 int X509_digest(const X509 *cert, const EVP_MD *md, unsigned char *data,
     unsigned int *len)
 {
-    if (EVP_MD_is_a(md, SN_sha1) && (cert->ex_flags & EXFLAG_SET) != 0
-        && (cert->ex_flags & EXFLAG_NO_FINGERPRINT) == 0) {
-        /* Asking for SHA1 and we already computed it. */
-        if (len != NULL)
-            *len = sizeof(cert->sha1_hash);
-        memcpy(data, cert->sha1_hash, sizeof(cert->sha1_hash));
-        return 1;
-    }
     return ossl_asn1_item_digest_ex(ASN1_ITEM_rptr(X509), md, (char *)cert,
         data, len, cert->libctx, cert->propq);
 }
@@ -764,8 +775,8 @@ int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
         && (data->flags & EXFLAG_NO_FINGERPRINT) == 0) {
         /* Asking for SHA1; always computed in CRL d2i. */
         if (len != NULL)
-            *len = sizeof(data->sha1_hash);
-        memcpy(md, data->sha1_hash, sizeof(data->sha1_hash));
+            *len = sizeof(data->fingerprint);
+        memcpy(md, data->fingerprint, sizeof(data->fingerprint));
         return 1;
     }
     return ossl_asn1_item_digest_ex(ASN1_ITEM_rptr(X509_CRL), type, (char *)data,

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -30,7 +30,7 @@
 #include "crypto/x509.h"
 #include "crypto/x509_acert.h"
 #include "crypto/rsa.h"
-#include "crypto/sha.h"
+#include "crypto/siphash.h"
 #include "x509_local.h"
 
 static void *RSA_new_thunk(void)
@@ -645,19 +645,20 @@ int X509_pubkey_digest(const X509 *data, const EVP_MD *type,
 }
 
 int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
-    unsigned char *hash, size_t hash_size)
+    unsigned char *hash)
 {
+    static const unsigned char key[SIPHASH_KEY_SIZE] = { 0 };
+    SIPHASH ctx = { 0 };
     unsigned char *der = NULL;
     int der_len;
 
-    if (!ossl_assert(hash_size >= SHA_DIGEST_LENGTH)) {
-        ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
-        return 0;
-    }
     der_len = ASN1_item_i2d((const ASN1_VALUE *)val, &der, it);
     if (der_len < 0)
         return 0;
-    ossl_sha1(der, (size_t)der_len, hash);
+    (void)SipHash_set_hash_size(&ctx, OSSL_X509_FINGERPRINT_SIZE);
+    (void)SipHash_Init(&ctx, key, 0, 0);
+    SipHash_Update(&ctx, der, (size_t)der_len);
+    (void)SipHash_Final(&ctx, hash, OSSL_X509_FINGERPRINT_SIZE);
     OPENSSL_free(der);
     return 1;
 }

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -143,7 +143,11 @@ int ossl_x509_verify_ex(const X509 *a, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
 
 int X509_verify(const X509 *a, EVP_PKEY *r)
 {
-    return ossl_x509_verify_ex(a, r, a->libctx, a->propq);
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
+
+    ossl_x509_get0_libctx(a, &libctx, &propq);
+    return ossl_x509_verify_ex(a, r, libctx, propq);
 }
 
 int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
@@ -198,6 +202,8 @@ static int bad_keyid_exts(const STACK_OF(X509_EXTENSION) *exts)
 int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
     const STACK_OF(X509_EXTENSION) *exts;
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
 
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
@@ -216,9 +222,10 @@ int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
      * which exist below are the same.
      */
     x->cert_info.enc.modified = 1;
+    ossl_x509_get0_libctx(x, &libctx, &propq);
     return ASN1_item_sign_ex(ASN1_ITEM_rptr(X509_CINF), &x->cert_info.signature,
         &x->sig_alg, &x->signature, &x->cert_info, NULL,
-        pkey, md, x->libctx, x->propq);
+        pkey, md, libctx, propq);
 }
 
 int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx)
@@ -672,8 +679,12 @@ int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
 int X509_digest(const X509 *cert, const EVP_MD *md, unsigned char *data,
     unsigned int *len)
 {
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
+
+    ossl_x509_get0_libctx(cert, &libctx, &propq);
     return ossl_asn1_item_digest_ex(ASN1_ITEM_rptr(X509), md, (char *)cert,
-        data, len, cert->libctx, cert->propq);
+        data, len, libctx, propq);
 }
 
 ASN1_OCTET_STRING *ossl_x509_digest_sig_ex(const X509 *cert,
@@ -769,6 +780,9 @@ err:
 ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
     EVP_MD **md_used, int *md_is_fallback)
 {
+    OSSL_LIB_CTX *libctx;
+    const char *propq;
+
     if (cert == NULL) {
         if (md_used != NULL)
             *md_used = NULL;
@@ -777,8 +791,8 @@ ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
-    return ossl_x509_digest_sig_ex(cert, md_used, md_is_fallback,
-        cert->libctx, cert->propq);
+    ossl_x509_get0_libctx(cert, &libctx, &propq);
+    return ossl_x509_digest_sig_ex(cert, md_used, md_is_fallback, libctx, propq);
 }
 
 int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -676,9 +676,9 @@ int X509_digest(const X509 *cert, const EVP_MD *md, unsigned char *data,
         data, len, cert->libctx, cert->propq);
 }
 
-/* calculate cert digest using the same hash algorithm as in its signature */
-ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
-    EVP_MD **md_used, int *md_is_fallback)
+ASN1_OCTET_STRING *ossl_x509_digest_sig_ex(const X509 *cert,
+    EVP_MD **md_used, int *md_is_fallback,
+    OSSL_LIB_CTX *libctx, const char *propq)
 {
     unsigned int len;
     unsigned char hash[EVP_MAX_MD_SIZE];
@@ -691,11 +691,6 @@ ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
         *md_used = NULL;
     if (md_is_fallback != NULL)
         *md_is_fallback = 0;
-
-    if (cert == NULL) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
-        return NULL;
-    }
 
     if (!OBJ_find_sigid_algs(X509_get_signature_nid(cert), &mdnid, &pknid)) {
         ERR_raise(ERR_LIB_X509, X509_R_UNKNOWN_SIGID_ALGS);
@@ -719,8 +714,8 @@ ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
             }
             RSA_PSS_PARAMS_free(pss);
             /* Fetch explicitly and do not fallback */
-            if ((md = EVP_MD_fetch(cert->libctx, EVP_MD_get0_name(mmd),
-                     cert->propq))
+            if ((md = EVP_MD_fetch(libctx, EVP_MD_get0_name(mmd),
+                     propq))
                 == NULL)
                 /* Error code from fetch is sufficient */
                 return NULL;
@@ -737,8 +732,8 @@ ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
                 md_name = "SHA256";
                 break;
             }
-            if ((md = EVP_MD_fetch(cert->libctx, md_name,
-                     cert->propq))
+            if ((md = EVP_MD_fetch(libctx, md_name,
+                     propq))
                 == NULL)
                 return NULL;
             if (md_is_fallback != NULL)
@@ -748,8 +743,8 @@ ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
             ERR_raise(ERR_LIB_X509, X509_R_UNSUPPORTED_ALGORITHM);
             return NULL;
         }
-    } else if ((md = EVP_MD_fetch(cert->libctx, OBJ_nid2sn(mdnid),
-                    cert->propq))
+    } else if ((md = EVP_MD_fetch(libctx, OBJ_nid2sn(mdnid),
+                    propq))
         == NULL) {
         ERR_raise(ERR_LIB_X509, X509_R_UNSUPPORTED_ALGORITHM);
         return NULL;
@@ -768,6 +763,22 @@ ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
 err:
     EVP_MD_free(md);
     return NULL;
+}
+
+/* calculate cert digest using the same hash algorithm as in its signature */
+ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert,
+    EVP_MD **md_used, int *md_is_fallback)
+{
+    if (cert == NULL) {
+        if (md_used != NULL)
+            *md_used = NULL;
+        if (md_is_fallback != NULL)
+            *md_is_fallback = 0;
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+        return NULL;
+    }
+    return ossl_x509_digest_sig_ex(cert, md_used, md_is_fallback,
+        cert->libctx, cert->propq);
 }
 
 int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -130,14 +130,20 @@ static int i2d_ECPrivateKey_thunk(const void *a, unsigned char **out)
 }
 #endif
 
-int X509_verify(const X509 *a, EVP_PKEY *r)
+int ossl_x509_verify_ex(const X509 *a, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
+    const char *propq)
 {
     if (X509_ALGOR_cmp(&a->sig_alg, &a->cert_info.signature) != 0)
         return 0;
 
     return ASN1_item_verify_ex(ASN1_ITEM_rptr(X509_CINF), &a->sig_alg,
         &a->signature, &a->cert_info,
-        a->distinguishing_id, r, a->libctx, a->propq);
+        a->distinguishing_id, r, libctx, propq);
+}
+
+int X509_verify(const X509 *a, EVP_PKEY *r)
+{
+    return ossl_x509_verify_ex(a, r, a->libctx, a->propq);
 }
 
 int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OSSL_LIB_CTX *libctx,

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -245,7 +245,7 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         break;
 
     case ASN1_OP_D2I_POST:
-        if (!X509_CRL_digest(crl, EVP_sha1(), crl->sha1_hash, NULL))
+        if (!X509_CRL_digest(crl, EVP_sha1(), crl->fingerprint, NULL))
             crl->flags |= EXFLAG_NO_FINGERPRINT;
         crl->idp = X509_CRL_get_ext_d2i(crl, NID_issuing_distribution_point, &i, NULL);
         if (crl->idp == NULL && i != -1) {

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -466,7 +466,8 @@ int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, const X509 *x)
     return 0;
 }
 
-static int def_crl_verify(X509_CRL *crl, EVP_PKEY *r)
+static int def_crl_verify_ex(X509_CRL *crl, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
+    const char *propq)
 {
     if (X509_ALGOR_cmp(&crl->sig_alg, &crl->crl.sig_alg) != 0) {
         ERR_raise(ERR_LIB_X509, X509_R_CRL_SIGNATURE_ALGORITHM_MISMATCH);
@@ -474,7 +475,21 @@ static int def_crl_verify(X509_CRL *crl, EVP_PKEY *r)
     }
     return ASN1_item_verify_ex(ASN1_ITEM_rptr(X509_CRL_INFO),
         &crl->sig_alg, &crl->signature, &crl->crl, NULL,
-        r, crl->libctx, crl->propq);
+        r, libctx, propq);
+}
+
+static int def_crl_verify(X509_CRL *crl, EVP_PKEY *r)
+{
+    return def_crl_verify_ex(crl, r, crl->libctx, crl->propq);
+}
+
+int ossl_x509_crl_verify_ex(X509_CRL *crl, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
+    const char *propq)
+{
+    /* A custom X509_CRL_METHOD has no library context to be told about */
+    if (crl->meth->crl_verify != def_crl_verify)
+        return X509_CRL_verify(crl, r);
+    return def_crl_verify_ex(crl, r, libctx, propq);
 }
 
 static int crl_revoked_issuer_match(X509_CRL *crl, const X509_NAME *nm,

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -208,7 +208,8 @@ static int crl_set_issuers(X509_CRL *crl)
 
 /*
  * The X509_CRL structure needs a bit of customisation. Cache some extensions
- * and hash of the whole CRL or set EXFLAG_NO_FINGERPRINT if this fails.
+ * and the internal-use fingerprint of the whole CRL, or set
+ * EXFLAG_NO_FINGERPRINT if this fails.
  */
 static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     void *exarg)
@@ -245,7 +246,8 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         break;
 
     case ASN1_OP_D2I_POST:
-        if (!X509_CRL_digest(crl, EVP_sha1(), crl->fingerprint, NULL))
+        if (!ossl_x509_internal_fingerprint(ASN1_ITEM_rptr(X509_CRL), crl,
+                crl->fingerprint, sizeof(crl->fingerprint)))
             crl->flags |= EXFLAG_NO_FINGERPRINT;
         crl->idp = X509_CRL_get_ext_d2i(crl, NID_issuing_distribution_point, &i, NULL);
         if (crl->idp == NULL && i != -1) {

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -247,7 +247,7 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 
     case ASN1_OP_D2I_POST:
         if (!ossl_x509_internal_fingerprint(ASN1_ITEM_rptr(X509_CRL), crl,
-                crl->fingerprint, sizeof(crl->fingerprint)))
+                crl->fingerprint))
             crl->flags |= EXFLAG_NO_FINGERPRINT;
         crl->idp = X509_CRL_get_ext_d2i(crl, NID_issuing_distribution_point, &i, NULL);
         if (crl->idp == NULL && i != -1) {

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -376,6 +376,10 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
         goto error;
     }
 
+    /* The replacement inherits the library context of the object it replaces */
+    if (*x != NULL && !x509_pubkey_set0_libctx(pk, (*x)->libctx, (*x)->propq))
+        goto error;
+
     X509_PUBKEY_free(*x);
     if (!EVP_PKEY_up_ref(pkey)) {
         ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);

--- a/crypto/x509/x_req.c
+++ b/crypto/x509/x_req.c
@@ -60,13 +60,10 @@ static int req_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 
     case ASN1_OP_FREE_POST:
         ASN1_OCTET_STRING_free(ret->distinguishing_id);
-        OPENSSL_free(ret->propq);
         break;
     case ASN1_OP_DUP_POST: {
         X509_REQ *old = exarg;
 
-        if (!ossl_x509_req_set0_libctx(ret, old->libctx, old->propq))
-            return 0;
         if (old->req_info.pubkey != NULL) {
             EVP_PKEY *pkey = X509_PUBKEY_get0(old->req_info.pubkey);
 
@@ -85,16 +82,12 @@ static int req_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
             }
         }
     } break;
-    case ASN1_OP_GET0_LIBCTX: {
-        OSSL_LIB_CTX **libctx = exarg;
-
-        *libctx = ret->libctx;
-    } break;
-    case ASN1_OP_GET0_PROPQ: {
-        const char **propq = exarg;
-
-        *propq = ret->propq;
-    } break;
+    case ASN1_OP_GET0_LIBCTX:
+        ossl_x509_req_get0_libctx(ret, exarg, NULL);
+        break;
+    case ASN1_OP_GET0_PROPQ:
+        ossl_x509_req_get0_libctx(ret, NULL, exarg);
+        break;
     }
 
     return 1;
@@ -133,35 +126,18 @@ ASN1_OCTET_STRING *X509_REQ_get0_distinguishing_id(X509_REQ *x)
     return x->distinguishing_id;
 }
 
-/*
- * This should only be used if the X509_REQ object was embedded inside another
- * asn1 object and it needs a libctx to operate.
- * Use X509_REQ_new_ex() instead if possible.
- */
-int ossl_x509_req_set0_libctx(X509_REQ *x, OSSL_LIB_CTX *libctx,
-    const char *propq)
+void ossl_x509_req_get0_libctx(const X509_REQ *x, OSSL_LIB_CTX **libctx,
+    const char **propq)
 {
-    if (x != NULL) {
-        x->libctx = libctx;
-        OPENSSL_free(x->propq);
-        x->propq = NULL;
-        if (propq != NULL) {
-            x->propq = OPENSSL_strdup(propq);
-            if (x->propq == NULL)
-                return 0;
-        }
-    }
-    return 1;
+    if (libctx != NULL)
+        *libctx = NULL;
+    if (propq != NULL)
+        *propq = NULL;
+    if (x->req_info.pubkey != NULL)
+        (void)ossl_x509_PUBKEY_get0_libctx(libctx, propq, x->req_info.pubkey);
 }
 
 X509_REQ *X509_REQ_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
-    X509_REQ *req = NULL;
-
-    req = (X509_REQ *)ASN1_item_new(ASN1_ITEM_rptr(X509_REQ));
-    if (!ossl_x509_req_set0_libctx(req, libctx, propq)) {
-        X509_REQ_free(req);
-        req = NULL;
-    }
-    return req;
+    return (X509_REQ *)ASN1_item_new_ex(ASN1_ITEM_rptr(X509_REQ), libctx, propq);
 }

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -95,26 +95,15 @@ static int x509_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         ASIdentifiers_free(ret->rfc3779_asid);
 #endif
         ASN1_OCTET_STRING_free(ret->distinguishing_id);
-        OPENSSL_free(ret->propq);
         break;
 
-    case ASN1_OP_DUP_POST: {
-        X509 *old = exarg;
+    case ASN1_OP_GET0_LIBCTX:
+        ossl_x509_get0_libctx(ret, exarg, NULL);
+        break;
 
-        if (!ossl_x509_set0_libctx(ret, old->libctx, old->propq))
-            return 0;
-    } break;
-    case ASN1_OP_GET0_LIBCTX: {
-        OSSL_LIB_CTX **libctx = exarg;
-
-        *libctx = ret->libctx;
-    } break;
-
-    case ASN1_OP_GET0_PROPQ: {
-        const char **propq = exarg;
-
-        *propq = ret->propq;
-    } break;
+    case ASN1_OP_GET0_PROPQ:
+        ossl_x509_get0_libctx(ret, NULL, exarg);
+        break;
 
     default:
         break;
@@ -132,36 +121,20 @@ ASN1_SEQUENCE_ref(X509, x509_cb) = {
 IMPLEMENT_ASN1_FUNCTIONS(X509)
 IMPLEMENT_ASN1_DUP_FUNCTION(X509)
 
-/*
- * This should only be used if the X509 object was embedded inside another
- * asn1 object and it needs a libctx to operate.
- * Use X509_new_ex() instead if possible.
- */
-int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq)
+void ossl_x509_get0_libctx(const X509 *x, OSSL_LIB_CTX **libctx,
+    const char **propq)
 {
-    if (x != NULL) {
-        x->libctx = libctx;
-        OPENSSL_free(x->propq);
-        x->propq = NULL;
-        if (propq != NULL) {
-            x->propq = OPENSSL_strdup(propq);
-            if (x->propq == NULL)
-                return 0;
-        }
-    }
-    return 1;
+    if (libctx != NULL)
+        *libctx = NULL;
+    if (propq != NULL)
+        *propq = NULL;
+    if (x->cert_info.key != NULL)
+        (void)ossl_x509_PUBKEY_get0_libctx(libctx, propq, x->cert_info.key);
 }
 
 X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
-    X509 *cert = NULL;
-
-    cert = (X509 *)ASN1_item_new_ex(ASN1_ITEM_rptr(X509), libctx, propq);
-    if (!ossl_x509_set0_libctx(cert, libctx, propq)) {
-        X509_free(cert);
-        cert = NULL;
-    }
-    return cert;
+    return (X509 *)ASN1_item_new_ex(ASN1_ITEM_rptr(X509), libctx, propq);
 }
 
 int X509_set_ex_data(X509 *r, int idx, void *arg)

--- a/doc/internal/man3/x509v3_cache_extensions.pod
+++ b/doc/internal/man3/x509v3_cache_extensions.pod
@@ -16,9 +16,9 @@ x509v3_cache_extensions
 This function processes any X509v3 extensions present in an X509 object I<x>
 and caches the result of that processing as well as further derived info,
 for instance whether the certificate is self-issued or has version X.509v1.
-It computes an internal-use SHA1 fingerprint of the certificate, used only by
-L<X509_cmp(3)> and never exposed to callers, with the built-in SHA1
-implementation, independent of any library context or property query string,
+It computes an internal-use fingerprint of the certificate, used only by
+L<X509_cmp(3)> and never exposed to callers,
+independent of any library context or property query string,
 and stores the result in x->fingerprint;
 on failure (the certificate cannot be DER encoded, for instance because it is
 still under construction, or memory allocation failed) it sets

--- a/doc/internal/man3/x509v3_cache_extensions.pod
+++ b/doc/internal/man3/x509v3_cache_extensions.pod
@@ -23,8 +23,6 @@ and stores the result in x->fingerprint;
 on failure (the certificate cannot be DER encoded, for instance because it is
 still under construction, or memory allocation failed) it sets
 B<EXFLAG_NO_FINGERPRINT> in x->flags instead.
-It sets B<X509_SIG_INFO_VALID> in x->flags if x->siginf was filled successfully,
-which may not be possible if a referenced algorithm is unknown or not available.
 Many OpenSSL functions that use an X509 object call this function implicitly.
 
 =head1 RETURN VALUES

--- a/doc/internal/man3/x509v3_cache_extensions.pod
+++ b/doc/internal/man3/x509v3_cache_extensions.pod
@@ -16,9 +16,13 @@ x509v3_cache_extensions
 This function processes any X509v3 extensions present in an X509 object I<x>
 and caches the result of that processing as well as further derived info,
 for instance whether the certificate is self-issued or has version X.509v1.
-It computes the SHA1 digest of the certificate using the default library context
-and property query string and stores the result in x->sha1_hash,
-or on failure sets B<EXFLAG_NO_FINGERPRINT> in x->flags.
+It computes an internal-use SHA1 fingerprint of the certificate, used only by
+L<X509_cmp(3)> and never exposed to callers, with the built-in SHA1
+implementation, independent of any library context or property query string,
+and stores the result in x->fingerprint;
+on failure (the certificate cannot be DER encoded, for instance because it is
+still under construction, or memory allocation failed) it sets
+B<EXFLAG_NO_FINGERPRINT> in x->flags instead.
 It sets B<X509_SIG_INFO_VALID> in x->flags if x->siginf was filled successfully,
 which may not be possible if a referenced algorithm is unknown or not available.
 Many OpenSSL functions that use an X509 object call this function implicitly.

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -28,8 +28,7 @@ The X509_cmp() function compares two B<X509> objects indicated by parameters
 I<a> and I<b>. The comparison is based on the B<memcmp> result of the hash
 values of two B<X509> objects and the canonical (DER) encoding values.
 A certificate that has been modified since it was signed or decoded, and
-not signed again, compares equal only to itself, and sorts after any
-certificate that has not been modified.
+not signed again, compares equal only to itself.
 
 The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
 parameters I<a> and I<b>, any of which may be NULL.
@@ -52,8 +51,7 @@ objects, respectively.
 The X509_CRL_match() function compares two B<X509_CRL> objects. Unlike the
 X509_CRL_cmp() function, this function compares the whole CRL content instead
 of just the issuer name. A CRL that has been modified since it was signed or
-decoded, and not signed again, compares equal only to itself, and sorts after
-any CRL that has not been modified.
+decoded, and not signed again, compares equal only to itself.
 
 =head1 RETURN VALUES
 
@@ -70,8 +68,11 @@ to indicate an error, and callers should still be prepared to receive it.
 
 These functions in fact utilize the underlying B<memcmp> of the C library to do
 the comparison job. Data to be compared varies from DER encoding data, hash
-value or B<ASN1_STRING>. The sign of the comparison can be used to order the
-objects but it does not have a special meaning in some cases.
+value or B<ASN1_STRING>. The sign of the result of X509_cmp() and
+X509_CRL_match() orders objects consistently only while none of them has been
+modified since it was signed or decoded, and the internal hash of each could
+be computed. A modified object compares unequal to every other object, but
+two modified objects are not ordered with respect to each other.
 
 X509_NAME_cmp() and wrappers utilize the value B<-2> to indicate errors in some
 circumstances, which could cause confusion for the applications.

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -56,8 +56,10 @@ The B<X509> comparison functions return B<-1>, B<0>, or B<1> if object I<a> is
 found to be less than, to match, or be greater than object I<b>, respectively.
 
 X509_NAME_cmp(), X509_issuer_and_serial_cmp(), X509_issuer_name_cmp(),
-X509_subject_name_cmp(), X509_CRL_cmp(), and X509_CRL_match()
+X509_subject_name_cmp(), and X509_CRL_cmp()
 may return B<-2> to indicate an error.
+X509_CRL_match() no longer returns B<-2>, but did so in earlier versions
+to indicate an error, and callers should still be prepared to receive it.
 
 =head1 NOTES
 

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -27,6 +27,9 @@ certificates, X509 CRL objects and various values in an X509 certificate.
 The X509_cmp() function compares two B<X509> objects indicated by parameters
 I<a> and I<b>. The comparison is based on the B<memcmp> result of the hash
 values of two B<X509> objects and the canonical (DER) encoding values.
+A certificate that has been modified since it was signed or decoded, and
+not signed again, compares equal only to itself, and sorts after any
+certificate that has not been modified.
 
 The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
 parameters I<a> and I<b>, any of which may be NULL.
@@ -48,7 +51,9 @@ objects, respectively.
 
 The X509_CRL_match() function compares two B<X509_CRL> objects. Unlike the
 X509_CRL_cmp() function, this function compares the whole CRL content instead
-of just the issuer name.
+of just the issuer name. A CRL that has been modified since it was signed or
+decoded, and not signed again, compares equal only to itself, and sorts after
+any CRL that has not been modified.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/X509_get_extension_flags.pod
+++ b/doc/man3/X509_get_extension_flags.pod
@@ -86,8 +86,9 @@ ASN1 object itself.
 
 =item B<EXFLAG_NO_FINGERPRINT>
 
-Failed to compute the internal SHA1 hash value of the certificate or CRL.
-This may be due to malloc failure or because no SHA1 implementation was found.
+Failed to compute the internal fingerprint of the certificate or CRL,
+because it could not be DER encoded (for instance a certificate still under
+construction) or on memory allocation failure.
 
 =item B<EXFLAG_INVALID_POLICY>
 

--- a/doc/man3/X509_new.pod
+++ b/doc/man3/X509_new.pod
@@ -28,7 +28,7 @@ X509_new_ex() allocates and initializes a X509 structure with a
 library context of I<libctx>, property query of I<propq> and a reference
 count of B<1>. Many X509 functions such as X509_check_purpose(), and
 X509_verify() use this library context to select which providers supply the
-fetched algorithms (SHA1 is used internally). This created X509 object can then
+fetched algorithms. This created X509 object can then
 be used when loading binary data using d2i_X509().
 
 X509_new() is similar to X509_new_ex() but sets the library context

--- a/include/crypto/pkcs7.h
+++ b/include/crypto/pkcs7.h
@@ -13,7 +13,7 @@
 
 #include <openssl/pkcs7.h>
 
-void ossl_pkcs7_resolve_libctx(PKCS7 *p7);
+void ossl_pkcs7_SignerInfos_set_ctx(PKCS7 *p7);
 
 void ossl_pkcs7_set0_libctx(PKCS7 *p7, OSSL_LIB_CTX *ctx);
 int ossl_pkcs7_set1_propq(PKCS7 *p7, const char *propq);

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -414,6 +414,26 @@ int ossl_x509_crl_verify_ex(X509_CRL *crl, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
 int ossl_x509_get_signature_info_ex(const X509 *x, int *mdnid, int *pknid,
     int *secbits, uint32_t *flags, OSSL_LIB_CTX *libctx, const char *propq);
 
+/**
+ * @brief Digest a certificate with its own signature digest, fetching from
+ *        @p libctx.
+ *
+ * Like X509_digest_sig(), but the digest is fetched from the given library
+ * context and property query rather than the certificate's own.
+ *
+ * @param cert the certificate to digest
+ * @param md_used where to store the digest used, owned by the caller;
+ *                may be NULL
+ * @param md_is_fallback where to store whether a fallback digest was used
+ *                       because the signature algorithm has none; may be NULL
+ * @param libctx the library context to fetch from, NULL for the default
+ * @param propq the property query to fetch with, may be NULL
+ * @returns the digest as a new ASN1_OCTET_STRING, or NULL on error
+ */
+ASN1_OCTET_STRING *ossl_x509_digest_sig_ex(const X509 *cert,
+    EVP_MD **md_used, int *md_is_fallback,
+    OSSL_LIB_CTX *libctx, const char *propq);
+
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
 int ossl_x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx,
     const char *propq);

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -19,6 +19,19 @@
 #include "crypto/types.h"
 
 #include <crypto/asn1.h>
+#include <crypto/siphash.h>
+
+/*
+ * Size in bytes of the internal X509 / X509_CRL fingerprint, see
+ * ossl_x509_internal_fingerprint(). The fingerprint only short-circuits
+ * X509_cmp() and X509_CRL_match(), which compare the encodings on a match,
+ * so a collision costs one extra memcmp. With 64 bits a collision among
+ * n objects has probability about n^2 / 2^65: one in 10^12 for 10,000
+ * certificates, and even odds only at around 2^32 of them. The SipHash key
+ * is fixed, so an attacker can craft certificates that collide, but gains
+ * only that memcmp per colliding pair on certificates they had to supply.
+ */
+#define OSSL_X509_FINGERPRINT_SIZE SIPHASH_MIN_DIGEST_SIZE
 
 /* Internal X509 structures and functions: not for application use */
 
@@ -119,8 +132,12 @@ struct X509_crl_st {
     ASN1_INTEGER *crl_number;
     ASN1_INTEGER *base_crl_number;
     STACK_OF(GENERAL_NAMES) *issuers;
-    /* internal-use fingerprint for X509_CRL_match(), see ossl_x509_internal_fingerprint() */
-    unsigned char fingerprint[SHA_DIGEST_LENGTH];
+    /*
+     * Internal-use fingerprint for X509_CRL_match(), see
+     * ossl_x509_internal_fingerprint(). Not cryptographically secure and
+     * not collision free: a match is confirmed by comparing the CRLs.
+     */
+    unsigned char fingerprint[OSSL_X509_FINGERPRINT_SIZE];
     /* alternative method to handle this CRL */
     const X509_CRL_METHOD *meth;
     void *meth_data;
@@ -197,8 +214,12 @@ struct x509_st {
     STACK_OF(IPAddressFamily) *rfc3779_addr;
     struct ASIdentifiers_st *rfc3779_asid;
 #endif
-    /* internal-use fingerprint for X509_cmp(), see ossl_x509_internal_fingerprint() */
-    unsigned char fingerprint[SHA_DIGEST_LENGTH];
+    /*
+     * Internal-use fingerprint for X509_cmp(), see
+     * ossl_x509_internal_fingerprint(). Not cryptographically secure and
+     * not collision free: a match is confirmed by comparing the certificates.
+     */
+    unsigned char fingerprint[OSSL_X509_FINGERPRINT_SIZE];
     X509_CERT_AUX *aux;
     CRYPTO_RWLOCK *lock;
     volatile int ex_cached;
@@ -324,22 +345,23 @@ int ossl_x509v3_cache_extensions(const X509 *x);
  * The fingerprint is cached in X509 / X509_CRL fingerprint and used only for
  * internal identity comparison (X509_cmp(), X509_CRL_match()); it is never
  * returned to callers, so the algorithm is an implementation detail
- * (currently SHA-1). It uses the built-in implementation directly rather
- * than fetching one, so the result depends on neither the library context
- * nor the property query string of the object and stays valid if the object
- * is moved to another library context. It fails only if the object cannot be
+ * (currently SipHash-2-4 with a fixed key and 64-bit output; a collision
+ * only costs the callers a fall through to their encoding comparison).
+ * Callers hash the whole signed object (X509, X509_CRL). No algorithm
+ * is fetched, so the result depends on neither the library context nor the
+ * property query string of the object and stays valid if the object is
+ * moved to another library context. It fails only if the object cannot be
  * DER encoded, for instance a certificate still under construction, or on
  * an allocation failure in the encoder.
  *
  * @param it the ASN1_ITEM describing @p val
  * @param val the object to encode and hash
- * @param hash output buffer for the fingerprint
- * @param hash_size size in bytes of @p hash, must be at least
- *                  SHA_DIGEST_LENGTH
+ * @param hash output buffer for the fingerprint, OSSL_X509_FINGERPRINT_SIZE
+ *             bytes
  * @returns 1 on success, 0 on failure
  */
 int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
-    unsigned char *hash, size_t hash_size);
+    unsigned char *hash);
 
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
 int ossl_x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx,

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -226,9 +226,6 @@ struct x509_st {
 
     /* Set on live certificates for authentication purposes */
     ASN1_OCTET_STRING *distinguishing_id;
-
-    OSSL_LIB_CTX *libctx;
-    char *propq;
 } /* X509 */;
 
 /*
@@ -434,7 +431,19 @@ ASN1_OCTET_STRING *ossl_x509_digest_sig_ex(const X509 *cert,
     EVP_MD **md_used, int *md_is_fallback,
     OSSL_LIB_CTX *libctx, const char *propq);
 
-int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
+/**
+ * @brief Get the library context and property query of a certificate.
+ *
+ * A certificate has no library context of its own; the one given to
+ * X509_new_ex(), or to the decoder of the structure it is embedded in, is
+ * kept by its X509_PUBKEY, which needs it to decode the public key.
+ *
+ * @param x the certificate
+ * @param libctx where to store the library context, may be NULL
+ * @param propq where to store the property query, may be NULL
+ */
+void ossl_x509_get0_libctx(const X509 *x, OSSL_LIB_CTX **libctx,
+    const char **propq);
 int ossl_x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx,
     const char *propq);
 int ossl_x509_req_set0_libctx(X509_REQ *x, OSSL_LIB_CTX *libctx,

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -98,8 +98,6 @@ struct X509_req_st {
 
     /* Set on live certificates for authentication purposes */
     ASN1_OCTET_STRING *distinguishing_id;
-    OSSL_LIB_CTX *libctx;
-    char *propq;
 };
 
 struct X509_crl_info_st {
@@ -446,8 +444,18 @@ void ossl_x509_get0_libctx(const X509 *x, OSSL_LIB_CTX **libctx,
     const char **propq);
 int ossl_x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx,
     const char *propq);
-int ossl_x509_req_set0_libctx(X509_REQ *x, OSSL_LIB_CTX *libctx,
-    const char *propq);
+/**
+ * @brief Get the library context and property query of a request.
+ *
+ * As for ossl_x509_get0_libctx(): the request has none of its own; the
+ * one given to X509_REQ_new_ex() is kept by its X509_PUBKEY.
+ *
+ * @param x the certificate request
+ * @param libctx where to store the library context, may be NULL
+ * @param propq where to store the property query, may be NULL
+ */
+void ossl_x509_req_get0_libctx(const X509_REQ *x, OSSL_LIB_CTX **libctx,
+    const char **propq);
 int ossl_asn1_item_digest_ex(const ASN1_ITEM *it, const EVP_MD *type,
     void *data, unsigned char *md, unsigned int *len,
     OSSL_LIB_CTX *libctx, const char *propq);

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -178,7 +178,6 @@ struct x509_st {
     X509_CINF cert_info;
     X509_ALGOR sig_alg;
     ASN1_BIT_STRING signature;
-    X509_SIG_INFO siginf;
     CRYPTO_REF_COUNT references;
     CRYPTO_EX_DATA ex_data;
     /* These contain copies of various extension values */
@@ -318,7 +317,6 @@ int ossl_a2i_ipadd(unsigned char *ipout, const char *ipasc);
 int ossl_x509_set1_time(int *modified, ASN1_TIME **ptm, const ASN1_TIME *tm);
 int ossl_x509_print_ex_brief(BIO *bio, const X509 *cert, unsigned long neg_cflags);
 int ossl_x509v3_cache_extensions(const X509 *x);
-int ossl_x509_init_sig_info(const X509 *x, X509_SIG_INFO *info);
 
 /**
  * @brief Compute the internal-use fingerprint of a DER-encodable object.

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -119,8 +119,8 @@ struct X509_crl_st {
     ASN1_INTEGER *crl_number;
     ASN1_INTEGER *base_crl_number;
     STACK_OF(GENERAL_NAMES) *issuers;
-    /* hash of CRL */
-    unsigned char sha1_hash[SHA_DIGEST_LENGTH];
+    /* internal-use fingerprint for X509_CRL_match(), see ossl_x509_internal_fingerprint() */
+    unsigned char fingerprint[SHA_DIGEST_LENGTH];
     /* alternative method to handle this CRL */
     const X509_CRL_METHOD *meth;
     void *meth_data;
@@ -198,7 +198,8 @@ struct x509_st {
     STACK_OF(IPAddressFamily) *rfc3779_addr;
     struct ASIdentifiers_st *rfc3779_asid;
 #endif
-    unsigned char sha1_hash[SHA_DIGEST_LENGTH];
+    /* internal-use fingerprint for X509_cmp(), see ossl_x509_internal_fingerprint() */
+    unsigned char fingerprint[SHA_DIGEST_LENGTH];
     X509_CERT_AUX *aux;
     CRYPTO_RWLOCK *lock;
     volatile int ex_cached;
@@ -318,6 +319,29 @@ int ossl_x509_set1_time(int *modified, ASN1_TIME **ptm, const ASN1_TIME *tm);
 int ossl_x509_print_ex_brief(BIO *bio, const X509 *cert, unsigned long neg_cflags);
 int ossl_x509v3_cache_extensions(const X509 *x);
 int ossl_x509_init_sig_info(const X509 *x, X509_SIG_INFO *info);
+
+/**
+ * @brief Compute the internal-use fingerprint of a DER-encodable object.
+ *
+ * The fingerprint is cached in X509 / X509_CRL fingerprint and used only for
+ * internal identity comparison (X509_cmp(), X509_CRL_match()); it is never
+ * returned to callers, so the algorithm is an implementation detail
+ * (currently SHA-1). It uses the built-in implementation directly rather
+ * than fetching one, so the result depends on neither the library context
+ * nor the property query string of the object and stays valid if the object
+ * is moved to another library context. It fails only if the object cannot be
+ * DER encoded, for instance a certificate still under construction, or on
+ * an allocation failure in the encoder.
+ *
+ * @param it the ASN1_ITEM describing @p val
+ * @param val the object to encode and hash
+ * @param hash output buffer for the fingerprint
+ * @param hash_size size in bytes of @p hash, must be at least
+ *                  SHA_DIGEST_LENGTH
+ * @returns 1 on success, 0 on failure
+ */
+int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
+    unsigned char *hash, size_t hash_size);
 
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
 int ossl_x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx,

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -363,6 +363,57 @@ int ossl_x509v3_cache_extensions(const X509 *x);
 int ossl_x509_internal_fingerprint(const ASN1_ITEM *it, const void *val,
     unsigned char *hash);
 
+/**
+ * @brief Verify a certificate signature, fetching algorithms from @p libctx.
+ *
+ * Like X509_verify(), but the signature algorithm is fetched from the given
+ * library context and property query rather than the certificate's own.
+ *
+ * @param a the certificate to verify
+ * @param r the public key of the issuer
+ * @param libctx the library context to fetch from, NULL for the default
+ * @param propq the property query to fetch with, may be NULL
+ * @returns 1 if the signature is valid, 0 if not, -1 on error
+ */
+int ossl_x509_verify_ex(const X509 *a, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
+    const char *propq);
+
+/**
+ * @brief Verify a CRL signature, fetching algorithms from @p libctx.
+ *
+ * Like X509_CRL_verify(), but the signature algorithm is fetched from the
+ * given library context and property query rather than the CRL's own. A
+ * CRL with a custom X509_CRL_METHOD is verified by that method, which is
+ * not told about the library context.
+ *
+ * @param crl the CRL to verify
+ * @param r the public key of the issuer
+ * @param libctx the library context to fetch from, NULL for the default
+ * @param propq the property query to fetch with, may be NULL
+ * @returns 1 if the signature is valid, 0 if not, -1 on error
+ */
+int ossl_x509_crl_verify_ex(X509_CRL *crl, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
+    const char *propq);
+
+/**
+ * @brief Describe a certificate's signature, fetching from @p libctx.
+ *
+ * Like X509_get_signature_info(), but any digest needed to determine the
+ * security bits is fetched from the given library context and property
+ * query rather than the certificate's own.
+ *
+ * @param x the certificate
+ * @param mdnid where to store the digest NID, may be NULL
+ * @param pknid where to store the public key algorithm NID, may be NULL
+ * @param secbits where to store the security bits, may be NULL
+ * @param flags where to store the X509_SIG_INFO flags, may be NULL
+ * @param libctx the library context to fetch from, NULL for the default
+ * @param propq the property query to fetch with, may be NULL
+ * @returns 1 if the information is valid, 0 if it is not available
+ */
+int ossl_x509_get_signature_info_ex(const X509 *x, int *mdnid, int *pknid,
+    int *secbits, uint32_t *flags, OSSL_LIB_CTX *libctx, const char *propq);
+
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
 int ossl_x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx,
     const char *propq);

--- a/ssl/build.info
+++ b/ssl/build.info
@@ -52,11 +52,7 @@ ENDIF
 # siphash.c is needed by dtls_conn_lookup.c (DTLS) and quic_lcidm.c (QUIC)
 # for hash-flooding resistant connection lookup
 IF[{- !$disabled{dtls} || !$disabled{quic} -}]
-  IF[{- $disabled{siphash} -}]
-    SOURCE[../libssl]=../crypto/siphash/siphash.c
-  ELSE
-    SHARED_SOURCE[../libssl]=../crypto/siphash/siphash.c
-  ENDIF
+  SHARED_SOURCE[../libssl]=../crypto/siphash/siphash.c
 ENDIF
 
 IF[{- $target{needs_c99_snprintf_compat} -}]

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -15,6 +15,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>
 #include <openssl/err.h>
+#include <openssl/provider.h>
 #include "testutil.h"
 
 static const char *certs_dir;
@@ -751,6 +752,79 @@ err:
     return testresult;
 }
 
+/*
+ * Verify a chain of certificates decoded in the default library context
+ * through a store context created in a library context that has no
+ * signature algorithms. The signatures must be checked in the store
+ * context's library context, so verification must fail there and succeed
+ * with a store context in the default library context.
+ */
+static int do_test_store_ctx_libctx(int use_empty_libctx, int expected,
+    int expected_error)
+{
+    X509 *eecert = load_cert_from_file(ee_cert); /* may result in NULL */
+    X509 *untrcert = load_cert_from_file(ca_cert);
+    X509 *trcert = load_cert_from_file(sroot_cert);
+    STACK_OF(X509) *trusted = sk_X509_new_null();
+    STACK_OF(X509) *untrusted = sk_X509_new_null();
+    OSSL_LIB_CTX *libctx = NULL;
+    OSSL_PROVIDER *nullprov = NULL;
+    X509_STORE_CTX *ctx = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(eecert)
+        || !TEST_ptr(untrcert)
+        || !TEST_ptr(trcert)
+        || !TEST_ptr(trusted)
+        || !TEST_ptr(untrusted))
+        goto err;
+
+    if (use_empty_libctx) {
+        if (!TEST_ptr(libctx = OSSL_LIB_CTX_new())
+            || !TEST_ptr(nullprov = OSSL_PROVIDER_load(libctx, "null")))
+            goto err;
+    }
+    if (!TEST_ptr(ctx = X509_STORE_CTX_new_ex(libctx, NULL)))
+        goto err;
+
+    if (!TEST_true(sk_X509_push(trusted, trcert)))
+        goto err;
+    trcert = NULL;
+    if (!TEST_true(sk_X509_push(untrusted, untrcert)))
+        goto err;
+    untrcert = NULL;
+
+    if (!TEST_true(X509_STORE_CTX_init(ctx, NULL, eecert, untrusted)))
+        goto err;
+    X509_STORE_CTX_set0_trusted_stack(ctx, trusted);
+
+    if (!TEST_int_eq(X509_verify_cert(ctx), expected)
+        || !TEST_int_eq(X509_STORE_CTX_get_error(ctx), expected_error))
+        goto err;
+
+    testresult = 1;
+err:
+    OSSL_STACK_OF_X509_free(trusted);
+    OSSL_STACK_OF_X509_free(untrusted);
+    X509_STORE_CTX_free(ctx);
+    X509_free(eecert);
+    X509_free(untrcert);
+    X509_free(trcert);
+    OSSL_PROVIDER_unload(nullprov);
+    OSSL_LIB_CTX_free(libctx);
+    return testresult;
+}
+
+static int test_store_ctx_default_libctx(void)
+{
+    return do_test_store_ctx_libctx(0, 1, X509_V_OK);
+}
+
+static int test_store_ctx_empty_libctx(void)
+{
+    return do_test_store_ctx_libctx(1, 0, X509_V_ERR_CERT_SIGNATURE_FAILURE);
+}
+
 static int test_purpose_ssl_client(void)
 {
     return do_test_purpose(X509_PURPOSE_SSL_CLIENT, 0);
@@ -795,6 +869,8 @@ int setup_tests(void)
     ADD_TEST(test_self_signed_good);
     ADD_TEST(test_self_signed_bad);
     ADD_TEST(test_self_signed_error);
+    ADD_TEST(test_store_ctx_default_libctx);
+    ADD_TEST(test_store_ctx_empty_libctx);
     ADD_TEST(test_purpose_ssl_client);
     ADD_TEST(test_purpose_ssl_server);
     ADD_TEST(test_purpose_any);

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -1273,8 +1273,91 @@ err:
     return ret;
 }
 
+/*
+ * Signing leaves the cached encoding of the signed part current and equal
+ * to the decoded one; modifying the object afterwards marks it stale.
+ */
+static int test_sign_caches_encoding(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509_NAME *name = NULL;
+    X509 *cert = NULL, *cert_copy = NULL;
+    X509_CRL *crl = NULL, *crl_copy = NULL;
+    X509_REQ *req = NULL, *req_copy = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)"sign test", -1, -1, 0)))
+        goto err;
+
+    /* Certificate */
+    if (!TEST_ptr(cert = X509_new())
+        || !TEST_true(cert->cert_info.enc.modified)
+        || !TEST_true(X509_set_subject_name(cert, name))
+        || !TEST_true(X509_set_issuer_name(cert, name))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notBefore(cert), 0))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notAfter(cert), 3600))
+        || !TEST_true(X509_set_pubkey(cert, pkey))
+        || !TEST_int_gt(X509_sign(cert, pkey, EVP_sha256()), 0)
+        || !TEST_false(cert->cert_info.enc.modified)
+        || !TEST_ptr(cert_copy = X509_dup(cert))
+        || !TEST_false(cert_copy->cert_info.enc.modified)
+        || !TEST_mem_eq(cert->cert_info.enc.enc,
+            (size_t)cert->cert_info.enc.len,
+            cert_copy->cert_info.enc.enc,
+            (size_t)cert_copy->cert_info.enc.len)
+        || !TEST_int_eq(X509_cmp(cert, cert_copy), 0)
+        || !TEST_true(X509_set_version(cert, X509_VERSION_2))
+        || !TEST_true(cert->cert_info.enc.modified)
+        || !TEST_int_gt(X509_sign(cert, pkey, EVP_sha256()), 0)
+        || !TEST_false(cert->cert_info.enc.modified)
+        || !TEST_int_ne(X509_cmp(cert, cert_copy), 0))
+        goto err;
+
+    /* CRL */
+    if (!TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(crl->crl.enc.modified)
+        || !TEST_true(X509_CRL_set_issuer_name(crl, name))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, X509_getm_notBefore(cert)))
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
+        || !TEST_false(crl->crl.enc.modified)
+        || !TEST_ptr(crl_copy = X509_CRL_dup(crl))
+        || !TEST_false(crl_copy->crl.enc.modified)
+        || !TEST_mem_eq(crl->crl.enc.enc, (size_t)crl->crl.enc.len,
+            crl_copy->crl.enc.enc, (size_t)crl_copy->crl.enc.len))
+        goto err;
+
+    /* Request */
+    if (!TEST_ptr(req = X509_REQ_new())
+        || !TEST_true(req->req_info.enc.modified)
+        || !TEST_true(X509_REQ_set_subject_name(req, name))
+        || !TEST_true(X509_REQ_set_pubkey(req, pkey))
+        || !TEST_int_gt(X509_REQ_sign(req, pkey, EVP_sha256()), 0)
+        || !TEST_false(req->req_info.enc.modified)
+        || !TEST_ptr(req_copy = X509_REQ_dup(req))
+        || !TEST_false(req_copy->req_info.enc.modified)
+        || !TEST_mem_eq(req->req_info.enc.enc, (size_t)req->req_info.enc.len,
+            req_copy->req_info.enc.enc, (size_t)req_copy->req_info.enc.len))
+        goto err;
+
+    ret = 1;
+err:
+    X509_REQ_free(req_copy);
+    X509_REQ_free(req);
+    X509_CRL_free(crl_copy);
+    X509_CRL_free(crl);
+    X509_free(cert_copy);
+    X509_free(cert);
+    X509_NAME_free(name);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
 int setup_tests(void)
 {
+    ADD_TEST(test_sign_caches_encoding);
     ADD_TEST(test_standard_exts);
     ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     ADD_ALL_TESTS(test_ipaddr_to_asc, OSSL_NELEM(ipaddr_to_asc_tests));

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -20,6 +20,7 @@
 #include "internal/nelem.h"
 #include "crypto/x509.h"
 #include "crypto/evp.h"
+#include "../crypto/asn1/asn1_local.h"
 
 /**********************************************************************
  *
@@ -279,6 +280,61 @@ err:
     X509_CRL_free(copy);
     X509_CRL_free(crl);
     ASN1_INTEGER_free(num);
+    ASN1_TIME_free(tm);
+    X509_NAME_free(name);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
+/*
+ * A failed encoding save discards the cached encoding, and the item is
+ * encoded from its fields afterwards.
+ */
+static int test_enc_save_failure(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509_NAME *name = NULL;
+    X509_CRL *crl = NULL, *copy = NULL;
+    X509_CRL_INFO *info = NULL;
+    ASN1_TIME *tm = NULL;
+    unsigned char *der = NULL, *der_copy = NULL;
+    unsigned char buf[1] = { 0 };
+    int len, len_copy, ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)"enc save test", -1, -1, 0))
+        || !TEST_ptr(tm = ASN1_TIME_set(NULL, 0))
+        || !TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(X509_CRL_set_issuer_name(crl, name))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, tm))
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
+        || !TEST_ptr(copy = X509_CRL_dup(crl))
+        || !TEST_false(copy->crl.enc.modified)
+        || !TEST_ptr(copy->crl.enc.enc))
+        goto err;
+
+    /* A zero input length is a failure */
+    info = &copy->crl;
+    if (!TEST_false(ossl_asn1_enc_save((ASN1_VALUE **)&info, buf, 0,
+            ASN1_ITEM_rptr(X509_CRL_INFO)))
+        || !TEST_ptr_null(copy->crl.enc.enc)
+        || !TEST_int_eq(copy->crl.enc.len, 0)
+        || !TEST_true(copy->crl.enc.modified))
+        goto err;
+
+    if (!TEST_int_gt(len = i2d_X509_CRL(crl, &der), 0)
+        || !TEST_int_gt(len_copy = i2d_X509_CRL(copy, &der_copy), 0)
+        || !TEST_mem_eq(der, (size_t)len, der_copy, (size_t)len_copy))
+        goto err;
+
+    ret = 1;
+err:
+    OPENSSL_free(der_copy);
+    OPENSSL_free(der);
+    X509_CRL_free(copy);
+    X509_CRL_free(crl);
     ASN1_TIME_free(tm);
     X509_NAME_free(name);
     EVP_PKEY_free(pkey);
@@ -1223,6 +1279,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     ADD_ALL_TESTS(test_ipaddr_to_asc, OSSL_NELEM(ipaddr_to_asc_tests));
     ADD_TEST(test_crl_add_ext_modifies);
+    ADD_TEST(test_enc_save_failure);
     ADD_TEST(tests_X509_PURPOSE);
     ADD_TEST(tests_X509_check_time);
     ADD_TEST(tests_X509_check_crypto);

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -1355,9 +1355,76 @@ err:
     return ret;
 }
 
+/* A modified, unsigned certificate or CRL is equal only to itself */
+static int test_cmp_modified(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509_NAME *name = NULL;
+    X509 *cert = NULL, *copy = NULL;
+    X509_CRL *crl = NULL, *crl_copy = NULL;
+    ASN1_INTEGER *serial = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)"cmp test", -1, -1, 0))
+        || !TEST_ptr(serial = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(serial, 2)))
+        goto err;
+
+    if (!TEST_ptr(cert = X509_new())
+        || !TEST_true(X509_set_subject_name(cert, name))
+        || !TEST_true(X509_set_issuer_name(cert, name))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notBefore(cert), 0))
+        || !TEST_ptr(X509_gmtime_adj(X509_getm_notAfter(cert), 3600))
+        || !TEST_true(X509_set_pubkey(cert, pkey))
+        || !TEST_int_gt(X509_sign(cert, pkey, EVP_sha256()), 0)
+        || !TEST_ptr(copy = X509_dup(cert))
+        || !TEST_int_eq(X509_cmp(cert, copy), 0)
+        || !TEST_int_eq(X509_cmp(cert, cert), 0)
+        /* The copy is modified but still equal to itself */
+        || !TEST_true(X509_set_serialNumber(copy, serial))
+        || !TEST_int_eq(X509_cmp(copy, copy), 0)
+        || !TEST_int_eq(X509_cmp(cert, copy), -1)
+        || !TEST_int_eq(X509_cmp(copy, cert), 1)
+        /* Both modified: unequal */
+        || !TEST_true(X509_set_serialNumber(cert, serial))
+        || !TEST_int_ne(X509_cmp(cert, copy), 0)
+        /* Signing again makes them comparable and equal */
+        || !TEST_int_gt(X509_sign(cert, pkey, EVP_sha256()), 0)
+        || !TEST_int_gt(X509_sign(copy, pkey, EVP_sha256()), 0)
+        || !TEST_int_eq(X509_cmp(cert, copy), 0))
+        goto err;
+
+    if (!TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(X509_CRL_set_issuer_name(crl, name))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, X509_getm_notBefore(cert)))
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0)
+        || !TEST_ptr(crl_copy = X509_CRL_dup(crl))
+        || !TEST_int_eq(X509_CRL_match(crl, crl), 0)
+        || !TEST_true(X509_CRL_set_version(crl_copy, X509_CRL_VERSION_2))
+        || !TEST_int_eq(X509_CRL_match(crl_copy, crl_copy), 0)
+        || !TEST_int_eq(X509_CRL_match(crl, crl_copy), -1)
+        || !TEST_int_eq(X509_CRL_match(crl_copy, crl), 1))
+        goto err;
+
+    ret = 1;
+err:
+    X509_CRL_free(crl_copy);
+    X509_CRL_free(crl);
+    X509_free(copy);
+    X509_free(cert);
+    ASN1_INTEGER_free(serial);
+    X509_NAME_free(name);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_sign_caches_encoding);
+    ADD_TEST(test_cmp_modified);
     ADD_TEST(test_standard_exts);
     ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     ADD_ALL_TESTS(test_ipaddr_to_asc, OSSL_NELEM(ipaddr_to_asc_tests));

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -232,6 +232,59 @@ static int test_ipaddr_to_asc(int idx)
     return good;
 }
 
+/* Adding an extension to a CRL marks its cached encoding stale */
+static int test_crl_add_ext_modifies(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509_NAME *name = NULL;
+    X509_CRL *crl = NULL, *copy = NULL;
+    ASN1_TIME *tm = NULL;
+    ASN1_INTEGER *num = NULL;
+    X509_EXTENSION *ext = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)2048))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (const unsigned char *)"crl ext test", -1, -1, 0))
+        || !TEST_ptr(tm = ASN1_TIME_set(NULL, 0))
+        || !TEST_ptr(num = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(num, 1))
+        || !TEST_ptr(crl = X509_CRL_new())
+        || !TEST_true(X509_CRL_set_issuer_name(crl, name))
+        || !TEST_true(X509_CRL_set1_lastUpdate(crl, tm))
+        || !TEST_int_gt(X509_CRL_sign(crl, pkey, EVP_sha256()), 0))
+        goto err;
+
+    /* X509_CRL_add1_ext_i2d() on a decoded copy */
+    if (!TEST_ptr(copy = X509_CRL_dup(crl))
+        || !TEST_false(copy->crl.enc.modified)
+        || !TEST_true(X509_CRL_add1_ext_i2d(copy, NID_crl_number, num, 0, 0))
+        || !TEST_true(copy->crl.enc.modified))
+        goto err;
+    X509_CRL_free(copy);
+    copy = NULL;
+
+    /* X509_CRL_add_ext() on a decoded copy */
+    if (!TEST_ptr(ext = X509V3_EXT_i2d(NID_crl_number, 0, num))
+        || !TEST_ptr(copy = X509_CRL_dup(crl))
+        || !TEST_false(copy->crl.enc.modified)
+        || !TEST_true(X509_CRL_add_ext(copy, ext, -1))
+        || !TEST_true(copy->crl.enc.modified))
+        goto err;
+
+    ret = 1;
+err:
+    X509_EXTENSION_free(ext);
+    X509_CRL_free(copy);
+    X509_CRL_free(crl);
+    ASN1_INTEGER_free(num);
+    ASN1_TIME_free(tm);
+    X509_NAME_free(name);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
 static int ck_purp(ossl_unused const X509_PURPOSE *purpose,
     ossl_unused const X509 *x, int ca)
 {
@@ -1169,6 +1222,7 @@ int setup_tests(void)
     ADD_TEST(test_standard_exts);
     ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     ADD_ALL_TESTS(test_ipaddr_to_asc, OSSL_NELEM(ipaddr_to_asc_tests));
+    ADD_TEST(test_crl_add_ext_modifies);
     ADD_TEST(tests_X509_PURPOSE);
     ADD_TEST(tests_X509_check_time);
     ADD_TEST(tests_X509_check_crypto);


### PR DESCRIPTION
Follow-on to #32686, on which this is based.

An X509 carried its own library context and property query. The
X509_PUBKEY inside it holds the same pair and is the one that needs
it, to decode the public key. The ASN.1 decoder seeds the X509_PUBKEY
with the context it is given, including for certificates embedded in
CMS, PKCS#7 and CMP structures, but cannot reach the copy in the X509;
`ossl_x509_set0_libctx()` and the "resolve libctx" loops existed only
to patch that copy afterwards, on possibly shared certificates, and
left the public key in the old context anyway. With #32686 the
extension cache no longer depends on a context, so the copy can go.

1. Verify chains in the X509_STORE_CTX's library context, as
   `X509_STORE_CTX_new_ex(3)` documents. Previously each certificate's
   own context was used, so certificates decoded in the default context
   were verified by the default provider even through a FIPS store
   context. Test added.
2. Decode CMP responses in the CMP context's library context instead
   of a NULL one.
3. Remove the library context from X509; read it from the X509_PUBKEY.
   `X509_PUBKEY_set()` passes the context on to the replacement key.
   Delete `ossl_x509_set0_libctx()` and its callers.
4. Same for X509_REQ; also fixes `X509_REQ_new_ex()` never seeding its
   public key with the context.
5. Rename the CMS and PKCS7 "resolve libctx" functions for what they
   still do.

No public API or ABI change; `X509_new_ex(3)` behaves as documented.
X509_CRL keeps its own context, having no public key to hold it.

This in turn sits under https://github.com/openssl/openssl/pull/32693

Relates to: https://github.com/openssl/openssl/issues/30162

##### Checklist

- [x] documentation is added or updated
- [x] tests are added or updated

