### PR TITLE
providers: hardware-accelerated AES-GCM-SIV (up to 15x)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,17 @@ OpenSSL 4.1
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * The AES-GCM-SIV provider is now hardware-accelerated end to end. POLYVAL no
+   longer enters the GHASH kernel one block per call, the keystream is no
+   longer produced one EVP call per block, and both halves have native
+   kernels on x86-64 (AES-NI, AVX-512 VAES/VPCLMULQDQ, bitsliced AES on
+   SSSE3-only CPUs) and aarch64 (FEAT_AES/PMULL). AES-256-GCM-SIV at 1 MiB
+   goes from ~0.6 GB/s to 8.5-10 GB/s on Zen 4, 5.7 GB/s on AVX2-class
+   CPUs, 4.8 GB/s on AES-NI-without-AVX CPUs and 7 GB/s on Apple M3; the
+   output is unchanged.
+
+   *Alexey Eromenko*
+
  * Refactored remaining cipher `OSSL_PARAM` name parsing so that
    automatically generated parsers are used instead of
    `OSSL_PARAM_locate()` calls.  This should ensure that the list

--- a/crypto/aes/asm/bsaes-x86_64.pl
+++ b/crypto/aes/asm/bsaes-x86_64.pl
@@ -115,7 +115,7 @@ open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\""
 
 my ($inp,$out,$len,$key,$ivp)=("%rdi","%rsi","%rdx","%rcx");
 my @XMM=map("%xmm$_",(15,0..14));	# best on Atom, +10% over (0..15)
