### PR TITLE
dtls: fix DTLSv1_listen record sequence after cookie verify

### DIFF
--- a/doc/designs/quic-design/record-layer.md
+++ b/doc/designs/quic-design/record-layer.md
@@ -274,8 +274,11 @@ configuration, or it may be negotiated during the handshake.
 
 `increment_sequence_ctr()`: force the record layer to increment its sequence
 counter. In most cases the record layer will entirely manage its own sequence
-counters. However in the DTLSv1_listen() corner case, libssl needs to initialise
-the record layer with an incremented sequence counter.
+counters.
+
+`set_sequence()`: force the record layer to set its record sequence number to a
+specific value. For DTLS this is used by `DTLSv1_listen()` to continue the
+handshake with the record sequence number from the cookie-bearing ClientHello.
 
 `alloc_buffers()`: called by libssl to request that the record layer allocate
 its buffers. This is a hint only and the record layer is expected to manage its
@@ -588,6 +591,12 @@ struct ossl_record_method_st {
      * Increment the record sequence number
      */
     int (*increment_sequence_ctr)(OSSL_RECORD_LAYER *rl);
+
+    /*
+     * Set the record sequence number to a specific value. For DTLS this is the
+     * 6-byte network-order uint48 sequence number, excluding the epoch.
+     */
+    int (*set_sequence)(OSSL_RECORD_LAYER *rl, const unsigned char *sequence);
 
     /*
      * Allocate read or write buffers. Does nothing if already allocated.

--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -307,6 +307,12 @@ struct ossl_record_method_st {
     int (*increment_sequence_ctr)(OSSL_RECORD_LAYER *rl);
 
     /*
+     * Set the record sequence number to a specific value. For DTLS this is the
+     * 6-byte network-order uint48 sequence number, excluding the epoch.
+     */
+    int (*set_sequence)(OSSL_RECORD_LAYER *rl, const unsigned char *sequence);
+
+    /*
      * Allocate read or write buffers. Does nothing if already allocated.
      * Assumes default buffer length and 1 pipeline.
      */

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -791,7 +791,12 @@ int DTLSv1_listen(SSL *ssl, BIO_ADDR *client)
     s->d1->handshake_read_seq = 1;
     s->d1->handshake_write_seq = 1;
     s->d1->next_handshake_write_seq = 1;
-    s->rlayer.wrlmethod->increment_sequence_ctr(s->rlayer.wrl);
+    if (s->rlayer.wrlmethod->set_sequence == NULL
+        || !s->rlayer.wrlmethod->set_sequence(s->rlayer.wrl, seq + 2)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        ret = -1;
+        goto end;
+    }
 
     /*
      * We are doing cookie exchange, so make sure we set that option in the

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -592,6 +592,7 @@ static const OSSL_RECORD_METHOD quic_tls_record_method = {
     quic_set_max_frag_len,
     quic_get_max_record_overhead, /* Never called */
     quic_increment_sequence_ctr, /* Never called */
+    NULL,
     quic_alloc_buffers,
     quic_free_buffers
 };

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -12,6 +12,8 @@
 #include "../record_local.h"
 #include "recmethod_local.h"
 
+static int dtls_increment_sequence_ctr(OSSL_RECORD_LAYER *rl);
+
 /* mod 128 saturating subtract of two 64-bit values in big-endian order */
 static int satsub64be(const unsigned char *v1, const unsigned char *v2)
 {
@@ -679,7 +681,25 @@ int dtls_post_encryption_processing(OSSL_RECORD_LAYER *rl,
         return 0;
     }
 
-    return tls_increment_sequence_ctr(rl);
+    return dtls_increment_sequence_ctr(rl);
+}
+
+static int dtls_increment_sequence_ctr(OSSL_RECORD_LAYER *rl)
+{
+    int i;
+
+    /* DTLS serializes only the low 48 bits as the record sequence number. */
+    for (i = SEQ_NUM_SIZE; i > 2; i--) {
+        ++(rl->sequence[i - 1]);
+        if (rl->sequence[i - 1] != 0)
+            break;
+    }
+    if (i == 2) {
+        /* Sequence has wrapped */
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, SSL_R_SEQUENCE_CTR_WRAPPED);
+        return 0;
+    }
+    return 1;
 }
 
 static size_t dtls_get_max_record_overhead(OSSL_RECORD_LAYER *rl)
