### PR TITLE
Fix memory leaks in rsa_multiprime_keygen() on error

### DIFF
--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -537,8 +537,12 @@ static int rsa_multiprime_keygen(RSA *rsa, int bits, int primes,
         rsa->p = rsa->q;
         rsa->q = tmp;
         /* mirror this in our factor stack */
-        if (!sk_BIGNUM_insert(factors, sk_BIGNUM_delete(factors, 0), 1))
+        tmp = sk_BIGNUM_delete(factors, 0);
+        if (!sk_BIGNUM_insert(factors, tmp, 1)) {
+            /* the factor is no longer on the stack, so free it here */
+            BN_clear_free(tmp);
             goto err;
+        }
     }
 
     /* calculate d */
@@ -603,9 +607,10 @@ static int rsa_multiprime_keygen(RSA *rsa, int bits, int primes,
     }
     ok = 1;
 err:
-    sk_BIGNUM_free(factors);
-    sk_BIGNUM_free(exps);
-    sk_BIGNUM_free(coeffs);
+    /* On error, these stacks may still contain BIGNUMs. */
+    sk_BIGNUM_pop_free(factors, BN_clear_free);
+    sk_BIGNUM_pop_free(exps, BN_clear_free);
+    sk_BIGNUM_pop_free(coeffs, BN_clear_free);
     if (ok == -1) {
         ERR_raise(ERR_LIB_RSA, ERR_R_BN_LIB);
         ok = 0;


### PR DESCRIPTION
Found using an experimental static analyzer I'm developing.