### PR TITLE
CT: handle negative returns when loading a log store

### DIFF
--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -236,7 +236,8 @@ int CTLOG_STORE_load_file(CTLOG_STORE *store, const char *file)
         goto end;
     }
 
-    if (!CONF_parse_list(enabled_logs, ',', 1, ctlog_store_load_log, load_ctx) || load_ctx->invalid_log_entries > 0) {
+    if (CONF_parse_list(enabled_logs, ',', 1, ctlog_store_load_log, load_ctx) <= 0
+        || load_ctx->invalid_log_entries > 0) {
         ERR_raise(ERR_LIB_CT, CT_R_LOG_CONF_INVALID);
         goto end;
     }

--- a/test/ct/log_list_missing_section.cnf
+++ b/test/ct/log_list_missing_section.cnf
@@ -1,0 +1,8 @@
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+enabled_logs = missing_section

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -509,6 +509,29 @@ static int test_ctlog_from_base64(void)
     return 1;
 }
 
+static int test_ctlog_store_load_file_mfail(void)
+{
+    CTLOG_STORE *store = NULL;
+    char *file = NULL;
+    int ret, result = -1;
+
+    if (!TEST_ptr(file = test_mk_file_path(ct_dir, "log_list_missing_section.cnf"))
+        || !TEST_ptr(store = CTLOG_STORE_new()))
+        goto end;
+
+    MFAIL_start();
+    ret = CTLOG_STORE_load_file(store, file);
+    MFAIL_end();
+
+    /* A missing log section must fail, even if an allocation fails. */
+    result = TEST_int_eq(ret, 0) ? 1 : -1;
+
+end:
+    CTLOG_STORE_free(store);
+    OPENSSL_free(file);
+    return result;
+}
+
 static int test_ctlog_store_add0_log(void)
 {
     CTLOG_STORE *store = NULL;
@@ -653,6 +676,7 @@ int setup_tests(void)
     ADD_TEST(test_encode_tls_sct);
     ADD_TEST(test_default_ct_policy_eval_ctx_time_is_now);
     ADD_TEST(test_ctlog_from_base64);
+    ADD_MFAIL_NO_CHECK_TEST(test_ctlog_store_load_file_mfail);
     ADD_TEST(test_ctlog_store_add0_log);
     ADD_TEST(test_ctlog_store_add0_log_validates_sct);
     ADD_TEST(test_ctlog_store_add0_log_null);


### PR DESCRIPTION
`CTLOG_STORE_load_file` can report success if `ctlog_store_load_log` can't allocate a log name. `CONF_parse_list` propagates the callback's `-1` return, which the current `!CONF_parse_list(...)` check doesn't catch.

This changes the check to `<= 0` so the load returns `0` on that path. It keeps the existing handling of malformed log entries.

The regression test uses the existing allocation failure framework with a configuration naming a missing log section. Loading that file must always fail, even if an allocation fails. The test reproduces the unexpected success before the fix and passes with it.

Backport to 4.0, 3.6, and 3.5 branches require separate PRs. They predate `ADD_MFAIL_NO_CHECK_TEST`, but their backports can retain exhaustive allocation failure coverage with `OPENSSL_MALLOC_FAILURES`: 4.0 and 3.6 can extend their existing count-and-replay tests, while 3.5 can add the same pattern gated by `crypto-mdebug`. 

Fixes #32703 

##### Checklist

- [x] tests are added or updated
