### PR TITLE
Fix NULL dereference and memory leak in ASN1_item_dup() 

### DIFF
--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -82,10 +82,14 @@ void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
     p = b;
     ret = ASN1_item_d2i_ex(NULL, &p, i, it, libctx, propq);
     OPENSSL_free(b);
+    if (ret == NULL)
+        return NULL;
 
     if (asn1_cb != NULL
-        && !asn1_cb(ASN1_OP_DUP_POST, &ret, it, (void *)x))
+        && !asn1_cb(ASN1_OP_DUP_POST, &ret, it, (void *)x)) {
+        ASN1_item_free(ret, it);
         goto auxerr;
+    }
 
     return ret;
 

--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -88,7 +88,8 @@ void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
     if (asn1_cb != NULL
         && !asn1_cb(ASN1_OP_DUP_POST, &ret, it, (void *)x)) {
         ASN1_item_free(ret, it);
-        goto auxerr;
+        ERR_raise_data(ERR_LIB_ASN1, ASN1_R_AUX_ERROR, "Type=%s", it->sname);
+        return NULL;
     }
 
     return ret;

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -683,6 +683,32 @@ err:
     return ok;
 }
 
+#ifndef OPENSSL_NO_ECX
+static int test_asn1_item_dup_mfail(void)
+{
+    EVP_PKEY *key = NULL;
+    X509_REQ *src = NULL, *dup = NULL;
+    int ret = -1;
+
+    if (!TEST_ptr(key = EVP_PKEY_Q_keygen(NULL, NULL, "ED25519"))
+        || !TEST_ptr(src = X509_REQ_new_ex(NULL, ""))
+        || !TEST_true(X509_REQ_set_pubkey(src, key))
+        || !TEST_int_gt(X509_REQ_sign(src, key, NULL), 0))
+        goto end;
+
+    MFAIL_start();
+    dup = X509_REQ_dup(src);
+    MFAIL_end();
+
+    ret = dup != NULL;
+end:
+    EVP_PKEY_free(key);
+    X509_REQ_free(src);
+    X509_REQ_free(dup);
+    return ret;
+}
+#endif
+
 int setup_tests(void)
 {
     ADD_TEST(test_tbl_standard);
@@ -698,5 +724,8 @@ int setup_tests(void)
     ADD_TEST(test_ossl_uni2utf8);
     ADD_TEST(test_empty_uni_conversions);
     ADD_TEST(test_asn1_string_to_utf8);
+#ifndef OPENSSL_NO_ECX
+    ADD_MFAIL_NO_CHECK_TEST(test_asn1_item_dup_mfail);
+#endif
     return 1;
 }

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -692,6 +692,7 @@ static int test_asn1_item_dup_mfail(void)
 
     if (!TEST_ptr(key = EVP_PKEY_Q_keygen(NULL, NULL, "ED25519"))
         || !TEST_ptr(src = X509_REQ_new_ex(NULL, ""))
+        || !TEST_true(X509_REQ_set_version(src, X509_REQ_VERSION_1))
         || !TEST_true(X509_REQ_set_pubkey(src, key))
         || !TEST_int_gt(X509_REQ_sign(src, key, NULL), 0))
         goto end;

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -23,6 +23,7 @@
 #include <openssl/pkcs12.h>
 #include <openssl/objects.h>
 #include <openssl/posix_time.h>
+#include <openssl/asn1t.h>
 #include "testutil.h"
 #include "internal/nelem.h"
 
@@ -683,6 +684,52 @@ err:
     return ok;
 }
 
+static int asn1_dup_test_op_dup_post_count;
+static int asn1_dup_test_op_free_post_count;
+static int asn1_dup_test_cb(int operation, ASN1_VALUE **in, const ASN1_ITEM *it,
+    void *exarg)
+{
+    if (operation == ASN1_OP_DUP_POST) {
+        asn1_dup_test_op_dup_post_count++;
+        return 0;
+    }
+    if (operation == ASN1_OP_FREE_POST)
+        asn1_dup_test_op_free_post_count++;
+    return 1;
+}
+
+typedef struct {
+    ASN1_INTEGER *value;
+} ASN1_DUP_TEST;
+
+ASN1_SEQUENCE_cb(ASN1_DUP_TEST, asn1_dup_test_cb) = {
+    ASN1_SIMPLE(ASN1_DUP_TEST, value, ASN1_INTEGER)
+} static_ASN1_SEQUENCE_END_cb(ASN1_DUP_TEST, ASN1_DUP_TEST)
+
+IMPLEMENT_STATIC_ASN1_ALLOC_FUNCTIONS(ASN1_DUP_TEST)
+
+static int test_asn1_item_dup_failure_frees(void)
+{
+    ASN1_DUP_TEST *src = NULL, *dup = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(src = ASN1_DUP_TEST_new())
+        || !TEST_true(ASN1_INTEGER_set(src->value, 1)))
+        goto end;
+
+    asn1_dup_test_op_dup_post_count = 0;
+    asn1_dup_test_op_free_post_count = 0;
+    dup = ASN1_item_dup(ASN1_ITEM_rptr(ASN1_DUP_TEST), src);
+
+    ret = TEST_ptr_null(dup)
+        && TEST_int_eq(asn1_dup_test_op_dup_post_count, 1)
+        && TEST_int_eq(asn1_dup_test_op_free_post_count, 1);
+end:
+    ASN1_DUP_TEST_free(src);
+    ASN1_DUP_TEST_free(dup);
+    return ret;
+}
+
 #ifndef OPENSSL_NO_ECX
 static int test_asn1_item_dup_mfail(void)
 {
@@ -725,6 +772,7 @@ int setup_tests(void)
     ADD_TEST(test_ossl_uni2utf8);
     ADD_TEST(test_empty_uni_conversions);
     ADD_TEST(test_asn1_string_to_utf8);
+    ADD_TEST(test_asn1_item_dup_failure_frees);
 #ifndef OPENSSL_NO_ECX
     ADD_MFAIL_NO_CHECK_TEST(test_asn1_item_dup_mfail);
 #endif


### PR DESCRIPTION
If ASN1_item_d2i_ex() fails asn1_cb() can dereference return
value of ASN1_item_d2i_ex() which is NULL causing NULL dereference.
Also if ASN1_item_d2i_ex() succeeds and asn1_cb() fails it causes
a memory leak.

- [x] tests are added or updated