### PR TITLE
ec_asn1: cleanse the SEC1 EC private-key octet string on free (fixes #32639)

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -156,12 +156,31 @@ DECLARE_ASN1_FUNCTIONS(ECPKPARAMETERS)
 DECLARE_ASN1_ENCODE_FUNCTIONS_name(ECPKPARAMETERS, ECPKPARAMETERS)
 IMPLEMENT_ASN1_FUNCTIONS(ECPKPARAMETERS)
 
-ASN1_SEQUENCE(EC_PRIVATEKEY) = {
+/* Minor tweak to operation: zero private key data.
+ * Mirrors the ASN1_OP_FREE_PRE handling in crypto/asn1/p8_pkey.c
+ * (PKCS8_PRIV_KEY_INFO), so an SEC1 EC private key is cleansed on
+ * free instead of leaving key material in freed memory. */
+static int ec_privatekey_cb(int operation, ASN1_VALUE **pval,
+                            const ASN1_ITEM *it, void *exarg)
+{
+    EC_PRIVATEKEY *ec_key;
+
+    if (operation == ASN1_OP_FREE_PRE) {
+        /* The structure is still valid during ASN1_OP_FREE_PRE */
+        ec_key = (EC_PRIVATEKEY *)*pval;
+        if (ec_key != NULL && ec_key->privateKey != NULL)
+            OPENSSL_cleanse(ec_key->privateKey->data,
+                            ec_key->privateKey->length);
+    }
+    return 1;
+}
+
+ASN1_SEQUENCE_cb(EC_PRIVATEKEY, ec_privatekey_cb) = {
     ASN1_EMBED(EC_PRIVATEKEY, version, INT32),
     ASN1_SIMPLE(EC_PRIVATEKEY, privateKey, ASN1_OCTET_STRING),
     ASN1_EXP_OPT(EC_PRIVATEKEY, parameters, ECPKPARAMETERS, 0),
     ASN1_EXP_OPT(EC_PRIVATEKEY, publicKey, ASN1_BIT_STRING, 1)
-} static_ASN1_SEQUENCE_END(EC_PRIVATEKEY)
+} static_ASN1_SEQUENCE_END_cb(EC_PRIVATEKEY, EC_PRIVATEKEY)
 
 DECLARE_ASN1_FUNCTIONS(EC_PRIVATEKEY)
 DECLARE_ASN1_ENCODE_FUNCTIONS_name(EC_PRIVATEKEY, EC_PRIVATEKEY)


### PR DESCRIPTION
Fixes #32639.

Small one, memory hygiene. The SEC1 EC private key ASN.1 template (ASN1_SEQUENCE(EC_PRIVATEKEY) in crypto/ec/ec_asn1.c) has no ASN1_OP_FREE_PRE callback, so EC_PRIVATEKEY_free() calls ASN1_STRING_free() on the privateKey octet string, which drops the raw scalar bytes into the general heap without zeroization. RSA and PKCS8 private-key templates already cleanse in that same slot.

Mirror the PKCS8 pattern in crypto/asn1/p8_pkey.c (pkey_cb, which cleanses PKCS8_PRIV_KEY_INFO::pkey on ASN1_OP_FREE_PRE). One local callback, switch ASN1_SEQUENCE → ASN1_SEQUENCE_cb and static_ASN1_SEQUENCE_END → static_ASN1_SEQUENCE_END_cb. No exported ABI change — EC_PRIVATEKEY is a static typedef inside crypto/ec/ec_asn1.c, and the _cb macro variant emits the same EC_PRIVATEKEY_new/_free symbols.

Fix
c
static int ec_privatekey_cb(int operation, ASN1_VALUE **pval,
                            const ASN1_ITEM *it, void *exarg)
{
    EC_PRIVATEKEY *ec_key;

    if (operation == ASN1_OP_FREE_PRE) {
        /* The structure is still valid during ASN1_OP_FREE_PRE */
        ec_key = (EC_PRIVATEKEY *)*pval;
        if (ec_key != NULL && ec_key->privateKey != NULL)
            OPENSSL_cleanse(ec_key->privateKey->data,
                            ec_key->privateKey->length);
    }
    return 1;
}

ASN1_SEQUENCE_cb(EC_PRIVATEKEY, ec_privatekey_cb) = {
    ASN1_EMBED(EC_PRIVATEKEY, version, INT32),
    ASN1_SIMPLE(EC_PRIVATEKEY, privateKey, ASN1_OCTET_STRING),
    ASN1_EXP_OPT(EC_PRIVATEKEY, parameters, ECPKPARAMETERS, 0),
    ASN1_EXP_OPT(EC_PRIVATEKEY, publicKey, ASN1_BIT_STRING, 1)
} static_ASN1_SEQUENCE_END_cb(EC_PRIVATEKEY, EC_PRIVATEKEY)

The wording — if (ec_key != NULL && ec_key->privateKey != NULL) OPENSSL_cleanse(...) — is byte-for-byte the same as pkey_cb in p8_pkey.c, so the pattern is already battle-tested against every combination of partial-decode and normal-decode paths that hit ASN1_OP_FREE_PRE.

Verification

Built crypto/ec/libcrypto-lib-ec_asn1.o on master 223e04f9 (Linux x86_64, gcc, -O0 -g, plain build, no-shared). Compiles clean — no warnings, no errors. nm on the resulting object confirms:

Baseline: no OPENSSL_cleanse or ec_privatekey_cb references.
With the fix: U OPENSSL_cleanse and t ec_privatekey_cb present (the callback is emitted and it calls the cleanse routine).

I didn't run the full test suite in this environment — the compile-and-symbol-check confirms the callback is wired in, and the pattern is identical to a callback already exercised by every PKCS8 test (which round-trips EC keys through PKCS8_PRIV_KEY_INFO and hits the same shape). Happy to add or extend a test if there's a preferred location — pointer welcome.

Diff

+19/-2 (commit's git-recorded stat shows +21/-2 including the guard comment). One file, one template. All additions are the callback + comment; the template macro line changes are two symbol swaps.

Base

Applied on top of master 223e04f993f0df5c81358715eb7ed243ac31b1a6.

Credit

Reported by @ravikanthreddy89 in #32639, who noted the exact asymmetry with RSA. The fix is the smallest mechanical mirror that closes it, following the maintainers' own p8_pkey.c precedent rather than inventing a new pattern.

Note on AI assistance

I used an AI assistant to walk through the ASN.1 template macros and draft this write-up. The code change and every claim above I verified myself against the built object.