### PR TITLE
crypto: release child providers before parent method stores

### DIFF
--- a/crypto/context.c
+++ b/crypto/context.c
@@ -276,6 +276,9 @@ static void context_deinit_objs(OSSL_LIB_CTX *ctx)
         ossl_decoder_cache_free(ctx->decoder_cache);
         ctx->decoder_cache = NULL;
     }
+
+    ossl_provider_store_free_child_owners(ctx->provider_store);
+
     if (ctx->decoder_store != NULL) {
         ossl_method_store_free(ctx->decoder_store);
         ctx->decoder_store = NULL;

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -638,6 +638,130 @@ int ossl_method_store_remove_all_provided(OSSL_METHOD_STORE *store,
     return 1;
 }
 
+/** @brief Search state shared by the method-store teardown callbacks. */
+struct teardown_method_data {
+    const OSSL_PROVIDER *prov;
+    void *method; /* Borrowed match; NULL until one is found. */
+};
+
+/**
+ * @brief Find the first implementation belonging to the teardown provider.
+ * @param idx Algorithm index (unused).
+ * @param alg Algorithm whose implementations are searched.
+ * @param arg Search state; an existing match is retained.
+ */
+static void alg_find_provider_method(ossl_uintmax_t idx, ALGORITHM *alg,
+    void *arg)
+{
+    struct teardown_method_data *data = arg;
+    int i;
+
+    if (data->method != NULL)
+        return;
+    for (i = 0; i < sk_IMPLEMENTATION_num(alg->impls); i++) {
+        IMPLEMENTATION *impl = sk_IMPLEMENTATION_value(alg->impls, i);
+
+        if (impl->provider == data->prov) {
+            data->method = impl->method.method;
+            return;
+        }
+    }
+}
+
+/**
+ * @brief Remove implementation references to a method during teardown.
+ * @param idx Algorithm index (unused).
+ * @param alg Algorithm whose implementations are pruned.
+ * @param arg Method identity, used only for pointer comparison.
+ */
+static void alg_teardown_method(ossl_uintmax_t idx, ALGORITHM *alg, void *arg)
+{
+    const void *method = arg;
+    int i;
+
+    for (i = sk_IMPLEMENTATION_num(alg->impls); i-- > 0;) {
+        IMPLEMENTATION *impl = sk_IMPLEMENTATION_value(alg->impls, i);
+
+        if (impl->method.method == method) {
+            (void)sk_IMPLEMENTATION_delete(alg->impls, i);
+            impl_free(impl);
+        }
+    }
+}
+
+static void *query_find_provider_method(QUERY *query,
+    const OSSL_PROVIDER *prov)
+{
+    for (; query != NULL; query = query->next) {
+        if (query->prov == prov)
+            return query->method.method;
+    }
+    return NULL;
+}
+
+/**
+ * @brief Unlink cache aliases before releasing their method references.
+ * @param head Cache or archive list to prune; updated in place.
+ * @param method Method identity, including aliases with no provider in the key.
+ */
+static void query_teardown_method(QUERY **head, const void *method)
+{
+    QUERY *query;
+
+    while ((query = *head) != NULL) {
+        if (query->method.method == method) {
+            *head = query->next;
+            impl_cache_free_unlinked(query);
+        } else {
+            head = &query->next;
+        }
+    }
+}
+
+void ossl_method_store_remove_all_provided_teardown(OSSL_METHOD_STORE *store,
+    const OSSL_PROVIDER *prov)
+{
+    struct teardown_method_data data;
+    void *method;
+    int i, j;
+
+    if (store == NULL || prov == NULL)
+        return;
+
+    /*
+     * The owning library context is being destroyed; no readers remain.
+     * Remove both provider-specific and provider-agnostic cache aliases for
+     * each method before releasing the provider which owns a child context.
+     */
+    for (;;) {
+        data.prov = prov;
+        data.method = NULL;
+        for (i = 0; i < NUM_SHARDS && data.method == NULL; i++) {
+            STORED_ALGORITHMS *sa = &store->algs[i];
+
+            ossl_sa_ALGORITHM_doall_arg(sa->algs,
+                alg_find_provider_method, &data);
+            for (j = 0; j < MAX_CACHE_LINES && data.method == NULL; j++)
+                data.method = query_find_provider_method(
+                    sa->cache_lists[j], prov);
+            if (data.method == NULL)
+                data.method = query_find_provider_method(sa->archive, prov);
+        }
+        if ((method = data.method) == NULL)
+            return;
+
+        for (i = 0; i < NUM_SHARDS; i++) {
+            STORED_ALGORITHMS *sa = &store->algs[i];
+
+            for (j = 0; j < MAX_CACHE_LINES; j++)
+                query_teardown_method(&sa->cache_lists[j], method);
+            query_teardown_method(&sa->archive, method);
+            ossl_sa_ALGORITHM_doall_arg(sa->algs,
+                alg_teardown_method, method);
+        }
+    }
+}
+
 static void alg_do_one(ALGORITHM *alg, IMPLEMENTATION *impl,
     void (*fn)(int id, void *method, void *fnarg),
     void *fnarg)

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -26,6 +26,7 @@
 #include "internal/nelem.h"
 #include "internal/thread_once.h"
 #include "internal/provider.h"
+#include "internal/property.h"
 #include "internal/refcount.h"
 #include "internal/bio.h"
 #include "internal/core.h"
@@ -245,6 +246,63 @@ static void provider_deactivate_free(OSSL_PROVIDER *prov)
 static void ossl_provider_child_cb_free(OSSL_PROVIDER_CHILD_CB *cb)
 {
     OPENSSL_free(cb);
+}
+
+/**
+ * @brief Drop parent method-store references to a child-context owner.
+ * @param prov Provider in a library context being destroyed with no users left.
+ *
+ * All parent stores must remain alive until the provider's child contexts have
+ * released methods borrowed from them.
+ */
+static void provider_store_purge_child_owner_methods(OSSL_PROVIDER *prov)
+{
+    OSSL_LIB_CTX *libctx = prov->libctx;
+
+    ossl_method_store_remove_all_provided_teardown(
+        ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_EVP_METHOD_STORE_INDEX),
+        prov);
+    ossl_method_store_remove_all_provided_teardown(
+        ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DECODER_STORE_INDEX),
+        prov);
+    ossl_method_store_remove_all_provided_teardown(
+        ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_ENCODER_STORE_INDEX),
+        prov);
+    ossl_method_store_remove_all_provided_teardown(
+        ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_STORE_LOADER_STORE_INDEX),
+        prov);
+}
+
+void ossl_provider_store_free_child_owners(void *vstore)
+{
+    struct provider_store_st *store = vstore;
+    OSSL_PROVIDER_CHILD_CB *child_cb;
+    OSSL_PROVIDER *prov;
+    int i;
+
+    if (store == NULL)
+        return;
+
+    /* Child contexts may hold methods borrowed from this parent context. */
+    while ((child_cb = sk_OSSL_PROVIDER_CHILD_CB_value(store->child_cbs, 0))
+        != NULL) {
+        prov = child_cb->prov;
+
+        for (i = sk_OSSL_PROVIDER_CHILD_CB_num(store->child_cbs) - 1;
+            i >= 0; i--) {
+            child_cb = sk_OSSL_PROVIDER_CHILD_CB_value(store->child_cbs, i);
+            if (child_cb->prov == prov) {
+                sk_OSSL_PROVIDER_CHILD_CB_delete(store->child_cbs, i);
+                ossl_provider_child_cb_free(child_cb);
+            }
+        }
+
+        if (sk_OSSL_PROVIDER_delete_ptr(store->providers, prov) == NULL)
+            continue;
+
+        provider_store_purge_child_owner_methods(prov);
+        provider_deactivate_free(prov);
+    }
 }
 #endif
 

