### PR TITLE
refcount: declare Windows CRYPTO_REF_COUNT as volatile long

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -96,18 +96,18 @@ static __inline__ int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 #define HAVE_ATOMICS 1
 
 typedef struct {
-    volatile int val;
+    volatile long val;
 } CRYPTO_REF_COUNT;
 
 static __inline bool CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, 1) + 1;
+    *ret = _InterlockedExchangeAdd(&refcnt->val, 1) + 1;
     return true;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, -1) - 1;
+    *ret = _InterlockedExchangeAdd(&refcnt->val, -1) - 1;
     return 1;
 }
 
@@ -116,7 +116,7 @@ static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 #define HAVE_ATOMICS 1
 
 typedef struct {
-    volatile int val;
+    volatile long val;
 } CRYPTO_REF_COUNT;
 
 #if (defined(_M_ARM) && _M_ARM >= 7) || defined(_M_ARM64)


### PR DESCRIPTION
_InterlockedExchangeAdd() is prototyped as

    LONG _InterlockedExchangeAdd(volatile LONG *, LONG)

but CRYPTO_REF_COUNT held a volatile int. The MSVC branch passed &refcnt->val straight in, which does not compile:

    refcount.h(189): note: 'LONG _InterlockedExchangeAdd(volatile LONG *,LONG)':
        cannot convert argument 1 from 'volatile int *' to 'volatile LONG *'
    refcount.h(189): note: Types pointed to are unrelated

Declare val as volatile long in both the __ICL/_WIN32 and the _MSC_VER variants and drop the cast, so the object type matches what the intrinsic operates on.

Fixes: https://github.com/openssl/openssl/issues/21080