-my $ecb=0;	# suppress unreferenced ECB subroutines, spare some space...
+my $ecb=1;	# the AES-GCM-SIV provider uses bsaes_ecb_encrypt_blocks on SSSE3-without-AES-NI
 
 {
 my ($key,$rounds,$const)=("%rax","%r10d","%r11");

--- a/providers/implementations/ciphers/cipher_aes_gcm_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv.c
@@ -70,7 +70,7 @@ static void *ossl_aes_gcm_siv_dupctx(void *vctx)
         return NULL;
     /* NULL-out these things we create later */
     ret->aad = NULL;
-    ret->ecb_ctx = NULL;
+    ret->scratch = NULL;
 
     if (in->aad != NULL) {
         if ((ret->aad = OPENSSL_memdup(in->aad, UP16(ret->aad_len))) == NULL)

--- a/providers/implementations/ciphers/cipher_aes_gcm_siv.h
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv.h
@@ -11,12 +11,22 @@
 #define OSSL_PROVIDERS_IMPLEMENTATIONS_CIPHERS_CIPHER_AES_GCM_SIV_H
 
 #include <openssl/aes.h>
+#include <openssl/modes.h>
 #include "prov/ciphercommon.h"
 #include "crypto/aes_platform.h"
 
 #define BLOCK_SIZE 16
 #define NONCE_SIZE 12
 #define TAG_SIZE 16
+
+/*
+ * Scratch owned by the context, allocated on first use and cleared with the
+ * context: POLYVAL stages its byte-reversed input here for the platform GHASH
+ * kernel, and the generic CTR path builds and encrypts its counter blocks here.
+ * 4 KiB runs: the GHASH and ECB kernels are flat from 4 KiB upward, and a run
+ * this size stays in L1D beside the input and output on every CPU measured.
+ */
+#define GCM_SIV_SCRATCH (4 * 1024)
 
 /* AAD manipulation macros */
 #define UP16(x) (((x) + 15) & ~0x0F)
@@ -34,13 +44,24 @@ typedef struct prov_cipher_hw_aes_gcm_siv_st {
 
 /* Arranged for alignment purposes */
 typedef struct prov_aes_gcm_siv_ctx_st {
-    EVP_CIPHER_CTX *ecb_ctx;
     const PROV_CIPHER_HW_AES_GCM_SIV *hw; /* maybe not used, yet? */
     uint8_t *aad; /* Allocated, rounded up to 16 bytes, from user */
+    uint8_t *scratch; /* GCM_SIV_SCRATCH bytes, see above; NULL until first use */
     OSSL_LIB_CTX *libctx;
     OSSL_PROVIDER *provctx;
     size_t aad_len; /* actual AAD length */
     size_t key_len;
+    AES_KEY ks; /* the message-encryption key schedule (msg_enc_key) */
+    AES_KEY ks_bulk; /* a SECOND schedule of the same key for a bulk kernel that wants
+                      * a different layout (x86 bitsliced ECB: the standard schedule) */
+    const AES_KEY *ecb_key; /* the schedule `ecb` takes: &ks, or &ks_bulk */
+    size_t ecb_min_blocks; /* runs shorter than this go through `block` instead of `ecb` */
+    block128_f block; /* one-block AES encrypt under ks: aesni / aes_v8 / vpaes / AES_encrypt */
+    ecb128_f ecb; /* multi-block ECB encrypt under *ecb_key, or NULL where the platform has none */
+    int vaes; /* x86-64: the AVX-512/VAES keystream kernel is usable on this CPU */
+    int aesni_ctr; /* x86-64: the 128-bit AES-NI keystream kernel is usable (AES-NI, no VAES) */
+    int native_polyval; /* a native POLYVAL kernel is usable: x86-64 VPCLMULQDQ / PCLMULQDQ, aarch64 PMULL */
+    int armv8_ctr; /* aarch64: the fused AESE/AESMC keystream kernel is usable (FEAT_AES) */
     uint8_t key_gen_key[32]; /* from user */
     uint8_t msg_enc_key[32]; /* depends on key size */
     uint8_t msg_auth_key[BLOCK_SIZE];
@@ -59,7 +80,17 @@ typedef struct prov_aes_gcm_siv_ctx_st {
 const PROV_CIPHER_HW_AES_GCM_SIV *ossl_prov_cipher_hw_aes_gcm_siv(size_t keybits);
 
 void ossl_polyval_ghash_init(u128 Htable[16], const uint64_t H[2]);
-void ossl_polyval_ghash_hash(const u128 Htable[16], uint8_t *tag, const uint8_t *inp, size_t len);
+/*
+ * POLYVAL len bytes (a multiple of 16) into tag. scratch/scratch_len (may be NULL/0)
+ * is staging space for the byte-reversed input: the larger it is, the longer each
+ * GHASH kernel call.
+ */
+void ossl_polyval_ghash_hash(const u128 Htable[16], uint8_t *tag, const uint8_t *inp,
+    size_t len, uint8_t *scratch, size_t scratch_len, const uint8_t *H);
+/*
+ * H (the 16-byte POLYVAL key, msg_auth_key) enables the native POLYVAL kernels on
+ * x86-64 (VPCLMULQDQ, else PCLMULQDQ); pass NULL to take the GHASH route.
+ */
 
 /* Define GSWAP8/GSWAP4 - used for BOTH little and big endian architectures */
 static ossl_inline uint32_t GSWAP4(uint32_t n)

--- a/providers/implementations/ciphers/cipher_aes_gcm_siv_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv_hw.c
@@ -14,7 +14,8 @@
  */
 #include "internal/deprecated.h"
 
-#include <openssl/evp.h>
+#include <string.h>
+#include <openssl/crypto.h>
 #include <openssl/proverr.h>
 #include <internal/endian.h>
 #include <prov/implementations.h>
@@ -22,90 +23,453 @@
 
 static int aes_gcm_siv_ctr32(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *init_counter,
     unsigned char *out, const unsigned char *in, size_t len);
+static int aes_gcm_siv_decrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *in,
+    unsigned char *out, size_t len);
+static int aes_gcm_siv_encrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *in,
+    unsigned char *out, size_t len);
+
+/*
+ * The scratch is per context and NOT copied by dupctx (a copy re-creates its own),
+ * so it is made here, on first use, rather than only in initkey: EVP_CIPHER_CTX_copy
+ * of a keyed context followed by an update must work (evp_test does exactly that).
+ */
+static int scratch_ready(PROV_AES_GCM_SIV_CTX *ctx)
+{
+    if (ctx->scratch == NULL)
+        ctx->scratch = OPENSSL_malloc(GCM_SIV_SCRATCH);
+    return ctx->scratch != NULL;
+}
+
+/*
+ * No-hardware tiers (v4 prototype).
+ *  x86-64 with SSSE3 but no AES-NI (Core 2, early Atom): OpenSSL's vector-permute
+ *  AES (vpaes) does ~340 MB/s per core-class here while its BITSLICED AES (bsaes,
+ *  eight blocks in parallel, used by OpenSSL only for CTR/CBC/XTS) does ~700. The
+ *  bitsliced ECB exists in bsaes-x86_64.pl behind `$ecb=1` and takes the STANDARD
+ *  key schedule; single blocks (key derivation, the tag) stay on vpaes, which is
+ *  constant-time, so a second schedule of the message key is kept for the bulk.
+ *  aarch64 without FEAT_AES (Raspberry Pi 3/4): vpaes-armv8 exports a two-block
+ *  interleaved ECB; use it instead of one vpaes_encrypt per block.
+ */
+#if defined(__x86_64__) && defined(BSAES_CAPABLE) && defined(VPAES_CAPABLE)
+void bsaes_ecb_encrypt_blocks(const unsigned char *in, unsigned char *out, size_t blocks,
+    const AES_KEY *key);
+static void bsaes_ecb_wrap(const unsigned char *in, unsigned char *out, size_t len,
+    const void *key, int enc)
+{
+    (void)enc;
+    bsaes_ecb_encrypt_blocks(in, out, len / BLOCK_SIZE, (const AES_KEY *)key);
+}
+#define GCM_SIV_BSAES 1
+#endif
+#if defined(__aarch64__) && defined(VPAES_CAPABLE)
+void vpaes_ecb_encrypt(const unsigned char *in, unsigned char *out, size_t len,
+    const AES_KEY *key);
+static void vpaes_ecb_wrap(const unsigned char *in, unsigned char *out, size_t len,
+    const void *key, int enc)
+{
+    (void)enc;
+    vpaes_ecb_encrypt(in, out, len, (const AES_KEY *)key);
+}
+#define GCM_SIV_VPAES_ECB 1
+#endif
+
+static ossl_inline void put_le32(uint8_t *p, uint32_t v)
+{
+    p[0] = (uint8_t)v;
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+}
+
+/*
+ * x86-64 with AVX-512 + VAES: the keystream for 32 blocks at a time in eight zmm
+ * registers, XORed straight over the input — one pass, no buffers. The counter is
+ * the little-endian 32-bit word in bytes 0..3 (RFC 8452 section 4), so it is
+ * advanced with a lane-wise 32-bit add that wraps exactly as the spec's counter
+ * does. Gated at run time on OpenSSL's own VAES/VPCLMULQDQ/AVX-512 probe (the one
+ * the AES-GCM provider uses), and compiled only where the compiler supports
+ * per-function target attributes.
+ */
+#if defined(__x86_64__) && defined(AESNI_CAPABLE) && (defined(__GNUC__) || defined(__clang__)) \
+    && !defined(OPENSSL_NO_GCM_SIV_VAES)
+#include <immintrin.h>
+int ossl_vaes_vpclmulqdq_capable(void);
+#define GCM_SIV_VAES 1
+
+__attribute__((target("avx512f,avx512bw,vaes")))
+/*
+ * nr is the AES round count from the KEY LENGTH (10/12/14). It is deliberately not
+ * read from key->rounds: aesni_set_encrypt_key() records Nr - 1 there (aesni_encrypt
+ * counts aesenc iterations), where AES_set_encrypt_key() records Nr — and a kernel
+ * that trusted the field ran every block one round short.
+ */
+static size_t ctr32le_vaes(const AES_KEY *key, int nr, const unsigned char ctr[16],
+    unsigned char *out, const unsigned char *in, size_t len)
+{
+    const unsigned char *rk = (const unsigned char *)key->rd_key;
+    const int rounds = nr;
+    __m512i k[15], x[8], c, inc4;
+    size_t done = 0;
+    int r, i;
+
+    for (r = 0; r <= rounds; r++)
+        k[r] = _mm512_broadcast_i32x4(_mm_loadu_si128((const __m128i *)(rk + 16 * r)));
+    /* lane i of c holds counter + i in its first dword; each further vector adds 4 */
+    c = _mm512_add_epi32(_mm512_broadcast_i32x4(_mm_loadu_si128((const __m128i *)ctr)),
+        _mm512_set_epi32(0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0));
+    inc4 = _mm512_set_epi32(0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 4, 0, 0, 0, 4);
+
+    while (len - done >= 512) {
+        for (i = 0; i < 8; i++) {
+            x[i] = _mm512_xor_si512(c, k[0]);
+            c = _mm512_add_epi32(c, inc4);
+        }
+        for (r = 1; r < rounds; r++)
+            for (i = 0; i < 8; i++)
+                x[i] = _mm512_aesenc_epi128(x[i], k[r]);
+        for (i = 0; i < 8; i++) {
+            x[i] = _mm512_aesenclast_epi128(x[i], k[rounds]);
+            _mm512_storeu_si512((void *)(out + done + 64 * i),
+                _mm512_xor_si512(x[i], _mm512_loadu_si512((const void *)(in + done + 64 * i))));
+        }
+        done += 512;
+    }
+    while (len - done >= 64) {
+        __m512i y = _mm512_xor_si512(c, k[0]);
+
+        c = _mm512_add_epi32(c, inc4);
+        for (r = 1; r < rounds; r++)
+            y = _mm512_aesenc_epi128(y, k[r]);
+        y = _mm512_aesenclast_epi128(y, k[rounds]);
+        _mm512_storeu_si512((void *)(out + done),
+            _mm512_xor_si512(y, _mm512_loadu_si512((const void *)(in + done))));
+        done += 64;
+    }
+    OPENSSL_cleanse(k, sizeof(k));
+    OPENSSL_cleanse(x, sizeof(x));
+    _mm256_zeroupper();
+    return done;
+}
+#endif
+
+/*
+ * x86-64 with AES-NI but no VAES (Westmere through Zen 2/3, most Intel client
+ * parts): the keystream 8 blocks at a time in xmm registers, XORed straight
+ * over the input — the same shape as ctr32le_vaes at 128 bits. Replaces the
+ * fill / ECB / XOR passes over the scratch on this tier.
+ */
+#if defined(__x86_64__) && defined(AESNI_CAPABLE) && (defined(__GNUC__) || defined(__clang__))
+#include <wmmintrin.h>
+#define GCM_SIV_AESNI_CTR 1
+
+__attribute__((target("aes,sse4.1,ssse3"))) static size_t ctr32le_aesni(const AES_KEY *key, int nr, const unsigned char ctr[16],
+    unsigned char *out, const unsigned char *in, size_t len)
+{
+    const unsigned char *rk = (const unsigned char *)key->rd_key;
+    __m128i k[15], x[8], c, one;
+    size_t done = 0;
+    int r, i;
+
+    for (r = 0; r <= nr; r++)
+        k[r] = _mm_loadu_si128((const __m128i *)(rk + 16 * r));
+    c = _mm_loadu_si128((const __m128i *)ctr);
+    one = _mm_set_epi32(0, 0, 0, 1); /* the little-endian counter is dword 0 */
+
+    while (len - done >= 128) {
+        for (i = 0; i < 8; i++) {
+            x[i] = _mm_xor_si128(c, k[0]);
+            c = _mm_add_epi32(c, one);
+        }
+        for (r = 1; r < nr; r++)
+            for (i = 0; i < 8; i++)
+                x[i] = _mm_aesenc_si128(x[i], k[r]);
+        for (i = 0; i < 8; i++) {
+            x[i] = _mm_aesenclast_si128(x[i], k[nr]);
+            _mm_storeu_si128((__m128i *)(out + done + 16 * i),
+                _mm_xor_si128(x[i], _mm_loadu_si128((const __m128i *)(in + done + 16 * i))));
+        }
+        done += 128;
+    }
+    while (len - done >= 16) {
+        __m128i y = _mm_xor_si128(c, k[0]);
+
+        c = _mm_add_epi32(c, one);
+        for (r = 1; r < nr; r++)
+            y = _mm_aesenc_si128(y, k[r]);
+        y = _mm_aesenclast_si128(y, k[nr]);
+        _mm_storeu_si128((__m128i *)(out + done),
+            _mm_xor_si128(y, _mm_loadu_si128((const __m128i *)(in + done))));
+        done += 16;
+    }
+    OPENSSL_cleanse(k, sizeof(k));
+    OPENSSL_cleanse(x, sizeof(x));
+    return done;
+}
+#endif
+
+/*
+ * aarch64 with FEAT_AES: the keystream for eight blocks at a time in NEON
+ * registers, XORed straight over the input — one pass, no buffers (v5 filled the
+ * scratch with counter blocks, ran aes_v8_ecb_encrypt over it and XORed: three
+ * passes). aes_v8_set_encrypt_key stores the round keys in the byte order AESE
+ * consumes (aes_v8_encrypt loads them with ld1 and feeds aese directly), so they
+ * load straight into registers. The rounds are unrolled per key size: a runtime
+ * round loop is left rolled by the compiler and its AESE+AESMC pairs drift apart,
+ * losing the fusion Apple and Arm cores rely on. The little-endian counter is
+ * lane 0 (RFC 8452 section 4); nr from the key length, as above.
+ */
+#if defined(__aarch64__) && defined(__ARM_NEON) && defined(HWAES_CAPABLE) \
+    && (defined(__GNUC__) || defined(__clang__)) && !defined(OPENSSL_NO_GCM_SIV_ARMV8)
+#include <arm_neon.h>
+#define GCM_SIV_ARMV8_CTR 1
+#if defined(__clang__)
+#define GCM_SIV_ARMV8 __attribute__((target("crypto")))
+#else
+#define GCM_SIV_ARMV8 __attribute__((target("+crypto")))
+#endif
+#define GCM_SIV_CTR8_R(i)                   \
+    do {                                    \
+        const uint8x16_t k_ = k[i];         \
+        b0 = vaesmcq_u8(vaeseq_u8(b0, k_)); \
+        b1 = vaesmcq_u8(vaeseq_u8(b1, k_)); \
+        b2 = vaesmcq_u8(vaeseq_u8(b2, k_)); \
+        b3 = vaesmcq_u8(vaeseq_u8(b3, k_)); \
+        b4 = vaesmcq_u8(vaeseq_u8(b4, k_)); \
+        b5 = vaesmcq_u8(vaeseq_u8(b5, k_)); \
+        b6 = vaesmcq_u8(vaeseq_u8(b6, k_)); \
+        b7 = vaesmcq_u8(vaeseq_u8(b7, k_)); \
+    } while (0)
+
+/* nr is a compile-time constant after inlining (the caller switches on it) */
+GCM_SIV_ARMV8 static ossl_inline __attribute__((always_inline))
+size_t
+ctr32le_armv8_nr(const uint8x16_t *k, const int nr, uint32x4_t base, uint32_t c,
+    unsigned char *out, const unsigned char *in, size_t len)
+{
+    size_t done = 0;
+
+    while (len - done >= 128) {
+        uint8x16_t b0 = vreinterpretq_u8_u32(vsetq_lane_u32(c, base, 0));
+        uint8x16_t b1 = vreinterpretq_u8_u32(vsetq_lane_u32(c + 1, base, 0));
+        uint8x16_t b2 = vreinterpretq_u8_u32(vsetq_lane_u32(c + 2, base, 0));
+        uint8x16_t b3 = vreinterpretq_u8_u32(vsetq_lane_u32(c + 3, base, 0));
+        uint8x16_t b4 = vreinterpretq_u8_u32(vsetq_lane_u32(c + 4, base, 0));
+        uint8x16_t b5 = vreinterpretq_u8_u32(vsetq_lane_u32(c + 5, base, 0));
+        uint8x16_t b6 = vreinterpretq_u8_u32(vsetq_lane_u32(c + 6, base, 0));
+        uint8x16_t b7 = vreinterpretq_u8_u32(vsetq_lane_u32(c + 7, base, 0));
+        const unsigned char *p = in + done;
+        unsigned char *q = out + done;
+
+        GCM_SIV_CTR8_R(0);
+        GCM_SIV_CTR8_R(1);
+        GCM_SIV_CTR8_R(2);
+        GCM_SIV_CTR8_R(3);
+        GCM_SIV_CTR8_R(4);
+        GCM_SIV_CTR8_R(5);
+        GCM_SIV_CTR8_R(6);
+        GCM_SIV_CTR8_R(7);
+        GCM_SIV_CTR8_R(8);
+        if (nr >= 12) {
+            GCM_SIV_CTR8_R(9);
+            GCM_SIV_CTR8_R(10);
+        }
+        if (nr >= 14) {
+            GCM_SIV_CTR8_R(11);
+            GCM_SIV_CTR8_R(12);
+        }
+        {
+            const uint8x16_t kl = k[nr - 1], kf = k[nr];
+
+            b0 = veorq_u8(vaeseq_u8(b0, kl), kf);
+            b1 = veorq_u8(vaeseq_u8(b1, kl), kf);
+            b2 = veorq_u8(vaeseq_u8(b2, kl), kf);
+            b3 = veorq_u8(vaeseq_u8(b3, kl), kf);
+            b4 = veorq_u8(vaeseq_u8(b4, kl), kf);
+            b5 = veorq_u8(vaeseq_u8(b5, kl), kf);
+            b6 = veorq_u8(vaeseq_u8(b6, kl), kf);
+            b7 = veorq_u8(vaeseq_u8(b7, kl), kf);
+        }
+        vst1q_u8(q, veorq_u8(b0, vld1q_u8(p)));
+        vst1q_u8(q + 16, veorq_u8(b1, vld1q_u8(p + 16)));
+        vst1q_u8(q + 32, veorq_u8(b2, vld1q_u8(p + 32)));
+        vst1q_u8(q + 48, veorq_u8(b3, vld1q_u8(p + 48)));
+        vst1q_u8(q + 64, veorq_u8(b4, vld1q_u8(p + 64)));
+        vst1q_u8(q + 80, veorq_u8(b5, vld1q_u8(p + 80)));
+        vst1q_u8(q + 96, veorq_u8(b6, vld1q_u8(p + 96)));
+        vst1q_u8(q + 112, veorq_u8(b7, vld1q_u8(p + 112)));
+        done += 128;
+        c += 8;
+    }
+    while (len - done >= 16) {
+        uint8x16_t b = vreinterpretq_u8_u32(vsetq_lane_u32(c, base, 0));
+        int r;
+
+        for (r = 0; r < nr - 1; r++)
+            b = vaesmcq_u8(vaeseq_u8(b, k[r]));
+        b = veorq_u8(vaeseq_u8(b, k[nr - 1]), k[nr]);
+        vst1q_u8(out + done, veorq_u8(b, vld1q_u8(in + done)));
+        done += 16;
+        c++;
+    }
+    return done;
+}
+
+GCM_SIV_ARMV8 static size_t ctr32le_armv8(const AES_KEY *key, int nr, const unsigned char ctr[16],
+    unsigned char *out, const unsigned char *in, size_t len)
+{
+    const unsigned char *rk = (const unsigned char *)key->rd_key;
+    uint8x16_t k[15];
+    uint32x4_t base;
+    uint32_t c;
+    size_t done;
+    int r;
+
+    for (r = 0; r <= nr; r++)
+        k[r] = vld1q_u8(rk + 16 * r);
+    base = vreinterpretq_u32_u8(vld1q_u8(ctr));
+    c = vgetq_lane_u32(base, 0);
+    switch (nr) {
+    case 10:
+        done = ctr32le_armv8_nr(k, 10, base, c, out, in, len);
+        break;
+    case 12:
+        done = ctr32le_armv8_nr(k, 12, base, c, out, in, len);
+        break;
+    default:
+        done = ctr32le_armv8_nr(k, 14, base, c, out, in, len);
+        break;
+    }
+    OPENSSL_cleanse(k, sizeof(k));
+    return done;
+}
+#endif
 
 static int aes_gcm_siv_initkey(void *vctx)
 {
     PROV_AES_GCM_SIV_CTX *ctx = (PROV_AES_GCM_SIV_CTX *)vctx;
-    uint8_t output[BLOCK_SIZE];
-    uint32_t counter = 0x0;
+    int (*set_key)(const unsigned char *, int, AES_KEY *);
+    AES_KEY kgk;
+    uint8_t block_in[BLOCK_SIZE], block_out[BLOCK_SIZE];
+    uint32_t counter = 0;
     size_t i;
-    union {
-        uint32_t counter;
-        uint8_t block[BLOCK_SIZE];
-    } data;
-    int out_len;
-    EVP_CIPHER *ecb = NULL;
-    DECLARE_IS_ENDIAN;
+    int ret = 0;
 
-    switch (ctx->key_len) {
-    case 16:
-        ecb = EVP_CIPHER_fetch(ctx->libctx, "AES-128-ECB", NULL);
-        break;
-    case 24:
-        ecb = EVP_CIPHER_fetch(ctx->libctx, "AES-192-ECB", NULL);
-        break;
-    case 32:
-        ecb = EVP_CIPHER_fetch(ctx->libctx, "AES-256-ECB", NULL);
-        break;
-    default:
-        goto err;
-    }
-
-    if (ctx->ecb_ctx == NULL && (ctx->ecb_ctx = EVP_CIPHER_CTX_new()) == NULL)
-        goto err;
-    if (!EVP_EncryptInit_ex2(ctx->ecb_ctx, ecb, ctx->key_gen_key, NULL, NULL))
-        goto err;
-
-    memset(&data, 0, sizeof(data));
-    memcpy(&data.block[sizeof(data.counter)], ctx->nonce, NONCE_SIZE);
+    if (ctx->key_len != 16 && ctx->key_len != 24 && ctx->key_len != 32)
+        return 0;
 
     ctx->generated_tag = 0;
     memset(ctx->tag, 0, TAG_SIZE);
 
-    /* msg_auth_key is always 16 bytes in size, regardless of AES128/AES256 */
-    /* counter is stored little-endian */
-    for (i = 0; i < BLOCK_SIZE; i += 8) {
-        if (IS_LITTLE_ENDIAN) {
-            data.counter = counter;
-        } else {
-            data.counter = GSWAP4(counter);
+    /* The platform AES, the same ladder the other AES providers climb. */
+    ctx->ecb = NULL;
+    ctx->ecb_key = &ctx->ks;
+    ctx->ecb_min_blocks = 1;
+    ctx->vaes = 0;
+    ctx->aesni_ctr = 0;
+    ctx->native_polyval = 0;
+    ctx->armv8_ctr = 0;
+#ifdef HWAES_CAPABLE
+    if (HWAES_CAPABLE) {
+        set_key = HWAES_set_encrypt_key;
+        ctx->block = (block128_f)HWAES_encrypt;
+#ifdef HWAES_ecb_encrypt
+        ctx->ecb = (ecb128_f)HWAES_ecb_encrypt;
+#endif
+#ifdef GCM_SIV_ARMV8_CTR
+        /* the fused keystream kernel above, and the PMULL POLYVAL kernel in
+         * _polyval.c where the CPU has PMULL (every FEAT_AES core does) */
+        ctx->armv8_ctr = 1;
+        ctx->native_polyval = (OPENSSL_armcap_P & ARMV8_PMULL) ? 1 : 0;
+#endif
+    } else
+#endif
+#ifdef AESNI_CAPABLE
+        if (AESNI_CAPABLE) {
+        set_key = aesni_set_encrypt_key;
+        ctx->block = (block128_f)aesni_encrypt;
+        ctx->ecb = (ecb128_f)aesni_ecb_encrypt;
+#ifdef GCM_SIV_VAES
+        ctx->vaes = ossl_vaes_vpclmulqdq_capable() ? 1 : 0;
+#endif
+#ifdef GCM_SIV_AESNI_CTR
+        ctx->aesni_ctr = !ctx->vaes;
+#endif
+        /*
+         * native POLYVAL: VPCLMULQDQ (with VAES); else the 128-bit PCLMULQDQ kernel,
+         * but ONLY where OpenSSL itself would use the 4-block gcm_ghash_clmul — on
+         * CPUs with AVX and MOVBE (Haswell onward, every Zen) gcm128.c picks the
+         * 8-block gcm_ghash_avx, which is faster than the 4-block kernel (measured:
+         * -6 % on Zen 2 with the kernel forced on). Same predicate as gcm_get_funcs.
+         */
+        ctx->native_polyval = ctx->vaes
+            || ((OPENSSL_ia32cap_P[1] & (1 << 1)) /* PCLMULQDQ */
+                && ((OPENSSL_ia32cap_P[1] >> 22) & 0x41) != 0x41 /* not (MOVBE && AVX) */);
+    } else
+#endif
+#ifdef VPAES_CAPABLE
+        if (VPAES_CAPABLE) {
+        set_key = vpaes_set_encrypt_key;
+        ctx->block = (block128_f)vpaes_encrypt;
+#ifdef GCM_SIV_BSAES
+        if (BSAES_CAPABLE) { /* bulk keystream on the bitsliced kernel */
+            ctx->ecb = bsaes_ecb_wrap;
+            ctx->ecb_key = &ctx->ks_bulk;
+            /* bsaes_ecb_encrypt_blocks converts the key only on its >= 8-block
+             * path; entered with fewer it uses an unconverted key and crashes
+             * (measured), so short runs take the block function */
+            ctx->ecb_min_blocks = 8;
         }
-        /* Block size is 16 (128 bits), but only 8 bytes are used */
-        out_len = BLOCK_SIZE;
-        if (!EVP_EncryptUpdate(ctx->ecb_ctx, output, &out_len, data.block, BLOCK_SIZE))
-            goto err;
-        memcpy(&ctx->msg_auth_key[i], output, 8);
-        counter++;
+#endif
+#ifdef GCM_SIV_VPAES_ECB
+        ctx->ecb = vpaes_ecb_wrap;
+#endif
+    } else
+#endif
+    {
+        set_key = AES_set_encrypt_key;
+        ctx->block = (block128_f)AES_encrypt;
     }
 
+    if (!scratch_ready(ctx))
+        return 0;
+
+    /* RFC 8452 section 4: both keys from AES(key_gen_key) over LE32(counter) || nonce */
+    if (set_key(ctx->key_gen_key, (int)(ctx->key_len * 8), &kgk) < 0)
+        goto err;
+    memset(block_in, 0, BLOCK_SIZE);
+    memcpy(block_in + sizeof(counter), ctx->nonce, NONCE_SIZE);
+
+    /* msg_auth_key is always 16 bytes in size, regardless of AES128/AES256 */
+    for (i = 0; i < BLOCK_SIZE; i += 8) {
+        put_le32(block_in, counter);
+        ctx->block(block_in, block_out, &kgk);
+        memcpy(&ctx->msg_auth_key[i], block_out, 8);
+        counter++;
+    }
     /* msg_enc_key length is directly tied to key length AES128/AES256 */
     for (i = 0; i < ctx->key_len; i += 8) {
-        if (IS_LITTLE_ENDIAN) {
-            data.counter = counter;
-        } else {
-            data.counter = GSWAP4(counter);
-        }
-        /* Block size is 16 bytes (128 bits), but only 8 bytes are used */
-        out_len = BLOCK_SIZE;
-        if (!EVP_EncryptUpdate(ctx->ecb_ctx, output, &out_len, data.block, BLOCK_SIZE))
-            goto err;
-        memcpy(&ctx->msg_enc_key[i], output, 8);
+        put_le32(block_in, counter);
+        ctx->block(block_in, block_out, &kgk);
+        memcpy(&ctx->msg_enc_key[i], block_out, 8);
         counter++;
     }
-
-    if (!EVP_EncryptInit_ex2(ctx->ecb_ctx, ecb, ctx->msg_enc_key, NULL, NULL))
+    if (set_key(ctx->msg_enc_key, (int)(ctx->key_len * 8), &ctx->ks) < 0)
         goto err;
+#ifdef GCM_SIV_BSAES
+    if (ctx->ecb_key == &ctx->ks_bulk
+        && AES_set_encrypt_key(ctx->msg_enc_key, (int)(ctx->key_len * 8), &ctx->ks_bulk) < 0)
+        goto err;
+#endif
 
     /* Freshen up the state */
     ctx->used_enc = 0;
     ctx->used_dec = 0;
-    EVP_CIPHER_free(ecb);
-    return 1;
+    ret = 1;
 err:
-    EVP_CIPHER_CTX_free(ctx->ecb_ctx);
-    EVP_CIPHER_free(ecb);
-    ctx->ecb_ctx = NULL;
-    return 0;
+    OPENSSL_cleanse(&kgk, sizeof(kgk));
+    OPENSSL_cleanse(block_out, sizeof(block_out));
+    return ret;
 }
 
 static int aes_gcm_siv_aad(PROV_AES_GCM_SIV_CTX *ctx,
@@ -138,128 +502,6 @@ static int aes_gcm_siv_aad(PROV_AES_GCM_SIV_CTX *ctx,
     return 1;
 }
 
-static int aes_gcm_siv_encrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *in,
-    unsigned char *out, size_t len)
-{
-    uint64_t len_blk[2];
-    uint8_t S_s[TAG_SIZE];
-    uint8_t counter_block[TAG_SIZE];
-    uint8_t padding[BLOCK_SIZE];
-    size_t i;
-    int64_t len64 = len;
-    int out_len;
-    int error = 0;
-    DECLARE_IS_ENDIAN;
-
-    ctx->generated_tag = 0;
-    /* need to check the size of the input! */
-    if (len64 > ((int64_t)1 << 36))
-        return 0;
-
-    if (IS_LITTLE_ENDIAN) {
-        len_blk[0] = (uint64_t)ctx->aad_len * 8;
-        len_blk[1] = (uint64_t)len * 8;
-    } else {
-        len_blk[0] = GSWAP8((uint64_t)ctx->aad_len * 8);
-        len_blk[1] = GSWAP8((uint64_t)len * 8);
-    }
-    memset(S_s, 0, TAG_SIZE);
-    ossl_polyval_ghash_init(ctx->Htable, (const uint64_t *)ctx->msg_auth_key);
-
-    if (ctx->aad != NULL) {
-        /* AAD is allocated with padding, but need to adjust length */
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, ctx->aad, UP16(ctx->aad_len));
-    }
-    if (DOWN16(len) > 0)
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, in, DOWN16(len));
-    if (!IS16(len)) {
-        /* deal with padding - probably easier to memset the padding first rather than calculate */
-        memset(padding, 0, sizeof(padding));
-        memcpy(padding, &in[DOWN16(len)], REMAINDER16(len));
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, padding, sizeof(padding));
-    }
-    ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *)len_blk, sizeof(len_blk));
-
-    for (i = 0; i < NONCE_SIZE; i++)
-        S_s[i] ^= ctx->nonce[i];
-
-    S_s[TAG_SIZE - 1] &= 0x7f;
-    out_len = sizeof(ctx->tag);
-    error |= !EVP_EncryptUpdate(ctx->ecb_ctx, ctx->tag, &out_len, S_s, sizeof(S_s));
-    memcpy(counter_block, ctx->tag, TAG_SIZE);
-    counter_block[TAG_SIZE - 1] |= 0x80;
-
-    error |= !aes_gcm_siv_ctr32(ctx, counter_block, out, in, len);
-
-    ctx->generated_tag = !error;
-    /* Regardless of error */
-    ctx->used_enc = 1;
-    return !error;
-}
-
-static int aes_gcm_siv_decrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *in,
-    unsigned char *out, size_t len)
-{
-    uint8_t counter_block[TAG_SIZE];
-    uint64_t len_blk[2];
-    uint8_t S_s[TAG_SIZE];
-    size_t i;
-    uint64_t padding[2];
-    int64_t len64 = len;
-    int out_len;
-    int error = 0;
-    DECLARE_IS_ENDIAN;
-
-    ctx->generated_tag = 0;
-    /* need to check the size of the input! */
-    if (len64 > ((int64_t)1 << 36))
-        return 0;
-
-    memcpy(counter_block, ctx->user_tag, sizeof(counter_block));
-    counter_block[TAG_SIZE - 1] |= 0x80;
-
-    error |= !aes_gcm_siv_ctr32(ctx, counter_block, out, in, len);
-
-    if (IS_LITTLE_ENDIAN) {
-        len_blk[0] = (uint64_t)ctx->aad_len * 8;
-        len_blk[1] = (uint64_t)len * 8;
-    } else {
-        len_blk[0] = GSWAP8((uint64_t)ctx->aad_len * 8);
-        len_blk[1] = GSWAP8((uint64_t)len * 8);
-    }
-    memset(S_s, 0, TAG_SIZE);
-    ossl_polyval_ghash_init(ctx->Htable, (const uint64_t *)ctx->msg_auth_key);
-    if (ctx->aad != NULL) {
-        /* AAD allocated with padding, but need to adjust length */
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, ctx->aad, UP16(ctx->aad_len));
-    }
-    if (DOWN16(len) > 0)
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, out, DOWN16(len));
-    if (!IS16(len)) {
-        /* deal with padding - probably easier to "memset" the padding first rather than calculate */
-        padding[0] = padding[1] = 0;
-        memcpy(padding, &out[DOWN16(len)], REMAINDER16(len));
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *)padding, sizeof(padding));
-    }
-    ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *)len_blk, TAG_SIZE);
-
-    for (i = 0; i < NONCE_SIZE; i++)
-        S_s[i] ^= ctx->nonce[i];
-
-    S_s[TAG_SIZE - 1] &= 0x7f;
-
-    /*
-     * In the ctx, user_tag is the one received/set by the user,
-     * and tag is generated from the input
-     */
-    out_len = sizeof(ctx->tag);
-    error |= !EVP_EncryptUpdate(ctx->ecb_ctx, ctx->tag, &out_len, S_s, sizeof(S_s));
-    ctx->generated_tag = !error;
-    /* Regardless of error */
-    ctx->used_dec = 1;
-    return !error;
-}
-
 static int aes_gcm_siv_finish(PROV_AES_GCM_SIV_CTX *ctx)
 {
     int ret = 0;
@@ -282,6 +524,132 @@ static int aes_gcm_siv_finish(PROV_AES_GCM_SIV_CTX *ctx)
     if (ret == 0 && ctx->have_user_tag)
         ERR_raise(ERR_LIB_PROV, PROV_R_BAD_DECRYPT);
     return ret;
+}
+
+static int aes_gcm_siv_encrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *in,
+    unsigned char *out, size_t len)
+{
+    uint64_t len_blk[2];
+    uint8_t S_s[TAG_SIZE];
+    uint8_t counter_block[TAG_SIZE];
+    uint8_t padding[BLOCK_SIZE];
+    size_t i;
+    int64_t len64 = len;
+    int error = 0;
+    DECLARE_IS_ENDIAN;
+
+    ctx->generated_tag = 0;
+    /* need to check the size of the input! */
+    if (len64 > ((int64_t)1 << 36))
+        return 0;
+    if (!scratch_ready(ctx))
+        return 0;
+
+    if (IS_LITTLE_ENDIAN) {
+        len_blk[0] = (uint64_t)ctx->aad_len * 8;
+        len_blk[1] = (uint64_t)len * 8;
+    } else {
+        len_blk[0] = GSWAP8((uint64_t)ctx->aad_len * 8);
+        len_blk[1] = GSWAP8((uint64_t)len * 8);
+    }
+    memset(S_s, 0, TAG_SIZE);
+    ossl_polyval_ghash_init(ctx->Htable, (const uint64_t *)ctx->msg_auth_key);
+
+    if (ctx->aad != NULL) {
+        /* AAD is allocated with padding, but need to adjust length */
+        ossl_polyval_ghash_hash(ctx->Htable, S_s, ctx->aad, UP16(ctx->aad_len),
+            ctx->scratch, GCM_SIV_SCRATCH, ctx->native_polyval ? ctx->msg_auth_key : NULL);
+    }
+    if (DOWN16(len) > 0)
+        ossl_polyval_ghash_hash(ctx->Htable, S_s, in, DOWN16(len),
+            ctx->scratch, GCM_SIV_SCRATCH, ctx->native_polyval ? ctx->msg_auth_key : NULL);
+    if (!IS16(len)) {
+        /* deal with padding - probably easier to memset the padding first rather than calculate */
+        memset(padding, 0, sizeof(padding));
+        memcpy(padding, &in[DOWN16(len)], REMAINDER16(len));
+        ossl_polyval_ghash_hash(ctx->Htable, S_s, padding, sizeof(padding), NULL, 0, NULL);
+    }
+    ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *)len_blk, sizeof(len_blk), NULL, 0, NULL);
+
+    for (i = 0; i < NONCE_SIZE; i++)
+        S_s[i] ^= ctx->nonce[i];
+
+    S_s[TAG_SIZE - 1] &= 0x7f;
+    ctx->block(S_s, ctx->tag, &ctx->ks);
+    memcpy(counter_block, ctx->tag, TAG_SIZE);
+    counter_block[TAG_SIZE - 1] |= 0x80;
+
+    error |= !aes_gcm_siv_ctr32(ctx, counter_block, out, in, len);
+
+    ctx->generated_tag = !error;
+    /* Regardless of error */
+    ctx->used_enc = 1;
+    return !error;
+}
+
+static int aes_gcm_siv_decrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *in,
+    unsigned char *out, size_t len)
+{
+    uint8_t counter_block[TAG_SIZE];
+    uint64_t len_blk[2];
+    uint8_t S_s[TAG_SIZE];
+    size_t i;
+    uint64_t padding[2];
+    int64_t len64 = len;
+    int error = 0;
+    DECLARE_IS_ENDIAN;
+
+    ctx->generated_tag = 0;
+    /* need to check the size of the input! */
+    if (len64 > ((int64_t)1 << 36))
+        return 0;
+    if (!scratch_ready(ctx))
+        return 0;
+
+    memcpy(counter_block, ctx->user_tag, sizeof(counter_block));
+    counter_block[TAG_SIZE - 1] |= 0x80;
+
+    error |= !aes_gcm_siv_ctr32(ctx, counter_block, out, in, len);
+
+    if (IS_LITTLE_ENDIAN) {
+        len_blk[0] = (uint64_t)ctx->aad_len * 8;
+        len_blk[1] = (uint64_t)len * 8;
+    } else {
+        len_blk[0] = GSWAP8((uint64_t)ctx->aad_len * 8);
+        len_blk[1] = GSWAP8((uint64_t)len * 8);
+    }
+    memset(S_s, 0, TAG_SIZE);
+    ossl_polyval_ghash_init(ctx->Htable, (const uint64_t *)ctx->msg_auth_key);
+    if (ctx->aad != NULL) {
+        /* AAD allocated with padding, but need to adjust length */
+        ossl_polyval_ghash_hash(ctx->Htable, S_s, ctx->aad, UP16(ctx->aad_len),
+            ctx->scratch, GCM_SIV_SCRATCH, ctx->native_polyval ? ctx->msg_auth_key : NULL);
+    }
+    if (DOWN16(len) > 0)
+        ossl_polyval_ghash_hash(ctx->Htable, S_s, out, DOWN16(len),
+            ctx->scratch, GCM_SIV_SCRATCH, ctx->native_polyval ? ctx->msg_auth_key : NULL);
+    if (!IS16(len)) {
+        /* deal with padding - probably easier to "memset" the padding first rather than calculate */
+        padding[0] = padding[1] = 0;
+        memcpy(padding, &out[DOWN16(len)], REMAINDER16(len));
+        ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *)padding, sizeof(padding), NULL, 0, NULL);
+    }
+    ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *)len_blk, TAG_SIZE, NULL, 0, NULL);
+
+    for (i = 0; i < NONCE_SIZE; i++)
+        S_s[i] ^= ctx->nonce[i];
+
+    S_s[TAG_SIZE - 1] &= 0x7f;
+
+    /*
+     * In the ctx, user_tag is the one received/set by the user,
+     * and tag is generated from the input
+     */
+    ctx->block(S_s, ctx->tag, &ctx->ks);
+    ctx->generated_tag = !error;
+    /* Regardless of error */
+    ctx->used_dec = 1;
+    return !error;
 }
 
 static int aes_gcm_siv_cipher(void *vctx, unsigned char *out,
@@ -319,28 +687,30 @@ static void aes_gcm_siv_clean_ctx(void *vctx)
 {
     PROV_AES_GCM_SIV_CTX *ctx = (PROV_AES_GCM_SIV_CTX *)vctx;
 
-    EVP_CIPHER_CTX_free(ctx->ecb_ctx);
-    ctx->ecb_ctx = NULL;
+    OPENSSL_clear_free(ctx->scratch, GCM_SIV_SCRATCH);
+    ctx->scratch = NULL;
+    OPENSSL_cleanse(&ctx->ks, sizeof(ctx->ks));
+    OPENSSL_cleanse(&ctx->ks_bulk, sizeof(ctx->ks_bulk));
 }
 
 static int aes_gcm_siv_dup_ctx(void *vdst, void *vsrc)
 {
     PROV_AES_GCM_SIV_CTX *dst = (PROV_AES_GCM_SIV_CTX *)vdst;
-    PROV_AES_GCM_SIV_CTX *src = (PROV_AES_GCM_SIV_CTX *)vsrc;
+    const PROV_AES_GCM_SIV_CTX *src = (const PROV_AES_GCM_SIV_CTX *)vsrc;
 
-    dst->ecb_ctx = NULL;
-    if (src->ecb_ctx != NULL) {
-        if ((dst->ecb_ctx = EVP_CIPHER_CTX_new()) == NULL)
-            goto err;
-        if (!EVP_CIPHER_CTX_copy(dst->ecb_ctx, src->ecb_ctx))
-            goto err;
-    }
+    /*
+     * The key schedules and dispatch pointers were copied with the struct, but
+     * ecb_key POINTS INTO the struct (&ks or &ks_bulk of the source): left as
+     * copied, the copy would run its bulk kernel on the source's schedule — a
+     * dangling pointer once the source is freed or re-keyed. This was latent in
+     * v2..v5: test_evp copies a keyed context before every variant and passed
+     * only because the source's memory still held the schedule; a four-byte
+     * change to the struct (v6) moved the heap layout and it read a zeroed
+     * schedule instead. The scratch is re-created on the copy's first use.
+     */
+    dst->ecb_key = (src->ecb_key == &src->ks_bulk) ? &dst->ks_bulk : &dst->ks;
+    dst->scratch = NULL;
     return 1;
-
-err:
-    EVP_CIPHER_CTX_free(dst->ecb_ctx);
-    dst->ecb_ctx = NULL;
-    return 0;
 }
 
 static const PROV_CIPHER_HW_AES_GCM_SIV aes_gcm_siv_hw = {
@@ -355,43 +725,96 @@ const PROV_CIPHER_HW_AES_GCM_SIV *ossl_prov_cipher_hw_aes_gcm_siv(size_t keybits
     return &aes_gcm_siv_hw;
 }
 
-/* AES-GCM-SIV needs AES-CTR32, which is different than the AES-CTR implementation */
+/*
+ * AES-GCM-SIV needs AES-CTR32 with a LITTLE-endian 32-bit counter in the first
+ * four bytes of the block (RFC 8452 section 4), which the AES-CTR kernels
+ * (big-endian counter in the last four bytes) cannot provide. On AVX-512/VAES
+ * the keystream is made and applied in one pass (ctr32le_vaes). Elsewhere the
+ * counter blocks are written into the scratch a run at a time, the platform
+ * ECB kernel encrypts them IN PLACE, and the keystream is XORed eight bytes at
+ * a time. Measured on Zen 2 / Haswell / Skylake-SP: this exact shape (one
+ * buffer, in-place ECB, 8-byte XOR) is 30-40 % faster than a counter template
+ * encrypted out of place with a 64-byte XOR, which the compiler turns into
+ * stack traffic. Without an ECB kernel the block function is used.
+ */
 static int aes_gcm_siv_ctr32(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *init_counter,
     unsigned char *out, const unsigned char *in, size_t len)
 {
-    uint8_t keystream[BLOCK_SIZE];
-    int out_len;
-    size_t i;
-    size_t j;
-    size_t todo;
+    uint8_t *ks = ctx->scratch;
     uint32_t counter;
-    int error = 0;
-    union {
-        uint32_t x32[BLOCK_SIZE / sizeof(uint32_t)];
-        uint8_t x8[BLOCK_SIZE];
-    } block;
-    DECLARE_IS_ENDIAN;
+    size_t done = 0, i, j, todo, nblocks;
 
-    memcpy(&block, init_counter, sizeof(block));
-    if (IS_BIG_ENDIAN) {
-        counter = GSWAP4(block.x32[0]);
+    if (ctx->scratch == NULL)
+        return 0;
+    counter = (uint32_t)init_counter[0] | ((uint32_t)init_counter[1] << 8)
+        | ((uint32_t)init_counter[2] << 16) | ((uint32_t)init_counter[3] << 24);
+
+#ifdef GCM_SIV_VAES
+    if (ctx->vaes && len >= 64) {
+        done = ctr32le_vaes(&ctx->ks, (int)(ctx->key_len / 4 + 6), init_counter, out, in, len);
+        counter += (uint32_t)(done / BLOCK_SIZE);
+        if (done == len)
+            return 1;
     }
+#endif
+#ifdef GCM_SIV_AESNI_CTR
+    if (ctx->aesni_ctr && len - done >= 16) {
+        uint8_t ctr2[16];
 
-    for (i = 0; i < len; i += sizeof(block)) {
-        out_len = BLOCK_SIZE;
-        error |= !EVP_EncryptUpdate(ctx->ecb_ctx, keystream, &out_len, (uint8_t *)&block, sizeof(block));
-        if (IS_LITTLE_ENDIAN) {
-            block.x32[0]++;
-        } else {
+        memcpy(ctr2, init_counter, 16);
+        put_le32(ctr2, counter);
+        done += ctr32le_aesni(&ctx->ks, (int)(ctx->key_len / 4 + 6), ctr2, out + done, in + done,
+            len - done);
+        counter = (uint32_t)init_counter[0] | ((uint32_t)init_counter[1] << 8)
+            | ((uint32_t)init_counter[2] << 16) | ((uint32_t)init_counter[3] << 24);
+        counter += (uint32_t)(done / BLOCK_SIZE);
+        if (done == len)
+            return 1;
+    }
+#endif
+#ifdef GCM_SIV_ARMV8_CTR
+    if (ctx->armv8_ctr && len - done >= 16) {
+        uint8_t ctr2[16];
+
+        memcpy(ctr2, init_counter, 16);
+        put_le32(ctr2, counter);
+        done += ctr32le_armv8(&ctx->ks, (int)(ctx->key_len / 4 + 6), ctr2, out + done, in + done,
+            len - done);
+        counter = (uint32_t)init_counter[0] | ((uint32_t)init_counter[1] << 8)
+            | ((uint32_t)init_counter[2] << 16) | ((uint32_t)init_counter[3] << 24);
+        counter += (uint32_t)(done / BLOCK_SIZE);
+        if (done == len)
+            return 1;
+    }
+#endif
+
+    while (done < len) {
+        todo = len - done;
+        if (todo > GCM_SIV_SCRATCH)
+            todo = GCM_SIV_SCRATCH;
+        nblocks = UP16(todo) / BLOCK_SIZE;
+        for (i = 0; i < nblocks; i++) {
+            memcpy(ks + i * BLOCK_SIZE, init_counter, BLOCK_SIZE);
+            put_le32(ks + i * BLOCK_SIZE, counter);
             counter++;
-            block.x32[0] = GSWAP4(counter);
         }
-        todo = len - i;
-        if (todo > sizeof(keystream))
-            todo = sizeof(keystream);
-        /* Non optimal, but avoids alignment issues */
-        for (j = 0; j < todo; j++)
-            out[i + j] = in[i + j] ^ keystream[j];
+        if (ctx->ecb != NULL && nblocks >= ctx->ecb_min_blocks) {
+            ctx->ecb(ks, ks, nblocks * BLOCK_SIZE, ctx->ecb_key, 1);
+        } else {
+            for (i = 0; i < nblocks; i++)
+                ctx->block(ks + i * BLOCK_SIZE, ks + i * BLOCK_SIZE, &ctx->ks);
+        }
+        for (j = 0; j + 8 <= todo; j += 8) {
+            uint64_t a, b;
+
+            memcpy(&a, in + done + j, 8);
+            memcpy(&b, ks + j, 8);
+            a ^= b;
+            memcpy(out + done + j, &a, 8);
+        }
+        for (; j < todo; j++)
+            out[done + j] = in[done + j] ^ ks[j];
+        done += todo;
     }
-    return !error;
+    return 1;
 }

--- a/providers/implementations/ciphers/cipher_aes_gcm_siv_polyval.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv_polyval.c
@@ -14,10 +14,308 @@
  */
 #include "internal/deprecated.h"
 
-#include <openssl/evp.h>
+#include <string.h>
+#include <openssl/crypto.h>
 #include <internal/endian.h>
 #include <prov/implementations.h>
 #include "cipher_aes_gcm_siv.h"
+
+#if defined(__aarch64__) && defined(__ARM_NEON)
+#include <arm_neon.h>
+#define GCM_SIV_REVERSE_NEON 1
+#if defined(HWAES_CAPABLE) && (defined(__GNUC__) || defined(__clang__)) \
+    && !defined(OPENSSL_NO_GCM_SIV_PMULL)
+#define GCM_SIV_POLYVAL_PMULL 1
+#endif
+#elif defined(__x86_64__) && defined(AESNI_CAPABLE) && (defined(__GNUC__) || defined(__clang__))
+#include <immintrin.h>
+#define GCM_SIV_REVERSE_SSSE3 1
+#ifndef OPENSSL_NO_GCM_SIV_VAES
+#define GCM_SIV_POLYVAL_VPCLMUL 1
+int ossl_vaes_vpclmulqdq_capable(void);
+#endif
+#endif
+
+#ifdef GCM_SIV_POLYVAL_VPCLMUL
+/*
+ * Native POLYVAL on VPCLMULQDQ: no byte reversal, no GHASH kernel. POLYVAL is
+ * dot(a, b) = a * b * x^-128 mod (x^128 + x^127 + x^126 + x^121 + 1) over
+ * little-endian elements; 16 blocks are multiplied by H^16..H^1 as four
+ * 4-lane Karatsuba products (three VPCLMULQDQ each), the lanes are folded and
+ * ONE Montgomery reduction closes the step. Math and layout after libkryp's
+ * gcm_vaes.c (MIT, Alexey Eromenko and Claude AI), which is byte-verified
+ * against this provider. Engaged only for runs of >= 256 bytes; the tail
+ * takes the GHASH route below, which continues the same accumulator.
+ */
+__attribute__((target("pclmul,sse4.1,ssse3"))) static __m128i pv_reduce(__m128i zlo, __m128i zhi)
+{
+    uint64_t z0 = (uint64_t)_mm_cvtsi128_si64(zlo);
+    uint64_t z1 = (uint64_t)_mm_extract_epi64(zlo, 1);
+    uint64_t z2 = (uint64_t)_mm_cvtsi128_si64(zhi);
+    uint64_t z3 = (uint64_t)_mm_extract_epi64(zhi, 1);
+    uint64_t w1 = z1 ^ (z0 << 57) ^ (z0 << 62) ^ (z0 << 63);
+    uint64_t w2 = z2 ^ z0 ^ (z0 >> 7) ^ (z0 >> 2) ^ (z0 >> 1);
+    uint64_t rl = w2 ^ (w1 << 57) ^ (w1 << 62) ^ (w1 << 63);
+    uint64_t rh = z3 ^ w1 ^ (w1 >> 7) ^ (w1 >> 2) ^ (w1 >> 1);
+
+    return _mm_set_epi64x((long long)rh, (long long)rl);
+}
+
+__attribute__((target("pclmul,sse4.1,ssse3"))) static __m128i pv_mul(__m128i a, __m128i h)
+{
+    __m128i lo = _mm_clmulepi64_si128(a, h, 0x00);
+    __m128i hi = _mm_clmulepi64_si128(a, h, 0x11);
+    __m128i ax = _mm_xor_si128(a, _mm_shuffle_epi32(a, 0x4e));
+    __m128i hx = _mm_xor_si128(h, _mm_shuffle_epi32(h, 0x4e));
+    __m128i mid = _mm_clmulepi64_si128(ax, hx, 0x00);
+
+    mid = _mm_xor_si128(mid, _mm_xor_si128(lo, hi));
+    lo = _mm_xor_si128(lo, _mm_slli_si128(mid, 8));
+    hi = _mm_xor_si128(hi, _mm_srli_si128(mid, 8));
+    return pv_reduce(lo, hi);
+}
+
+/*
+ * 128-bit PCLMULQDQ POLYVAL for AES-NI CPUs without VPCLMULQDQ (Westmere through
+ * Zen 3): four blocks against H^4..H^1 per Montgomery reduction (three PCLMULQDQ
+ * Karatsuba products each), the same math as pv_mul. Consumes floor(len/64)*64.
+ */
+__attribute__((target("pclmul,sse4.1,ssse3"))) static ossl_inline void clmul128_acc(__m128i a, __m128i h, __m128i *zlo, __m128i *zhi)
+{
+    __m128i lo = _mm_clmulepi64_si128(a, h, 0x00);
+    __m128i hi = _mm_clmulepi64_si128(a, h, 0x11);
+    __m128i ax = _mm_xor_si128(a, _mm_shuffle_epi32(a, 0x4e));
+    __m128i hx = _mm_xor_si128(h, _mm_shuffle_epi32(h, 0x4e));
+    __m128i mid = _mm_clmulepi64_si128(ax, hx, 0x00);
+
+    mid = _mm_xor_si128(mid, _mm_xor_si128(lo, hi));
+    lo = _mm_xor_si128(lo, _mm_slli_si128(mid, 8));
+    hi = _mm_xor_si128(hi, _mm_srli_si128(mid, 8));
+    *zlo = _mm_xor_si128(*zlo, lo);
+    *zhi = _mm_xor_si128(*zhi, hi);
+}
+
+__attribute__((target("pclmul,sse4.1,ssse3"))) static size_t polyval_pclmulqdq(const uint8_t H[16], const uint8_t *data, size_t len,
+    uint8_t acc16[16])
+{
+    __m128i h1, h2, h3, h4, acc;
+    size_t done = 0;
+
+    h1 = _mm_loadu_si128((const __m128i *)H);
+    h2 = pv_mul(h1, h1);
+    h3 = pv_mul(h2, h1);
+    h4 = pv_mul(h3, h1);
+    acc = _mm_loadu_si128((const __m128i *)acc16);
+    while (len - done >= 64) {
+        __m128i zlo = _mm_setzero_si128(), zhi = _mm_setzero_si128();
+
+        clmul128_acc(_mm_xor_si128(acc, _mm_loadu_si128((const __m128i *)(data + done))), h4, &zlo, &zhi);
+        clmul128_acc(_mm_loadu_si128((const __m128i *)(data + done + 16)), h3, &zlo, &zhi);
+        clmul128_acc(_mm_loadu_si128((const __m128i *)(data + done + 32)), h2, &zlo, &zhi);
+        clmul128_acc(_mm_loadu_si128((const __m128i *)(data + done + 48)), h1, &zlo, &zhi);
+        acc = pv_reduce(zlo, zhi);
+        done += 64;
+    }
+    _mm_storeu_si128((__m128i *)acc16, acc);
+    return done;
+}
+
+/* POLYVAL floor(len/256)*256 bytes of data into acc16; returns the bytes consumed. */
+__attribute__((target("avx512f,avx512bw,vpclmulqdq,pclmul,sse4.1,ssse3"))) static size_t polyval_vpclmulqdq(const uint8_t H[16], const uint8_t *data, size_t len,
+    uint8_t acc16[16])
+{
+    __m128i p[16], acc;
+    __m512i pw[4];
+    size_t done = 0;
+    int i;
+
+    /* P_1 = H, P_k = P_(k-1) * H; pw[j] lane l holds P_(16 - (4j + l)) so that
+     * block 0 (with the accumulator) pairs with P_16 and block 15 with P_1 */
+    p[0] = _mm_loadu_si128((const __m128i *)H);
+    for (i = 1; i < 16; i++)
+        p[i] = pv_mul(p[i - 1], p[0]);
+    for (i = 0; i < 4; i++)
+        pw[i] = _mm512_set_epi64(
+            _mm_extract_epi64(p[16 - (4 * i + 3) - 1], 1), _mm_cvtsi128_si64(p[16 - (4 * i + 3) - 1]),
+            _mm_extract_epi64(p[16 - (4 * i + 2) - 1], 1), _mm_cvtsi128_si64(p[16 - (4 * i + 2) - 1]),
+            _mm_extract_epi64(p[16 - (4 * i + 1) - 1], 1), _mm_cvtsi128_si64(p[16 - (4 * i + 1) - 1]),
+            _mm_extract_epi64(p[16 - (4 * i + 0) - 1], 1), _mm_cvtsi128_si64(p[16 - (4 * i + 0) - 1]));
+    acc = _mm_loadu_si128((const __m128i *)acc16);
+
+    while (len - done >= 256) {
+        __m512i zlo = _mm512_setzero_si512(), zhi = zlo, zmid = zlo;
+        __m512i d[4];
+        __m256i lo2, hi2;
+        __m128i lo1, hi1;
+
+        d[0] = _mm512_loadu_si512((const void *)(data + done));
+        d[1] = _mm512_loadu_si512((const void *)(data + done + 64));
+        d[2] = _mm512_loadu_si512((const void *)(data + done + 128));
+        d[3] = _mm512_loadu_si512((const void *)(data + done + 192));
+        /* the accumulator enters with block 0 (zext: lanes 1..3 must be zero) */
+        d[0] = _mm512_xor_si512(d[0], _mm512_zextsi128_si512(acc));
+        for (i = 0; i < 4; i++) {
+            __m512i a = d[i], h = pw[i];
+            __m512i lo = _mm512_clmulepi64_epi128(a, h, 0x00);
+            __m512i hi = _mm512_clmulepi64_epi128(a, h, 0x11);
+            __m512i ax = _mm512_xor_si512(a, _mm512_shuffle_epi32(a, 0x4e));
+            __m512i hx = _mm512_xor_si512(h, _mm512_shuffle_epi32(h, 0x4e));
+            __m512i mid = _mm512_clmulepi64_epi128(ax, hx, 0x00);
+
+            mid = _mm512_xor_si512(mid, _mm512_xor_si512(lo, hi));
+            zlo = _mm512_xor_si512(zlo, lo);
+            zhi = _mm512_xor_si512(zhi, hi);
+            zmid = _mm512_xor_si512(zmid, mid);
+        }
+        /* fold mid into lo/hi per lane, then the four lanes into one 256-bit product */
+        zlo = _mm512_xor_si512(zlo, _mm512_bslli_epi128(zmid, 8));
+        zhi = _mm512_xor_si512(zhi, _mm512_bsrli_epi128(zmid, 8));
+        lo2 = _mm256_xor_si256(_mm512_castsi512_si256(zlo), _mm512_extracti64x4_epi64(zlo, 1));
+        hi2 = _mm256_xor_si256(_mm512_castsi512_si256(zhi), _mm512_extracti64x4_epi64(zhi, 1));
+        lo1 = _mm_xor_si128(_mm256_castsi256_si128(lo2), _mm256_extracti128_si256(lo2, 1));
+        hi1 = _mm_xor_si128(_mm256_castsi256_si128(hi2), _mm256_extracti128_si256(hi2, 1));
+        acc = pv_reduce(lo1, hi1);
+        done += 256;
+    }
+    _mm_storeu_si128((__m128i *)acc16, acc);
+    OPENSSL_cleanse(p, sizeof(p));
+    OPENSSL_cleanse(pw, sizeof(pw));
+    _mm256_zeroupper();
+    return done;
+}
+#endif
+
+#ifdef GCM_SIV_POLYVAL_PMULL
+/*
+ * Native POLYVAL on PMULL (ARMv8 Crypto Extensions): no byte reversal, no GHASH
+ * kernel. Eight blocks are multiplied by H^8..H^1 as Karatsuba products (three
+ * PMULLs each, the key's Karatsuba half precomputed), the three partial sums
+ * are folded once and ONE Montgomery reduction closes the step. Eight, not
+ * four, because on these cores the hash is bound by the latency of the
+ * reduction chain rather than by PMULL throughput: the 4-block gcm_ghash_v8
+ * route runs 8.4-8.9 GB/s on an M3 Max, this kernel 14 GB/s. PMULL/PMULL2 are
+ * inline asm on full vector registers: fed through vmull_p64's scalar
+ * operands the compiler hoists the key halves into general-purpose registers
+ * and pays an fmov/dup before every multiply. Math and layout after libkryp's
+ * kryp_pmull_armv8.h (MIT, Alexey Eromenko and Claude AI), byte-verified
+ * against this provider. Engaged for runs of >= 64 bytes; the tail takes the
+ * GHASH route below, which continues the same accumulator.
+ */
+#if defined(__clang__)
+#define GCM_SIV_ARMV8 __attribute__((target("crypto")))
+#else
+#define GCM_SIV_ARMV8 __attribute__((target("+crypto")))
+#endif
+
+GCM_SIV_ARMV8 static ossl_inline uint64x2_t pvn_pmull_lo(uint64x2_t a, uint64x2_t b)
+{
+    uint64x2_t r;
+
+    __asm__("pmull %0.1q, %1.1d, %2.1d" : "=w"(r) : "w"(a), "w"(b));
+    return r;
+}
+
+GCM_SIV_ARMV8 static ossl_inline uint64x2_t pvn_pmull_hi(uint64x2_t a, uint64x2_t b)
+{
+    uint64x2_t r;
+
+    __asm__("pmull2 %0.1q, %1.2d, %2.2d" : "=w"(r) : "w"(a), "w"(b));
+    return r;
+}
+
+/* (zlo, zhi, zmid) += a * h, Karatsuba, no reduction; hx = both lanes lo(h)^hi(h) */
+GCM_SIV_ARMV8 static ossl_inline void pvn_clmul3(uint64x2_t a, uint64x2_t h, uint64x2_t hx,
+    uint64x2_t *zlo, uint64x2_t *zhi, uint64x2_t *zmid)
+{
+    uint64x2_t ax = veorq_u64(a, vextq_u64(a, a, 1));
+
+    *zlo = veorq_u64(*zlo, pvn_pmull_lo(a, h));
+    *zhi = veorq_u64(*zhi, pvn_pmull_hi(a, h));
+    *zmid = veorq_u64(*zmid, pvn_pmull_lo(ax, hx));
+}
+
+/* Montgomery reduction by x^-128 mod x^128+x^127+x^126+x^121+1 (two PMULL by x^57+x^62+x^63) */
+GCM_SIV_ARMV8 static ossl_inline uint64x2_t pvn_reduce(uint64x2_t zlo, uint64x2_t zhi, uint64x2_t zmid)
+{
+    const uint64x2_t M = vdupq_n_u64(0xC200000000000000ULL);
+    const uint64x2_t zero = vdupq_n_u64(0);
+    uint64x2_t P1, P2, WW, R;
+
+    zmid = veorq_u64(zmid, veorq_u64(zlo, zhi)); /* fold the middle term */
+    zlo = veorq_u64(zlo, vextq_u64(zero, zmid, 1));
+    zhi = veorq_u64(zhi, vextq_u64(zmid, zero, 1));
+    P1 = pvn_pmull_lo(zlo, M);
+    WW = vcombine_u64(vget_high_u64(zlo), vget_low_u64(zhi)); /* [z1, z2] */
+    WW = veorq_u64(WW, P1);
+    WW = veorq_u64(WW, vcombine_u64(vget_low_u64(zero), vget_low_u64(zlo)));
+    P2 = pvn_pmull_lo(WW, M);
+    R = vcombine_u64(vget_high_u64(WW), vget_high_u64(zhi)); /* [w2, z3] */
+    R = veorq_u64(R, P2);
+    R = veorq_u64(R, vcombine_u64(vget_low_u64(zero), vget_low_u64(WW)));
+    return R;
+}
+
+GCM_SIV_ARMV8 static ossl_inline uint64x2_t pvn_mul(uint64x2_t a, uint64x2_t h)
+{
+    uint64x2_t zlo = vdupq_n_u64(0), zhi = zlo, zmid = zlo;
+
+    pvn_clmul3(a, h, veorq_u64(h, vextq_u64(h, h, 1)), &zlo, &zhi, &zmid);
+    return pvn_reduce(zlo, zhi, zmid);
+}
+
+/* POLYVAL floor(len/64)*64 bytes of data into acc16; returns the bytes consumed. */
+GCM_SIV_ARMV8 static size_t polyval_pmull(const uint8_t H[16], const uint8_t *data, size_t len,
+    uint8_t acc16[16])
+{
+    uint64x2_t h[8], hx[8], acc;
+    size_t done = 0;
+    int n = len >= 128 ? 8 : 4, i;
+
+    h[0] = vreinterpretq_u64_u8(vld1q_u8(H));
+    h[1] = pvn_mul(h[0], h[0]);
+    h[2] = pvn_mul(h[1], h[0]);
+    h[3] = pvn_mul(h[1], h[1]);
+    if (n == 8) {
+        h[4] = pvn_mul(h[3], h[0]);
+        h[5] = pvn_mul(h[3], h[1]);
+        h[6] = pvn_mul(h[3], h[2]);
+        h[7] = pvn_mul(h[3], h[3]);
+    }
+    for (i = 0; i < n; i++)
+        hx[i] = veorq_u64(h[i], vextq_u64(h[i], h[i], 1));
+    acc = vreinterpretq_u64_u8(vld1q_u8(acc16));
+    while (len - done >= 128) {
+        uint64x2_t zlo = vdupq_n_u64(0), zhi = zlo, zmid = zlo;
+        const uint8_t *d = data + done;
+
+        pvn_clmul3(veorq_u64(acc, vreinterpretq_u64_u8(vld1q_u8(d))), h[7], hx[7], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 16)), h[6], hx[6], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 32)), h[5], hx[5], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 48)), h[4], hx[4], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 64)), h[3], hx[3], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 80)), h[2], hx[2], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 96)), h[1], hx[1], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 112)), h[0], hx[0], &zlo, &zhi, &zmid);
+        acc = pvn_reduce(zlo, zhi, zmid);
+        done += 128;
+    }
+    if (len - done >= 64) {
+        uint64x2_t zlo = vdupq_n_u64(0), zhi = zlo, zmid = zlo;
+        const uint8_t *d = data + done;
+
+        pvn_clmul3(veorq_u64(acc, vreinterpretq_u64_u8(vld1q_u8(d))), h[3], hx[3], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 16)), h[2], hx[2], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 32)), h[1], hx[1], &zlo, &zhi, &zmid);
+        pvn_clmul3(vreinterpretq_u64_u8(vld1q_u8(d + 48)), h[0], hx[0], &zlo, &zhi, &zmid);
+        acc = pvn_reduce(zlo, zhi, zmid);
+        done += 64;
+    }
+    vst1q_u8(acc16, vreinterpretq_u8_u64(acc));
+    OPENSSL_cleanse(h, sizeof(h));
+    OPENSSL_cleanse(hx, sizeof(hx));
+    return done;
+}
+#endif
 
 static ossl_inline void mulx_ghash(uint64_t *a)
 {
@@ -43,18 +341,58 @@ static ossl_inline void mulx_ghash(uint64_t *a)
     }
 }
 