--- a/include/crypto/context.h
+++ b/include/crypto/context.h
@@ -33,6 +33,16 @@ void *ossl_threads_ctx_new(OSSL_LIB_CTX *);
 #endif
 
 void ossl_provider_store_free(void *);
+/**
+ * @brief Release providers owning child contexts before parent method stores.
+ * @param vstore Provider store in a library context being destroyed, or NULL.
+ *
+ * No concurrent context users may remain. The decoder cache must already have
+ * been released. Child callbacks and cached methods are detached before the
+ * corresponding provider references are released. The store itself is retained
+ * for ossl_provider_store_free().
+ */
+void ossl_provider_store_free_child_owners(void *vstore);
 void ossl_property_string_data_free(void *);
 void ossl_stored_namemap_free(void *);
 void ossl_property_defns_free(void *);

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -70,6 +70,18 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store,
     const OSSL_PROVIDER **prov, void **method);
 int ossl_method_store_remove_all_provided(OSSL_METHOD_STORE *store,
     const OSSL_PROVIDER *prov);
+/**
+ * @brief Release a provider's methods and all their cache aliases at teardown.
+ * @param store Method store in a library context being destroyed, or NULL.
+ * @param prov Provider whose methods are to be removed, or NULL.
+ *
+ * The caller must ensure that no concurrent store users remain. This function
+ * takes no store locks: releasing methods may destroy child library contexts.
+ * Provider-agnostic aliases are removed by method identity as well. The store
+ * remains owned by its library context and must subsequently be freed.
+ */
+void ossl_method_store_remove_all_provided_teardown(OSSL_METHOD_STORE *store,
+    const OSSL_PROVIDER *prov);
 
 /* Get the global properties associate with the specified library context */
 OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *ctx,

