### PR TITLE
Fix ChaCha20-Poly1305 AAD handling after empty EVP_Cipher() call

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -283,10 +283,22 @@ static int chacha20_poly1305_cipher(void *vctx, unsigned char *out,
     const unsigned char *in, size_t inl)
 {
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
+    PROV_CHACHA20_POLY1305_CTX *cctx = (PROV_CHACHA20_POLY1305_CTX *)vctx;
     PROV_CIPHER_HW_CHACHA20_POLY1305 *hw = (PROV_CIPHER_HW_CHACHA20_POLY1305 *)ctx->hw;
 
     if (!ossl_prov_is_running())
         return 0;
+
+    /*
+     * An empty non-final call must not pad pending AAD: len.text would remain
+     * zero, allowing further AAD updates after the padding. TLS record mode
+     * still requires the full record, including the tag.
+     */
+    if (cctx->tls_payload_length == NO_TLS_PAYLOAD_LENGTH
+        && in != NULL && inl == 0) {
+        *outl = 0;
+        return 1;
+    }
 
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4495,6 +4495,145 @@ err:
     EVP_CIPHER_free(cipher);
     return ret;
 }
+
+/*
+ * These distinct AAD inputs previously produced the same tag when split
+ * around an empty EVP_Cipher() call.
+ */
+static int test_chacha20_poly1305_zero_length_cipher(void)
+{
+    static const unsigned char key[32] = { 1 };
+    static const unsigned char iv[12] = { 2 };
+    static const unsigned char plaintext[] = { 0x42 };
+    /* aad[0] is 61 62 followed by 16 zero bytes, split after 1 byte. */
+    /* aad[1] is 61, 15 zero bytes, 62, 00, split after 17 bytes. */
+    static const unsigned char aad[2][18] = {
+        { 0x61, 0x62 },
+        { 0x61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x62, 0 }
+    };
+    static const int split[2] = { 1, 17 };
+    unsigned char ciphertext[2][sizeof(plaintext)];
+    unsigned char tag[2][16], ref_tag[16];
+    unsigned char scratch[1], dummy = 0, recovered[sizeof(plaintext)];
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *cipher = NULL;
+    int i, outl, finl, ret = 0;
+
+    if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, "ChaCha20-Poly1305",
+                      testpropq)))
+        goto end;
+
+    /* Reference: aad[0] fed in one update, no empty call. */
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_true(EVP_EncryptInit_ex2(ctx, cipher, key, iv, NULL))
+        || !TEST_true(EVP_EncryptUpdate(ctx, NULL, &outl, aad[0],
+            (int)sizeof(aad[0])))
+        || !TEST_true(EVP_EncryptUpdate(ctx, ciphertext[0], &outl, plaintext,
+            (int)sizeof(plaintext)))
+        || !TEST_true(EVP_EncryptFinal_ex(ctx, ciphertext[0] + outl, &finl))
+        || !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG,
+                            sizeof(ref_tag), ref_tag),
+            0))
+        goto end;
+    EVP_CIPHER_CTX_free(ctx);
+    ctx = NULL;
+
+    /* Encrypt with each AAD split around an empty EVP_Cipher() call. */
+    for (i = 0; i < 2; i++) {
+        if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+            || !TEST_true(EVP_EncryptInit_ex2(ctx, cipher, key, iv, NULL))
+            || !TEST_true(EVP_EncryptUpdate(ctx, NULL, &outl, aad[i],
+                split[i]))
+            /*
+             * EVP_Cipher() returns the number of bytes written for a
+             * custom cipher, so 0 is the expected success value here.
+             */
+            || !TEST_int_eq(EVP_Cipher(ctx, scratch, &dummy, 0), 0)
+            || !TEST_true(EVP_EncryptUpdate(ctx, NULL, &outl,
+                aad[i] + split[i],
+                (int)sizeof(aad[i]) - split[i]))
+            || !TEST_true(EVP_EncryptUpdate(ctx, ciphertext[i], &outl,
+                plaintext, (int)sizeof(plaintext)))
+            || !TEST_true(EVP_EncryptFinal_ex(ctx, ciphertext[i] + outl,
+                &finl))
+            || !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG,
+                                sizeof(tag[i]), tag[i]),
+                0))
+            goto end;
+        EVP_CIPHER_CTX_free(ctx);
+        ctx = NULL;
+    }
+
+    /* Check tag transparency and distinct tags for the two AAD values. */
+    if (!TEST_mem_eq(tag[0], sizeof(tag[0]), ref_tag, sizeof(ref_tag))
+        || !TEST_mem_ne(tag[0], sizeof(tag[0]), tag[1], sizeof(tag[1])))
+        goto end;
+
+    /* Decryption with the matching AAD accepts the tag. */
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_true(EVP_DecryptInit_ex2(ctx, cipher, key, iv, NULL))
+        || !TEST_true(EVP_DecryptUpdate(ctx, NULL, &outl, aad[0], split[0]))
+        || !TEST_int_eq(EVP_Cipher(ctx, scratch, &dummy, 0), 0)
+        || !TEST_true(EVP_DecryptUpdate(ctx, NULL, &outl, aad[0] + split[0],
+            (int)sizeof(aad[0]) - split[0]))
+        || !TEST_true(EVP_DecryptUpdate(ctx, recovered, &outl, ciphertext[0],
+            (int)sizeof(ciphertext[0])))
+        || !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG,
+                            sizeof(tag[0]), tag[0]),
+            0)
+        || !TEST_true(EVP_DecryptFinal_ex(ctx, recovered + outl, &finl))
+        || !TEST_mem_eq(recovered, sizeof(recovered), plaintext,
+            sizeof(plaintext)))
+        goto end;
+    EVP_CIPHER_CTX_free(ctx);
+    ctx = NULL;
+
+    /* Decryption with the other AAD rejects the tag. */
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_true(EVP_DecryptInit_ex2(ctx, cipher, key, iv, NULL))
+        || !TEST_true(EVP_DecryptUpdate(ctx, NULL, &outl, aad[1], split[1]))
+        || !TEST_int_eq(EVP_Cipher(ctx, scratch, &dummy, 0), 0)
+        || !TEST_true(EVP_DecryptUpdate(ctx, NULL, &outl, aad[1] + split[1],
+            (int)sizeof(aad[1]) - split[1]))
+        || !TEST_true(EVP_DecryptUpdate(ctx, recovered, &outl, ciphertext[0],
+            (int)sizeof(ciphertext[0])))
+        || !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG,
+                            sizeof(tag[0]), tag[0]),
+            0)
+        || !TEST_false(EVP_DecryptFinal_ex(ctx, recovered + outl, &finl)))
+        goto end;
+    ERR_clear_error();
+    EVP_CIPHER_CTX_free(ctx);
+    ctx = NULL;
+
+    /*
+     * A TLS record with no plaintext still requires a 16-byte tag.
+     * The TLS AAD record length is 0 for encryption and 16 for decryption;
+     * a zero-length EVP_Cipher() call must fail in both cases.
+     */
+    for (i = 0; i < 2; i++) {
+        unsigned char tls_aad[EVP_AEAD_TLS1_AAD_LEN] = { 0 };
+
+        tls_aad[EVP_AEAD_TLS1_AAD_LEN - 1] = (i == 0) ? 0 : 16;
+        if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+            || !(i == 0
+                    ? TEST_true(EVP_EncryptInit_ex2(ctx, cipher, key, iv, NULL))
+                    : TEST_true(EVP_DecryptInit_ex2(ctx, cipher, key, iv, NULL)))
+            || !TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_TLS1_AAD,
+                                sizeof(tls_aad), tls_aad),
+                0)
+            || !TEST_int_eq(EVP_Cipher(ctx, scratch, &dummy, 0), -1))
+            goto end;
+        EVP_CIPHER_CTX_free(ctx);
+        ctx = NULL;
+    }
+
+    ret = 1;
+end:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    return ret;
+}
 #endif /* !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305) */
 
 #ifndef OPENSSL_NO_DH
