### PR TITLE
CI: fix capability assignments in cross compile workflows

### DIFF
--- a/.github/workflows/aarch64-more-cross-compiles.yml
+++ b/.github/workflows/aarch64-more-cross-compiles.yml
@@ -201,8 +201,8 @@ jobs:
 
     - name: Set OpenSSL caps environment
       if: matrix.platform.opensslcapsname != ''
-      run: echo "OPENSSL_${{ matrix.platform.opensslcapsname }}=\
-                 ${{ matrix.platform.opensslcaps }}" >> $GITHUB_ENV
+      run: |
+        echo "OPENSSL_${{ matrix.platform.opensslcapsname }}=${{ matrix.platform.opensslcaps }}" >> "$GITHUB_ENV"
 
     - name: get cpu info
       run: cat /proc/cpuinfo

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -228,8 +228,8 @@ jobs:
 
     - name: Set OpenSSL caps environment
       if: matrix.platform.opensslcapsname != ''
-      run: echo "OPENSSL_${{ matrix.platform.opensslcapsname }}=\
-                 ${{ matrix.platform.opensslcaps }}" >> $GITHUB_ENV
+      run: |
+        echo "OPENSSL_${{ matrix.platform.opensslcapsname }}=${{ matrix.platform.opensslcaps }}" >> "$GITHUB_ENV"
 
     - name: get cpu info
       if: matrix.platform.tests != 'none'

--- a/.github/workflows/riscv-more-cross-compiles.yml
+++ b/.github/workflows/riscv-more-cross-compiles.yml
@@ -326,8 +326,8 @@ jobs:
 
     - name: Set OpenSSL caps environment
       if: matrix.platform.opensslcapsname != ''
-      run: echo "OPENSSL_${{ matrix.platform.opensslcapsname }}=\
-                 ${{ matrix.platform.opensslcaps }}" >> $GITHUB_ENV
+      run: |
+        echo "OPENSSL_${{ matrix.platform.opensslcapsname }}=${{ matrix.platform.opensslcaps }}" >> "$GITHUB_ENV"
 
     - name: get cpu info
       run: cat /proc/cpuinfo


### PR DESCRIPTION
Found while reviewing #31929.

YAML folds the line break in the capability assignment into a space, leaving a literal backslash in the exported value. AArch64 then reads `\ 0x1d` as zero, while s390x rejects `\ z900` and ignores the override.

**This means the AArch64 CI jobs can pass without exercising the optimized code they're meant to test**, so regressions in that code can go unnoticed.

Put the assignment on a single shell line inside a literal YAML block in each affected workflow.

Verified locally that YAML parsing followed by Bash preserves the intended values, including both s390x mask formats.

<!-- [aarch64 ci] [riscv ci] -->