-#define aligned64(p) (((uintptr_t)p & 0x07) == 0)
+/*
+ * Reverse 16 bytes: two 64-bit loads, each byte-swapped, stored crosswise. A pure
+ * byte reversal on either endianness; memcpy keeps it alignment-safe. Reads both
+ * halves before writing, so in == out works.
+ */
 static ossl_inline void byte_reverse16(uint8_t *out, const uint8_t *in)
 {
-    if (aligned64(out) && aligned64(in)) {
-        ((uint64_t *)out)[0] = GSWAP8(((uint64_t *)in)[1]);
-        ((uint64_t *)out)[1] = GSWAP8(((uint64_t *)in)[0]);
-    } else {
-        int i;
+    uint64_t lo, hi;
 
-        for (i = 0; i < 16; i++)
-            out[i] = in[15 - i];
+    memcpy(&lo, in, 8);
+    memcpy(&hi, in + 8, 8);
+    lo = GSWAP8(lo);
+    hi = GSWAP8(hi);
+    memcpy(out, &hi, 8);
+    memcpy(out + 8, &lo, 8);
+}
+
+#ifdef GCM_SIV_REVERSE_SSSE3
+__attribute__((target("ssse3"))) static void reverse_blocks_ssse3(uint8_t *out, const uint8_t *in, size_t n)
+{
+    /* pshufb control: output byte i takes input byte 15 - i */
+    const __m128i m = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    size_t i;
+
+    for (i = 0; i < n; i += 16)
+        _mm_storeu_si128((__m128i *)(out + i),
+            _mm_shuffle_epi8(_mm_loadu_si128((const __m128i *)(in + i)), m));
+}
+#endif
+
+/* Byte-reverse n bytes (a multiple of 16) block by block, in -> out. */
+static void reverse_blocks(uint8_t *out, const uint8_t *in, size_t n)
+{
+    size_t i;
+
+#if defined(GCM_SIV_REVERSE_NEON)
+    for (i = 0; i < n; i += 16) {
+        uint8x16_t v = vld1q_u8(in + i);
+
+        v = vrev64q_u8(v); /* reverse within each 64-bit half ... */
+        v = vextq_u8(v, v, 8); /* ... then swap the halves */
+        vst1q_u8(out + i, v);
     }
+    return;
+#elif defined(GCM_SIV_REVERSE_SSSE3)
+    if (OPENSSL_ia32cap_P[1] & (1 << 9)) { /* SSSE3 */
+        reverse_blocks_ssse3(out, in, n);
+        return;
+    }
+#endif
+    for (i = 0; i < n; i += 16)
+        byte_reverse16(out + i, in + i);
 }
 
 /* Initialization of POLYVAL via existing GHASH implementation */
@@ -74,22 +412,66 @@ void ossl_polyval_ghash_init(u128 Htable[16], const uint64_t H[2])
     ossl_gcm_init_4bit(Htable, (uint64_t *)tmp);
 }
 
