### PR TITLE
Don't use RWLOCKS in windows

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -9,10 +9,6 @@
 
 #include "internal/e_os.h"
 
-#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600
-#define USE_RWLOCK
-#endif
-
 #include <assert.h>
 #include <openssl/crypto.h>
 #include <crypto/cryptlib.h>


### PR DESCRIPTION
@quarckster analysis in https://github.com/openssl/openssl/issues/32145 Shows that SRWLOCK performance in windows is slower and much more jittery than it is with CRITICAL_SECTIONS.  This is a test to see if unilaterally using critical sections returns to our previous performance level

