### PR TITLE
Update pyca-cryptography submodule to unbreak test_external_pyca

### DIFF
--- a/test/recipes/95-test_external_pyca_data/cryptography.sh
+++ b/test/recipes/95-test_external_pyca_data/cryptography.sh
@@ -64,6 +64,9 @@ echo "------------------------------------------------------------------"
 echo "Building cryptography and installing test requirements"
 echo "------------------------------------------------------------------"
 OPENSSL_LIB_DIR="$O_LIB" OPENSSL_INCLUDE_DIR="$INSTALLTOP/include/" pip install . --group test
+# Replace the PyPI cryptography_vectors with the in-tree one so the
+# versions match when the submodule is not pinned at a PyPI release
+pip install ./vectors
 
 echo "------------------------------------------------------------------"
 echo "Print linked libraries"


### PR DESCRIPTION
The recently re-enabled `test_external_pyca` job (#32668) fails in the GCM invalid-tag tests. Commit f7d2d2acef (#32587) changed AEAD tag verification failures to leave `PROV_R_BAD_DECRYPT` on the error queue, while the pinned cryptography 50.0.0 revision raises `InvalidTag` only when the error queue is empty, so a bad tag now surfaces as a misleading `ValueError` about block length instead.

As proposed by @idrassi in https://github.com/openssl/openssl/pull/32743#issuecomment-5587502726, update the submodule to pyca/cryptography@e83bbe58e373536636baaa7c33a64a6e8f04c953 (51.0.0-dev1), which contains the upstream fix (pyca/cryptography#15596) and still supports Python 3.9 as used by the CI job.

Pinning a non-release snapshot exposes a second problem: the `test` dependency group installs `cryptography_vectors` from PyPI (currently 50.0.1), which no longer matches the built 51.0.0-dev1 and makes `test_vector_version` fail. The second commit installs the in-tree vectors package on top of the PyPI one so the versions stay in sync regardless of the pinned revision.