@@ -713,6 +733,12 @@ static size_t dtls_get_max_record_overhead(OSSL_RECORD_LAYER *rl)
     return DTLS1_RT_HEADER_LENGTH + rl->eivlen + blocksize + rl->taglen;
 }
 
+static int dtls_set_sequence(OSSL_RECORD_LAYER *rl, const unsigned char *sequence)
+{
+    memcpy(&rl->sequence[2], sequence, 6);
+    return 1;
+}
+
 const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     dtls_new_record_layer,
     dtls_free,
@@ -736,7 +762,8 @@ const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     tls_get_compression,
     tls_set_max_frag_len,
     dtls_get_max_record_overhead,
-    tls_increment_sequence_ctr,
+    dtls_increment_sequence_ctr,
+    dtls_set_sequence,
     tls_alloc_buffers,
     tls_free_buffers
 };

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -597,6 +597,7 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     tls_set_max_frag_len,
     NULL,
     tls_increment_sequence_ctr,
+    NULL,
     ktls_alloc_buffers,
     tls_free_buffers
 };

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -2165,6 +2165,7 @@ const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_set_max_frag_len,
     NULL,
     tls_increment_sequence_ctr,
+    NULL,
     tls_alloc_buffers,
     tls_free_buffers
 };

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <limits.h>
 #include <openssl/ssl.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
@@ -16,6 +17,10 @@
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_SOCK
+
+#define DTLS_RECORD_EPOCH_AND_SEQ_LEN 8
+
+static const char *certsdir = NULL;
 
 /* Just a ClientHello without a cookie */
 static const unsigned char clienthello_nocookie[] = {
@@ -316,6 +321,7 @@ static int dtls_listen_test(int i)
         goto err;
     BIO_set_mem_eof_return(inbio, -1);
     SSL_set0_rbio(ssl, inbio);
+    inbio = NULL;
 
     /* Process the incoming packet */
     if (!TEST_int_ge(ret = DTLSv1_listen(ssl, peer), 0))
@@ -347,12 +353,171 @@ err:
     OPENSSL_free(peer);
     return success;
 }