--- a/test/build.info
+++ b/test/build.info
@@ -287,7 +287,7 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[provfetchtest]=provfetchtest.c
   INCLUDE[provfetchtest]=../include ../apps/include
-  DEPEND[provfetchtest]=../libcrypto libtestutil.a
+  DEPEND[provfetchtest]=../libcrypto.a libtestutil.a
 
   SOURCE[prov_config_test]=prov_config_test.c
   INCLUDE[prov_config_test]=../include ../apps/include
@@ -1350,6 +1350,14 @@ IF[{- !$disabled{tests} -}]
     IF[{- defined $target{shared_defflag} -}]
       SOURCE[fake-cipher]=fake-cipher.ld
       GENERATE[fake-cipher.ld]=../util/providers.num
+    ENDIF
+    MODULES{noinst}=tls-provider-child
+    SOURCE[tls-provider-child]=tls-provider-module.c tls-provider.c
+    INCLUDE[tls-provider-child]=.. ../include ../apps/include
+    DEFINE[tls-provider-child]=TLS_PROVIDER_CHILD_LIBCTX
+    DEPEND[tls-provider-child]=../libcrypto
+    IF[{- defined $target{shared_defflag} -}]
+      SOURCE[tls-provider-child]=p_test.ld
     ENDIF
   ENDIF
   IF[{- $disabled{module} || !$target{dso_scheme} -}]

--- a/test/provfetchtest.c
+++ b/test/provfetchtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2021-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,7 +14,22 @@
 #include <openssl/store.h>
 #include <openssl/rand.h>
 #include <openssl/core_names.h>
+#include "internal/thread_arch.h"
 #include "testutil.h"
