### PR TITLE
OSSL_FN: Add shared OSSL_FN ctx-size composition helpers

### DIFF
--- a/crypto/fn/fn_exp.c
+++ b/crypto/fn/fn_exp.c
@@ -98,9 +98,6 @@ size_t OSSL_FN_mod_exp_mont_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     size_t own_size = OSSL_FN_CTX_size(1, n_numbers, n_numbers * ml);
 
     size_t nested_size = mod_exp_mont_nested(a, m, in_mont);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
@@ -133,9 +130,6 @@ size_t OSSL_FN_mod_exp_simple_ctx_size(const OSSL_FN *r,
     size_t mul_size = OSSL_FN_mod_mul_ctx_size(m, m, m, m);
 
     size_t nested_size = ossl_fn_ctx_max_size(mod_size, mul_size);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 

--- a/crypto/fn/fn_exp.c
+++ b/crypto/fn/fn_exp.c
@@ -8,7 +8,6 @@
  */
 
 #include "internal/cryptlib.h"
-#include "internal/safe_math.h"
 #include "crypto/fnerr.h"
 #include "fn_local.h"
 
@@ -28,8 +27,6 @@
 #define MONT_MUL_MOD
 #undef RECP_MUL_MOD
 
-OSSL_SAFE_MATH_ADDU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
-
 /* maximum precomputation table size for *variable* sliding windows */
 #define TABLE_SIZE 32
 
@@ -42,19 +39,6 @@ OSSL_SAFE_MATH_ADDU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
             : (b) > 79         ? 4               \
             : (b) > 23         ? 3               \
                                : 1)
-
-static size_t ctx_add_size(size_t a, size_t b)
-{
-    int err = 0;
-    size_t r = safe_add_size_t(a, b, &err);
-
-    return err == 0 ? r : 0;
-}
-
-static size_t ctx_max_size(size_t a, size_t b)
-{
-    return a > b ? a : b;
-}
 
 /*-
  * mod_exp_mont_nested() -- Montgomery-path nested arena size for
@@ -87,8 +71,8 @@ static size_t mod_exp_mont_nested(const OSSL_FN *a, const OSSL_FN *m,
      * Montgomery-domain values, so it uses the non-reducing
      * OSSL_FN_mul_mont_quick() and its smaller ctx_size.
      */
