### PR TITLE
dtls: keep datagram framing after record discard

### DIFF
--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -453,6 +453,25 @@ uint64_t dtls13_reconstruct_seq_num(uint64_t max_seq_num, uint64_t truncated,
     return best;
 }
 
+/* Consume a discarded record's body so following records stay framed */
+static void dtls_discard_record_body(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rr,
+    size_t reclen, size_t hdrlen)
+{
+    size_t already = rl->packet_length - hdrlen, more, nread = 0;
+
+    if (reclen > already) {
+        more = reclen - already;
+        /* For DTLS read_n() consumes at most the rest of the datagram */
+        (void)rl->funcs->read_n(rl, more, more, 1, 1, &nread);
+    } else {
+        /* Give back over-read bytes belonging to the next record */
+        rl->rbuf.left += already - reclen;
+        rl->rbuf.offset -= already - reclen;
+    }
+    rr->length = 0;
+    rl->packet_length = 0;
+}
+
 /*-
  * Call this to get a new input record.
  * It will return <= 0 if more data is needed, normally due to an error
@@ -552,9 +571,10 @@ again:
             && rr->type != SSL3_RT_HANDSHAKE
             && rr->type != SSL3_RT_ACK
             && !DTLS13_UNI_HDR_FIX_BITS_IS_SET(rr->type)) {
-            /* Silently discard */
+            /* Silently discard; the record length is unknown so drop it all */
             rr->length = 0;
             rl->packet_length = 0;
+            rl->rbuf.left = 0;
             goto again;
         }
 
@@ -589,8 +609,10 @@ again:
                  */
                 || (lbitisset ? !PACKET_get_net_2(&dtlsrecord, &length)
                               : (length = (unsigned int)TLS_BUFFER_get_len(&rl->rbuf)) > 0)) {
+                /* The record length is unknown so drop the whole datagram */
                 rr->length = 0;
                 rl->packet_length = 0;
+                rl->rbuf.left = 0;
                 goto again;
             }
 
@@ -608,8 +630,8 @@ again:
                 if (eebits == 2 && (epoch64 == 1 || epoch64 == 0)) {
                     epoch64 = 2;
                 } else {
-                    rr->length = 0;
-                    rl->packet_length = 0;
+                    dtls_discard_record_body(rl, rr, length,
+                        (size_t)(PACKET_data(&dtlsrecord) - rl->packet));
                     goto again;
                 }
             }
@@ -618,8 +640,10 @@ again:
                 || !PACKET_get_net_2(&dtlsrecord, &epoch)
                 || !PACKET_copy_bytes(&dtlsrecord, recseqnum, 6)
                 || !PACKET_get_net_2(&dtlsrecord, &length)) {
+                /* The record length is unknown so drop the whole datagram */
                 rr->length = 0;
                 rl->packet_length = 0;
+                rl->rbuf.left = 0;
                 goto again;
             }
             epoch64 = epoch;
@@ -646,23 +670,20 @@ again:
                 && rl->version == DTLS1_3_VERSION)) {
             if (rr->rec_version != rl->version) {
                 /* unexpected version, silently discard */
-                rr->length = 0;
-                rl->packet_length = 0;
+                dtls_discard_record_body(rl, rr, rr->length, rechdrlen);
                 goto again;
             }
         }
 
         if (rr->rec_version >> 8 != (rl->version == DTLS_ANY_VERSION ? DTLS1_VERSION_MAJOR : rl->version >> 8)) {
             /* wrong version, silently discard record */
-            rr->length = 0;
-            rl->packet_length = 0;
+            dtls_discard_record_body(rl, rr, rr->length, rechdrlen);
             goto again;
         }
 
         if (rr->length > SSL3_RT_MAX_ENCRYPTED_LENGTH) {
             /* record too long, silently discard it */
-            rr->length = 0;
-            rl->packet_length = 0;
+            dtls_discard_record_body(rl, rr, rr->length, rechdrlen);
             goto again;
         }
 
@@ -672,8 +693,7 @@ again:
          */
         if (rr->length > rl->max_frag_len + SSL3_RT_MAX_ENCRYPTED_OVERHEAD) {
             /* record too long, silently discard it */
-            rr->length = 0;
-            rl->packet_length = 0;
+            dtls_discard_record_body(rl, rr, rr->length, rechdrlen);
             goto again;
         }
 

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -1476,6 +1476,113 @@ end:
 }
 #endif /* OPENSSL_NO_DTLS1_3 */
 
