### PR TITLE
test: show a failing command's stderr under a quiet harness

### DIFF
--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -468,10 +468,22 @@ the function C<with> further down.
 =cut
 
 sub run {
-    my ($cmd, $display_cmd) = shift->(0);
+    my ($cmd, $display_cmd, @stderr_redirected) = shift->(0);
     my %opts = @_;
 
     return () if !$cmd;
+
+    my $harness_quiet = $ENV{HARNESS_ACTIVE} && !$ENV{HARNESS_VERBOSE};
+
+    # Under a non-verbose harness, STDERR is the harness's TAP pipe, which a
+    # chatty command must not write to.  Its stderr is kept in a file that is
+    # only written out, as TAP comments, when the command fails.  A stderr
+    # redirection made by the recipe is left alone.
+    my $stderr_file;
+    if ($harness_quiet && $^O ne 'VMS' && !grep { $_ } @stderr_redirected) {
+        $stderr_file = catfile(result_dir(), "stderr-$$.log");
+        $cmd .= " 2> ".$stderr_file;
+    }
 
     my $prefix = "";
     if ( $^O eq "VMS" ) { # VMS
@@ -535,7 +547,17 @@ sub run {
         ${$opts{statusvar}} = $r;
     }
 
-    my $harness_quiet = $ENV{HARNESS_ACTIVE} && !$ENV{HARNESS_VERBOSE};
+    if (defined $stderr_file) {
+        if (!$r && open(my $errfh, '<', $stderr_file)) {
+            while (<$errfh>) {
+                chomp;
+                print STDOUT "# $_\n";
+            }
+            close $errfh;
+        }
+        unlink $stderr_file;
+    }
+
     if ($^O eq 'VMS') {
         # Restore STDOUT / STDERR on VMS
         if ($harness_quiet) {
@@ -1384,13 +1406,11 @@ sub __decorate_cmd {
 
     my $display_cmd = "$cmdstr$stdin$stdout$stderr";
 
-    # Under a non-verbose harness nothing drains the command's stderr, so a
-    # chatty command can fill the pipe buffer and then block forever waiting
-    # for a reader that never comes.  Send it to the null device unless the
-    # recipe asked for a specific redirection.  On VMS this also keeps
-    # program output from escaping TAP::Parser.
-    $stderr=" 2> ".$null
-        unless $stderr || !$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE};
+    # VMS program output escapes TAP::Parser
+    if ($^O eq 'VMS') {
+        $stderr=" 2> ".$null
+            unless $stderr || !$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE};
+    }
 
     $cmdstr .= "$stdin$stdout$stderr";
 
@@ -1399,7 +1419,8 @@ sub __decorate_cmd {
         print STDERR "DEBUG[__decorate_cmd]: \$display_cmd = \"$display_cmd\"\n";
     }
 
-    return ($cmdstr, $display_cmd);
+    # Tell run() if the recipe redirected stderr itself
+    return ($cmdstr, $display_cmd, exists($opts{stderr}));
 }
 
 =head1 SEE ALSO


### PR DESCRIPTION
#32615 sends the stderr of every command a recipe runs to the null device under a non-verbose harness, which is how CI runs. Since then a failing C test shows only its "not ok" line in the log, for example https://github.com/openssl/openssl/actions/runs/34159824788/job/101859096532 where a 60 second timeout in quic_radix_test left no trace of the op.

Keep commands away from the harness pipe as #32615 does, but send stderr to a file in the result directory and print it as TAP comments when the command fails. Passing commands still add nothing to the pipe, so the situation from #32128 cannot recur, while failures get their diagnostics back.

Writing stderr out only after the command has finished loses nothing compared to before #32615. In non-verbose mode the harness itself buffers all output of a recipe and prints it only when a test fails, so a test killed from outside never had its stderr shown either. Verbose mode is untouched and still streams stderr live, which is the mode to use when hunting a hang. A timeout inside the test, like the radix script deadline, fails the command and gets its stderr printed.

A follow-up will make quic_radix_test print its script dump and execution trace only when a script fails, which removes the 3.8 MB of stderr per passing run that triggered #32128 in the first place.
