### PR TITLE
quic-radix: inject the path challenge flood only into 1-RTT packets

### DIFF
--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -663,8 +663,14 @@ static int mutcbk_inject_frames(const QUIC_PKT_HDR *hdrin,
      * packet send itself failed (tearing down the connection), so once
      * we're done mutating we must pass subsequent packets through
      * unmodified instead.
+     *
+     * PATH_CHALLENGE is only valid in 0-RTT and 1-RTT packets. The client can
+     * still send a Handshake packet after SSL_connect() returns, e.g. a PTO
+     * probe while HANDSHAKE_DONE is in flight, which the server drops once the
+     * handshake is confirmed. So only a 1-RTT packet is mutated and anything
+     * else passes through without consuming the one shot.
      */
-    if (mutctx->mutctx_done) {
+    if (mutctx->mutctx_done || hdrin->type != QUIC_PKT_TYPE_1RTT) {
         *hdrout = (QUIC_PKT_HDR *)hdrin;
         *iovecout = iovecin;
         *numout = numin;
@@ -777,6 +783,7 @@ DEF_FUNC(mount_flood)
 
     mutctx.mutctx_inject = inject_frames;
     mutctx.mutctx_inject_sz = sizeof(PATH_CHALLENGE_FRAMES) - 1;
+    mutctx.mutctx_done = 0;
     REQUIRE_SSL(ssl);
     ch = ossl_quic_conn_get_channel(ssl);
     if (!TEST_ptr(ch))


### PR DESCRIPTION
Fixes an intermittent failure of check_pc_flood on the shared macOS job, which now shows up as a 60 second hang of 70-test_quic_multistream.t since that recipe also runs quic_radix_test for qlog coverage.

The qlog output from the failed job shows the one shot mutator firing on the client's Handshake PTO probe sent before HANDSHAKE_DONE arrived. The server has already discarded its Handshake keys at that point and drops the packet, so the flood never reaches it and check_flood_stats spins until the script deadline.

Restrict the injection to 1-RTT packets and reset the one shot flag when the flood is mounted.

Failing job: https://github.com/openssl/openssl/actions/runs/34159824788/job/101859096532