+
+#ifndef OPENSSL_NO_DTLS1_2
+static unsigned char *create_cookie_clienthello(int *outlen,
+    const unsigned char *seq)
+{
+    SSL_CTX *ctx = NULL;
+    SSL *ssl = NULL;
+    BIO *rbio = NULL, *wbio = NULL;
+    BIO *ssl_rbio = NULL, *ssl_wbio = NULL;
+    char *data = NULL;
+    long datalen;
+    unsigned char *ret = NULL;
+    int sslret;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new(DTLS_client_method()))
+        || !TEST_ptr(ssl = SSL_new(ctx))
+        || !TEST_ptr(rbio = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(wbio = BIO_new(BIO_s_mem())))
+        goto err;
+
+    ssl_rbio = rbio;
+    ssl_wbio = wbio;
+    SSL_set0_rbio(ssl, rbio);
+    SSL_set0_wbio(ssl, wbio);
+    rbio = wbio = NULL;
+    SSL_set_connect_state(ssl);
+
+    if (!TEST_int_le(sslret = SSL_connect(ssl), 0)
+        || !TEST_int_eq(SSL_get_error(ssl, sslret), SSL_ERROR_WANT_READ)
+        || !TEST_int_gt(BIO_reset(ssl_wbio), 0)
+        || !TEST_int_eq(BIO_write(ssl_rbio, verify, sizeof(verify)),
+            sizeof(verify))
+        || !TEST_int_le(sslret = SSL_connect(ssl), 0)
+        || !TEST_int_eq(SSL_get_error(ssl, sslret), SSL_ERROR_WANT_READ)
+        || !TEST_long_ge(datalen = BIO_get_mem_data(ssl_wbio, &data),
+            DTLS1_RT_HEADER_LENGTH)
+        || !TEST_long_le(datalen, INT_MAX))
+        goto err;
+
+    if (!TEST_ptr(ret = OPENSSL_memdup(data, datalen)))
+        goto err;
+
+    *outlen = (int)datalen;
+
+    /* DTLS record header bytes 3..10 are epoch and sequence number. */
+    memcpy(ret + 3, seq, DTLS_RECORD_EPOCH_AND_SEQ_LEN);
+
+err:
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    BIO_free(rbio);
+    BIO_free(wbio);
+    return ret;
+}
+
+static int dtls_listen_write_seq_test(int tst)
+{
+    static const unsigned char initial_seq[DTLS_RECORD_EPOCH_AND_SEQ_LEN] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02
+    };
+    static const unsigned char wrap_seq[DTLS_RECORD_EPOCH_AND_SEQ_LEN] = {
+        0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+    };
+    static const unsigned char expected_record_seq[2 + DTLS_RECORD_EPOCH_AND_SEQ_LEN] = {
+        0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x02
+    };
+    const unsigned char *seq = tst == 0 ? initial_seq : wrap_seq;
+    unsigned char *inbuf = NULL;
+    int inbuflen = 0;
+    SSL_CTX *ctx = NULL;
+    SSL *ssl = NULL;
+    BIO *outbio = NULL;
+    BIO *inbio = NULL;
+    BIO_ADDR *peer = NULL;
+    char *cert = NULL;
+    char *privkey = NULL;
+    char *data;
+    long datalen;
+    int ret, success = 0;
+
+    if (!TEST_ptr(inbuf = create_cookie_clienthello(&inbuflen, seq)))
+        goto err;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new(DTLS_server_method()))
+        || !TEST_ptr(peer = BIO_ADDR_new()))
+        goto err;
+    SSL_CTX_set_cookie_generate_cb(ctx, cookie_gen);
+    SSL_CTX_set_cookie_verify_cb(ctx, cookie_verify);
+    cert = test_mk_file_path(certsdir, "servercert.pem");
+    privkey = test_mk_file_path(certsdir, "serverkey.pem");
+    if (!TEST_ptr(cert)
+        || !TEST_ptr(privkey)
+        || !TEST_true(SSL_CTX_use_certificate_file(ctx, cert,
+            SSL_FILETYPE_PEM))
+        || !TEST_true(SSL_CTX_use_PrivateKey_file(ctx, privkey,
+            SSL_FILETYPE_PEM)))
+        goto err;
+
+    if (!TEST_ptr(ssl = SSL_new(ctx))
+        || !TEST_ptr(outbio = BIO_new(BIO_s_mem())))
+        goto err;
+
+    SSL_set0_wbio(ssl, outbio);
+    if (!TEST_ptr(inbio = BIO_new_mem_buf(inbuf, inbuflen)))
+        goto err;
+
+    BIO_set_mem_eof_return(inbio, -1);
+    SSL_set0_rbio(ssl, inbio);
+    inbio = NULL;
+
+    if (!TEST_int_eq(ret = DTLSv1_listen(ssl, peer), 1))
+        goto err;
+
+    datalen = BIO_get_mem_data(outbio, &data);
+    if (!TEST_long_eq(datalen, 0))
+        goto err;
+
+    ret = SSL_accept(ssl);
+    if (tst == 1) {
+        if (!TEST_int_le(ret, 0)
+            || !TEST_int_eq(SSL_get_error(ssl, ret), SSL_ERROR_SSL)
+            || !TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+                SSL_R_SEQUENCE_CTR_WRAPPED))
+            goto err;
+        success = 1;
+        goto err;
+    }
+
+    if (!TEST_int_le(ret, 0)
+        || !TEST_int_eq(SSL_get_error(ssl, ret), SSL_ERROR_WANT_READ))
+        goto err;
+
+    datalen = BIO_get_mem_data(outbio, &data);
+    if (!TEST_long_ge(datalen, DTLS1_RT_HEADER_LENGTH)
+        || !TEST_mem_eq(data + 1, sizeof(expected_record_seq),
+            expected_record_seq, sizeof(expected_record_seq)))
+        goto err;
+
+    SSL_set0_rbio(ssl, NULL);
+    success = 1;
+
+err:
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    BIO_free(inbio);
+    OPENSSL_free(inbuf);
+    OPENSSL_free(cert);
+    OPENSSL_free(privkey);
+    OPENSSL_free(peer);
+    return success;
+}
+#endif
 #endif
 
 int setup_tests(void)
 {
 #ifndef OPENSSL_NO_SOCK
+    if (!TEST_ptr(certsdir = test_get_argument(0)))
+        return 0;
+
     ADD_ALL_TESTS(dtls_listen_test, (int)OSSL_NELEM(testpackets));
+#ifndef OPENSSL_NO_DTLS1_2
+    ADD_ALL_TESTS(dtls_listen_write_seq_test, 2);
+#endif
 #endif
     return 1;
 }

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -14,6 +14,15 @@
 #include <openssl/err.h>
 #include <openssl/conf.h>
 #include "internal/nelem.h"