@@ -10148,6 +10287,7 @@ int setup_tests(void)
 #endif
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     ADD_TEST(test_decrypt_null_chunks);
+    ADD_TEST(test_chacha20_poly1305_zero_length_cipher);
 #endif
 #ifndef OPENSSL_NO_DH
     ADD_TEST(test_DH_priv_pub);


### PR DESCRIPTION
Fixes #32752

An `EVP_Cipher(ctx, out, in, 0)` call with non-NULL input and output between two AAD fragments entered the provider's payload path, padded the pending AAD and cleared `ctx->aad`, while leaving `ctx->len.text` at zero. A subsequent AAD update was therefore accepted after the padding. The distinct AAD inputs in the issue then produced identical Poly1305 transcripts and tags, and cross-verified.

Treat non-final calls with zero input length as no-ops outside TLS record mode, matching the existing Update behavior. Preserve NULL-input finalization and the TLS full-record path. A zero-length `EVP_Cipher` call in TLS record mode continues to fail; a valid record with zero plaintext still includes its authentication tag.

Tags affected by the extra AAD padding change to the RFC 8439 result. Such previously generated tags will fail verification against the corrected transcript.

The new regression checks tag transparency against an unsplit AAD reference, distinct tags for the issue's two AAD values, successful decryption with matching AAD, and rejection with the other AAD. It also checks that a zero-length `EVP_Cipher` call in TLS record mode still fails in both directions. It fails against the parent implementation with the malformed tag from the issue.

The provider issue also reproduces on the 4.0, 3.6, 3.5, and 3.4 revisions listed in the issue. The provider guard ports to those branches; 3.6 requires editing `cipher_chacha20_poly1305.c.in`, and the test registration needs a small adjustment to preserve the adjacent stable-branch late-AAD test. The relevant hardware padding logic is shared, although the files are not byte-identical.

The 3.x branches additionally retain a separate legacy ChaCha20-Poly1305 implementation in `crypto/evp/e_chacha20_poly1305.c`. Review confirmed the same collision there, including through an empty `EVP_CipherUpdate` call. Those branches need a companion legacy fix and regression coverage alongside the provider backport.

##### Checklist

- [x] tests are added or updated