+#if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) \
+    && !defined(OPENSSL_NO_THREAD_POOL)
+#include "threadstest.h"
+#endif /* defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_NO_THREAD_POOL) */
+
+#define CHILD_RANDOM_CHECK "child-random-check"
+
+static int dummy_provider_init(const OSSL_CORE_HANDLE *handle,
+    const OSSL_DISPATCH *in, const OSSL_DISPATCH **out, void **provctx);
+#if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) \
+    && !defined(OPENSSL_NO_THREAD_POOL)
+static int dummy_provider_init_deferred(const OSSL_CORE_HANDLE *handle,
+    const OSSL_DISPATCH *in, const OSSL_DISPATCH **out, void **provctx);
+#endif /* defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_NO_THREAD_POOL) */
 
 static int dummy_decoder_decode(void *ctx, OSSL_CORE_BIO *cin, int selection,
     OSSL_CALLBACK *object_cb, void *object_cbarg,
@@ -175,6 +190,32 @@ static const OSSL_ALGORITHM dummy_rand[] = {
     { NULL, NULL, NULL }
 };
 
+static void *dummy_keymgmt_new(void *provctx)
+{
+    return provctx;
+}
+
+static void dummy_keymgmt_free(void *keydata)
+{
+}
+
+static int dummy_keymgmt_has(const void *keydata, int selection)
+{
+    return 1;
+}
+
+static const OSSL_DISPATCH dummy_keymgmt_functions[] = {
+    { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))dummy_keymgmt_new },
+    { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))dummy_keymgmt_free },
+    { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))dummy_keymgmt_has },
+    OSSL_DISPATCH_END
+};
+
+static const OSSL_ALGORITHM dummy_keymgmt[] = {
+    { "DUMMY-KEY", "provider=dummy", dummy_keymgmt_functions },
+    { NULL, NULL, NULL }
+};
+
 static const OSSL_ALGORITHM *dummy_query(void *provctx, int operation_id,
     int *no_cache)
 {
@@ -188,20 +229,160 @@ static const OSSL_ALGORITHM *dummy_query(void *provctx, int operation_id,
         return dummy_store;
     case OSSL_OP_RAND:
         return dummy_rand;
+    case OSSL_OP_KEYMGMT:
+        return dummy_keymgmt;
     }
     return NULL;
 }
 
+/**
+ * @brief Probe the child RNG and release its state on the calling thread.
+ * @param provctx Child library context to exercise.
+ * @param params Receives the probe result under CHILD_RANDOM_CHECK.
+ * @returns 1 if the result was stored or not requested, 0 on parameter failure.
+ */
+static int dummy_get_params(void *provctx, OSSL_PARAM params[])
+{
+    OSSL_PARAM *param = OSSL_PARAM_locate(params, CHILD_RANDOM_CHECK);
+    unsigned char bytes[32];
+    int result;
+
+    if (param == NULL)
+        return 1;
+    result = RAND_priv_bytes_ex(provctx, bytes, sizeof(bytes), 0) > 0;
+    OPENSSL_cleanse(bytes, sizeof(bytes));
+    OPENSSL_thread_stop_ex(provctx);
+    return OSSL_PARAM_set_int(param, result);
+}
+
 static const OSSL_DISPATCH dummy_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))dummy_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))dummy_query },
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
     OSSL_DISPATCH_END
 };
 