+#if !defined(OPENSSL_NO_DTLS1_2) || !defined(OPENSSL_NO_DTLS1_3)
+/* A DTLSv1.2 record with an unexpected version that gets silently discarded */
+static unsigned char record_badversion[] = {
+    SSL3_RT_APPLICATION_DATA, /* Content type */
+    0xfe, 0xff, /* Unexpected record version */
+    0, 1, /* Epoch */
+    0, 0, 0, 0, 0xff, 0xff, /* Record sequence number */
+    0, 16, /* Record length */
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5 /* Dummy data */
+};
+
+/* A DTLSv1.3 record with mismatched epoch bits that gets silently discarded */
+static unsigned char record_badepochbits[] = {
+    0x2d, /* Unified header: fixed bits, S and L bit, epoch bits 01 */
+    0, 42, /* Record sequence number */
+    0, 16, /* Record length */
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5 /* Dummy data */
+};
+
+/*
+ * Test that a record silently discarded by the record layer does not break
+ * the framing of the records that follow it in the same datagram.
+ */
+static int test_discard_record_framing(int version)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *sssl = NULL, *cssl = NULL;
+    int testresult = 0;
+    BIO *bio;
+    char msg[] = { 0x00, 0x01, 0x02, 0x03 };
+    unsigned char pkt[512], *fragment;
+    size_t fraglen;
+    char buf[10];
+    int ret;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(),
+            version, version,
+            &sctx, &cctx, cert, privkey)))
+        return 0;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, NULL))
+        || !TEST_true(create_ssl_connection(sssl, cssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /* Drain pending post-handshake messages, e.g. ACKs and session tickets */
+    while ((ret = SSL_read(cssl, buf, sizeof(buf))) > 0)
+        ;
+    if (!TEST_int_eq(SSL_get_error(cssl, ret), SSL_ERROR_WANT_READ))
+        goto end;
+
+    if (!TEST_int_eq(SSL_write(sssl, msg, sizeof(msg)), (int)sizeof(msg)))
+        goto end;
+
+    if (version == DTLS1_3_VERSION) {
+        fragment = record_badepochbits;
+        fraglen = sizeof(record_badepochbits);
+    } else {
+        fragment = record_badversion;
+        fraglen = sizeof(record_badversion);
+    }
+    memcpy(pkt, fragment, fraglen);
+
+    /* Recreate the app data datagram with the discarded record prepended */
+    bio = SSL_get_wbio(sssl);
+    if (!TEST_ptr(bio)
+        || !TEST_int_gt(ret = BIO_read(bio, pkt + fraglen,
+                            (int)(sizeof(pkt) - fraglen)),
+            0)
+        || !TEST_int_eq(mempacket_test_inject(bio, (char *)pkt,
+                            (int)fraglen + ret, -1,
+                            INJECT_PACKET_IGNORE_REC_SEQ),
+            (int)fraglen + ret))
+        goto end;
+
+    /* The app data record following the discarded one must still be read */
+    if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg))
+        || !TEST_mem_eq(buf, sizeof(msg), msg, sizeof(msg)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(cssl);
+    SSL_free(sssl);
+    SSL_CTX_free(cctx);
+    SSL_CTX_free(sctx);
+
+    return testresult;
+}
+
+#ifndef OPENSSL_NO_DTLS1_2
+static int test_discard_record_framing_dtls1(void)
+{
+    return test_discard_record_framing(DTLS1_2_VERSION);
+}
+#endif /* OPENSSL_NO_DTLS1_2 */
+
+#ifndef OPENSSL_NO_DTLS1_3
+static int test_discard_record_framing_dtls13(void)
+{
+    return test_discard_record_framing(DTLS1_3_VERSION);
+}
+#endif /* OPENSSL_NO_DTLS1_3 */
+#endif /* !OPENSSL_NO_DTLS1_2 || !OPENSSL_NO_DTLS1_3 */
+
 /* Confirm that we can create a connections using DTLSv1_listen() */
 #ifndef OPENSSL_NO_DTLS1_2
 static int test_listen(void)
@@ -1554,6 +1661,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DTLS1_2
     ADD_TEST(test_listen);
     ADD_TEST(test_duplicate_app_data_dtls1);
+    ADD_TEST(test_discard_record_framing_dtls1);
 #endif
 #ifndef OPENSSL_NO_DTLS1_3
     ADD_TEST(test_duplicate_app_data_dtls13);
@@ -1561,6 +1669,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_dtls13_forged_plaintext_alert, 8);
     ADD_ALL_TESTS(test_dtls13_forged_plaintext_alert_plant, 3);
     ADD_TEST(test_dtls13_epoch0_plaintext_alert);
+    ADD_TEST(test_discard_record_framing_dtls13);
 #endif
 
     return 1;


### PR DESCRIPTION
When a record is silently discarded at the header stage, its body is left unconsumed in the read buffer, so the remaining bytes of the datagram are parsed as a new record header. Any valid records coalesced after the discarded one in the same datagram are garbled and lost, and bogus header callbacks are invoked. This can for example drop valid records arriving together with a delayed record from an old epoch around a DTLSv1.3 key transition.

Consume the body of a discarded record when its length is known so the records that follow it remain correctly framed. When the header cannot be parsed, drop the rest of the datagram as its framing is unknown.

I noticed this when checking #32622 . It's not a big deal but makes sense to fix it.