-    mont_size = ctx_max_size(OSSL_FN_to_mont_ctx_size(NULL, a, in_mont),
-        ctx_max_size(OSSL_FN_mul_mont_quick_ctx_size(NULL, NULL, NULL, in_mont),
+    mont_size = ossl_fn_ctx_max_size(OSSL_FN_to_mont_ctx_size(NULL, a, in_mont),
+        ossl_fn_ctx_max_size(OSSL_FN_mul_mont_quick_ctx_size(NULL, NULL, NULL, in_mont),
             OSSL_FN_from_mont_ctx_size(NULL, NULL, in_mont)));
 
     return mont_size;
@@ -117,7 +101,7 @@ size_t OSSL_FN_mod_exp_mont_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 /*
@@ -148,11 +132,11 @@ size_t OSSL_FN_mod_exp_simple_ctx_size(const OSSL_FN *r,
      */
     size_t mul_size = OSSL_FN_mod_mul_ctx_size(m, m, m, m);
 
-    size_t nested_size = ctx_max_size(mod_size, mul_size);
+    size_t nested_size = ossl_fn_ctx_max_size(mod_size, mul_size);
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 #ifdef RECP_MUL_MOD

--- a/crypto/fn/fn_kron.c
+++ b/crypto/fn/fn_kron.c
@@ -192,8 +192,5 @@ size_t OSSL_FN_kronecker_ctx_size(const OSSL_FN *a, const OSSL_FN *b)
 
     size_t nested_size = OSSL_FN_mod_ctx_size(&t_L, &t_L, &t_L);
 
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }

--- a/crypto/fn/fn_kron.c
+++ b/crypto/fn/fn_kron.c
@@ -8,23 +8,12 @@
  */
 
 #include <openssl/err.h>
-#include "internal/safe_math.h"
 #include "crypto/fnerr.h"
 #include "fn_local.h"
-
-OSSL_SAFE_MATH_ADDU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
 
 /* least significant word; 0 if the operand has no limbs (i.e. is zero) */
 #define lsw(n) \
     (((n)->dsize == 0) ? (OSSL_FN_ULONG)0 : (n)->d[0])
-
-static size_t ctx_add_size(size_t a, size_t b)
-{
-    int err = 0;
-    size_t r = safe_add_size_t(a, b, &err);
-
-    return err == 0 ? r : 0;
-}
 
 /*-
  * OSSL_FN_kronecker() computes the Kronecker symbol (a/b), returning -1, 0,
@@ -206,5 +195,5 @@ size_t OSSL_FN_kronecker_ctx_size(const OSSL_FN *a, const OSSL_FN *b)
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }

--- a/crypto/fn/fn_mod.c
+++ b/crypto/fn/fn_mod.c
@@ -40,9 +40,6 @@ size_t OSSL_FN_mod_add_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
 
     own_size = OSSL_FN_CTX_size(1, 1, tl);
     nested_size = OSSL_FN_mod_ctx_size(r, &t, m);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
@@ -156,9 +153,6 @@ size_t OSSL_FN_mod_sub_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     mod_a_size = OSSL_FN_mod_ctx_size(&am, a, m);
     mod_b_size = OSSL_FN_mod_ctx_size(&bm, b, m);
     nested_size = ossl_fn_ctx_max_size(mod_a_size, mod_b_size);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
@@ -301,9 +295,6 @@ size_t OSSL_FN_mod_mul_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
 
     own_size = OSSL_FN_CTX_size(1, 1, tl);
     nested_size = ossl_fn_ctx_max_size(mul_size, mod_size);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
@@ -358,9 +349,6 @@ size_t OSSL_FN_mod_sqr_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     sqr_size = OSSL_FN_sqr_ctx_size(&t, a);
     mod_size = OSSL_FN_mod_ctx_size(r, &t, m);
     nested_size = ossl_fn_ctx_max_size(sqr_size, mod_size);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
@@ -401,9 +389,6 @@ size_t OSSL_FN_mod_lshift1_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
 
     own_size = OSSL_FN_CTX_size(1, 1, tl);
     nested_size = OSSL_FN_mod_ctx_size(r, &t, m);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
@@ -465,9 +450,6 @@ size_t OSSL_FN_mod_lshift_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
 
     own_size = OSSL_FN_CTX_size(1, 1, ml);
     nested_size = OSSL_FN_mod_ctx_size(&ra, a, m);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 

--- a/crypto/fn/fn_mod.c
+++ b/crypto/fn/fn_mod.c
@@ -16,19 +16,6 @@
 OSSL_SAFE_MATH_ADDU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
 OSSL_SAFE_MATH_MULU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
 
-static size_t ctx_add_size(size_t a, size_t b)
-{
-    int err = 0;
-    size_t r = safe_add_size_t(a, b, &err);
-
-    return err == 0 ? r : 0;
-}
-
-static size_t ctx_max_size(size_t a, size_t b)
-{
-    return a > b ? a : b;
-}
-
 /*
  * The *_ctx_size helpers below use local OSSL_FN headers with only |dsize|
  * set to represent temporaries that the corresponding operation allocates
@@ -56,7 +43,7 @@ size_t OSSL_FN_mod_add_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 int OSSL_FN_mod_add(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b,
@@ -168,11 +155,11 @@ size_t OSSL_FN_mod_sub_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     own_size = OSSL_FN_CTX_size(1, n_numbers, n_numbers * ml);
     mod_a_size = OSSL_FN_mod_ctx_size(&am, a, m);
     mod_b_size = OSSL_FN_mod_ctx_size(&bm, b, m);
-    nested_size = ctx_max_size(mod_a_size, mod_b_size);
+    nested_size = ossl_fn_ctx_max_size(mod_a_size, mod_b_size);
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 int OSSL_FN_mod_sub(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b,
@@ -313,11 +300,11 @@ size_t OSSL_FN_mod_mul_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     }
 
     own_size = OSSL_FN_CTX_size(1, 1, tl);
-    nested_size = ctx_max_size(mul_size, mod_size);
+    nested_size = ossl_fn_ctx_max_size(mul_size, mod_size);
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 /* slow but works */
@@ -370,11 +357,11 @@ size_t OSSL_FN_mod_sqr_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     own_size = OSSL_FN_CTX_size(1, 1, tl);
     sqr_size = OSSL_FN_sqr_ctx_size(&t, a);
     mod_size = OSSL_FN_mod_ctx_size(r, &t, m);
-    nested_size = ctx_max_size(sqr_size, mod_size);
+    nested_size = ossl_fn_ctx_max_size(sqr_size, mod_size);
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 int OSSL_FN_mod_sqr(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *m,
@@ -417,7 +404,7 @@ size_t OSSL_FN_mod_lshift1_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 int OSSL_FN_mod_lshift1(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *m,
@@ -481,7 +468,7 @@ size_t OSSL_FN_mod_lshift_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 int OSSL_FN_mod_lshift(OSSL_FN *r, const OSSL_FN *a, int n, const OSSL_FN *m,

--- a/crypto/fn/fn_mod_inv.c
+++ b/crypto/fn/fn_mod_inv.c
@@ -69,9 +69,6 @@ size_t OSSL_FN_mod_inverse_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     size_t mod_size = OSSL_FN_mod_ctx_size(r, &t_L, n);
 
     size_t nested_size = ossl_fn_ctx_max_size(div_size, mod_size);
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 

--- a/crypto/fn/fn_mod_inv.c
+++ b/crypto/fn/fn_mod_inv.c
@@ -8,24 +8,8 @@
  */
 
 #include "internal/cryptlib.h"
-#include "internal/safe_math.h"
 #include "crypto/fnerr.h"
 #include "fn_local.h"
-
-OSSL_SAFE_MATH_ADDU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
-
-static size_t ctx_add_size(size_t a, size_t b)
-{
-    int err = 0;
-    size_t r = safe_add_size_t(a, b, &err);
-
-    return err == 0 ? r : 0;
-}
-
-static size_t ctx_max_size(size_t a, size_t b)
-{
-    return a > b ? a : b;
-}
 
 /*-
  * OSSL_FN_mod_inverse_ctx_size() calculates a plausible upper bound
@@ -84,11 +68,11 @@ size_t OSSL_FN_mod_inverse_ctx_size(const OSSL_FN *r, const OSSL_FN *a,
     /* OSSL_FN_mod(r, Y, n): the final reduction, r is the caller's. */
     size_t mod_size = OSSL_FN_mod_ctx_size(r, &t_L, n);
 
-    size_t nested_size = ctx_max_size(div_size, mod_size);
+    size_t nested_size = ossl_fn_ctx_max_size(div_size, mod_size);
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }
 
 /*-

--- a/crypto/fn/fn_sqrt.c
+++ b/crypto/fn/fn_sqrt.c
@@ -8,24 +8,8 @@
  */
 
 #include <openssl/err.h>
-#include "internal/safe_math.h"
 #include "crypto/fnerr.h"
 #include "fn_local.h"
-
-OSSL_SAFE_MATH_ADDU(size_t, size_t, OSSL_SAFE_MATH_MAXU(size_t))
-
-static size_t ctx_add_size(size_t a, size_t b)
-{
-    int err = 0;
-    size_t r = safe_add_size_t(a, b, &err);
-
-    return err == 0 ? r : 0;
-}
-
-static size_t ctx_max_size(size_t a, size_t b)
-{
-    return a > b ? a : b;
-}
 
 /*-
  * OSSL_FN_mod_sqrt() computes ret such that ret^2 == a (mod p), using the
@@ -419,13 +403,13 @@ size_t OSSL_FN_mod_sqrt_ctx_size(const OSSL_FN *ret, const OSSL_FN *a,
     size_t mod_size = OSSL_FN_mod_ctx_size(p, a, p);
     size_t kronecker_size = OSSL_FN_kronecker_ctx_size(p, p);
 
-    size_t nested_size = ctx_max_size(mod_exp_size,
-        ctx_max_size(mod_sqr_size,
-            ctx_max_size(mod_mul_size,
-                ctx_max_size(mod_size, kronecker_size))));
+    size_t nested_size = ossl_fn_ctx_max_size(mod_exp_size,
+        ossl_fn_ctx_max_size(mod_sqr_size,
+            ossl_fn_ctx_max_size(mod_mul_size,
+                ossl_fn_ctx_max_size(mod_size, kronecker_size))));
 
     if (own_size == 0 || nested_size == 0)
         return 0;
 
-    return ctx_add_size(own_size, nested_size);
+    return ossl_fn_ctx_add_size(own_size, nested_size);
 }

--- a/crypto/fn/fn_sqrt.c
+++ b/crypto/fn/fn_sqrt.c
@@ -408,8 +408,5 @@ size_t OSSL_FN_mod_sqrt_ctx_size(const OSSL_FN *ret, const OSSL_FN *a,
             ossl_fn_ctx_max_size(mod_mul_size,
                 ossl_fn_ctx_max_size(mod_size, kronecker_size))));
 
-    if (own_size == 0 || nested_size == 0)
-        return 0;
-
     return ossl_fn_ctx_add_size(own_size, nested_size);
 }

--- a/include/crypto/fn.h
+++ b/include/crypto/fn.h
@@ -193,6 +193,15 @@ OSSL_FN *OSSL_FN_copy(OSSL_FN *a, const OSSL_FN *b);
  */
 OSSL_FN *OSSL_FN_copy_truncate(OSSL_FN *a, const OSSL_FN *b);
 
+/*
+ * Sentinel return value for the OSSL_FN_*_ctx_size() family, meaning "this
+ * operation needs no context"; the caller may skip the OSSL_FN_CTX
+ * allocation and pass NULL, which such an operation must accept.  This is
+ * unambiguous because every genuine arena holds at least one frame, so 1
+ * is smaller than any possible real size.
+ */
+#define OSSL_FN_CTX_SIZE_NONE ((size_t)1)
+
 /**
  * Calculate the arena payload size for an OSSL_FN_CTX.
  *

--- a/include/crypto/fn_intern.h
+++ b/include/crypto/fn_intern.h
@@ -17,11 +17,35 @@
 #pragma once
 
 #include <stdbool.h>
+#include "internal/common.h"
+#include "internal/safe_math.h"
 #include "crypto/fn.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/*
+ * Context-size composition helpers, shared by all the *_ctx_size()
+ * functions, which all compose nested arena budgets the same way: sum the
+ * operation's own scratch frame with the largest nested frame it may need.
+ *
+ * ossl_fn_ctx_add_size() adds two sizes overflow-safely, returning 0 on
+ * overflow (0 is the "cannot size" sentinel for all *_ctx_size()
+ * functions).  ossl_fn_ctx_max_size() picks the larger of two sequential
+ * frame budgets.
+ */
+static ossl_inline ossl_unused size_t ossl_fn_ctx_add_size(size_t a, size_t b)
+{
+    if (ossl_unlikely(b > OSSL_SAFE_MATH_MAXU(size_t) - a))
+        return 0;
+    return a + b;
+}
+
+static ossl_inline ossl_unused size_t ossl_fn_ctx_max_size(size_t a, size_t b)
+{
+    return a > b ? a : b;
+}
 
 #if OSSL_FN_BYTES == 4
 /* 32-bit systems */

--- a/include/crypto/fn_intern.h
+++ b/include/crypto/fn_intern.h
@@ -30,21 +30,32 @@ extern "C" {
  * functions, which all compose nested arena budgets the same way: sum the
  * operation's own scratch frame with the largest nested frame it may need.
  *
- * ossl_fn_ctx_add_size() adds two sizes overflow-safely, returning 0 on
- * overflow (0 is the "cannot size" sentinel for all *_ctx_size()
- * functions).  ossl_fn_ctx_max_size() picks the larger of two sequential
- * frame budgets.
+ * ossl_fn_ctx_add_size() adds two sizes overflow-safely, and
+ * ossl_fn_ctx_max_size() picks the larger of two sequential frame budgets.
+ * Both honour the *_ctx_size() result convention: 0 (error) is sticky,
+ * OSSL_FN_CTX_SIZE_NONE counts as 0, and a resulting 0 maps back to
+ * OSSL_FN_CTX_SIZE_NONE.
  */
 static ossl_inline ossl_unused size_t ossl_fn_ctx_add_size(size_t a, size_t b)
 {
+    if (ossl_unlikely(a == 0 || b == 0))
+        return 0;
+    a = (a == OSSL_FN_CTX_SIZE_NONE) ? 0 : a;
+    b = (b == OSSL_FN_CTX_SIZE_NONE) ? 0 : b;
     if (ossl_unlikely(b > OSSL_SAFE_MATH_MAXU(size_t) - a))
         return 0;
-    return a + b;
+    a += b;
+    return (a == 0) ? OSSL_FN_CTX_SIZE_NONE : a;
 }
 
 static ossl_inline ossl_unused size_t ossl_fn_ctx_max_size(size_t a, size_t b)
 {
-    return a > b ? a : b;
+    if (ossl_unlikely(a == 0 || b == 0))
+        return 0;
+    a = (a == OSSL_FN_CTX_SIZE_NONE) ? 0 : a;
+    b = (b == OSSL_FN_CTX_SIZE_NONE) ? 0 : b;
+    a = (a > b) ? a : b;
+    return (a == 0) ? OSSL_FN_CTX_SIZE_NONE : a;
 }
 
 #if OSSL_FN_BYTES == 4

--- a/test/fn_internal_test.c
+++ b/test/fn_internal_test.c
@@ -442,6 +442,33 @@ end:
     return ret;
 }
 
+static int test_ctx_size_compose(void)
+{
+    size_t s1 = 42, s2 = 100;
+    size_t maxu = OSSL_SAFE_MATH_MAXU(size_t);
+
+    return TEST_size_t_eq(ossl_fn_ctx_add_size(s1, s2), s1 + s2)
+        && TEST_size_t_eq(ossl_fn_ctx_add_size(OSSL_FN_CTX_SIZE_NONE, s1),
+            s1)
+        && TEST_size_t_eq(ossl_fn_ctx_add_size(s1, OSSL_FN_CTX_SIZE_NONE),
+            s1)
+        && TEST_size_t_eq(ossl_fn_ctx_add_size(OSSL_FN_CTX_SIZE_NONE,
+                              OSSL_FN_CTX_SIZE_NONE),
+            OSSL_FN_CTX_SIZE_NONE)
+        && TEST_size_t_eq(ossl_fn_ctx_add_size(0, s1), 0)
+        && TEST_size_t_eq(ossl_fn_ctx_add_size(s1, 0), 0)
+        && TEST_size_t_eq(ossl_fn_ctx_add_size(maxu, s1), 0)
+        && TEST_size_t_eq(ossl_fn_ctx_max_size(s1, s2), s2)
+        && TEST_size_t_eq(ossl_fn_ctx_max_size(s2, s1), s2)
+        && TEST_size_t_eq(ossl_fn_ctx_max_size(OSSL_FN_CTX_SIZE_NONE, s1),
+            s1)
+        && TEST_size_t_eq(ossl_fn_ctx_max_size(OSSL_FN_CTX_SIZE_NONE,
+                              OSSL_FN_CTX_SIZE_NONE),
+            OSSL_FN_CTX_SIZE_NONE)
+        && TEST_size_t_eq(ossl_fn_ctx_max_size(0, s1), 0)
+        && TEST_size_t_eq(ossl_fn_ctx_max_size(s1, 0), 0);
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_struct);
@@ -452,6 +479,7 @@ int setup_tests(void)
     ADD_TEST(test_secure_ctx);
     ADD_TEST(test_secure_ctx_size);
     ADD_TEST(test_ctx_peak_used);
+    ADD_TEST(test_ctx_size_compose);
 
     return 1;
 }


### PR DESCRIPTION
Every `*_ctx_size()` composes nested arena budgets the same way: sum
the operation's own scratch frame with the largest nested frame it
may need.  Each `crypto/fn/fn_*.c` file carried its own file-static
`ctx_add_size()` / `ctx_max_size()` for this, and `crypto/fn/fn_local.h`
being off-limits outside `crypto/fn/` forces algorithm code to mirror
them.

Promote them to `ossl_fn_ctx_add_size()` / `ossl_fn_ctx_max_size()` in
`include/crypto/fn_intern.h`.

Assisted-by: Pi:moonshotai/kimi-k3
Signed-off-by: Richard Levitte <levitte@openssl.foundation>