-static int dummy_provider_init(const OSSL_CORE_HANDLE *handle,
+#if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) \
+    && !defined(OPENSSL_NO_THREAD_POOL)
+static OSSL_LIB_CTX *child_teardown_libctx;
+static OSSL_PROVIDER *child_teardown_provider;
+static CRYPTO_MUTEX *child_teardown_mutex;
+static CRYPTO_CONDVAR *child_teardown_condvar;
+static int child_teardown_worker_result;
+static int child_teardown_worker_ready;
+static int child_teardown_worker_release;
+
+/**
+ * @brief Exercise child-provider methods, then park until teardown is complete.
+ *
+ * Release child and parent per-thread state before signalling readiness. The
+ * parked worker must no longer use either context while the parent is freed.
+ */
+static void child_teardown_worker(void)
+{
+    EVP_KEYMGMT *keymgmt = NULL;
+    int random_ok = 0;
+    OSSL_PARAM params[] = {
+        OSSL_PARAM_int(CHILD_RANDOM_CHECK, &random_ok),
+        OSSL_PARAM_END
+    };
+
+    keymgmt = EVP_KEYMGMT_fetch(child_teardown_libctx, "DUMMY-KEY", NULL);
+    child_teardown_worker_result = keymgmt != NULL
+        && OSSL_PROVIDER_get_params(child_teardown_provider, params)
+        && random_ok;
+    EVP_KEYMGMT_free(keymgmt);
+    OPENSSL_thread_stop_ex(child_teardown_libctx);
+
+    ossl_crypto_mutex_lock(child_teardown_mutex);
+    child_teardown_worker_ready = 1;
+    ossl_crypto_condvar_signal(child_teardown_condvar);
+    while (!child_teardown_worker_release)
+        ossl_crypto_condvar_wait(child_teardown_condvar,
+            child_teardown_mutex);
+    ossl_crypto_mutex_unlock(child_teardown_mutex);
+}
+
+/**
+ * @brief Check parent teardown after deferred child-provider use on a worker.
+ * @returns 1 on success, 0 on setup, provider-operation or thread-join failure.
+ */
+static int test_child_provider_method_teardown(void)
+{
+    OSSL_LIB_CTX *libctx = NULL;
+    OSSL_PROVIDER *deflt = NULL;
+    OSSL_PROVIDER *dummy = NULL;
+    thread_t thread = 0;
+    int thread_started = 0;
+    int result = 0;
+
+    child_teardown_worker_result = 0;
+    child_teardown_worker_ready = 0;
+    child_teardown_worker_release = 0;
+    if (!TEST_ptr(libctx = OSSL_LIB_CTX_new())
+        || !TEST_ptr(child_teardown_mutex = ossl_crypto_mutex_new())
+        || !TEST_ptr(child_teardown_condvar = ossl_crypto_condvar_new())
+        || !TEST_true(OSSL_PROVIDER_add_builtin(libctx,
+            "dummy-teardown-prov", dummy_provider_init_deferred))
+        || !TEST_ptr(deflt = OSSL_PROVIDER_load(libctx, "default"))
+        || !TEST_ptr(dummy = OSSL_PROVIDER_load(libctx,
+                         "dummy-teardown-prov")))
+        goto err;
+
+    child_teardown_libctx = libctx;
+    child_teardown_provider = dummy;
+    if (!TEST_true(thread_started = run_thread(&thread,
+                       child_teardown_worker)))
+        goto err;
+
+    ossl_crypto_mutex_lock(child_teardown_mutex);
+    while (!child_teardown_worker_ready)
+        ossl_crypto_condvar_wait(child_teardown_condvar,
+            child_teardown_mutex);
+    ossl_crypto_mutex_unlock(child_teardown_mutex);
+    if (!TEST_true(child_teardown_worker_result)
+        || !TEST_true(OSSL_PROVIDER_unload(dummy)))
+        goto err;
+    dummy = NULL;
+    if (!TEST_true(OSSL_PROVIDER_unload(deflt)))
+        goto err;
+    deflt = NULL;
+    OSSL_LIB_CTX_free(libctx);
+    libctx = NULL;
+
+    ossl_crypto_mutex_lock(child_teardown_mutex);
+    child_teardown_worker_release = 1;
+    ossl_crypto_condvar_signal(child_teardown_condvar);
+    ossl_crypto_mutex_unlock(child_teardown_mutex);
+    result = wait_for_thread(thread);
+    thread_started = 0;
+    if (!TEST_true(result))
+        goto err;
+
+    result = 1;
+err:
+    if (thread_started) {
+        ossl_crypto_mutex_lock(child_teardown_mutex);
+        child_teardown_worker_release = 1;
+        ossl_crypto_condvar_signal(child_teardown_condvar);
+        ossl_crypto_mutex_unlock(child_teardown_mutex);
+        (void)wait_for_thread(thread);
+    }
+    OSSL_PROVIDER_unload(dummy);
+    OSSL_PROVIDER_unload(deflt);
+    OSSL_LIB_CTX_free(libctx);
+    child_teardown_libctx = NULL;
+    child_teardown_provider = NULL;
+    ossl_crypto_condvar_free(&child_teardown_condvar);
+    ossl_crypto_mutex_free(&child_teardown_mutex);
+    return result;
+}
+#endif /* defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_NO_THREAD_POOL) */
+
+static int dummy_provider_init_common(const OSSL_CORE_HANDLE *handle,
     const OSSL_DISPATCH *in,
     const OSSL_DISPATCH **out,
-    void **provctx)
+    void **provctx, int initialize_random)
 {
     OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new_child(handle, in);
     unsigned char buf[32];
@@ -213,11 +394,31 @@ static int dummy_provider_init(const OSSL_CORE_HANDLE *handle,
      * Do some work using the child libctx, to make sure this is possible from
      * inside the init function.
      */
-    if (RAND_bytes_ex(libctx, buf, sizeof(buf), 0) <= 0)
+    if (initialize_random
+        && RAND_bytes_ex(libctx, buf, sizeof(buf), 0) <= 0)
         return 0;
 
     return 1;
 }
+
+static int dummy_provider_init(const OSSL_CORE_HANDLE *handle,
+    const OSSL_DISPATCH *in,
+    const OSSL_DISPATCH **out,
+    void **provctx)
+{
+    return dummy_provider_init_common(handle, in, out, provctx, 1);
+}
+
+#if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) \
+    && !defined(OPENSSL_NO_THREAD_POOL)
+static int dummy_provider_init_deferred(const OSSL_CORE_HANDLE *handle,
+    const OSSL_DISPATCH *in,
+    const OSSL_DISPATCH **out,
+    void **provctx)
+{
+    return dummy_provider_init_common(handle, in, out, provctx, 0);
+}
+#endif /* defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_NO_THREAD_POOL) */
 
 /*
  * Try fetching and freeing various things.
@@ -292,6 +493,10 @@ err:
 int setup_tests(void)
 {
     ADD_ALL_TESTS(fetch_test, 8);
+#if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) \
+    && !defined(OPENSSL_NO_THREAD_POOL)
+    ADD_TEST(test_child_provider_method_teardown);
+#endif /* defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_NO_THREAD_POOL) */
 
     return 1;
 }

