### PR TITLE
apps: reject malformed trailing certificates in nseq -toseq

### DIFF
--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -92,7 +92,21 @@ int nseq_main(int argc, char **argv)
         seq->certs = sk_X509_new_null();
         if (seq->certs == NULL)
             goto end;
-        while ((x509 = PEM_read_bio_X509(in, NULL, NULL, NULL))) {
+        for (;;) {
+            ERR_set_mark();
+            x509 = PEM_read_bio_X509(in, NULL, NULL, NULL);
+            if (x509 == NULL) {
+                if (sk_X509_num(seq->certs) > 0
+                    && ERR_GET_REASON(ERR_peek_last_error()) == PEM_R_NO_START_LINE) {
+                    ERR_pop_to_mark();
+                    break;
+                }
+                ERR_clear_last_mark();
+                BIO_printf(bio_err, "%s: Error reading certs file %s\n",
+                    prog, infile);
+                ERR_print_errors(bio_err);
+                goto end;
+            }
             if (!sk_X509_push(seq->certs, x509))
                 goto end;
         }
@@ -103,7 +117,12 @@ int nseq_main(int argc, char **argv)
             ERR_print_errors(bio_err);
             goto end;
         }
-        PEM_write_bio_NETSCAPE_CERT_SEQUENCE(out, seq);
+        if (!PEM_write_bio_NETSCAPE_CERT_SEQUENCE(out, seq)) {
+            BIO_printf(bio_err, "%s: Error writing sequence file %s\n",
+                prog, outfile);
+            ERR_print_errors(bio_err);
+            goto end;
+        }
         ret = 0;
         goto end;
     }

--- a/test/recipes/20-test_nseq.t
+++ b/test/recipes/20-test_nseq.t
@@ -1,0 +1,50 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use File::Copy qw(copy);
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+setup("test_nseq");
+
+plan tests => 5;
+
+my $cert = srctop_file("test", "certs", "ca-cert.pem");
+my $valid_sequence = "nseq-valid.seq";
+my $malformed_input = "nseq-malformed.pem";
+my $malformed_sequence = "nseq-malformed.seq";
+my $malformed_stderr = "nseq-malformed.err";
+
+ok(run(app(["openssl", "nseq", "-toseq", "-in", $cert,
+            "-out", $valid_sequence])),
+   "convert a valid certificate to a sequence");
+ok(run(app(["openssl", "nseq", "-in", $valid_sequence,
+            "-out", "nseq-valid.pem"])),
+   "read the generated certificate sequence");
+
+ok(copy($cert, $malformed_input), "copy the valid certificate");
+open my $fh, ">>", $malformed_input
+    or die "Could not open $malformed_input: $!";
+print $fh <<'EOF';
+-----BEGIN CERTIFICATE-----
+not a valid base64 encoded certificate
+-----END CERTIFICATE-----
+EOF
+close $fh or die "Could not close $malformed_input: $!";
+
+ok(!run(app(["openssl", "nseq", "-toseq", "-in", $malformed_input,
+             "-out", $malformed_sequence],
+            stderr => $malformed_stderr)),
+   "reject a malformed trailing certificate");
+open my $errfh, "<", $malformed_stderr
+    or die "Could not open $malformed_stderr: $!";
+my $stderr = do { local $/; <$errfh> };
+close $errfh;
+like($stderr, qr/PEM routines/, "report the PEM parsing error");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->



`openssl nseq -toseq` treated every failed `PEM_read_bio_X509()` call as normal end-of-input. As a result, a valid certificate followed by a malformed PEM certificate could produce a silently truncated certificate sequence and exit successfully.

`PEM_read_bio_X509()` returns `NULL` both at EOF and on parsing errors.

This change follows the existing pattern used by `crypto/x509/by_file.c`:

- treat `PEM_R_NO_START_LINE` as normal EOF only after at least one certificate has been read;
- report all other PEM errors and fail;
- check the return value of `PEM_write_bio_NETSCAPE_CERT_SEQUENCE()`.




##### Checklist

- [x] tests are added or updated
