### PR TITLE
apps: pass the SRP callback argument itself, not the address of its function parameter

### DIFF
--- a/apps/lib/tlssrp_depr.c
+++ b/apps/lib/tlssrp_depr.c
@@ -123,7 +123,7 @@ int set_up_srp_arg(SSL_CTX *ctx, SRP_ARG *srp_arg, int srp_lateuser, int c_msg,
     }
     srp_arg->msg = c_msg;
     srp_arg->debug = c_debug;
-    SSL_CTX_set_srp_cb_arg(ctx, &srp_arg);
+    SSL_CTX_set_srp_cb_arg(ctx, srp_arg);
     SSL_CTX_set_srp_client_pwd_callback(ctx, ssl_give_srp_client_pwd_cb);
     SSL_CTX_set_srp_strength(ctx, srp_arg->strength);
     if (c_msg || c_debug || srp_arg->amp == 0)
@@ -208,7 +208,7 @@ int set_up_srp_verifier_file(SSL_CTX *ctx, srpsrvparm *srp_callback_parm,
         return 0;
     }
     SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, verify_callback);
-    SSL_CTX_set_srp_cb_arg(ctx, &srp_callback_parm);
+    SSL_CTX_set_srp_cb_arg(ctx, srp_callback_parm);
     SSL_CTX_set_srp_username_callback(ctx, ssl_srp_server_param_cb);
 
     return 1;


### PR DESCRIPTION
Fixes #32565.

`set_up_srp_arg()` and `set_up_srp_verifier_file()` in `apps/lib/tlssrp_depr.c` both stored the address of a function parameter as the SRP callback argument. Both parameters are already pointers (`SRP_ARG *srp_arg`, `srpsrvparm *srp_callback_parm`), so the `&` handed libssl a `SRP_ARG **` / `srpsrvparm **` that pointed at the setter function's own 8-byte parameter slot — a stack slot that dies when the setter returns. `SSL_CTX_set_srp_cb_arg` has a `void *` signature, so the type error compiled cleanly.

On the client side, the caller in `s_client_main()` passes `&srp_arg` to a stack-local `SRP_ARG` that lives for the process; on the server side, the caller passes `&srp_callback_parm` where `srp_callback_parm` is a file-scope static (`static srpsrvparm srp_callback_parm;` at `apps/s_server.c:288`). In both cases the pointer parameter already targets a lifetime that outlives the SSL_CTX, so passing it through unmodified satisfies the callback contract.

## Verified

`master` at `1935d215`, ASan+UBSan build (`./Configure linux-x86_64 no-shared enable-asan enable-ubsan enable-srp --debug -O0 && make -j4 build_programs`).

- Reporter's 213-byte fixed flight (`ServerHello` + SRP `ServerKeyExchange` + `ServerHelloDone`) delivered by a tiny Python harness to `s_client -srpuser alice`. Pre-fix the client aborts with `AddressSanitizer: stack-use-after-return apps/lib/tlssrp_depr.c:67 in ssl_srp_verify_param_cb`, `READ of size 4` in the dead frame of `set_up_srp_arg`, exit 134 — byte-for-byte the trace the reporter posted.
- With the fix, the same flight against the `-srpuser`-alone minimal arm no longer produces an ASan report.

## Notes

Reported and root-caused by @qifan-sailboat (Qifan Zhang, Palo Alto Networks); the suggested fix in the issue body is what this commit does.

Running the fix against the fuller `-srpuser` + `-srppass` arm surfaces a separate `heap-buffer-overflow` in `password_callback` at `apps/lib/apps_ui.c:201`. That's a pre-existing latent issue in a different function that the SRP flow never actually reached before, because the dangling pointer was silently discarding `-srppass`. Happy to open a follow-up if you'd like it filed separately.

I used an AI coding assistant while working on this. Every hunk was reviewed by a human before commit, the reproducer and the ASan comparison were run on real hardware, and the diff is two `&` removed with no logic change.

**Secondary finding	Fix EXPOSES a pre-existing heap-buffer-overflow at apps/lib/apps_ui.c:201 in password_callback (strlen on non-null-terminated app_malloc buffer). Out of scope for this PR; recommend filing separately after this lands.