+#include "internal/time.h"
+#include "../ssl/ssl_local.h"
+/*
+ * Newer branches moved SSL_CONNECTION_FROM_SSL_ONLY() out of ssl_local.h
+ * into ssl_unwrap.h; keep both variants compilable for backports.
+ */
+#ifndef SSL_CONNECTION_FROM_SSL_ONLY
+#include "internal/ssl_unwrap.h"
+#endif
 #include "testutil.h"
 
 #ifndef OPENSSL_NO_SOCK
@@ -356,10 +365,11 @@ err:
 
 #ifndef OPENSSL_NO_DTLS1_2
 static unsigned char *create_cookie_clienthello(int *outlen,
-    const unsigned char *seq)
+    unsigned char *out_seq)
 {
     SSL_CTX *ctx = NULL;
     SSL *ssl = NULL;
+    SSL_CONNECTION *sc = NULL;
     BIO *rbio = NULL, *wbio = NULL;
     BIO *ssl_rbio = NULL, *ssl_wbio = NULL;
     char *data = NULL;
@@ -380,9 +390,28 @@ static unsigned char *create_cookie_clienthello(int *outlen,
     rbio = wbio = NULL;
     SSL_set_connect_state(ssl);
 
+    if (!TEST_ptr(sc = SSL_CONNECTION_FROM_SSL_ONLY(ssl)))
+        goto err;
+
+    /* Send the initial, cookie-less ClientHello: record sequence 0. */
     if (!TEST_int_le(sslret = SSL_connect(ssl), 0)
-        || !TEST_int_eq(SSL_get_error(ssl, sslret), SSL_ERROR_WANT_READ)
-        || !TEST_int_gt(BIO_reset(ssl_wbio), 0)
+        || !TEST_int_eq(SSL_get_error(ssl, sslret), SSL_ERROR_WANT_READ))
+        goto err;
+
+    /*
+     * Simulate the initial ClientHello (or the server's HelloVerifyRequest)
+     * being lost in transit: force the retransmit timer to look expired and
+     * drive a genuine retransmission of the buffered ClientHello through
+     * the normal write path. This consumes record sequence 1 for real,
+     * so the retried (with-cookie) ClientHello below naturally lands on
+     * sequence 2 -- rather than the test asserting that value by fiat.
+     */
+    sc->d1->next_timeout = ossl_ms2time(1);
+    if (!TEST_long_eq(DTLSv1_handle_timeout(ssl), 1))
+        goto err;
+
+    /* Neither copy of the cookie-less ClientHello is needed -- discard both. */
+    if (!TEST_int_gt(BIO_reset(ssl_wbio), 0)
         || !TEST_int_eq(BIO_write(ssl_rbio, verify, sizeof(verify)),
             sizeof(verify))
         || !TEST_int_le(sslret = SSL_connect(ssl), 0)
@@ -397,8 +426,14 @@ static unsigned char *create_cookie_clienthello(int *outlen,
 
     *outlen = (int)datalen;
 
-    /* DTLS record header bytes 3..10 are epoch and sequence number. */
-    memcpy(ret + 3, seq, DTLS_RECORD_EPOCH_AND_SEQ_LEN);
+    /*
+     * Report back the epoch+sequence number (DTLS record header bytes
+     * 3..10) that the client's own record layer actually assigned to the
+     * first record of the retried ClientHello. The caller uses this to
+     * work out what it should expect back from the server, instead of the
+     * test dictating a fixed sequence number.
+     */
+    memcpy(out_seq, ret + 3, DTLS_RECORD_EPOCH_AND_SEQ_LEN);
 
 err:
     SSL_free(ssl);
@@ -410,19 +445,10 @@ err:
 
 static int dtls_listen_write_seq_test(int tst)
 {
-    static const unsigned char initial_seq[DTLS_RECORD_EPOCH_AND_SEQ_LEN] = {
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02
-    };
-    static const unsigned char wrap_seq[DTLS_RECORD_EPOCH_AND_SEQ_LEN] = {
-        0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
-    };
-    static const unsigned char expected_record_seq[2 + DTLS_RECORD_EPOCH_AND_SEQ_LEN] = {
-        0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x02
-    };
-    const unsigned char *seq = tst == 0 ? initial_seq : wrap_seq;
+    unsigned char actual_seq[DTLS_RECORD_EPOCH_AND_SEQ_LEN];
     unsigned char *inbuf = NULL;
     int inbuflen = 0;
+    SSL_CONNECTION *s = NULL;
     SSL_CTX *ctx = NULL;
     SSL *ssl = NULL;
     BIO *outbio = NULL;
@@ -434,7 +460,7 @@ static int dtls_listen_write_seq_test(int tst)
     long datalen;
     int ret, success = 0;
 
-    if (!TEST_ptr(inbuf = create_cookie_clienthello(&inbuflen, seq)))
+    if (!TEST_ptr(inbuf = create_cookie_clienthello(&inbuflen, actual_seq)))
         goto err;
 
     if (!TEST_ptr(ctx = SSL_CTX_new(DTLS_server_method()))
@@ -471,6 +497,20 @@ static int dtls_listen_write_seq_test(int tst)
     if (!TEST_long_eq(datalen, 0))
         goto err;
 
+    if (tst == 1) {
+        static const unsigned char max_seq[6] = {
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+        };
+
+        /* Drive the DTLS 1.2 write-side uint48 wrap path directly. */
+        s = SSL_CONNECTION_FROM_SSL_ONLY(ssl);
+        if (!TEST_ptr(s)
+            || !TEST_true(s->rlayer.wrlmethod->set_sequence != NULL)
+            || !TEST_true(s->rlayer.wrlmethod->set_sequence(s->rlayer.wrl,
+                max_seq)))
+            goto err;
+    }
+
     ret = SSL_accept(ssl);
     if (tst == 1) {
         if (!TEST_int_le(ret, 0)
@@ -488,8 +528,18 @@ static int dtls_listen_write_seq_test(int tst)
 
     datalen = BIO_get_mem_data(outbio, &data);
     if (!TEST_long_ge(datalen, DTLS1_RT_HEADER_LENGTH)
-        || !TEST_mem_eq(data + 1, sizeof(expected_record_seq),
-            expected_record_seq, sizeof(expected_record_seq)))
+        /* The server's response record is always DTLS1.2 once a cookie has
+         * been validated -- that's what DTLSv1_listen() negotiates down to. */
+        || !TEST_uint_eq(((unsigned char)data[1] << 8) | (unsigned char)data[2],
+            DTLS1_2_VERSION)
+        /*
+         * This is the actual regression check: the server's write sequence
+         * must continue from the epoch/sequence number of the ClientHello
+         * record DTLSv1_listen() validated the cookie against -- whatever
+         * that value turned out to be, not one the test dictates.
+         */
+        || !TEST_mem_eq(data + 3, DTLS_RECORD_EPOCH_AND_SEQ_LEN,
+            actual_seq, DTLS_RECORD_EPOCH_AND_SEQ_LEN))
         goto err;
 
     SSL_set0_rbio(ssl, NULL);

--- a/test/recipes/80-test_dtlsv1listen.t
+++ b/test/recipes/80-test_dtlsv1listen.t
@@ -6,7 +6,17 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+use OpenSSL::Test qw/:DEFAULT srctop_dir/;
+use OpenSSL::Test::Utils;
 
-use OpenSSL::Test::Simple;
+setup("test_dtlsv1listen");
 
-simple_test("test_dtlsv1listen", "dtlsv1listentest", "dh");
+plan skip_all => "No DTLS protocols are supported by this OpenSSL build"
+    if alldisabled(available_protocols("dtls"));
+
+plan skip_all => "DH is disabled in this OpenSSL build" if disabled("dh");
+
+plan tests => 1;
+
+ok(run(test(["dtlsv1listentest", srctop_dir("test", "certs")])),
+   "running dtlsv1listentest");


### PR DESCRIPTION
fix https://github.com/openssl/openssl/issues/32063

RFC 6347 requires the server to use the ClientHello record sequence number in both the HelloVerifyRequest and the initial ServerHello after cookie verification.

DTLSv1_listen() already copies the received ClientHello sequence into HelloVerifyRequest, but after a valid cookie it only incremented the write record sequence counter once. This is wrong if packet loss or delay caused the client to retransmit ClientHello before the valid-cookie ClientHello was processed.

(cherry picked from commit [ec444cb914aa3d4b21ce108e7953743998436369](https://github.com/openssl/openssl/pull/32064))


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