-/* Implementation of POLYVAL via existing GHASH implementation */
-void ossl_polyval_ghash_hash(const u128 Htable[16], uint8_t *tag, const uint8_t *inp, size_t len)
+/*
+ * POLYVAL via the GHASH implementation (RFC 8452 Appendix A):
+ *   POLYVAL(H, X_1..X_n)
+ *     = ByteReverse(GHASH(mulX_GHASH(ByteReverse(H)), ByteReverse(X_1), ...))
+ *
+ * The input is reversed into the staging buffer a run at a time and each run is
+ * handed to ghash in ONE call, so the platform kernel (PCLMULQDQ / PMULL / ...)
+ * runs its aggregated loop. Entering it per 16-byte block, as the original did,
+ * cost ~10x; from 4 KiB runs upward the kernels are flat, so the runs stay small
+ * enough to keep the staging buffer and the input inside L1D.
+ */
+void ossl_polyval_ghash_hash(const u128 Htable[16], uint8_t *tag, const uint8_t *inp,
+    size_t len, uint8_t *scratch, size_t scratch_len, const uint8_t *H)
 {
     uint64_t out[2];
-    uint64_t tmp[2];
-    size_t i;
+    uint8_t small[256];
+    uint8_t *buf = scratch != NULL ? scratch : small;
+    size_t cap = scratch != NULL ? scratch_len : sizeof(small);
+    size_t n;
 
-    byte_reverse16((uint8_t *)out, (uint8_t *)tag);
+#ifdef GCM_SIV_POLYVAL_VPCLMUL
+    /* tag IS the POLYVAL accumulator in POLYVAL byte order, so the native
+     * kernel updates it directly and the GHASH route below continues from it */
+    if (H != NULL) {
+        if (len >= 256 && ossl_vaes_vpclmulqdq_capable())
+            n = polyval_vpclmulqdq(H, inp, len, tag);
+        else if (len >= 64)
+            n = polyval_pclmulqdq(H, inp, len, tag);
+        else
+            n = 0;
+        inp += n;
+        len -= n;
+        if (len == 0)
+            return;
+    }
+#elif defined(GCM_SIV_POLYVAL_PMULL)
+    if (H != NULL && len >= 64) {
+        n = polyval_pmull(H, inp, len, tag);
+        inp += n;
+        len -= n;
+        if (len == 0)
+            return;
+    }
+#else
+    (void)H;
+#endif
+    byte_reverse16((uint8_t *)out, tag);
 
     /*
      * This implementation doesn't deal with partials, callers do,
      * so, len is a multiple of 16
      */
-    for (i = 0; i < len; i += 16) {
-        byte_reverse16((uint8_t *)tmp, &inp[i]);
-        ossl_gcm_ghash_4bit((uint64_t *)out, Htable, (uint8_t *)tmp, 16);
+    while (len > 0) {
+        n = len < cap ? len : cap;
+        reverse_blocks(buf, inp, n);
+        ossl_gcm_ghash_4bit((uint64_t *)out, Htable, buf, n);
+        inp += n;
+        len -= n;
     }
     byte_reverse16(tag, (uint8_t *)out);
+    if (scratch == NULL)
+        OPENSSL_cleanse(small, sizeof(small));
 }

--- a/test/build.info
+++ b/test/build.info
@@ -975,6 +975,7 @@ IF[{- !$disabled{tests} -}]
 
     IF[{- !$disabled{poly1305} -}]
       PROGRAMS{noinst}=poly1305_internal_test
+      PROGRAMS{noinst}=polyval_internal_test
     ENDIF
     IF[{- !$disabled{chacha} -}]
       PROGRAMS{noinst}=chacha_internal_test
@@ -1006,6 +1007,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[poly1305_internal_test]=poly1305_internal_test.c
     INCLUDE[poly1305_internal_test]=.. ../include ../apps/include
     DEPEND[poly1305_internal_test]=../libcrypto.a libtestutil.a
+
+    SOURCE[polyval_internal_test]=polyval_internal_test.c
+    INCLUDE[polyval_internal_test]=.. ../include ../apps/include
+    DEPEND[polyval_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[chacha_internal_test]=chacha_internal_test.c
     INCLUDE[chacha_internal_test]=.. ../include ../apps/include

--- a/test/polyval_internal_test.c
+++ b/test/polyval_internal_test.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Internal tests for the AES-GCM-SIV provider's POLYVAL (RFC 8452 section 3).
+ *
+ * POLYVAL and GHASH are the same field with opposite bit and byte conventions
+ * (RFC 8452 Appendix A), and the provider reaches the GHASH kernel by byte
+ * reversing every block. A wrong byte order anywhere in that path still yields
+ * a self-consistent AEAD, so it can only be caught against an independent
+ * definition. Two checks, run on every kernel the CPU has (the recipe re-runs
+ * this program with the capability vector masked down tier by tier):
+ *
+ *  1. the worked examples of RFC 8452 Appendix A (with Errata ID 5854 applied),
+ *     known answers with no GHASH in them;
+ *  2. a bit-serial reference POLYVAL written straight from the definition
+ *     (dot(a, b) = a * b * x^-128 mod x^128 + x^127 + x^126 + x^121 + 1, least
+ *     significant bit of byte 0 = coefficient of x^0), checked first against
+ *     the same example and then against ossl_polyval_ghash_hash() at every
+ *     length across the kernel boundaries (16-byte generic blocks, 4-block and
+ *     16-block native groups, 4 KiB reversal runs, and split calls).
+ */
+
+#include <string.h>
+#include "crypto/modes.h"
+#include "testutil.h"
+
+/* the provider's entry points (providers/implementations/ciphers/cipher_aes_gcm_siv.h) */
+void ossl_polyval_ghash_init(u128 Htable[16], const uint64_t H[2]);
+void ossl_polyval_ghash_hash(const u128 Htable[16], uint8_t *tag, const uint8_t *inp,
+    size_t len, uint8_t *scratch, size_t scratch_len, const uint8_t *H);
+
+/* ---- a bit-serial reference, from the definition ---- */
+
+static void load_le128(uint64_t w[2], const uint8_t b[16])
+{
+    int i;
+
+    w[0] = w[1] = 0;
+    for (i = 0; i < 8; i++) {
+        w[0] |= (uint64_t)b[i] << (8 * i);
+        w[1] |= (uint64_t)b[8 + i] << (8 * i);
+    }
+}
+
+static void store_le128(uint8_t b[16], const uint64_t w[2])
+{
+    int i;
+
+    for (i = 0; i < 8; i++) {
+        b[i] = (uint8_t)(w[0] >> (8 * i));
+        b[8 + i] = (uint8_t)(w[1] >> (8 * i));
+    }
+}
+
+/* r = a * b * x^-128 mod P, as four 64-bit words during the product */
+static void ref_dot(uint8_t r[16], const uint8_t a[16], const uint8_t b[16])
+{
+    uint64_t aw[2], bw[2], z[4] = { 0, 0, 0, 0 };
+    /* P = x^128 + x^127 + x^126 + x^121 + 1 as a 256-bit polynomial */
+    const uint64_t p[4] = { 1, (1ULL << 57) | (1ULL << 62) | (1ULL << 63), 1, 0 };
+    int i, k;
+
+    load_le128(aw, a);
+    load_le128(bw, b);
+    /* carry-less product: z = a * b, bit i of a adds b << i */
+    for (i = 0; i < 128; i++) {
+        if ((aw[i >> 6] >> (i & 63)) & 1) {
+            uint64_t s[4] = { 0, 0, 0, 0 };
+            int wi = i >> 6, bi = i & 63;
+
+            for (k = 0; k < 2; k++) {
+                s[k + wi] ^= bw[k] << bi;
+                if (bi != 0)
+                    s[k + wi + 1] ^= bw[k] >> (64 - bi);
+            }
+            for (k = 0; k < 4; k++)
+                z[k] ^= s[k];
+        }
+    }
+    /* multiply by x^-128 mod P: 128 exact divisions by x (Montgomery REDC) */
+    for (i = 0; i < 128; i++) {
+        if (z[0] & 1)
+            for (k = 0; k < 4; k++)
+                z[k] ^= p[k];
+        z[0] = (z[0] >> 1) | (z[1] << 63);
+        z[1] = (z[1] >> 1) | (z[2] << 63);
+        z[2] = (z[2] >> 1) | (z[3] << 63);
+        z[3] >>= 1;
+    }
+    store_le128(r, z);
+}
+
+/* S = POLYVAL(H, X_1 .. X_n) over len bytes (a multiple of 16), continuing from S */
+static void ref_polyval(uint8_t s[16], const uint8_t h[16], const uint8_t *x, size_t len)
+{
+    uint8_t t[16];
+    size_t i, j;
+
+    for (i = 0; i < len; i += 16) {
+        for (j = 0; j < 16; j++)
+            t[j] = s[j] ^ x[i + j];
+        ref_dot(s, t, h);
+    }
+}
+
+/*
+ * mulX_POLYVAL (RFC 8452 Appendix A): multiply by x in POLYVAL's convention.
+ * x^128 = x^127 + x^126 + x^121 + 1, so the carry folds into bits 127, 126, 121
+ * and 0.
+ */
+static void ref_mulx_polyval(uint8_t r[16], const uint8_t a[16])
+{
+    uint64_t w[2], carry;
+
+    load_le128(w, a);
+    carry = w[1] >> 63;
+    w[1] = (w[1] << 1) | (w[0] >> 63);
+    w[0] <<= 1;
+    if (carry) {
+        w[0] ^= 1;
+        w[1] ^= (1ULL << 57) | (1ULL << 62) | (1ULL << 63);
+    }
+    store_le128(r, w);
+}
+
+/* ---- the provider under test, driven the way the provider drives it ---- */
+
+static int provider_polyval(uint8_t s[16], const uint8_t h[16], const uint8_t *x, size_t len,
+    int with_scratch, int with_native)
+{
+    u128 Htable[16];
+    uint8_t scratch[4096];
+
+    ossl_polyval_ghash_init(Htable, (const uint64_t *)h);
+    ossl_polyval_ghash_hash(Htable, s, x, len, with_scratch ? scratch : NULL,
+        with_scratch ? sizeof(scratch) : 0, with_native ? h : NULL);
+    return 1;
+}
+
+static const uint8_t rfc_h[16] = {
+    0x25, 0x62, 0x93, 0x47, 0x58, 0x92, 0x42, 0x76, 0x1d, 0x31, 0xf8, 0x26, 0xba, 0x4b, 0x75, 0x7b
+};
+static const uint8_t rfc_x[32] = {
+    0x4f, 0x4f, 0x95, 0x66, 0x8c, 0x83, 0xdf, 0xb6, 0x40, 0x17, 0x62, 0xbb, 0x2d, 0x01, 0xa2, 0x62,
+    0xd1, 0xa2, 0x4d, 0xdd, 0x27, 0x21, 0xd0, 0x06, 0xbb, 0xe4, 0x5f, 0x20, 0xd3, 0xc9, 0xf3, 0x62
+};
+static const uint8_t rfc_polyval[16] = {
+    0xf7, 0xa3, 0xb4, 0x7b, 0x84, 0x61, 0x19, 0xfa, 0xe5, 0xb7, 0x86, 0x6c, 0xf5, 0xe5, 0xb7, 0x7e
+};
+
+static int test_rfc8452_appendix_a(void)
+{
+    uint8_t s[16], r[16];
+    static const uint8_t one[16] = { 0x01 };
+    static const uint8_t mulx_one[16] = { 0x02 };
+    static const uint8_t v[16] = {
+        0x9c, 0x98, 0xc0, 0x4d, 0xf9, 0x38, 0x7d, 0xed, 0x82, 0x81, 0x75, 0xa9, 0x2b, 0xa6, 0x52, 0xd8
+    };
+    /*
+     * RFC 8452 prints this as ...a5f2; Errata ID 5854 (verified) corrects the
+     * last byte to 0x72, which is what the polynomial gives.
+     */
+    static const uint8_t mulx_v[16] = {
+        0x39, 0x31, 0x81, 0x9b, 0xf2, 0x71, 0xfa, 0xda, 0x05, 0x03, 0xeb, 0x52, 0x57, 0x4c, 0xa5, 0x72
+    };
+    int m;
+
+    /* the reference agrees with the RFC (as corrected) before it is used as a reference */
+    ref_mulx_polyval(r, one);
+    if (!TEST_mem_eq(r, 16, mulx_one, 16))
+        return 0;
+    ref_mulx_polyval(r, v);
+    if (!TEST_mem_eq(r, 16, mulx_v, 16))
+        return 0;
+    memset(s, 0, 16);
+    ref_polyval(s, rfc_h, rfc_x, 32);
+    if (!TEST_mem_eq(s, 16, rfc_polyval, 16))
+        return 0;
+    /* the provider, with and without a scratch buffer / native kernels */
+    for (m = 0; m < 4; m++) {
+        memset(s, 0, 16);
+        provider_polyval(s, rfc_h, rfc_x, 32, m & 1, (m & 2) != 0);
+        if (!TEST_mem_eq(s, 16, rfc_polyval, 16)) {
+            TEST_info("mode scratch=%d native=%d", m & 1, (m & 2) != 0);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int test_polyval_vs_reference(void)
+{
+    static const size_t lens[] = {
+        16, 32, 48, 64, 80, 128, 240, 256, 272, 512, 1024, 4096, 4096 + 16, 8192 + 48
+    };
+    uint8_t h[16], *x, s_ref[16], s_prov[16], s_split[16];
+    uint32_t seed = 0x9e3779b9u;
+    size_t i, n, cut;
+    int ok = 0, m;
+
+    if (!TEST_ptr(x = OPENSSL_malloc(8192 + 48)))
+        return 0;
+    for (i = 0; i < 16; i++)
+        h[i] = (uint8_t)(seed = seed * 1103515245u + 12345u);
+    for (i = 0; i < 8192 + 48; i++)
+        x[i] = (uint8_t)((seed = seed * 1103515245u + 12345u) >> 16);
+
+    for (n = 0; n < OSSL_NELEM(lens); n++) {
+        memset(s_ref, 0, 16);
+        ref_polyval(s_ref, h, x, lens[n]);
+        for (m = 0; m < 4; m++) {
+            memset(s_prov, 0, 16);
+            provider_polyval(s_prov, h, x, lens[n], m & 1, (m & 2) != 0);
+            if (!TEST_mem_eq(s_prov, 16, s_ref, 16)) {
+                TEST_info("len %zu scratch=%d native=%d", lens[n], m & 1, (m & 2) != 0);
+                goto err;
+            }
+        }
+        /* two calls continuing the same accumulator == one call */
+        for (cut = 16; cut < lens[n]; cut += (lens[n] > 512 ? 240 : 16)) {
+            memset(s_split, 0, 16);
+            provider_polyval(s_split, h, x, cut, 1, 1);
+            provider_polyval(s_split, h, x + cut, lens[n] - cut, 1, 1);
+            if (!TEST_mem_eq(s_split, 16, s_ref, 16)) {
+                TEST_info("len %zu split at %zu", lens[n], cut);
+                goto err;
+            }
+        }
+    }
+    ok = 1;
+err:
+    OPENSSL_free(x);
+    return ok;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_rfc8452_appendix_a);
+    ADD_TEST(test_polyval_vs_reference);
+    return 1;
+}

--- a/test/recipes/03-test_internal_polyval.t
+++ b/test/recipes/03-test_internal_polyval.t
@@ -1,0 +1,38 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# The AES-GCM-SIV provider's POLYVAL has one kernel per CPU tier. Each run
+# below masks the capability vector down one tier (the variables are ignored on
+# the other architecture), so every kernel present is checked against the
+# reference, not just the fastest one. OPENSSL_armcap is an absolute value:
+# 61 = ARMV7_NEON | ARMV8_AES | ARMV8_SHA1 | ARMV8_SHA256 | ARMV8_PMULL.
+
+use strict;
+use warnings;
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_internal_polyval");
+
+my @tiers = (
+    [ "native",             undef,                                        undef ],
+    [ "no AVX-512 / VAES",  "~0:~0xFFFFFFFFD0230000",                     undef ],
+    [ "no AVX",             "~0x1000000000000000:~0xFFFFFFFFFFFFFFFF",    undef ],
+    [ "ARMv8 + AES/PMULL/SHA2, no SHA512/SHA3 (Cortex-A76 class)", undef, "61" ],
+    [ "SSSE3 only / NEON only", "~0x0200000200000000:~0xFFFFFFFFFFFFFFFF", "1" ],
+    [ "no SIMD",            "0",                                          "0" ],
+);
+
+plan tests => scalar @tiers;
+
+foreach my $t (@tiers) {
+    my ($name, $ia32cap, $armcap) = @$t;
+    local $ENV{OPENSSL_ia32cap} = $ia32cap if defined $ia32cap;
+    local $ENV{OPENSSL_armcap} = $armcap if defined $armcap;
+    ok(run(test(["polyval_internal_test"])), "POLYVAL vs reference, tier: $name");
+}


### PR DESCRIPTION
This makes the AES-GCM-SIV provider run on the platform's AES and carry-less-multiply hardware. Today both halves of the cipher go one 16-byte block at a time: POLYVAL enters the GHASH kernel per block (with a byte reversal and `gcm_get_funcs()` dispatch each time) and the CTR pass makes one `EVP_EncryptUpdate()` per block with a byte-wise XOR, so AES-256-GCM-SIV runs at ~0.6 GB/s on a Zen 4 core whose AES-256-GCM runs at 14 GB/s. Details and the per-tier numbers are in the commit message; the issue (#32674) carries the investigation.

What changes, in one paragraph: no EVP in the hot path (platform AES selected like the OCB provider, key schedule kept in the context); POLYVAL runs on native VPCLMULQDQ / PCLMULQDQ / PMULL kernels where they exist and through the GHASH kernel in 4 KiB byte-reversed runs elsewhere; the little-endian CTR32 keystream is generated and applied in one pass by fused kernels (VAES zmm, AES-NI xmm, AESE/AESMC on aarch64), with the platform ECB kernel over a 4 KiB scratch as the fallback, including the bitsliced `bsaes_ecb_encrypt_blocks` on SSSE3-only CPUs (enabled via `$ecb=1` in `bsaes-x86_64.pl`). The RFC 8452 arithmetic and the provider's contract are unchanged; output is byte-identical.

Benchmarks (AES-256-GCM-SIV, 1 MiB, MB/s, before → after): Zen 4 624 → 8599–10400 · Zen 2 505 → 3886 · Haswell 332 → 2678 · Skylake-SP 327 → 1939 · AES-NI-without-AVX (masked) 636 → 4800 · SSSE3-only (masked) 194 → 406 · Apple M3 Max 802 → 7086 · Cortex-A72 without crypto extensions 27 → 28.

Notes for review:
- The kernels are C with per-function target attributes (`__attribute__((target(...)))`, GCC and Clang); MSVC and other compilers take the portable path, which is still ~7x faster than before on AES-NI hardware. If the project prefers perlasm for these, I can convert them; the C versions are what was measured.
- `bsaes_ecb_encrypt_blocks` (previously compiled out) crashes when entered with fewer than 8 blocks — its short path runs before the key conversion. The provider only calls it with ≥ 8 blocks; fixing the routine itself is a separate change.
- Tests: `make test TESTS=test_evp` passes (the existing `evpciph_aes_gcm_siv.txt` vectors, including the context-copy variants, which caught a real bug in an earlier revision of this work). No new test files; a differential harness against an independent implementation (90,961 checks per platform) was used during development and is linked from the issue.
- Developed with AI assistance (declared in the commit trailer per CONTRIBUTING.md); every change was measured and reviewed by the author.

##### Checklist
- [ ] documentation is added or updated (no API or documented behaviour changes; CHANGES.md entry added)
- [x] tests are added or updated (existing test_evp vectors exercise the new paths; see notes)