--- a/test/recipes/04-test_provider_child_decoder.t
+++ b/test/recipes/04-test_provider_child_decoder.t
@@ -1,0 +1,28 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT bldtop_dir data_file/;
+use OpenSSL::Test::Utils;
+
+setup("test_provider_child_decoder");
+
+plan skip_all => "module support is disabled" if disabled("module");
+
+$ENV{OPENSSL_MODULES} = bldtop_dir("test");
+$ENV{OPENSSL_CONF} = data_file("openssl.cnf");
+
+plan tests => 2;
+
+ok(run(app(["openssl", "genpkey", "-algorithm", "xorhmacsig",
+            "-out", "xor-key.pem"])),
+   "generate a key through an autoloaded child-context provider");
+ok(run(app(["openssl", "pkey", "-in", "xor-key.pem", "-check", "-noout"])),
+   "decode the key and release the child provider at process exit");

--- a/test/recipes/04-test_provider_child_decoder_data/openssl.cnf
+++ b/test/recipes/04-test_provider_child_decoder_data/openssl.cnf
@@ -1,0 +1,14 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = providers
+
+[providers]
+default = default_sect
+tls-provider-child = tls_provider_sect
+
+[default_sect]
+activate = 1
+
+[tls_provider_sect]
+activate = 1

--- a/test/tls-provider-module.c
+++ b/test/tls-provider-module.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core.h>
+
+int tls_provider_init(const OSSL_CORE_HANDLE *handle,
+    const OSSL_DISPATCH *in,
+    const OSSL_DISPATCH **out,
+    void **provctx);
+
+OSSL_provider_init_fn OSSL_provider_init;
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
+    const OSSL_DISPATCH *in,
+    const OSSL_DISPATCH **out,
+    void **provctx)
+{
+    return tls_provider_init(handle, in, out, provctx);
+}

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -3215,7 +3215,11 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
     const OSSL_DISPATCH **out,
     void **provctx)
 {
+#if defined(TLS_PROVIDER_CHILD_LIBCTX)
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new_child(handle, in);
+#else
     OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new_from_dispatch(handle, in);
+#endif /* defined(TLS_PROVIDER_CHILD_LIBCTX) */
     OSSL_FUNC_core_obj_create_fn *c_obj_create = NULL;
     OSSL_FUNC_core_obj_add_sigid_fn *c_obj_add_sigid = NULL;
     PROV_XOR_CTX *xor_prov_ctx = xor_newprovctx(libctx);


### PR DESCRIPTION
This PR fixes a provider-lifetime issue discovered while developing the provider-defined TLS ciphersuite support discussed in #23093.

Cached method references can keep providers with child library contexts alive until parent method stores are already being torn down. This change clears decoder and method-cache references before releasing the affected providers.

Regression tests cover deferred threaded method use and decoder configuration autoload.

@t8m, would you have time to take a look?

Development was assisted by OpenAI Codex.


##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
