### PR TITLE
[master] `CHANGES.md`, `NEWS.md`: update for 4.1.0-alpha1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,76 +32,76 @@ OpenSSL 4.1
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
- * Refactored remaining cipher `OSSL_PARAM` name parsing so that
-   automatically generated parsers are used instead of
-   `OSSL_PARAM_locate()` calls.  This should ensure that the list
-   of acceptable parameters better matches those which are actually
-   processed.  It should also provide a small performance improvement,
-   because repeated iteration over passed parameter arrays is avoided.
+ * Refactored remaining cipher `OSSL_PARAM` name parsing so that automatically
+   generated parsers are used instead of `OSSL_PARAM_locate()` calls.
+   This should ensure that the list of acceptable parameters better matches
+   those which are actually processed.  It should also provide a small
+   performance improvement, because repeated iteration over passed parameter
+   arrays is avoided.
 
    *Dr Paul Dale*
 
- * Added a `seed_strict` option to the `random` configuration section
+ * Added a `seed_strict` option to the `random` configuration section,
    which makes the configured random seed source strictly enforced when
    a provider (such as the FIPS provider) requests entropy or a nonce.
 
-   When a provider requests seeding material before the primary DRBG has
-   been created, the request falls back to the operating system entropy
+   When a provider requests seeding material before the primary DRBG
+   has been created, the request falls back to the operating system entropy
    sources, because the seed source only comes into existence as a side
    effect of creating the primary DRBG.  Whether a configured seed source
-   is used therefore depends on operation order.  With `seed_strict`
-   enabled, the seed source is instead instantiated on demand and an
-   error is reported if it cannot be used.  The option is off by default
-   with two exceptions: the `JITTER` seed source seeds strictly unless
-   the option disables it and `enable-fips-jitter` builds always seed
-   strictly.  Additionally, the property query used to fetch the default
-   seed source can now be set at build time with
-   `-DOPENSSL_DEFAULT_SEED_PROPQ`.
+   is used therefore depends on operation order.  With `seed_strict` enabled,
+   the seed source is instead instantiated on demand and an error is reported
+   if it cannot be used.  The option is off by default with two exceptions:
+   the `JITTER` seed source seeds strictly unless the option disables it,
+   and `enable-fips-jitter` builds always seed strictly.  Additionally,
+   the property query used to fetch the default seed source can now be set
+   at build time with `-DOPENSSL_DEFAULT_SEED_PROPQ`.
 
    *Jakub Zelenka*
 
  * Fixed a bug where a TLS 1.3 session ticket could retain a stale ALPN
-   protocol from an earlier connection after a resumption negotiated a
-   different protocol (or none), on both the server and the client,
+   protocol from an earlier connection after a resumption negotiated
+   a different protocol (or none), on both the server and the client,
    which could otherwise affect a later 0-RTT decision.
 
    *Daniel Kubec and Viktor Dukhovni*
 
- * Implement extended support of metadata for symmetric key objects (EVP_SKEY).
+ * Implemented extended support of metadata for symmetric key objects
+   (`EVP_SKEY`).
 
    *Dmitry Belyavskiy*
 
- * Declare support for AArch64 Guarded Control Stack (GCS) in assembly code.
+ * Declared support for AArch64 Guarded Control Stack (GCS) in assembly code.
 
    When building with compilers that support GCS (Clang 18+, GCC 15+),
-   assembly modules are marked as compatible when branch protection is
-   enabled (e.g. -mbranch-protection=standard). No functional changes to
-   the assembly implementations are required, but compliance ensures
+   assembly modules are marked as compatible when branch protection
+   is enabled (e.g. `-mbranch-protection=standard`).  No functional changes
+   to the assembly implementations are required, but compliance ensures
    correct operation with shadow stack enforcement.
 
-   *Guillaume Gardet*
-   *Gowtham Suresh Kumar*
+   *Guillaume Gardet and Gowtham Suresh Kumar*
 
- * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
-   manpage for details.
+ * Added support for DTLS 1.3 ([RFC 9147]).
+   Refer to the `ossl-guide-dtlsv13(7)` manual page for details.
 
    *Frederik Wedel-Heinen and Ryan Hooper*
 
- * Added DTLS support to the SSL listener API. SSL_new_listener() can now
+ * Added DTLS support to the SSL listener API.  `SSL_new_listener()` can now
    create a DTLS listener that demultiplexes incoming datagrams into per-peer
-   connections accepted with SSL_accept_connection(). The listener performs
-   address validation (HelloVerifyRequest for DTLS 1.0/1.2, HelloRetryRequest
-   cookie for DTLS 1.3) by default; pass SSL_LISTENER_FLAG_NO_VALIDATE to
-   disable it. Refer to the SSL_new_listener(3) manpage for details.
+   connections accepted with `SSL_accept_connection()`.  The listener performs
+   address validation (`HelloVerifyRequest` for DTLS 1.0/1.2,
+   `HelloRetryRequest` cookie for DTLS 1.3) by default;  pass
+   `SSL_LISTENER_FLAG_NO_VALIDATE` to disable it.  Refer
+   to the `SSL_new_listener(3)` manual page for details.
 
    *Ryan Hooper*
 
- * Added configurable values for DTLS listeners, accessed via
-   SSL_get_value_uint() / SSL_set_value_uint():
-   SSL_VALUE_DTLS_LISTENER_MAX_PENDING_CONNS,
-   SSL_VALUE_DTLS_LISTENER_PENDING_TIMEOUT and
-   SSL_VALUE_DTLS_LISTENER_MAX_DGRAM_SIZE. Refer to the SSL_get_value_uint(3)
-   manpage for details.
+ * Added configurable values for DTLS listeners, accessed
+   via `SSL_get_value_uint()`/`SSL_set_value_uint()`:
+   `SSL_VALUE_DTLS_LISTENER_MAX_PENDING_CONNS`,
+   `SSL_VALUE_DTLS_LISTENER_PENDING_TIMEOUT`,
+   and `SSL_VALUE_DTLS_LISTENER_MAX_DGRAM_SIZE`. Refer
+   to the `SSL_get_value_uint(3)` manual page for details.
 
    *Ryan Hooper*
 
@@ -113,58 +113,58 @@ OpenSSL 4.1
    *Mounir IDRASSI*
 
  * Fixed QUIC child objects to inherit the effective flags of their explicit
-   event domain. `SSL_get0_domain()` now reports that domain for connections
+   event domain.  `SSL_get0_domain()` now reports that domain for connections
    and streams in the hierarchy.
 
    *Mounir IDRASSI*
 
  * Fixed TLS 1.3 clients to encrypt 0-RTT early data with the first offered
-   PSK identity (RFC 9846 section 4.3.10) when a 0-RTT-capable resumption
+   PSK identity ([RFC 9846 Section 4.3.10]) when a 0-RTT-capable resumption
    ticket has aged out and an external PSK is offered in its place. The early
-   data was being encrypted with the retired ticket's secret rather than the
-   external PSK's, causing the server to reject it with a bad record MAC.
+   data was being encrypted with the retired ticket's secret, rather than
+   the external PSK's, causing the server to reject it with a bad record MAC.
 
    *Viktor Dukhovni*
 
  * Fixed TLS 1.3 servers to reject early data when a resumed PSK's
-   ticket age is outside tolerance, per RFC 9846, instead of accepting
+   ticket age is outside tolerance, per [RFC 9846], instead of accepting
    0-RTT data from a ticket that has aged out.
 
    *Daniel Kubec*
 
- * TLS clients no longer send the TLS padding extension (RFC 7685). It was
-   only ever sent when `SSL_OP_TLSEXT_PADDING` was set, to work around a
-   ClientHello-length bug in F5 middleboxes; the fix shipped long ago and
-   the affected hardware is long out of support, so nothing should still
+ * TLS clients no longer send the TLS padding extension ([RFC 7685]).  It was
+   only ever sent when `SSL_OP_TLSEXT_PADDING` was set, to work around
+   a `ClientHello` length bug in F5 middleboxes;  the fix shipped long ago
+   and the affected hardware is long out of support, so nothing should still
    be running the problematic version.
-   `SSL_OP_TLSEXT_PADDING` is now a no-op retained for compatibility, and
-   is no longer included in `SSL_OP_ALL`.
+   `SSL_OP_TLSEXT_PADDING` is now a no-op retained for compatibility,
+   and is no longer included in `SSL_OP_ALL`.
 
    *Bob Beck*
 
- * Repeated fields in the `basicConstraints`, `basicAttConstraints`,
-   and `policyConstraints` X.509v3 extension configurations are now rejected
-   instead of silently using the last value.
+ * Fixed X.509v3 extension configuration parsing to reject repeated fields
+   in the `basicConstraints`, `basicAttConstraints`, and `policyConstraints`
+   X.509v3 extension configurations, instead of silently using the last value.
 
    *Adam Tabak*
 
- * The `tsget` utility now uses `Net::Curl::Easy` (from the `Net-Curl` CPAN
-   distribution) instead of the abandoned `WWW::Curl::Easy`.  Users who relied
-   on `tsget` must install `Net::Curl::Easy` before upgrading.
+ * Changed `tsget` utility to use `Net::Curl::Easy` (from the `Net-Curl` CPAN
+   distribution) instead of the abandoned `WWW::Curl::Easy`.  Users who rely
+   on `tsget` should install `Net::Curl::Easy` before upgrading.
 
    *Shreenidhi Shedi*
 
- * Added `CMS_add_standard_smimecap_ex()`, which populates an SMIMECapabilities
-   list using `EVP_CIPHER_fetch()` and `EVP_MD_fetch()` so that only algorithms
-   available in the active providers are advertised.  `PKCS7_sign_add_signer()`
-   was updated in the same way, so that legacy ciphers such as RC2 and DES are
-   no longer included in SMIMECapabilities by default when only the default
-   provider is loaded.
+ * Added `CMS_add_standard_smimecap_ex()` API function, which populates
+   an `SMIMECapabilities` list using `EVP_CIPHER_fetch()` and `EVP_MD_fetch()`
+   so that only algorithms available in the active providers are advertised.
+   `PKCS7_sign_add_signer()` was updated in the same way, so that legacy
+   ciphers, such as RC2 and DES, are no longer included in `SMIMECapabilities`
+   by default when only the default provider is loaded.
 
    *Todd Short*
 
- * Added various optimizations for the Elbrus2000 architecture in the
-   cryptographic and BN code.
+ * Added various optimizations for the Elbrus2000 architecture
+   in the cryptographic and BN code.
 
    *Gleb Popov*
 
@@ -178,22 +178,22 @@ OpenSSL 4.1
 
    *Viktor Dukhovni*
 
- * Added AVX512 optimized SHAKE x4 operations for ML-DSA on `x86_64`.
+ * Added AVX-512-optimized SHAKE x4 operations for ML-DSA on `x86_64`.
 
    *Marcel Cornu and Tomasz Kantecki*
 
- * EC key point format simplification.
+ * Simplified EC key point format handling.
 
    The point conversion form (compressed, uncompressed, or hybrid)
    is now a single value on the `EC_GROUP` and round-trips
    unchanged through import and export of `EC_KEY` objects.
 
-   Freshly generated keys have their public point encoded in
-   uncompressed form.  A `point-format` supplied at key generation
-   time via `OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT` is
-   validated (an invalid value is rejected) but otherwise ignored
-   on the generated key.  EC parameter generation continues to
-   honour the requested form on the group's generator; imported
+   Freshly generated keys have their public point encoded
+   in uncompressed form.  A `point-format` supplied at key generation
+   time via `OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT`
+   is validated (an invalid value is rejected) but otherwise ignored
+   on the generated key.  EC parameter generation continues
+   to honour the requested form on the group's generator;  imported
    keys keep their form.
 
    The `ec_point_formats` extension no longer affects TLS 1.2
@@ -202,32 +202,33 @@ OpenSSL 4.1
    and sends any EC certificate it has regardless of point form.
    TLS 1.3 disregards the extension entirely.
 
-   The RFC 4492/8422 section 5.1.2 requirement that the peer's
-   point-format list contain "uncompressed" is now enforced on
-   both sides (previously client-only), and only when an ECC
-   TLS 1.2 ciphersuite is negotiated -- a missing "uncompressed"
-   is ignored under TLS 1.3 or with a non-ECC cipher.
+   The [RFC 4492][RFC 4492 Section 5.1.2]/[8422 section 5.1.2][RFC 8422 Section 5.1.2]
+   requirement that the peer's point-format list contain "uncompressed" is now
+   enforced on both sides (previously client-only), and only when an ECC TLS 1.2
+   ciphersuite is negotiated—a missing "uncompressed" is ignored under TLS 1.3
+   or with a non-ECC cipher.
 
    *Viktor Dukhovni*
 
- * Added unit tests setup activated via `enable-unit-tests` option. This works
+ * Added unit tests setup activated via `enable-unit-tests` option.  This works
    only on platforms with ld `--wrap` support (Linux, BSD).
 
    *Jakub Zelenka*
 
  * Deprecated the `enable-unit-test` configure option and the
-   `SSL_test_functions()` function. Both will be removed in OpenSSL 5.0.
+   `SSL_test_functions()` function.  Both will be removed in OpenSSL 5.0.
 
    *Jakub Zelenka*
 
- * Deprecated BIO_snprintf() and BIO_vsnprintf(). C99 snprintf() is now
-   universally available, and the wrappers return -1 on truncation rather
-   than the would-have-been length, so callers reaching for the standard
-   idiom by reflex produce bugs. Use snprintf() and vsnprintf() directly.
+ * Deprecated `BIO_snprintf()` and `BIO_vsnprintf()`.  `snprintf()`, being part
+   of C99 standard, that is the baseline for OpenSSL since version 3.6,
+   is now considered universally available;  moreover, the fact that `BIO_*()`
+   functions return -1 on truncation, rather than the would-have-been length,
+   makes their usage error-prone.  Use `snprintf()` and `vsnprintf()` directly.
 
    *Bob Beck*
 
- * Added -testmode option for `s_time` app.
+ * Added `-testmode` option for `openssl s_time` command.
 
    *Jakub Zelenka*
 
@@ -237,31 +238,31 @@ OpenSSL 4.1
 
    *Mounir IDRASSI*
 
- * Added support for Ed25519 and Ed448 certificates in DTLS 1.2. Previously,
+ * Added support for Ed25519 and Ed448 certificates in DTLS 1.2.  Previously,
    these certificate types were only supported in TLS 1.2 and TLS 1.3.
 
    *Adriano Sela Aviles*
 
- * Add a build target to provide MSVC 2013 hacks in a C99 world.
-   The build target adds internal functions to provide C99 functions
-   that are not present with MSVC 2013.
+ * Added `VC-WIN32-MSVC2013` and `VC-WIN64A-MSVC2013` build targets to provide
+   internal functions for bridging the gaps in C99 standard support
+   that are present in MSVC 2013.
 
    *Bob Beck*
 
- * SubjectPublicKeyInfo blobs whose AlgorithmIdentifier uses id-RSAES-OAEP
-   (`NID_rsaesOaep`, 1.2.840.113549.1.1.7) with a plain RSAPublicKey body
-   are now decoded as RSA keys.  This is required for interoperability
-   with TPM 1.2 Endorsement Key certificates per TCG Credential Profiles
-   V1.2 section 3.2.7.  The OAEP AlgorithmIdentifier parameters are not
-   interpreted.
+ * Improved interoperability with TPM 1.2 Endorsement Key certificates
+   per [TCG Credential Profiles specification Version 1.2, Section 3.2.7]:
+   `SubjectPublicKeyInfo` blobs whose `AlgorithmIdentifier` uses
+   `id-RSAES-OAEP` (`NID_rsaesOaep`, 1.2.840.113549.1.1.7) with a plain
+   `RSAPublicKey` body are now decoded as RSA keys.  The OAEP
+   `AlgorithmIdentifier` parameters are not interpreted.
 
    *Craig Lorentzen*
 
- * Do not issue TLS1.3 session tickets if the server has explicitly disabled
+ * Do not issue TLS 1.3 session tickets if the server has explicitly disabled
    them via `SSL_OP_NO_TICKET` and also turned off the session cache with
    `SSL_SESS_CACHE_OFF`. Both conditions together indicate a clear intent to
-   suppress resumption, so sending NewSessionTicket messages would be wasteful
-   and misleading. TLS1.3 client that does not send the `psk_key_exchange_modes`
+   suppress resumption, so sending `NewSessionTicket` messages would be wasteful
+   and misleading. TLS 1.3 client that does not send the `psk_key_exchange_modes`
    extension, or that sends it together with [RFC 9149] parameters such as
    `new_session_count = 0` or `resumption_count = 0`, is effectively signaling
    no interest in session tickets and session resumption.
@@ -272,77 +273,70 @@ OpenSSL 4.1
 
    *Jakub Zelenka*
 
- * Windows-on-Itanium (VC-WIN64I) support was dropped - the Itanium
-   architecture has been discontinued and the platform is no longer
-   supported or tested.
+ * Dropped Windows-on-Itanium (`VC-WIN64I`) and Windows CE (`VC-CE`) targets
+   from Configurations.
 
    *Bob Beck*
 
- * Windows CE support was dropped - Windows CE has been unsupported since
-   2018 and does not have a modern C99 toolchain.
-
-   *Bob Beck*
-
- * Improved DTLS handshake robustness under UDP reordering by buffering and
-   replaying early ChangeCipherSpec (CCS) records at the expected state.
+ * Improved DTLS handshake robustness under UDP reordering by buffering
+   and replaying early `ChangeCipherSpec` (CCS) records at the expected state.
 
    *Tong Li*
 
- * Header files in OpenSSL are being changed to reflect modern development
-   practices - Include files should all be guarded for inclusion by a define
-   and must be self contained, meaning they include all dependencies they need
-   to compile on their own. Headers have been changed to include guards and
-   to include the dependencies they require.  Doing this will help the
-   future use of more modern tooling.
+ * Updated header files to reflect modern development practices: all include
+   files now have header guards and they are self-contained (they include all
+   dependencies they need to be included on their own).
 
    *Bob Beck*
 
- *  `ASN1_STRING_set()` and `ASN1_STRING_length()` have been
-    deprecated. The replacement functions `ASN1_STRING_set1_data()` or
-    `ASN1_STRING_set1_string()`, and `ASN1_STRING_get_length()` should be
-    used in their place. This prepares the ASN1_STRING type to support
-    modern size_t length values in the future.
+ * Deprecated `ASN1_STRING_set()` and `ASN1_STRING_length()`.  The replacement
+   functions `ASN1_STRING_set1_data()` or `ASN1_STRING_set1_string()`,
+   and `ASN1_STRING_get_length()` should be used in their place.  This prepares
+   the `ASN1_STRING` type to support modern `size_t` length values
+   in the future.
 
-    *Bob Beck*
+   *Bob Beck*
 
- * `EVP_CIPHER_CTX_get_num()` and `EVP_CIPHER_CTX_set_num()' have been deprecated.
-
-   Refer to ossl-migration-guide(7) for more info.
+ * Deprecated `EVP_CIPHER_CTX_get_num()` and `EVP_CIPHER_CTX_set_num()`
+   functions.  Refer to `ossl-migration-guide(7)` for more info.
 
    *Shane Lontis*
 
- * The functions `ASN1_BIT_STRING_name_print()`, `ASN1_BIT_STRING_num_asc(),
-   and `ASN1_BIT_STRING_set_asc()`, have been deprecated. Refer to the manual
+ * Deprecated `ASN1_BIT_STRING_name_print()`, `ASN1_BIT_STRING_num_asc()`,
+   and `ASN1_BIT_STRING_set_asc()` functions. Refer to the manual
    pages for more information.
 
    *Bob Beck*
 
- * The API functions `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`, and
-   `CRYPTO_atomic_cmp_exch_ptr` have been added to libcrypto.
+ * Added `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`,
+   and `CRYPTO_atomic_cmp_exch_ptr` functions to `libcrypto`, that implement
+   the respective atomic operations with a locking-based fallback on platforms
+   that do not support them.
 
    *Neil Horman*
 
- * The `openssl pkeyutl` command now uses memory-mapped I/O when reading
-   raw input from a file for oneshot sign/verify operations (such as Ed25519,
-   Ed448, and ML-DSA) on platforms that support it (Unix-like). The
-   `openssl dgst` command uses the same approach for one-shot sign/verify
-   when the input is from a file, removing the previous 16 MB limit for
-   file-based input. This improves performance and supports large files
-   without doubling memory use. Other platforms and stdin input continue to
-   use the existing buffer-based path.
+ * Added ability to utilise memory-mapped I/O when reading raw input
+   from a file for one-shot sign/verify operations (such as Ed25519,
+   Ed448, and ML-DSA) to `openssl pkeyutl` command on platforms
+   that support it (Unix-like).  The `openssl dgst` command uses the same
+   approach for one-shot sign/verify when the input is from a file, removing
+   the previous 16 MB limit for file-based input.  This improves performance
+   and supports large files without doubling memory use.  Other platforms
+   and `stdin` input continue to use the existing buffer-based implementation.
 
    *John Claus*
 
-* 'X509_check_host()', 'X509_check_email()', 'X509_check_ip()', and 'X509_check_ip_asc()'
-   have been deprecated. Applications should migrate to setting a reference identifier
-   to check using 'X509_VERIFY_PARAM_set1_host()', 'X509_VERIFY_PARAM_set1_email()', or
-   X509_VERIFY_PARAM_set1_ip_asc()', and using 'X509_verify_cert()'.
+ * Deprecated `X509_check_host()`, `X509_check_email()`, `X509_check_ip()`,
+   and `X509_check_ip_asc()` functions.  Applications should migrate to setting
+   a reference identifier to check using `X509_VERIFY_PARAM_set1_host()`,
+   `X509_VERIFY_PARAM_set1_email()`, or `X509_VERIFY_PARAM_set1_ip_asc()`,
+   and using `X509_verify_cert()`.
 
    *Bob Beck*
 
- * The API function `ASN1_STRING_new_not_owned` has been added to the
-   libcrypto. It provides the ability to construct an ASN1_STRING with data
-   for which ownership is not taken by the created ASN1_STRING object.
+ * Added `ASN1_STRING_new_not_owned()` function to `libcrypto`.  It provides
+   the ability to construct an `ASN1_STRING` with data for which ownership
+   is not taken by the created `ASN1_STRING` object.
 
    *Bob Beck*
 
@@ -352,113 +346,117 @@ OpenSSL 4.1
 
    *John Claus*
 
- * Added AVX2 optimized ML-DSA NTT operations on `x86_64`.
+ * Added AVX2-optimized ML-DSA NTT operations on `x86_64`.
 
    *Marcel Cornu and Tomasz Kantecki*
 
- * X509 certificate verification no longer consults the subject
-   distinguished name by default.  Previously, when a certificate
-   contained no subject alternative name of the type being checked,
-   the subject commonName (for host name checks) or emailAddress (for
-   email checks) was matched instead.  The subject dn is now checked
-   only when the `X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT` flag is set.
-   Correspondingly, during chain verification DNS name constraints are
-   applied to the subject commonName of the leaf certificate only when
-   that flag is set, rather than whenever the leaf had no DNS subject
-   alternative name.
+ * Updated X.509 certificate verification to no longer consult the subject
+   distinguished name (DN) by default.  Previously, when a certificate contained
+   no subject alternative name of the type being checked, the subject
+   `commonName` (for host name checks) or `emailAddress` (for email checks)
+   was matched instead.  The subject DN is now checked only when
+   the `X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT` flag is set.  Correspondingly,
+   during chain verification, DNS name constraints are applied to the subject
+   `commonName` of the leaf certificate only when that flag is set, rather than
+   whenever the leaf had no DNS subject alternative name.
 
    *Bob Beck*
 
- * Add `CMS_VERIFY_PARTIAL` flag to `CMS_verify()` and `-verify_partial` option
-   to `openssl cms -verify`.
+ * Added `CMS_VERIFY_PARTIAL` flag to `CMS_verify()`, `-verify_partial`
+   option to `openssl cms -verify` operation,
+   and `CMS_SignerInfo_get_verification_result()`
+   and `CMS_SignerInfo_get0_signer_cert()` functions.
 
-   If this flag is set, the call is successful also if not all, but at least
-   one of the individual signatures can be verified (perhaps due to CAs missing
-   from the local store, expired certificates, or unsupported algorithms). The
-   application would then call `CMS_get0_signers()` and check if the set of
-   valid signatures satisfies its policy.
-
-   To access detailed verification results, the new functions
-   `CMS_SignerInfo_get_verification_result()` and
-   `CMS_SignerInfo_get0_signer_cert()` can be used.
+   If the `CMS_VERIFY_PARTIAL` flag is set, the `CMS_verify()` call
+   is successful if at least one of the individual signatures can be verified
+   (as opposed to all of them), which may be useful to gracefully handle various
+   situations, like missing CAs, expired certificates, or unsupported
+   algorithms;  applications can call `CMS_get0_signers()` to check if the set
+   of valid signatures satisfies its policy, or use
+   `CMS_SignerInfo_get_verification_result()`
+   and `CMS_SignerInfo_get0_signer_cert()` functions to access the detailed
+   verification results.
 
    *Jan Lübbe*
 
- * Changed the output of the -disabled option for the list command.
-   Displaying disabled features, protocols, and algorithms, in relevant sections.
-   Disabled features are now generated at configuration time.
+ * Changed the output of the `-disabled` option for the `openssl list` command
+   to display disabled features, protocols, and algorithms, in relevant
+   sections.
 
    *Paul Louvel*
 
- * Added `CTLOG_STORE_add0_log()` to add individual CT logs to a `CTLOG_STORE`.
+ * Added `CTLOG_STORE_add0_log()` function to add individual CT logs
+   to a `CTLOG_STORE`.
 
    *Tim Perry*
 
- * Dropped `no-ecdsa` and `no-ecdh` options from `Configure` as these options
-   did not really disable the implementations. Use `no-ec` to disable the
-   elliptic curve support.
+ * Dropped `no-ecdsa` and `no-ecdh` options from `Configure`, as these options
+   did not really disable the implementations.  Use `no-ec` to disable
+   the elliptic curve support.
 
    *Tomáš Mráz*
 
- * Added `EVP_EC_affine2oct()` that converts the affine coordinates of an
-   EC point to an octet string conforming to Sec. 2.3.4 of the SECG SEC 1
-   ("Elliptic Curve Cryptography") standard.
+ * Added `EVP_EC_affine2oct()` function, that converts the affine coordinates
+   of an EC point to an octet string conforming
+   to [Section 2.3.4 of SECG SEC 1][SECG SEC 1 Section 2.3.4] ("Elliptic Curve
+   Cryptography") standard.
 
    *Igor Ustinov*
 
- * Made more QUIC transport parameters configurable via the
-   `SSL_get_value_uint`/`SSL_set_value_uint` functions. Now also configurable:
+ * Implemented an ability to configure additional QUIC transport parameters
+   via the `SSL_get_value_uint()`/`SSL_set_value_uint()` functions:
    `max_udp_payload_size`, `initial_max_data`,
    `initial_max_stream_data_bidi_local`, `initial_max_stream_data_uni`,
-   `ack_delay_exponent`, `max_ack_delay`.
+   `ack_delay_exponent`, and `max_ack_delay`.
 
    *Nikolas Gauder*
 
- * Add new verification error `X509_V_ERR_DUPLICATE_EXTENSION` with descriptive
-   message for certificates containing duplicate X.509 extensions, which are
-   explicitly prohibited by [RFC 5280].
+ * Added a new verification error, `X509_V_ERR_DUPLICATE_EXTENSION`,
+   with a descriptive message for certificates containing duplicate X.509
+   extensions, which are explicitly prohibited by [RFC 5280].
 
    *Daniel Kubec*
 
- * Deprecated `CMS_stream()` and `PKCS7_stream()`.  These are internal
-   plumbing that leaked into the public API, and no longer return a
-   streaming boundary.  Use `BIO_new_CMS()` or `BIO_new_PKCS7()` to stream
-   CMS and PKCS7 content.
+ * Deprecated `CMS_stream()` and `PKCS7_stream()` functions.  These are internal
+   plumbing that leaked into the public API, and no longer return a streaming
+   boundary.  Use `BIO_new_CMS()` or `BIO_new_PKCS7()` to stream CMS and PKCS#7
+   content.
 
    *Bob Beck*
 
- * Added `OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES` option for `OSSL_CMP_CTX` and
-   a corresponding `-nonmatched_error_nonces` option for the `openssl cmp` command.
+ * Added `OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES` option for `OSSL_CMP_CTX`
+   and a corresponding `-nonmatched_error_nonces` option for the `openssl cmp`
+   command.
 
    This work was sponsored by Siemens AG.
 
    *David von Oheimb*
 
- * Added support for RFC 8701 GREASE (Generate Random Extensions And Sustain
-   Extensibility). When `SSL_OP_GREASE` is set, the TLS client injects
+ * Added support for [RFC 8701] GREASE (Generate Random Extensions And Sustain
+   Extensibility).  When `SSL_OP_GREASE` is set, the TLS client injects
    reserved GREASE values into cipher suites, supported versions, supported
-   groups, signature algorithms, key share, and extensions in the ClientHello
-   to prevent ecosystem ossification. The `openssl s_client` command gains a
-   `-grease` option to enable this.
+   groups, signature algorithms, key share, and extensions in the `ClientHello`
+   to prevent ecosystem ossification.
+   Added `-grease` option to `openssl s_client` to enable this.
 
    *William McCormack*
 
- * The undocumented public functions `UTF8_putc()` and `UTF8_getc()`
-   were deprecated, and their functionality moved internal to the
-   library. No public replacement is planned.
+ * Deprecated undocumented public functions `UTF8_putc()` and `UTF8_getc()`,
+   No public replacement is planned.
 
    *Bob Beck*
 
- * Added IKEV2 KDF (EVP_KDF-IKEV2KDF) implementation.
+ * Added IKEV2 KDF (`EVP_KDF-IKEV2KDF`) to `EVP_KDF`.
 
    *Helen Zhang*
 
- * Added AVX-512 and VAES optimizations for AES-CBC decryption. Decryption
+ * Added AVX-512 and VAES optimizations for AES-CBC decryption.  Decryption
    performance for large inputs (1024 bytes or more) improved by 3.5x to 3.8x.
 
    *Madan Mohan Manokar*
 
- * Deprecated `ASN1_BIT_STRING_set()` in favour of `ASN1_BIT_STRING_set1()`.
+ * Deprecated `ASN1_BIT_STRING_set()` function in favour
+   of `ASN1_BIT_STRING_set1()`.
 
    *Norbert Pócs*
 
@@ -472,10 +470,10 @@ OpenSSL 4.1
 
    *Leon Timmermans*
 
- * Add `FIPS_mode()` as a convenience define to
-   `EVP_default_properties_is_fips_enabled(NULL)`, which is
-   shorthand to check whether the `fips=yes` property is currently enabled
-   in the default library context.
+ * Added `FIPS_mode()` macro as a convenience alias
+   to `EVP_default_properties_is_fips_enabled(NULL)`, which is a shorthand
+   to check whether the `fips=yes` property is currently enabled in the default
+   library context.
 
    *Dimitri John Ledkov*
 
@@ -24052,17 +24050,27 @@ ndif
 [ESV]: https://csrc.nist.gov/Projects/cryptographic-module-validation-program/entropy-validations
 [RFC 2578 (STD 58), section 3.5]: https://datatracker.ietf.org/doc/html/rfc2578#section-3.5
 [RFC 3211]: https://datatracker.ietf.org/doc/html/rfc3211
+[RFC 4492 Section 5.1.2]: https://datatracker.ietf.org/doc/html/rfc4492#section-5.1.2
+[RFC 5280]: https://datatracker.ietf.org/doc/html/rfc5280
 [RFC 5297]: https://datatracker.ietf.org/doc/html/rfc5297
 [RFC 7250]: https://datatracker.ietf.org/doc/html/rfc7250
+[RFC 7685]: https://datatracker.ietf.org/doc/html/rfc7685
 [RFC 7919]: https://datatracker.ietf.org/doc/html/rfc7919
 [RFC 8422]: https://datatracker.ietf.org/doc/html/rfc8422
+[RFC 8422 Section 5.1.2]: https://datatracker.ietf.org/doc/html/rfc8422#section-5.1.2
 [RFC 8446]: https://datatracker.ietf.org/doc/html/rfc8446
 [RFC 8446 Section 4.6.1]: https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.1
 [RFC 8452]: https://datatracker.ietf.org/doc/html/rfc8452
+[RFC 8701]: https://datatracker.ietf.org/doc/html/rfc8701
 [RFC 8998]: https://datatracker.ietf.org/doc/html/rfc8998#name-iana-considerations
+[RFC 9147]: https://datatracker.ietf.org/doc/html/rfc9147
 [RFC 9149]: https://datatracker.ietf.org/doc/html/rfc9149
+[RFC 9846]: https://datatracker.ietf.org/doc/html/rfc9846
+[RFC 9846 Section 4.3.10]: https://datatracker.ietf.org/doc/html/rfc9846#section-4.3.10
 [RFC 9849]: https://datatracker.ietf.org/doc/html/rfc9849
+[SECG SEC 1 Section 2.3.4]: https://www.secg.org/sec1-v2.pdf#subsubsection.2.3.4
 [SP 800-132]: https://csrc.nist.gov/pubs/sp/800/132/final
 [SP 800-185]: https://csrc.nist.gov/pubs/sp/800/185/final
 [SP 800-208]: https://csrc.nist.gov/pubs/sp/800/208/final
+[TCG Credential Profiles specification Version 1.2, Section 3.2.7]: https://trustedcomputinggroup.org/wp-content/uploads/Credential_Profiles_V1.2_Level2_Revision8.pdf#page=35
 [tls-hybrid-sm2-mlkem]: https://datatracker.ietf.org/doc/html/draft-yang-tls-hybrid-sm2-mlkem-03#name-iana-considerations

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ appropriate release branch.
 OpenSSL Releases
 ----------------
 
+ - [OpenSSL 4.1](#openssl-41)
  - [OpenSSL 4.0](#openssl-40)
  - [OpenSSL 3.6](#openssl-36)
  - [OpenSSL 3.5](#openssl-35)
@@ -43,11 +44,13 @@ OpenSSL 4.1
    groups, signature algorithms, key share, and extensions in the `ClientHello`
    to prevent ecosystem ossification.
    Added `-grease` option to `openssl s_client` to enable this.
+   <!-- https://github.com/openssl/openssl/pull/30303 -->
 
    *William McCormack*
 
  * Added support for Ed25519 and Ed448 certificates in DTLS 1.2.  Previously,
    these certificate types were only supported in TLS 1.2 and TLS 1.3.
+   <!-- https://github.com/openssl/openssl/pull/30007 -->
 
    *Adriano Sela Aviles*
 
@@ -75,6 +78,7 @@ OpenSSL 4.1
    `max_udp_payload_size`, `initial_max_data`,
    `initial_max_stream_data_bidi_local`, `initial_max_stream_data_uni`,
    `ack_delay_exponent`, and `max_ack_delay`.
+   <!-- https://github.com/openssl/openssl/pull/29664 -->
 
    *Nikolas Gauder*
 
@@ -103,17 +107,20 @@ OpenSSL 4.1
    enforced on both sides (previously client-only), and only when an ECC TLS 1.2
    ciphersuite is negotiated—a missing "uncompressed" is ignored under TLS 1.3
    or with a non-ECC cipher.
+   <!-- https://github.com/openssl/openssl/pull/30940 -->
 
    *Viktor Dukhovni*
 
  * Added a new verification error, `X509_V_ERR_DUPLICATE_EXTENSION`,
    with a descriptive message for certificates containing duplicate X.509
    extensions, which are explicitly prohibited by [RFC 5280].
+   <!-- https://github.com/openssl/openssl/pull/30233 -->
 
    *Daniel Kubec*
 
  * Implemented extended support of metadata for symmetric key objects
    (`EVP_SKEY`).
+   <!-- https://github.com/openssl/openssl/pull/32644 -->
 
    *Dmitry Belyavskiy*
 
@@ -131,6 +138,7 @@ OpenSSL 4.1
    `CMS_SignerInfo_get_verification_result()`
    and `CMS_SignerInfo_get0_signer_cert()` functions to access the detailed
    verification results.
+   <!-- https://github.com/openssl/openssl/pull/27604 -->
 
    *Jan Lübbe*
 
@@ -139,16 +147,25 @@ OpenSSL 4.1
    command.
 
    This work was sponsored by Siemens AG.
+   <!-- https://github.com/openssl/openssl/pull/29043 -->
 
    *David von Oheimb*
 
  * Changed the output of the `-disabled` option for the `openssl list` command
    to display disabled features, protocols, and algorithms, in relevant
    sections.
+   <!-- https://github.com/openssl/openssl/pull/30212 -->
 
    *Paul Louvel*
 
- * Added `-testmode` option for `openssl s_time` command.
+ * Added `-n` option for the `openssl rand` command to suppress the trailing
+   newline in hexadecimal output mode.
+   <!-- https://github.com/openssl/openssl/pull/31795 -->
+
+   *Evy Garden*
+
+ * Added `-testmode` option for the `openssl s_time` command.
+   <!-- https://github.com/openssl/openssl/pull/31192 -->
 
    *Jakub Zelenka*
 
@@ -160,8 +177,9 @@ OpenSSL 4.1
    the previous 16 MB limit for file-based input.  This improves performance
    and supports large files without doubling memory use.  Other platforms
    and `stdin` input continue to use the existing buffer-based implementation.
+   <!-- https://github.com/openssl/openssl/pull/30429 -->
 
-   *John Claus*
+   *John Claus, Viktor Dukhovni, and David von Oheimb*
 
  * Added a `seed_strict` option to the `random` configuration section,
    which makes the configured random seed source strictly enforced when
@@ -178,10 +196,12 @@ OpenSSL 4.1
    and `enable-fips-jitter` builds always seed strictly.  Additionally,
    the property query used to fetch the default seed source can now be set
    at build time with `-DOPENSSL_DEFAULT_SEED_PROPQ`.
+   <!-- https://github.com/openssl/openssl/pull/31939 -->
 
    *Jakub Zelenka*
 
  * Added IKEV2 KDF (`EVP_KDF-IKEV2KDF`) to `EVP_KDF`.
+   <!-- https://github.com/openssl/openssl/pull/30121 -->
 
    *Helen Zhang*
 
@@ -189,6 +209,7 @@ OpenSSL 4.1
    and `CRYPTO_atomic_cmp_exch_ptr` functions to `libcrypto`, that implement
    the respective atomic operations with a locking-based fallback on platforms
    that do not support them.
+   <!-- https://github.com/openssl/openssl/pull/30670 -->
 
    *Neil Horman*
 
@@ -196,17 +217,20 @@ OpenSSL 4.1
    of an EC point to an octet string conforming
    to [Section 2.3.4 of SECG SEC 1][SECG SEC 1 Section 2.3.4] ("Elliptic Curve
    Cryptography") standard.
+   <!-- https://github.com/openssl/openssl/pull/30597 -->
 
    *Igor Ustinov*
 
  * Added `EVP_KDF_CTX_get0_kdf()` and `EVP_KDF_CTX_get1_kdf()` functions
    as a replacement for the now deprecated `EVP_KDF_CTX_kdf()`.
+   <!-- https://github.com/openssl/openssl/pull/28954 -->
 
    *Leon Timmermans*
 
  * Added `ASN1_STRING_new_not_owned()` function to `libcrypto`.  It provides
    the ability to construct an `ASN1_STRING` with data for which ownership
    is not taken by the created `ASN1_STRING` object.
+   <!-- https://github.com/openssl/openssl/pull/30964 -->
 
    *Bob Beck*
 
@@ -216,11 +240,13 @@ OpenSSL 4.1
    `PKCS7_sign_add_signer()` was updated in the same way, so that legacy
    ciphers, such as RC2 and DES, are no longer included in `SMIMECapabilities`
    by default when only the default provider is loaded.
+   <!-- https://github.com/openssl/openssl/pull/31990 -->
 
    *Todd Short*
 
  * Added `CTLOG_STORE_add0_log()` function to add individual CT logs
    to a `CTLOG_STORE`.
+   <!-- https://github.com/openssl/openssl/pull/30427 -->
 
    *Tim Perry*
 
@@ -228,6 +254,7 @@ OpenSSL 4.1
    to `EVP_default_properties_is_fips_enabled(NULL)`, which is a shorthand
    to check whether the `fips=yes` property is currently enabled in the default
    library context.
+   <!-- https://github.com/openssl/openssl/pull/30339 -->
 
    *Dimitri John Ledkov*
 
@@ -237,6 +264,7 @@ OpenSSL 4.1
    those which are actually processed.  It should also provide a small
    performance improvement, because repeated iteration over passed parameter
    arrays is avoided.
+   <!-- https://github.com/openssl/openssl/pull/32536 -->
 
    *Dr Paul Dale*
 
@@ -246,6 +274,7 @@ OpenSSL 4.1
    `id-RSAES-OAEP` (`NID_rsaesOaep`, 1.2.840.113549.1.1.7) with a plain
    `RSAPublicKey` body are now decoded as RSA keys.  The OAEP
    `AlgorithmIdentifier` parameters are not interpreted.
+   <!-- https://github.com/openssl/openssl/pull/30961 -->
 
    *Craig Lorentzen*
 
@@ -257,11 +286,13 @@ OpenSSL 4.1
    extension, or that sends it together with [RFC 9149] parameters such as
    `new_session_count = 0` or `resumption_count = 0`, is effectively signaling
    no interest in session tickets and session resumption.
+   <!-- https://github.com/openssl/openssl/pull/30639 -->
 
    *Daniel Kubec*
 
  * Improved DTLS handshake robustness under UDP reordering by buffering
    and replaying early `ChangeCipherSpec` (CCS) records at the expected state.
+   <!-- https://github.com/openssl/openssl/pull/30225 -->
 
    *Tong Li*
 
@@ -274,11 +305,13 @@ OpenSSL 4.1
    during chain verification, DNS name constraints are applied to the subject
    `commonName` of the leaf certificate only when that flag is set, rather than
    whenever the leaf had no DNS subject alternative name.
+   <!-- https://github.com/openssl/openssl/pull/31982 -->
 
    *Bob Beck*
 
  * Added various optimizations for the Elbrus2000 architecture
    in the cryptographic and BN code.
+   <!-- https://github.com/openssl/openssl/pull/31269 -->
 
    *Gleb Popov*
 
@@ -289,45 +322,68 @@ OpenSSL 4.1
    is enabled (e.g. `-mbranch-protection=standard`).  No functional changes
    to the assembly implementations are required, but compliance ensures
    correct operation with shadow stack enforcement.
+   <!-- https://github.com/openssl/openssl/pull/31162 -->
 
    *Guillaume Gardet and Gowtham Suresh Kumar*
 
+ * Added optimized ML-DSA and ML-KEM NTT operations on `ppc64le`.
+   <!-- https://github.com/openssl/openssl/pull/29611 -->
+   <!-- https://github.com/openssl/openssl/pull/30709 -->
+
+   *Danny Tsen*
+
  * Added optimized ML-DSA NTT operations on `s390x`
    (or other architectures with 128 bit vector registers).
+   <!-- https://github.com/openssl/openssl/pull/30812 -->
 
    *Timo Keller*
 
  * Added AVX2-optimized ML-DSA NTT operations on `x86_64`.
+   <!-- https://github.com/openssl/openssl/pull/30160 -->
 
    *Marcel Cornu and Tomasz Kantecki*
 
  * Added AVX-512-optimized SHAKE x4 operations for ML-DSA on `x86_64`.
+   <!-- https://github.com/openssl/openssl/pull/31090 -->
 
    *Marcel Cornu and Tomasz Kantecki*
 
  * Added AVX-512 and VAES optimizations for AES-CBC decryption.  Decryption
    performance for large inputs (1024 bytes or more) improved by 3.5x to 3.8x.
+   <!-- https://github.com/openssl/openssl/pull/30902 -->
 
    *Madan Mohan Manokar*
 
  * Added `VC-WIN32-MSVC2013` and `VC-WIN64A-MSVC2013` build targets to provide
    internal functions for bridging the gaps in C99 standard support
    that are present in MSVC 2013.
+   <!-- https://github.com/openssl/openssl/pull/31640 -->
+   <!-- https://github.com/openssl/openssl/pull/31988 -->
 
    *Bob Beck*
 
+ * Added support for the (BSD-specific) `mdoc` format for the manual pages
+   output, which can be selected via `--manpage-format=mdoc` configuration
+   option.  It requires presence of `pod2mdoc` utility in order for it to work.
+   <!-- https://github.com/openssl/openssl/pull/28450 -->
+
+   *Enji Cooper*
+
  * Added unit tests setup activated via `enable-unit-tests` option.  This works
    only on platforms with ld `--wrap` support (Linux, BSD).
+   <!-- https://github.com/openssl/openssl/pull/30788 -->
 
    *Jakub Zelenka*
 
  * Added test framework for testing function memory allocation failures.
+   <!-- https://github.com/openssl/openssl/pull/30871 -->
 
    *Jakub Zelenka*
 
  * Updated header files to reflect modern development practices: all include
    files now have header guards and they are self-contained (they include all
    dependencies they need to be included on their own).
+   <!-- https://github.com/openssl/openssl/pull/31001 -->
 
    *Bob Beck*
 
@@ -335,6 +391,7 @@ OpenSSL 4.1
    protocol from an earlier connection after a resumption negotiated
    a different protocol (or none), on both the server and the client,
    which could otherwise affect a later 0-RTT decision.
+   <!-- https://github.com/openssl/openssl/pull/32401 -->
 
    *Daniel Kubec and Viktor Dukhovni*
 
@@ -342,12 +399,14 @@ OpenSSL 4.1
    queued connections on allocation failure. Invalid arguments, including
    non-QUIC SSL objects, and internal failures now return `-1`, reserving `0`
    for "no connection available".
+   <!-- https://github.com/openssl/openssl/pull/32491 -->
 
    *Mounir IDRASSI*
 
  * Fixed QUIC child objects to inherit the effective flags of their explicit
    event domain.  `SSL_get0_domain()` now reports that domain for connections
    and streams in the hierarchy.
+   <!-- https://github.com/openssl/openssl/pull/32491 -->
 
    *Mounir IDRASSI*
 
@@ -356,42 +415,55 @@ OpenSSL 4.1
    ticket has aged out and an external PSK is offered in its place. The early
    data was being encrypted with the retired ticket's secret, rather than
    the external PSK's, causing the server to reject it with a bad record MAC.
+   <!-- https://github.com/openssl/openssl/pull/32202 -->
 
    *Viktor Dukhovni*
 
  * Fixed TLS 1.3 servers to reject early data when a resumed PSK's
    ticket age is outside tolerance, per [RFC 9846], instead of accepting
    0-RTT data from a ticket that has aged out.
+   <!-- https://github.com/openssl/openssl/pull/32202 -->
 
    *Daniel Kubec*
 
  * Fixed TLS 1.3 external PSK connections being wrongly rejected when
    the client sets a non-empty session ID context.
+   <!-- https://github.com/openssl/openssl/pull/31964 -->
 
    *Viktor Dukhovni*
 
  * Fixed a TLS 1.3 server with no session ID context to accept external PSK
    connections and to stop issuing unusable session tickets.
+   <!-- https://github.com/openssl/openssl/pull/31964 -->
 
    *Viktor Dukhovni*
 
  * Fixed TLS 1.3 servers to reject early data when the selected ciphersuite
    differs from the ciphersuite associated with the selected PSK. Same-hash
    PSK resumption can still continue without accepting 0-RTT data.
+   <!-- https://github.com/openssl/openssl/pull/32032 -->
 
    *Mounir IDRASSI*
 
  * Fixed X.509v3 extension configuration parsing to reject repeated fields
    in the `basicConstraints`, `basicAttConstraints`, and `policyConstraints`
    X.509v3 extension configurations, instead of silently using the last value.
+   <!-- https://github.com/openssl/openssl/pull/32181 -->
 
    *Adam Tabak*
 
  * Fixed X.509 verification of certificate chains that use DSA signatures
    with SHA-384 or SHA-512 by registering `dsa_with_SHA384` and
    `dsa_with_SHA512` in the signature-algorithm cross-reference table.
+   <!-- https://github.com/openssl/openssl/pull/30655 -->
 
    *John Claus*
+
+ * Fixed reading of binary data (for example, certificates in DER format)
+   by `openssl` command from `stdin` on Windows.
+   <!-- https://github.com/openssl/openssl/pull/30559 -->
+
+   *Milan Brož*
 
  * TLS clients no longer send the TLS padding extension ([RFC 7685]).  It was
    only ever sent when `SSL_OP_TLSEXT_PADDING` was set, to work around
@@ -400,17 +472,20 @@ OpenSSL 4.1
    be running the problematic version.
    `SSL_OP_TLSEXT_PADDING` is now a no-op retained for compatibility,
    and is no longer included in `SSL_OP_ALL`.
+   <!-- https://github.com/openssl/openssl/pull/32389 -->
 
    *Bob Beck*
 
  * Changed `tsget` utility to use `Net::Curl::Easy` (from the `Net-Curl` CPAN
    distribution) instead of the abandoned `WWW::Curl::Easy`.  Users who rely
    on `tsget` should install `Net::Curl::Easy` before upgrading.
+   <!-- https://github.com/openssl/openssl/pull/31445 -->
 
    *Shreenidhi Shedi*
 
  * Deprecated the `enable-unit-test` configure option and the
    `SSL_test_functions()` function.  Both will be removed in OpenSSL 5.0.
+   <!-- https://github.com/openssl/openssl/pull/30788 -->
 
    *Jakub Zelenka*
 
@@ -419,35 +494,41 @@ OpenSSL 4.1
    is now considered universally available;  moreover, the fact that `BIO_*()`
    functions return -1 on truncation, rather than the would-have-been length,
    makes their usage error-prone.  Use `snprintf()` and `vsnprintf()` directly.
+   <!-- https://github.com/openssl/openssl/pull/31640 -->
 
    *Bob Beck*
 
- * Deprecated undocumented public functions `UTF8_putc()` and `UTF8_getc()`,
+ * Deprecated undocumented public functions `UTF8_putc()` and `UTF8_getc()`.
    No public replacement is planned.
+   <!-- https://github.com/openssl/openssl/pull/30967 -->
 
    *Bob Beck*
 
  * Deprecated `EVP_CIPHER_CTX_get_num()` and `EVP_CIPHER_CTX_set_num()`
    functions.  Refer to `ossl-migration-guide(7)` for more info.
+   <!-- https://github.com/openssl/openssl/pull/30335 -->
 
    *Shane Lontis*
 
- * Deprecated `ASN1_STRING_set()` and `ASN1_STRING_length()`.  The replacement
-   functions `ASN1_STRING_set1_data()` or `ASN1_STRING_set1_string()`,
-   and `ASN1_STRING_get_length()` should be used in their place.  This prepares
-   the `ASN1_STRING` type to support modern `size_t` length values
-   in the future.
+ * Deprecated `ASN1_STRING_set()` and `ASN1_STRING_length()` functions.
+   The replacement functions `ASN1_STRING_set1_data()`
+   or `ASN1_STRING_set1_string()`, and `ASN1_STRING_get_length()` should be used
+   in their place.  This prepares the `ASN1_STRING` type to support modern
+   `size_t` length values in the future.
+   <!-- https://github.com/openssl/openssl/pull/31194 -->
 
    *Bob Beck*
 
  * Deprecated `ASN1_BIT_STRING_name_print()`, `ASN1_BIT_STRING_num_asc()`,
    and `ASN1_BIT_STRING_set_asc()` functions. Refer to the manual
    pages for more information.
+   <!-- https://github.com/openssl/openssl/pull/30853 -->
 
    *Bob Beck*
 
  * Deprecated `ASN1_BIT_STRING_set()` function in favour
    of `ASN1_BIT_STRING_set1()`.
+   <!-- https://github.com/openssl/openssl/pull/30692 -->
 
    *Norbert Pócs*
 
@@ -455,6 +536,7 @@ OpenSSL 4.1
    plumbing that leaked into the public API, and no longer return a streaming
    boundary.  Use `BIO_new_CMS()` or `BIO_new_PKCS7()` to stream CMS and PKCS#7
    content.
+   <!-- https://github.com/openssl/openssl/pull/32242 -->
 
    *Bob Beck*
 
@@ -463,17 +545,21 @@ OpenSSL 4.1
    a reference identifier to check using `X509_VERIFY_PARAM_set1_host()`,
    `X509_VERIFY_PARAM_set1_email()`, or `X509_VERIFY_PARAM_set1_ip_asc()`,
    and using `X509_verify_cert()`.
+   <!-- https://github.com/openssl/openssl/pull/30403 -->
 
    *Bob Beck*
 
  * Dropped Windows-on-Itanium (`VC-WIN64I`) and Windows CE (`VC-CE`) targets
    from Configurations.
+   <!-- https://github.com/openssl/openssl/pull/31601 -->
+   <!-- https://github.com/openssl/openssl/pull/31913 -->
 
    *Bob Beck*
 
  * Dropped `no-ecdsa` and `no-ecdh` options from `Configure`, as these options
    did not really disable the implementations.  Use `no-ec` to disable
    the elliptic curve support.
+   <!-- https://github.com/openssl/openssl/pull/30446 -->
 
    *Tomáš Mráz*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,59 +32,24 @@ OpenSSL 4.1
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
- * Refactored remaining cipher `OSSL_PARAM` name parsing so that automatically
-   generated parsers are used instead of `OSSL_PARAM_locate()` calls.
-   This should ensure that the list of acceptable parameters better matches
-   those which are actually processed.  It should also provide a small
-   performance improvement, because repeated iteration over passed parameter
-   arrays is avoided.
-
-   *Dr Paul Dale*
-
- * Added a `seed_strict` option to the `random` configuration section,
-   which makes the configured random seed source strictly enforced when
-   a provider (such as the FIPS provider) requests entropy or a nonce.
-
-   When a provider requests seeding material before the primary DRBG
-   has been created, the request falls back to the operating system entropy
-   sources, because the seed source only comes into existence as a side
-   effect of creating the primary DRBG.  Whether a configured seed source
-   is used therefore depends on operation order.  With `seed_strict` enabled,
-   the seed source is instead instantiated on demand and an error is reported
-   if it cannot be used.  The option is off by default with two exceptions:
-   the `JITTER` seed source seeds strictly unless the option disables it,
-   and `enable-fips-jitter` builds always seed strictly.  Additionally,
-   the property query used to fetch the default seed source can now be set
-   at build time with `-DOPENSSL_DEFAULT_SEED_PROPQ`.
-
-   *Jakub Zelenka*
-
- * Fixed a bug where a TLS 1.3 session ticket could retain a stale ALPN
-   protocol from an earlier connection after a resumption negotiated
-   a different protocol (or none), on both the server and the client,
-   which could otherwise affect a later 0-RTT decision.
-
-   *Daniel Kubec and Viktor Dukhovni*
-
- * Implemented extended support of metadata for symmetric key objects
-   (`EVP_SKEY`).
-
-   *Dmitry Belyavskiy*
-
- * Declared support for AArch64 Guarded Control Stack (GCS) in assembly code.
-
-   When building with compilers that support GCS (Clang 18+, GCC 15+),
-   assembly modules are marked as compatible when branch protection
-   is enabled (e.g. `-mbranch-protection=standard`).  No functional changes
-   to the assembly implementations are required, but compliance ensures
-   correct operation with shadow stack enforcement.
-
-   *Guillaume Gardet and Gowtham Suresh Kumar*
-
  * Added support for DTLS 1.3 ([RFC 9147]).
    Refer to the `ossl-guide-dtlsv13(7)` manual page for details.
 
    *Frederik Wedel-Heinen and Ryan Hooper*
+
+ * Added support for [RFC 8701] GREASE (Generate Random Extensions And Sustain
+   Extensibility).  When `SSL_OP_GREASE` is set, the TLS client injects
+   reserved GREASE values into cipher suites, supported versions, supported
+   groups, signature algorithms, key share, and extensions in the `ClientHello`
+   to prevent ecosystem ossification.
+   Added `-grease` option to `openssl s_client` to enable this.
+
+   *William McCormack*
+
+ * Added support for Ed25519 and Ed448 certificates in DTLS 1.2.  Previously,
+   these certificate types were only supported in TLS 1.2 and TLS 1.3.
+
+   *Adriano Sela Aviles*
 
  * Added DTLS support to the SSL listener API.  `SSL_new_listener()` can now
    create a DTLS listener that demultiplexes incoming datagrams into per-peer
@@ -105,82 +70,13 @@ OpenSSL 4.1
 
    *Ryan Hooper*
 
- * Fixed `SSL_listen_ex()` to correctly adopt a QUIC connection and to preserve
-   queued connections on allocation failure. Invalid arguments, including
-   non-QUIC SSL objects, and internal failures now return `-1`, reserving `0`
-   for "no connection available".
+ * Implemented an ability to configure additional QUIC transport parameters
+   via the `SSL_get_value_uint()`/`SSL_set_value_uint()` functions:
+   `max_udp_payload_size`, `initial_max_data`,
+   `initial_max_stream_data_bidi_local`, `initial_max_stream_data_uni`,
+   `ack_delay_exponent`, and `max_ack_delay`.
 
-   *Mounir IDRASSI*
-
- * Fixed QUIC child objects to inherit the effective flags of their explicit
-   event domain.  `SSL_get0_domain()` now reports that domain for connections
-   and streams in the hierarchy.
-
-   *Mounir IDRASSI*
-
- * Fixed TLS 1.3 clients to encrypt 0-RTT early data with the first offered
-   PSK identity ([RFC 9846 Section 4.3.10]) when a 0-RTT-capable resumption
-   ticket has aged out and an external PSK is offered in its place. The early
-   data was being encrypted with the retired ticket's secret, rather than
-   the external PSK's, causing the server to reject it with a bad record MAC.
-
-   *Viktor Dukhovni*
-
- * Fixed TLS 1.3 servers to reject early data when a resumed PSK's
-   ticket age is outside tolerance, per [RFC 9846], instead of accepting
-   0-RTT data from a ticket that has aged out.
-
-   *Daniel Kubec*
-
- * TLS clients no longer send the TLS padding extension ([RFC 7685]).  It was
-   only ever sent when `SSL_OP_TLSEXT_PADDING` was set, to work around
-   a `ClientHello` length bug in F5 middleboxes;  the fix shipped long ago
-   and the affected hardware is long out of support, so nothing should still
-   be running the problematic version.
-   `SSL_OP_TLSEXT_PADDING` is now a no-op retained for compatibility,
-   and is no longer included in `SSL_OP_ALL`.
-
-   *Bob Beck*
-
- * Fixed X.509v3 extension configuration parsing to reject repeated fields
-   in the `basicConstraints`, `basicAttConstraints`, and `policyConstraints`
-   X.509v3 extension configurations, instead of silently using the last value.
-
-   *Adam Tabak*
-
- * Changed `tsget` utility to use `Net::Curl::Easy` (from the `Net-Curl` CPAN
-   distribution) instead of the abandoned `WWW::Curl::Easy`.  Users who rely
-   on `tsget` should install `Net::Curl::Easy` before upgrading.
-
-   *Shreenidhi Shedi*
-
- * Added `CMS_add_standard_smimecap_ex()` API function, which populates
-   an `SMIMECapabilities` list using `EVP_CIPHER_fetch()` and `EVP_MD_fetch()`
-   so that only algorithms available in the active providers are advertised.
-   `PKCS7_sign_add_signer()` was updated in the same way, so that legacy
-   ciphers, such as RC2 and DES, are no longer included in `SMIMECapabilities`
-   by default when only the default provider is loaded.
-
-   *Todd Short*
-
- * Added various optimizations for the Elbrus2000 architecture
-   in the cryptographic and BN code.
-
-   *Gleb Popov*
-
- * Fixed TLS 1.3 external PSK connections being wrongly rejected when
-   the client sets a non-empty session ID context.
-
-   *Viktor Dukhovni*
-
- * Fixed a TLS 1.3 server with no session ID context to accept external PSK
-   connections and to stop issuing unusable session tickets.
-
-   *Viktor Dukhovni*
-
- * Added AVX-512-optimized SHAKE x4 operations for ML-DSA on `x86_64`.
-
-   *Marcel Cornu and Tomasz Kantecki*
+   *Nikolas Gauder*
 
  * Simplified EC key point format handling.
 
@@ -210,44 +106,139 @@ OpenSSL 4.1
 
    *Viktor Dukhovni*
 
- * Added unit tests setup activated via `enable-unit-tests` option.  This works
-   only on platforms with ld `--wrap` support (Linux, BSD).
+ * Added a new verification error, `X509_V_ERR_DUPLICATE_EXTENSION`,
+   with a descriptive message for certificates containing duplicate X.509
+   extensions, which are explicitly prohibited by [RFC 5280].
 
-   *Jakub Zelenka*
+   *Daniel Kubec*
 
- * Deprecated the `enable-unit-test` configure option and the
-   `SSL_test_functions()` function.  Both will be removed in OpenSSL 5.0.
+ * Implemented extended support of metadata for symmetric key objects
+   (`EVP_SKEY`).
 
-   *Jakub Zelenka*
+   *Dmitry Belyavskiy*
 
- * Deprecated `BIO_snprintf()` and `BIO_vsnprintf()`.  `snprintf()`, being part
-   of C99 standard, that is the baseline for OpenSSL since version 3.6,
-   is now considered universally available;  moreover, the fact that `BIO_*()`
-   functions return -1 on truncation, rather than the would-have-been length,
-   makes their usage error-prone.  Use `snprintf()` and `vsnprintf()` directly.
+ * Added `CMS_VERIFY_PARTIAL` flag to `CMS_verify()`, `-verify_partial`
+   option to `openssl cms -verify` operation,
+   and `CMS_SignerInfo_get_verification_result()`
+   and `CMS_SignerInfo_get0_signer_cert()` functions.
 
-   *Bob Beck*
+   If the `CMS_VERIFY_PARTIAL` flag is set, the `CMS_verify()` call
+   is successful if at least one of the individual signatures can be verified
+   (as opposed to all of them), which may be useful to gracefully handle various
+   situations, like missing CAs, expired certificates, or unsupported
+   algorithms;  applications can call `CMS_get0_signers()` to check if the set
+   of valid signatures satisfies its policy, or use
+   `CMS_SignerInfo_get_verification_result()`
+   and `CMS_SignerInfo_get0_signer_cert()` functions to access the detailed
+   verification results.
+
+   *Jan Lübbe*
+
+ * Added `OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES` option for `OSSL_CMP_CTX`
+   and a corresponding `-nonmatched_error_nonces` option for the `openssl cmp`
+   command.
+
+   This work was sponsored by Siemens AG.
+
+   *David von Oheimb*
+
+ * Changed the output of the `-disabled` option for the `openssl list` command
+   to display disabled features, protocols, and algorithms, in relevant
+   sections.
+
+   *Paul Louvel*
 
  * Added `-testmode` option for `openssl s_time` command.
 
    *Jakub Zelenka*
 
- * Fixed TLS 1.3 servers to reject early data when the selected ciphersuite
-   differs from the ciphersuite associated with the selected PSK. Same-hash
-   PSK resumption can still continue without accepting 0-RTT data.
+ * Added ability to utilise memory-mapped I/O when reading raw input
+   from a file for one-shot sign/verify operations (such as Ed25519,
+   Ed448, and ML-DSA) to `openssl pkeyutl` command on platforms
+   that support it (Unix-like).  The `openssl dgst` command uses the same
+   approach for one-shot sign/verify when the input is from a file, removing
+   the previous 16 MB limit for file-based input.  This improves performance
+   and supports large files without doubling memory use.  Other platforms
+   and `stdin` input continue to use the existing buffer-based implementation.
 
-   *Mounir IDRASSI*
+   *John Claus*
 
- * Added support for Ed25519 and Ed448 certificates in DTLS 1.2.  Previously,
-   these certificate types were only supported in TLS 1.2 and TLS 1.3.
+ * Added a `seed_strict` option to the `random` configuration section,
+   which makes the configured random seed source strictly enforced when
+   a provider (such as the FIPS provider) requests entropy or a nonce.
 
-   *Adriano Sela Aviles*
+   When a provider requests seeding material before the primary DRBG
+   has been created, the request falls back to the operating system entropy
+   sources, because the seed source only comes into existence as a side
+   effect of creating the primary DRBG.  Whether a configured seed source
+   is used therefore depends on operation order.  With `seed_strict` enabled,
+   the seed source is instead instantiated on demand and an error is reported
+   if it cannot be used.  The option is off by default with two exceptions:
+   the `JITTER` seed source seeds strictly unless the option disables it,
+   and `enable-fips-jitter` builds always seed strictly.  Additionally,
+   the property query used to fetch the default seed source can now be set
+   at build time with `-DOPENSSL_DEFAULT_SEED_PROPQ`.
 
- * Added `VC-WIN32-MSVC2013` and `VC-WIN64A-MSVC2013` build targets to provide
-   internal functions for bridging the gaps in C99 standard support
-   that are present in MSVC 2013.
+   *Jakub Zelenka*
+
+ * Added IKEV2 KDF (`EVP_KDF-IKEV2KDF`) to `EVP_KDF`.
+
+   *Helen Zhang*
+
+ * Added `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`,
+   and `CRYPTO_atomic_cmp_exch_ptr` functions to `libcrypto`, that implement
+   the respective atomic operations with a locking-based fallback on platforms
+   that do not support them.
+
+   *Neil Horman*
+
+ * Added `EVP_EC_affine2oct()` function, that converts the affine coordinates
+   of an EC point to an octet string conforming
+   to [Section 2.3.4 of SECG SEC 1][SECG SEC 1 Section 2.3.4] ("Elliptic Curve
+   Cryptography") standard.
+
+   *Igor Ustinov*
+
+ * Added `EVP_KDF_CTX_get0_kdf()` and `EVP_KDF_CTX_get1_kdf()` functions
+   as a replacement for the now deprecated `EVP_KDF_CTX_kdf()`.
+
+   *Leon Timmermans*
+
+ * Added `ASN1_STRING_new_not_owned()` function to `libcrypto`.  It provides
+   the ability to construct an `ASN1_STRING` with data for which ownership
+   is not taken by the created `ASN1_STRING` object.
 
    *Bob Beck*
+
+ * Added `CMS_add_standard_smimecap_ex()` API function, which populates
+   an `SMIMECapabilities` list using `EVP_CIPHER_fetch()` and `EVP_MD_fetch()`
+   so that only algorithms available in the active providers are advertised.
+   `PKCS7_sign_add_signer()` was updated in the same way, so that legacy
+   ciphers, such as RC2 and DES, are no longer included in `SMIMECapabilities`
+   by default when only the default provider is loaded.
+
+   *Todd Short*
+
+ * Added `CTLOG_STORE_add0_log()` function to add individual CT logs
+   to a `CTLOG_STORE`.
+
+   *Tim Perry*
+
+ * Added `FIPS_mode()` macro as a convenience alias
+   to `EVP_default_properties_is_fips_enabled(NULL)`, which is a shorthand
+   to check whether the `fips=yes` property is currently enabled in the default
+   library context.
+
+   *Dimitri John Ledkov*
+
+ * Refactored remaining cipher `OSSL_PARAM` name parsing so that automatically
+   generated parsers are used instead of `OSSL_PARAM_locate()` calls.
+   This should ensure that the list of acceptable parameters better matches
+   those which are actually processed.  It should also provide a small
+   performance improvement, because repeated iteration over passed parameter
+   arrays is avoided.
+
+   *Dr Paul Dale*
 
  * Improved interoperability with TPM 1.2 Endorsement Key certificates
    per [TCG Credential Profiles specification Version 1.2, Section 3.2.7]:
@@ -269,86 +260,10 @@ OpenSSL 4.1
 
    *Daniel Kubec*
 
- * Added test framework for testing function memory allocation failures.
-
-   *Jakub Zelenka*
-
- * Dropped Windows-on-Itanium (`VC-WIN64I`) and Windows CE (`VC-CE`) targets
-   from Configurations.
-
-   *Bob Beck*
-
  * Improved DTLS handshake robustness under UDP reordering by buffering
    and replaying early `ChangeCipherSpec` (CCS) records at the expected state.
 
    *Tong Li*
-
- * Updated header files to reflect modern development practices: all include
-   files now have header guards and they are self-contained (they include all
-   dependencies they need to be included on their own).
-
-   *Bob Beck*
-
- * Deprecated `ASN1_STRING_set()` and `ASN1_STRING_length()`.  The replacement
-   functions `ASN1_STRING_set1_data()` or `ASN1_STRING_set1_string()`,
-   and `ASN1_STRING_get_length()` should be used in their place.  This prepares
-   the `ASN1_STRING` type to support modern `size_t` length values
-   in the future.
-
-   *Bob Beck*
-
- * Deprecated `EVP_CIPHER_CTX_get_num()` and `EVP_CIPHER_CTX_set_num()`
-   functions.  Refer to `ossl-migration-guide(7)` for more info.
-
-   *Shane Lontis*
-
- * Deprecated `ASN1_BIT_STRING_name_print()`, `ASN1_BIT_STRING_num_asc()`,
-   and `ASN1_BIT_STRING_set_asc()` functions. Refer to the manual
-   pages for more information.
-
-   *Bob Beck*
-
- * Added `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`,
-   and `CRYPTO_atomic_cmp_exch_ptr` functions to `libcrypto`, that implement
-   the respective atomic operations with a locking-based fallback on platforms
-   that do not support them.
-
-   *Neil Horman*
-
- * Added ability to utilise memory-mapped I/O when reading raw input
-   from a file for one-shot sign/verify operations (such as Ed25519,
-   Ed448, and ML-DSA) to `openssl pkeyutl` command on platforms
-   that support it (Unix-like).  The `openssl dgst` command uses the same
-   approach for one-shot sign/verify when the input is from a file, removing
-   the previous 16 MB limit for file-based input.  This improves performance
-   and supports large files without doubling memory use.  Other platforms
-   and `stdin` input continue to use the existing buffer-based implementation.
-
-   *John Claus*
-
- * Deprecated `X509_check_host()`, `X509_check_email()`, `X509_check_ip()`,
-   and `X509_check_ip_asc()` functions.  Applications should migrate to setting
-   a reference identifier to check using `X509_VERIFY_PARAM_set1_host()`,
-   `X509_VERIFY_PARAM_set1_email()`, or `X509_VERIFY_PARAM_set1_ip_asc()`,
-   and using `X509_verify_cert()`.
-
-   *Bob Beck*
-
- * Added `ASN1_STRING_new_not_owned()` function to `libcrypto`.  It provides
-   the ability to construct an `ASN1_STRING` with data for which ownership
-   is not taken by the created `ASN1_STRING` object.
-
-   *Bob Beck*
-
- * Fixed X.509 verification of certificate chains that use DSA signatures
-   with SHA-384 or SHA-512 by registering `dsa_with_SHA384` and
-   `dsa_with_SHA512` in the signature-algorithm cross-reference table.
-
-   *John Claus*
-
- * Added AVX2-optimized ML-DSA NTT operations on `x86_64`.
-
-   *Marcel Cornu and Tomasz Kantecki*
 
  * Updated X.509 certificate verification to no longer consult the subject
    distinguished name (DN) by default.  Previously, when a certificate contained
@@ -362,60 +277,179 @@ OpenSSL 4.1
 
    *Bob Beck*
 
- * Added `CMS_VERIFY_PARTIAL` flag to `CMS_verify()`, `-verify_partial`
-   option to `openssl cms -verify` operation,
-   and `CMS_SignerInfo_get_verification_result()`
-   and `CMS_SignerInfo_get0_signer_cert()` functions.
+ * Added various optimizations for the Elbrus2000 architecture
+   in the cryptographic and BN code.
 
-   If the `CMS_VERIFY_PARTIAL` flag is set, the `CMS_verify()` call
-   is successful if at least one of the individual signatures can be verified
-   (as opposed to all of them), which may be useful to gracefully handle various
-   situations, like missing CAs, expired certificates, or unsupported
-   algorithms;  applications can call `CMS_get0_signers()` to check if the set
-   of valid signatures satisfies its policy, or use
-   `CMS_SignerInfo_get_verification_result()`
-   and `CMS_SignerInfo_get0_signer_cert()` functions to access the detailed
-   verification results.
+   *Gleb Popov*
 
-   *Jan Lübbe*
+ * Declared support for AArch64 Guarded Control Stack (GCS) in assembly code.
 
- * Changed the output of the `-disabled` option for the `openssl list` command
-   to display disabled features, protocols, and algorithms, in relevant
-   sections.
+   When building with compilers that support GCS (Clang 18+, GCC 15+),
+   assembly modules are marked as compatible when branch protection
+   is enabled (e.g. `-mbranch-protection=standard`).  No functional changes
+   to the assembly implementations are required, but compliance ensures
+   correct operation with shadow stack enforcement.
 
-   *Paul Louvel*
+   *Guillaume Gardet and Gowtham Suresh Kumar*
 
- * Added `CTLOG_STORE_add0_log()` function to add individual CT logs
-   to a `CTLOG_STORE`.
+ * Added optimized ML-DSA NTT operations on `s390x`
+   (or other architectures with 128 bit vector registers).
 
-   *Tim Perry*
+   *Timo Keller*
 
- * Dropped `no-ecdsa` and `no-ecdh` options from `Configure`, as these options
-   did not really disable the implementations.  Use `no-ec` to disable
-   the elliptic curve support.
+ * Added AVX2-optimized ML-DSA NTT operations on `x86_64`.
 
-   *Tomáš Mráz*
+   *Marcel Cornu and Tomasz Kantecki*
 
- * Added `EVP_EC_affine2oct()` function, that converts the affine coordinates
-   of an EC point to an octet string conforming
-   to [Section 2.3.4 of SECG SEC 1][SECG SEC 1 Section 2.3.4] ("Elliptic Curve
-   Cryptography") standard.
+ * Added AVX-512-optimized SHAKE x4 operations for ML-DSA on `x86_64`.
 
-   *Igor Ustinov*
+   *Marcel Cornu and Tomasz Kantecki*
 
- * Implemented an ability to configure additional QUIC transport parameters
-   via the `SSL_get_value_uint()`/`SSL_set_value_uint()` functions:
-   `max_udp_payload_size`, `initial_max_data`,
-   `initial_max_stream_data_bidi_local`, `initial_max_stream_data_uni`,
-   `ack_delay_exponent`, and `max_ack_delay`.
+ * Added AVX-512 and VAES optimizations for AES-CBC decryption.  Decryption
+   performance for large inputs (1024 bytes or more) improved by 3.5x to 3.8x.
 
-   *Nikolas Gauder*
+   *Madan Mohan Manokar*
 
- * Added a new verification error, `X509_V_ERR_DUPLICATE_EXTENSION`,
-   with a descriptive message for certificates containing duplicate X.509
-   extensions, which are explicitly prohibited by [RFC 5280].
+ * Added `VC-WIN32-MSVC2013` and `VC-WIN64A-MSVC2013` build targets to provide
+   internal functions for bridging the gaps in C99 standard support
+   that are present in MSVC 2013.
+
+   *Bob Beck*
+
+ * Added unit tests setup activated via `enable-unit-tests` option.  This works
+   only on platforms with ld `--wrap` support (Linux, BSD).
+
+   *Jakub Zelenka*
+
+ * Added test framework for testing function memory allocation failures.
+
+   *Jakub Zelenka*
+
+ * Updated header files to reflect modern development practices: all include
+   files now have header guards and they are self-contained (they include all
+   dependencies they need to be included on their own).
+
+   *Bob Beck*
+
+ * Fixed a bug where a TLS 1.3 session ticket could retain a stale ALPN
+   protocol from an earlier connection after a resumption negotiated
+   a different protocol (or none), on both the server and the client,
+   which could otherwise affect a later 0-RTT decision.
+
+   *Daniel Kubec and Viktor Dukhovni*
+
+ * Fixed `SSL_listen_ex()` to correctly adopt a QUIC connection and to preserve
+   queued connections on allocation failure. Invalid arguments, including
+   non-QUIC SSL objects, and internal failures now return `-1`, reserving `0`
+   for "no connection available".
+
+   *Mounir IDRASSI*
+
+ * Fixed QUIC child objects to inherit the effective flags of their explicit
+   event domain.  `SSL_get0_domain()` now reports that domain for connections
+   and streams in the hierarchy.
+
+   *Mounir IDRASSI*
+
+ * Fixed TLS 1.3 clients to encrypt 0-RTT early data with the first offered
+   PSK identity ([RFC 9846 Section 4.3.10]) when a 0-RTT-capable resumption
+   ticket has aged out and an external PSK is offered in its place. The early
+   data was being encrypted with the retired ticket's secret, rather than
+   the external PSK's, causing the server to reject it with a bad record MAC.
+
+   *Viktor Dukhovni*
+
+ * Fixed TLS 1.3 servers to reject early data when a resumed PSK's
+   ticket age is outside tolerance, per [RFC 9846], instead of accepting
+   0-RTT data from a ticket that has aged out.
 
    *Daniel Kubec*
+
+ * Fixed TLS 1.3 external PSK connections being wrongly rejected when
+   the client sets a non-empty session ID context.
+
+   *Viktor Dukhovni*
+
+ * Fixed a TLS 1.3 server with no session ID context to accept external PSK
+   connections and to stop issuing unusable session tickets.
+
+   *Viktor Dukhovni*
+
+ * Fixed TLS 1.3 servers to reject early data when the selected ciphersuite
+   differs from the ciphersuite associated with the selected PSK. Same-hash
+   PSK resumption can still continue without accepting 0-RTT data.
+
+   *Mounir IDRASSI*
+
+ * Fixed X.509v3 extension configuration parsing to reject repeated fields
+   in the `basicConstraints`, `basicAttConstraints`, and `policyConstraints`
+   X.509v3 extension configurations, instead of silently using the last value.
+
+   *Adam Tabak*
+
+ * Fixed X.509 verification of certificate chains that use DSA signatures
+   with SHA-384 or SHA-512 by registering `dsa_with_SHA384` and
+   `dsa_with_SHA512` in the signature-algorithm cross-reference table.
+
+   *John Claus*
+
+ * TLS clients no longer send the TLS padding extension ([RFC 7685]).  It was
+   only ever sent when `SSL_OP_TLSEXT_PADDING` was set, to work around
+   a `ClientHello` length bug in F5 middleboxes;  the fix shipped long ago
+   and the affected hardware is long out of support, so nothing should still
+   be running the problematic version.
+   `SSL_OP_TLSEXT_PADDING` is now a no-op retained for compatibility,
+   and is no longer included in `SSL_OP_ALL`.
+
+   *Bob Beck*
+
+ * Changed `tsget` utility to use `Net::Curl::Easy` (from the `Net-Curl` CPAN
+   distribution) instead of the abandoned `WWW::Curl::Easy`.  Users who rely
+   on `tsget` should install `Net::Curl::Easy` before upgrading.
+
+   *Shreenidhi Shedi*
+
+ * Deprecated the `enable-unit-test` configure option and the
+   `SSL_test_functions()` function.  Both will be removed in OpenSSL 5.0.
+
+   *Jakub Zelenka*
+
+ * Deprecated `BIO_snprintf()` and `BIO_vsnprintf()`.  `snprintf()`, being part
+   of C99 standard, that is the baseline for OpenSSL since version 3.6,
+   is now considered universally available;  moreover, the fact that `BIO_*()`
+   functions return -1 on truncation, rather than the would-have-been length,
+   makes their usage error-prone.  Use `snprintf()` and `vsnprintf()` directly.
+
+   *Bob Beck*
+
+ * Deprecated undocumented public functions `UTF8_putc()` and `UTF8_getc()`,
+   No public replacement is planned.
+
+   *Bob Beck*
+
+ * Deprecated `EVP_CIPHER_CTX_get_num()` and `EVP_CIPHER_CTX_set_num()`
+   functions.  Refer to `ossl-migration-guide(7)` for more info.
+
+   *Shane Lontis*
+
+ * Deprecated `ASN1_STRING_set()` and `ASN1_STRING_length()`.  The replacement
+   functions `ASN1_STRING_set1_data()` or `ASN1_STRING_set1_string()`,
+   and `ASN1_STRING_get_length()` should be used in their place.  This prepares
+   the `ASN1_STRING` type to support modern `size_t` length values
+   in the future.
+
+   *Bob Beck*
+
+ * Deprecated `ASN1_BIT_STRING_name_print()`, `ASN1_BIT_STRING_num_asc()`,
+   and `ASN1_BIT_STRING_set_asc()` functions. Refer to the manual
+   pages for more information.
+
+   *Bob Beck*
+
+ * Deprecated `ASN1_BIT_STRING_set()` function in favour
+   of `ASN1_BIT_STRING_set1()`.
+
+   *Norbert Pócs*
 
  * Deprecated `CMS_stream()` and `PKCS7_stream()` functions.  These are internal
    plumbing that leaked into the public API, and no longer return a streaming
@@ -424,58 +458,24 @@ OpenSSL 4.1
 
    *Bob Beck*
 
- * Added `OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES` option for `OSSL_CMP_CTX`
-   and a corresponding `-nonmatched_error_nonces` option for the `openssl cmp`
-   command.
-
-   This work was sponsored by Siemens AG.
-
-   *David von Oheimb*
-
- * Added support for [RFC 8701] GREASE (Generate Random Extensions And Sustain
-   Extensibility).  When `SSL_OP_GREASE` is set, the TLS client injects
-   reserved GREASE values into cipher suites, supported versions, supported
-   groups, signature algorithms, key share, and extensions in the `ClientHello`
-   to prevent ecosystem ossification.
-   Added `-grease` option to `openssl s_client` to enable this.
-
-   *William McCormack*
-
- * Deprecated undocumented public functions `UTF8_putc()` and `UTF8_getc()`,
-   No public replacement is planned.
+ * Deprecated `X509_check_host()`, `X509_check_email()`, `X509_check_ip()`,
+   and `X509_check_ip_asc()` functions.  Applications should migrate to setting
+   a reference identifier to check using `X509_VERIFY_PARAM_set1_host()`,
+   `X509_VERIFY_PARAM_set1_email()`, or `X509_VERIFY_PARAM_set1_ip_asc()`,
+   and using `X509_verify_cert()`.
 
    *Bob Beck*
 
- * Added IKEV2 KDF (`EVP_KDF-IKEV2KDF`) to `EVP_KDF`.
+ * Dropped Windows-on-Itanium (`VC-WIN64I`) and Windows CE (`VC-CE`) targets
+   from Configurations.
 
-   *Helen Zhang*
+   *Bob Beck*
 
- * Added AVX-512 and VAES optimizations for AES-CBC decryption.  Decryption
-   performance for large inputs (1024 bytes or more) improved by 3.5x to 3.8x.
+ * Dropped `no-ecdsa` and `no-ecdh` options from `Configure`, as these options
+   did not really disable the implementations.  Use `no-ec` to disable
+   the elliptic curve support.
 
-   *Madan Mohan Manokar*
-
- * Deprecated `ASN1_BIT_STRING_set()` function in favour
-   of `ASN1_BIT_STRING_set1()`.
-
-   *Norbert Pócs*
-
- * Added optimized ML-DSA NTT operations on `s390x`
-   (or other architectures with 128 bit vector registers).
-
-   *Timo Keller*
-
- * Added `EVP_KDF_CTX_get0_kdf()` and `EVP_KDF_CTX_get1_kdf()` functions
-   as a replacement for the now deprecated `EVP_KDF_CTX_kdf()`.
-
-   *Leon Timmermans*
-
- * Added `FIPS_mode()` macro as a convenience alias
-   to `EVP_default_properties_is_fips_enabled(NULL)`, which is a shorthand
-   to check whether the `fips=yes` property is currently enabled in the default
-   library context.
-
-   *Dimitri John Ledkov*
+   *Tomáš Mráz*
 
 OpenSSL 4.0
 -----------

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,17 +28,45 @@ OpenSSL 4.1
 
 ### Major changes between OpenSSL 4.0 and OpenSSL 4.1 [under development]
 
-  * Support for DTLS 1.3 (RFC 9147) added. The DTLS 1.3 work includes:
-    * DTLS 1.3 support in the SSL listener API. `SSL_new_listener()` can
-      create a DTLS listener that demultiplexes incoming datagrams into
-      per-peer connections accepted with `SSL_accept_connection()`.
-    See the ossl-guide-dtlsv13(7) manpage for details.
+OpenSSL 4.1.0 is a feature release adding significant new functionality
+to OpenSSL.
 
-  * API calls `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`, and
-    `CRYPTO_atomic_cmp_exch_ptr` have been added.
-  * Initial support for the Elbrus2000 (e2k) architecture
+This release incorporates the following potentially significant or incompatible
+changes:
 
-  * Fixed verification of DSA certificates signed with SHA-384 or SHA-512.
+  * Added `VC-WIN32-MSVC2013` and `VC-WIN64A-MSVC2013` build targets to provide
+    internal functions for bridging the gaps in C99 standard support
+    that are present in MSVC 2013.
+
+  * Added optimized ML-DSA and ML-KEM NTT operations on `ppc64le`;
+    optimized ML-DSA operations on `s390x`, and `x86_64`;
+    AVX-512-optimized SHAKE x4 operations for ML-DSA on `x86_64`;
+    AVX-512 and VAES optimizations for AES-CBC decryption on `x86_64`.
+
+  * Changed `tsget` utility to use `Net::Curl::Easy` (from the `Net-Curl` CPAN
+    distribution) instead of the abandoned `WWW::Curl::Easy`.  Users who rely
+    on `tsget` should install `Net::Curl::Easy` before upgrading.
+
+  * Dropped Windows-on-Itanium (`VC-WIN64I`) and Windows CE (`VC-CE`) targets
+    from Configurations.
+
+  * Dropped `no-ecdsa` and `no-ecdh` options from `Configure`, as these options
+    did not really disable the implementations.  Use `no-ec` to disable
+    the elliptic curve support.
+
+This release adds the following new features:
+
+  * Support for DTLS 1.3 ([RFC 9147]).
+    Refer to the `ossl-guide-dtlsv13(7)` manual page for details.
+
+  * Support for [RFC 8701] GREASE (Generate Random Extensions And Sustain
+    Extensibility).
+
+  * DTLS support in the SSL listener API.
+
+  * Support for IKEV2 KDF.
+
+  * Initial support for the Elbrus2000 (`e2k`) architecture.
 
 OpenSSL 4.0
 -----------
@@ -2536,7 +2564,9 @@ OpenSSL 0.9.x
 [README-QUIC.md]: ./README-QUIC.md
 [RFC 7919]: https://datatracker.ietf.org/doc/html/rfc7919
 [RFC 8422]: https://datatracker.ietf.org/doc/html/rfc8422
+[RFC 8701]: https://datatracker.ietf.org/doc/html/rfc8701
 [RFC 8998]: https://datatracker.ietf.org/doc/html/rfc8998#name-iana-considerations
+[RFC 9147]: https://datatracker.ietf.org/doc/html/rfc9147
 [RFC 9849]: https://datatracker.ietf.org/doc/html/rfc9849
 [SP 800-185]: https://csrc.nist.gov/pubs/sp/800/185/final
 [SP 800-208]: https://csrc.nist.gov/pubs/sp/800/208/final


### PR DESCRIPTION
4.1.0-alpha1 `CHANGES.md` includes the following:
 * (Summarily) DTLS 1.3 changes
 * https://github.com/openssl/openssl/pull/27604
 * https://github.com/openssl/openssl/pull/28450
 * https://github.com/openssl/openssl/pull/28954
 * https://github.com/openssl/openssl/pull/29043
 * https://github.com/openssl/openssl/pull/29611
 * https://github.com/openssl/openssl/pull/29664
 * https://github.com/openssl/openssl/pull/30007
 * https://github.com/openssl/openssl/pull/30121
 * https://github.com/openssl/openssl/pull/30160
 * https://github.com/openssl/openssl/pull/30212
 * https://github.com/openssl/openssl/pull/30225
 * https://github.com/openssl/openssl/pull/30233
 * https://github.com/openssl/openssl/pull/30303
 * https://github.com/openssl/openssl/pull/30335
 * https://github.com/openssl/openssl/pull/30339
 * https://github.com/openssl/openssl/pull/30403
 * https://github.com/openssl/openssl/pull/30427
 * https://github.com/openssl/openssl/pull/30429
 * https://github.com/openssl/openssl/pull/30446
 * https://github.com/openssl/openssl/pull/30559
 * https://github.com/openssl/openssl/pull/30597
 * https://github.com/openssl/openssl/pull/30639
 * https://github.com/openssl/openssl/pull/30655
 * https://github.com/openssl/openssl/pull/30670
 * https://github.com/openssl/openssl/pull/30692
 * https://github.com/openssl/openssl/pull/30709
 * https://github.com/openssl/openssl/pull/30788
 * https://github.com/openssl/openssl/pull/30812
 * https://github.com/openssl/openssl/pull/30853
 * https://github.com/openssl/openssl/pull/30871
 * https://github.com/openssl/openssl/pull/30902
 * https://github.com/openssl/openssl/pull/30940
 * https://github.com/openssl/openssl/pull/30961
 * https://github.com/openssl/openssl/pull/30964
 * https://github.com/openssl/openssl/pull/30967
 * https://github.com/openssl/openssl/pull/31001
 * https://github.com/openssl/openssl/pull/31090
 * https://github.com/openssl/openssl/pull/31192
 * https://github.com/openssl/openssl/pull/31194
 * https://github.com/openssl/openssl/pull/31269
 * https://github.com/openssl/openssl/pull/31162
 * https://github.com/openssl/openssl/pull/31445
 * https://github.com/openssl/openssl/pull/31601
 * https://github.com/openssl/openssl/pull/31640
 * https://github.com/openssl/openssl/pull/31795
 * https://github.com/openssl/openssl/pull/31913
 * https://github.com/openssl/openssl/pull/31939
 * https://github.com/openssl/openssl/pull/31964
 * https://github.com/openssl/openssl/pull/31982
 * https://github.com/openssl/openssl/pull/31988
 * https://github.com/openssl/openssl/pull/31990
 * https://github.com/openssl/openssl/pull/32032
 * https://github.com/openssl/openssl/pull/32181
 * https://github.com/openssl/openssl/pull/32202
 * https://github.com/openssl/openssl/pull/32242
 * https://github.com/openssl/openssl/pull/32389
 * https://github.com/openssl/openssl/pull/32401
 * https://github.com/openssl/openssl/pull/32491
 * https://github.com/openssl/openssl/pull/32536
 * https://github.com/openssl/openssl/pull/32644

4.1.0-alpha1 `NEWS.md` includes the following:
 * (Summarily) DTLS 1.3 changes
 * https://github.com/openssl/openssl/pull/29611
 * https://github.com/openssl/openssl/pull/30121
 * https://github.com/openssl/openssl/pull/30160
 * https://github.com/openssl/openssl/pull/30303
 * https://github.com/openssl/openssl/pull/30446
 * https://github.com/openssl/openssl/pull/30709
 * https://github.com/openssl/openssl/pull/30812
 * https://github.com/openssl/openssl/pull/30902
 * https://github.com/openssl/openssl/pull/31090
 * https://github.com/openssl/openssl/pull/31269
 * https://github.com/openssl/openssl/pull/31445
 * https://github.com/openssl/openssl/pull/31601
 * https://github.com/openssl/openssl/pull/31640
 * https://github.com/openssl/openssl/pull/31913

Already mentioned in 3.6.x/4.0.x change logs:
 * https://github.com/openssl/openssl/pull/30204
 * https://github.com/openssl/openssl/pull/30313
 * https://github.com/openssl/openssl/pull/30384
 * https://github.com/openssl/openssl/pull/31413
 * https://github.com/openssl/openssl/pull/30557
 * https://github.com/openssl/openssl/pull/30792
 * https://github.com/openssl/openssl/pull/31146
 * https://github.com/openssl/openssl/pull/31174
 * https://github.com/openssl/openssl/pull/31749

May be worth considering:
 * https://github.com/openssl/openssl/pull/30323
 * https://github.com/openssl/openssl/pull/30383
 * https://github.com/openssl/openssl/pull/30892
 * https://github.com/openssl/openssl/pull/30904
 * https://github.com/openssl/openssl/pull/31018
 * https://github.com/openssl/openssl/pull/31086
 * https://github.com/openssl/openssl/pull/31213
 * https://github.com/openssl/openssl/pull/31472
 * https://github.com/openssl/openssl/pull/31577
 * https://github.com/openssl/openssl/pull/31637
 * https://github.com/openssl/openssl/pull/31673
 * https://github.com/openssl/openssl/pull/31695
 * https://github.com/openssl/openssl/pull/31940
 * https://github.com/openssl/openssl/pull/32001
 * https://github.com/openssl/openssl/pull/32060
 * https://github.com/openssl/openssl/pull/32256
 * https://github.com/openssl/openssl/pull/32271
 * https://github.com/openssl/openssl/pull/32512

Not included:
 * https://github.com/openssl/openssl/pull/13882
 * https://github.com/openssl/openssl/pull/18003
 * https://github.com/openssl/openssl/pull/18914
 * https://github.com/openssl/openssl/pull/22259
 * https://github.com/openssl/openssl/pull/22260
 * https://github.com/openssl/openssl/pull/22261
 * https://github.com/openssl/openssl/pull/22273
 * https://github.com/openssl/openssl/pull/22275
 * https://github.com/openssl/openssl/pull/22285
 * https://github.com/openssl/openssl/pull/22360
 * https://github.com/openssl/openssl/pull/22362
 * https://github.com/openssl/openssl/pull/22363
 * https://github.com/openssl/openssl/pull/22364
 * https://github.com/openssl/openssl/pull/22366
 * https://github.com/openssl/openssl/pull/22376
 * https://github.com/openssl/openssl/pull/22378
 * https://github.com/openssl/openssl/pull/22380
 * https://github.com/openssl/openssl/pull/22400
 * https://github.com/openssl/openssl/pull/22401
 * https://github.com/openssl/openssl/pull/22416
 * https://github.com/openssl/openssl/pull/22935
 * https://github.com/openssl/openssl/pull/22936
 * https://github.com/openssl/openssl/pull/22937
 * https://github.com/openssl/openssl/pull/23041
 * https://github.com/openssl/openssl/pull/23077
 * https://github.com/openssl/openssl/pull/23229
 * https://github.com/openssl/openssl/pull/23242
 * https://github.com/openssl/openssl/pull/23320
 * https://github.com/openssl/openssl/pull/23375
 * https://github.com/openssl/openssl/pull/23511
 * https://github.com/openssl/openssl/pull/24226
 * https://github.com/openssl/openssl/pull/24293
 * https://github.com/openssl/openssl/pull/24345
 * https://github.com/openssl/openssl/pull/24425
 * https://github.com/openssl/openssl/pull/24426
 * https://github.com/openssl/openssl/pull/24509
 * https://github.com/openssl/openssl/pull/24524
 * https://github.com/openssl/openssl/pull/24525
 * https://github.com/openssl/openssl/pull/24605
 * https://github.com/openssl/openssl/pull/24607
 * https://github.com/openssl/openssl/pull/24981
 * https://github.com/openssl/openssl/pull/25119
 * https://github.com/openssl/openssl/pull/25668
 * https://github.com/openssl/openssl/pull/25683
 * https://github.com/openssl/openssl/pull/26035
 * https://github.com/openssl/openssl/pull/26150
 * https://github.com/openssl/openssl/pull/26211
 * https://github.com/openssl/openssl/pull/26226
 * https://github.com/openssl/openssl/pull/26401
 * https://github.com/openssl/openssl/pull/26465
 * https://github.com/openssl/openssl/pull/26532
 * https://github.com/openssl/openssl/pull/26574
 * https://github.com/openssl/openssl/pull/26912
 * https://github.com/openssl/openssl/pull/26922
 * https://github.com/openssl/openssl/pull/27357
 * https://github.com/openssl/openssl/pull/27554
 * https://github.com/openssl/openssl/pull/28000
 * https://github.com/openssl/openssl/pull/28127
 * https://github.com/openssl/openssl/pull/28172
 * https://github.com/openssl/openssl/pull/28192
 * https://github.com/openssl/openssl/pull/28373
 * https://github.com/openssl/openssl/pull/28455
 * https://github.com/openssl/openssl/pull/28456
 * https://github.com/openssl/openssl/pull/28636
 * https://github.com/openssl/openssl/pull/28735
 * https://github.com/openssl/openssl/pull/28858
 * https://github.com/openssl/openssl/pull/28905
 * https://github.com/openssl/openssl/pull/28909
 * https://github.com/openssl/openssl/pull/28926
 * https://github.com/openssl/openssl/pull/28973
 * https://github.com/openssl/openssl/pull/28986
 * https://github.com/openssl/openssl/pull/28988
 * https://github.com/openssl/openssl/pull/29067
 * https://github.com/openssl/openssl/pull/29074
 * https://github.com/openssl/openssl/pull/29081
 * https://github.com/openssl/openssl/pull/29083
 * https://github.com/openssl/openssl/pull/29221
 * https://github.com/openssl/openssl/pull/29295
 * https://github.com/openssl/openssl/pull/29321
 * https://github.com/openssl/openssl/pull/29440
 * https://github.com/openssl/openssl/pull/29448
 * https://github.com/openssl/openssl/pull/29449
 * https://github.com/openssl/openssl/pull/29469
 * https://github.com/openssl/openssl/pull/29501
 * https://github.com/openssl/openssl/pull/29592
 * https://github.com/openssl/openssl/pull/29606
 * https://github.com/openssl/openssl/pull/29609
 * https://github.com/openssl/openssl/pull/29610
 * https://github.com/openssl/openssl/pull/29626
 * https://github.com/openssl/openssl/pull/29680
 * https://github.com/openssl/openssl/pull/29745
 * https://github.com/openssl/openssl/pull/29772
 * https://github.com/openssl/openssl/pull/29773
 * https://github.com/openssl/openssl/pull/29786
 * https://github.com/openssl/openssl/pull/29790
 * https://github.com/openssl/openssl/pull/29794
 * https://github.com/openssl/openssl/pull/29814
 * https://github.com/openssl/openssl/pull/29839
 * https://github.com/openssl/openssl/pull/29841
 * https://github.com/openssl/openssl/pull/29847
 * https://github.com/openssl/openssl/pull/29849
 * https://github.com/openssl/openssl/pull/29851
 * https://github.com/openssl/openssl/pull/29887
 * https://github.com/openssl/openssl/pull/29894
 * https://github.com/openssl/openssl/pull/29899
 * https://github.com/openssl/openssl/pull/29900
 * https://github.com/openssl/openssl/pull/29901
 * https://github.com/openssl/openssl/pull/29911
 * https://github.com/openssl/openssl/pull/29913
 * https://github.com/openssl/openssl/pull/29915
 * https://github.com/openssl/openssl/pull/29918
 * https://github.com/openssl/openssl/pull/29946
 * https://github.com/openssl/openssl/pull/29961
 * https://github.com/openssl/openssl/pull/29984
 * https://github.com/openssl/openssl/pull/29996
 * https://github.com/openssl/openssl/pull/30019
 * https://github.com/openssl/openssl/pull/30037
 * https://github.com/openssl/openssl/pull/30061
 * https://github.com/openssl/openssl/pull/30141
 * https://github.com/openssl/openssl/pull/30150
 * https://github.com/openssl/openssl/pull/30167
 * https://github.com/openssl/openssl/pull/30179
 * https://github.com/openssl/openssl/pull/30206
 * https://github.com/openssl/openssl/pull/30213
 * https://github.com/openssl/openssl/pull/30223
 * https://github.com/openssl/openssl/pull/30243
 * https://github.com/openssl/openssl/pull/30254
 * https://github.com/openssl/openssl/pull/30258
 * https://github.com/openssl/openssl/pull/30266
 * https://github.com/openssl/openssl/pull/30271
 * https://github.com/openssl/openssl/pull/30274
 * https://github.com/openssl/openssl/pull/30279
 * https://github.com/openssl/openssl/pull/30280
 * https://github.com/openssl/openssl/pull/30286
 * https://github.com/openssl/openssl/pull/30287
 * https://github.com/openssl/openssl/pull/30289
 * https://github.com/openssl/openssl/pull/30293
 * https://github.com/openssl/openssl/pull/30298
 * https://github.com/openssl/openssl/pull/30305
 * https://github.com/openssl/openssl/pull/30311
 * https://github.com/openssl/openssl/pull/30312
 * https://github.com/openssl/openssl/pull/30314
 * https://github.com/openssl/openssl/pull/30317
 * https://github.com/openssl/openssl/pull/30319
 * https://github.com/openssl/openssl/pull/30320
 * https://github.com/openssl/openssl/pull/30321
 * https://github.com/openssl/openssl/pull/30324
 * https://github.com/openssl/openssl/pull/30325
 * https://github.com/openssl/openssl/pull/30329
 * https://github.com/openssl/openssl/pull/30331
 * https://github.com/openssl/openssl/pull/30332
 * https://github.com/openssl/openssl/pull/30333
 * https://github.com/openssl/openssl/pull/30336
 * https://github.com/openssl/openssl/pull/30342
 * https://github.com/openssl/openssl/pull/30347
 * https://github.com/openssl/openssl/pull/30349
 * https://github.com/openssl/openssl/pull/30350
 * https://github.com/openssl/openssl/pull/30351
 * https://github.com/openssl/openssl/pull/30352
 * https://github.com/openssl/openssl/pull/30353
 * https://github.com/openssl/openssl/pull/30354
 * https://github.com/openssl/openssl/pull/30355
 * https://github.com/openssl/openssl/pull/30365
 * https://github.com/openssl/openssl/pull/30371
 * https://github.com/openssl/openssl/pull/30372
 * https://github.com/openssl/openssl/pull/30373
 * https://github.com/openssl/openssl/pull/30374
 * https://github.com/openssl/openssl/pull/30375
 * https://github.com/openssl/openssl/pull/30376
 * https://github.com/openssl/openssl/pull/30382
 * https://github.com/openssl/openssl/pull/30386
 * https://github.com/openssl/openssl/pull/30388
 * https://github.com/openssl/openssl/pull/30389
 * https://github.com/openssl/openssl/pull/30390
 * https://github.com/openssl/openssl/pull/30392
 * https://github.com/openssl/openssl/pull/30394
 * https://github.com/openssl/openssl/pull/30395
 * https://github.com/openssl/openssl/pull/30397
 * https://github.com/openssl/openssl/pull/30399
 * https://github.com/openssl/openssl/pull/30400
 * https://github.com/openssl/openssl/pull/30401
 * https://github.com/openssl/openssl/pull/30404
 * https://github.com/openssl/openssl/pull/30405
 * https://github.com/openssl/openssl/pull/30406
 * https://github.com/openssl/openssl/pull/30410
 * https://github.com/openssl/openssl/pull/30415
 * https://github.com/openssl/openssl/pull/30416
 * https://github.com/openssl/openssl/pull/30417
 * https://github.com/openssl/openssl/pull/30419
 * https://github.com/openssl/openssl/pull/30420
 * https://github.com/openssl/openssl/pull/30421
 * https://github.com/openssl/openssl/pull/30423
 * https://github.com/openssl/openssl/pull/30425
 * https://github.com/openssl/openssl/pull/30428
 * https://github.com/openssl/openssl/pull/30434
 * https://github.com/openssl/openssl/pull/30436
 * https://github.com/openssl/openssl/pull/30437
 * https://github.com/openssl/openssl/pull/30438
 * https://github.com/openssl/openssl/pull/30441
 * https://github.com/openssl/openssl/pull/30443
 * https://github.com/openssl/openssl/pull/30444
 * https://github.com/openssl/openssl/pull/30445
 * https://github.com/openssl/openssl/pull/30447
 * https://github.com/openssl/openssl/pull/30452
 * https://github.com/openssl/openssl/pull/30460
 * https://github.com/openssl/openssl/pull/30461
 * https://github.com/openssl/openssl/pull/30463
 * https://github.com/openssl/openssl/pull/30464
 * https://github.com/openssl/openssl/pull/30472
 * https://github.com/openssl/openssl/pull/30474
 * https://github.com/openssl/openssl/pull/30476
 * https://github.com/openssl/openssl/pull/30477
 * https://github.com/openssl/openssl/pull/30479
 * https://github.com/openssl/openssl/pull/30483
 * https://github.com/openssl/openssl/pull/30484
 * https://github.com/openssl/openssl/pull/30485
 * https://github.com/openssl/openssl/pull/30490
 * https://github.com/openssl/openssl/pull/30493
 * https://github.com/openssl/openssl/pull/30500
 * https://github.com/openssl/openssl/pull/30502
 * https://github.com/openssl/openssl/pull/30503
 * https://github.com/openssl/openssl/pull/30504
 * https://github.com/openssl/openssl/pull/30505
 * https://github.com/openssl/openssl/pull/30506
 * https://github.com/openssl/openssl/pull/30507
 * https://github.com/openssl/openssl/pull/30509
 * https://github.com/openssl/openssl/pull/30510
 * https://github.com/openssl/openssl/pull/30511
 * https://github.com/openssl/openssl/pull/30512
 * https://github.com/openssl/openssl/pull/30515
 * https://github.com/openssl/openssl/pull/30516
 * https://github.com/openssl/openssl/pull/30517
 * https://github.com/openssl/openssl/pull/30519
 * https://github.com/openssl/openssl/pull/30520
 * https://github.com/openssl/openssl/pull/30521
 * https://github.com/openssl/openssl/pull/30522
 * https://github.com/openssl/openssl/pull/30524
 * https://github.com/openssl/openssl/pull/30528
 * https://github.com/openssl/openssl/pull/30529
 * https://github.com/openssl/openssl/pull/30530
 * https://github.com/openssl/openssl/pull/30531
 * https://github.com/openssl/openssl/pull/30532
 * https://github.com/openssl/openssl/pull/30533
 * https://github.com/openssl/openssl/pull/30535
 * https://github.com/openssl/openssl/pull/30536
 * https://github.com/openssl/openssl/pull/30541
 * https://github.com/openssl/openssl/pull/30542
 * https://github.com/openssl/openssl/pull/30550
 * https://github.com/openssl/openssl/pull/30555
 * https://github.com/openssl/openssl/pull/30556
 * https://github.com/openssl/openssl/pull/30558
 * https://github.com/openssl/openssl/pull/30560
 * https://github.com/openssl/openssl/pull/30561
 * https://github.com/openssl/openssl/pull/30563
 * https://github.com/openssl/openssl/pull/30566
 * https://github.com/openssl/openssl/pull/30567
 * https://github.com/openssl/openssl/pull/30570
 * https://github.com/openssl/openssl/pull/30572
 * https://github.com/openssl/openssl/pull/30573
 * https://github.com/openssl/openssl/pull/30576
 * https://github.com/openssl/openssl/pull/30580
 * https://github.com/openssl/openssl/pull/30583
 * https://github.com/openssl/openssl/pull/30585
 * https://github.com/openssl/openssl/pull/30587
 * https://github.com/openssl/openssl/pull/30589
 * https://github.com/openssl/openssl/pull/30595
 * https://github.com/openssl/openssl/pull/30596
 * https://github.com/openssl/openssl/pull/30598
 * https://github.com/openssl/openssl/pull/30601
 * https://github.com/openssl/openssl/pull/30602
 * https://github.com/openssl/openssl/pull/30603
 * https://github.com/openssl/openssl/pull/30606
 * https://github.com/openssl/openssl/pull/30607
 * https://github.com/openssl/openssl/pull/30608
 * https://github.com/openssl/openssl/pull/30609
 * https://github.com/openssl/openssl/pull/30611
 * https://github.com/openssl/openssl/pull/30612
 * https://github.com/openssl/openssl/pull/30613
 * https://github.com/openssl/openssl/pull/30614
 * https://github.com/openssl/openssl/pull/30615
 * https://github.com/openssl/openssl/pull/30616
 * https://github.com/openssl/openssl/pull/30618
 * https://github.com/openssl/openssl/pull/30619
 * https://github.com/openssl/openssl/pull/30623
 * https://github.com/openssl/openssl/pull/30624
 * https://github.com/openssl/openssl/pull/30625
 * https://github.com/openssl/openssl/pull/30626
 * https://github.com/openssl/openssl/pull/30628
 * https://github.com/openssl/openssl/pull/30629
 * https://github.com/openssl/openssl/pull/30630
 * https://github.com/openssl/openssl/pull/30632
 * https://github.com/openssl/openssl/pull/30634
 * https://github.com/openssl/openssl/pull/30635
 * https://github.com/openssl/openssl/pull/30643
 * https://github.com/openssl/openssl/pull/30646
 * https://github.com/openssl/openssl/pull/30647
 * https://github.com/openssl/openssl/pull/30648
 * https://github.com/openssl/openssl/pull/30650
 * https://github.com/openssl/openssl/pull/30651
 * https://github.com/openssl/openssl/pull/30653
 * https://github.com/openssl/openssl/pull/30661
 * https://github.com/openssl/openssl/pull/30663
 * https://github.com/openssl/openssl/pull/30667
 * https://github.com/openssl/openssl/pull/30668
 * https://github.com/openssl/openssl/pull/30669
 * https://github.com/openssl/openssl/pull/30673
 * https://github.com/openssl/openssl/pull/30674
 * https://github.com/openssl/openssl/pull/30677
 * https://github.com/openssl/openssl/pull/30683
 * https://github.com/openssl/openssl/pull/30686
 * https://github.com/openssl/openssl/pull/30690
 * https://github.com/openssl/openssl/pull/30691
 * https://github.com/openssl/openssl/pull/30695
 * https://github.com/openssl/openssl/pull/30696
 * https://github.com/openssl/openssl/pull/30703
 * https://github.com/openssl/openssl/pull/30704
 * https://github.com/openssl/openssl/pull/30705
 * https://github.com/openssl/openssl/pull/30712
 * https://github.com/openssl/openssl/pull/30713
 * https://github.com/openssl/openssl/pull/30714
 * https://github.com/openssl/openssl/pull/30718
 * https://github.com/openssl/openssl/pull/30720
 * https://github.com/openssl/openssl/pull/30727
 * https://github.com/openssl/openssl/pull/30730
 * https://github.com/openssl/openssl/pull/30731
 * https://github.com/openssl/openssl/pull/30738
 * https://github.com/openssl/openssl/pull/30746
 * https://github.com/openssl/openssl/pull/30751
 * https://github.com/openssl/openssl/pull/30754
 * https://github.com/openssl/openssl/pull/30761
 * https://github.com/openssl/openssl/pull/30763
 * https://github.com/openssl/openssl/pull/30764
 * https://github.com/openssl/openssl/pull/30765
 * https://github.com/openssl/openssl/pull/30767
 * https://github.com/openssl/openssl/pull/30768
 * https://github.com/openssl/openssl/pull/30776
 * https://github.com/openssl/openssl/pull/30783
 * https://github.com/openssl/openssl/pull/30785
 * https://github.com/openssl/openssl/pull/30790
 * https://github.com/openssl/openssl/pull/30795
 * https://github.com/openssl/openssl/pull/30796
 * https://github.com/openssl/openssl/pull/30797
 * https://github.com/openssl/openssl/pull/30803
 * https://github.com/openssl/openssl/pull/30807
 * https://github.com/openssl/openssl/pull/30813
 * https://github.com/openssl/openssl/pull/30814
 * https://github.com/openssl/openssl/pull/30819
 * https://github.com/openssl/openssl/pull/30824
 * https://github.com/openssl/openssl/pull/30829
 * https://github.com/openssl/openssl/pull/30830
 * https://github.com/openssl/openssl/pull/30832
 * https://github.com/openssl/openssl/pull/30834
 * https://github.com/openssl/openssl/pull/30838
 * https://github.com/openssl/openssl/pull/30844
 * https://github.com/openssl/openssl/pull/30845
 * https://github.com/openssl/openssl/pull/30847
 * https://github.com/openssl/openssl/pull/30848
 * https://github.com/openssl/openssl/pull/30856
 * https://github.com/openssl/openssl/pull/30857
 * https://github.com/openssl/openssl/pull/30858
 * https://github.com/openssl/openssl/pull/30859
 * https://github.com/openssl/openssl/pull/30860
 * https://github.com/openssl/openssl/pull/30863
 * https://github.com/openssl/openssl/pull/30864
 * https://github.com/openssl/openssl/pull/30865
 * https://github.com/openssl/openssl/pull/30872
 * https://github.com/openssl/openssl/pull/30877
 * https://github.com/openssl/openssl/pull/30881
 * https://github.com/openssl/openssl/pull/30888
 * https://github.com/openssl/openssl/pull/30891
 * https://github.com/openssl/openssl/pull/30893
 * https://github.com/openssl/openssl/pull/30896
 * https://github.com/openssl/openssl/pull/30901
 * https://github.com/openssl/openssl/pull/30903
 * https://github.com/openssl/openssl/pull/30905
 * https://github.com/openssl/openssl/pull/30906
 * https://github.com/openssl/openssl/pull/30913
 * https://github.com/openssl/openssl/pull/30914
 * https://github.com/openssl/openssl/pull/30916
 * https://github.com/openssl/openssl/pull/30917
 * https://github.com/openssl/openssl/pull/30918
 * https://github.com/openssl/openssl/pull/30923
 * https://github.com/openssl/openssl/pull/30933
 * https://github.com/openssl/openssl/pull/30935
 * https://github.com/openssl/openssl/pull/30938
 * https://github.com/openssl/openssl/pull/30941
 * https://github.com/openssl/openssl/pull/30942
 * https://github.com/openssl/openssl/pull/30943
 * https://github.com/openssl/openssl/pull/30944
 * https://github.com/openssl/openssl/pull/30945
 * https://github.com/openssl/openssl/pull/30956
 * https://github.com/openssl/openssl/pull/30957
 * https://github.com/openssl/openssl/pull/30962
 * https://github.com/openssl/openssl/pull/30963
 * https://github.com/openssl/openssl/pull/30965
 * https://github.com/openssl/openssl/pull/30969
 * https://github.com/openssl/openssl/pull/30972
 * https://github.com/openssl/openssl/pull/30973
 * https://github.com/openssl/openssl/pull/30977
 * https://github.com/openssl/openssl/pull/30978 
   "util: remove find-doc-nits -o option and missing*111.txt files"
 * https://github.com/openssl/openssl/pull/30981 
   "demos/guide/tls-client-block.c: switch to HTTP/1.1"
 * https://github.com/openssl/openssl/pull/30988 
   "test: respect disabled IPv6 in bio_tfo_test"
 * https://github.com/openssl/openssl/pull/30991 
   "Address `allocfail` test failures"
 * https://github.com/openssl/openssl/pull/30998 
   "DTLS 1.3 Buffer App Data received before ACK"
 * https://github.com/openssl/openssl/pull/31010 
   "According to RFC8446 there must always be one identity in the list"
 * https://github.com/openssl/openssl/pull/31011 
   "ssl/record/methods/tls_common.c: call BIO_free_all() on rl-&gt;bio in tls_int_free"
 * https://github.com/openssl/openssl/pull/31016 
   "Fix the no-deprecated symbol CI test"
 * https://github.com/openssl/openssl/pull/31017 
   "Check wrlmethod existence before sending alert"
 * https://github.com/openssl/openssl/pull/31019 
   "Replace one missing snprint with BIO_snprintf"
 * https://github.com/openssl/openssl/pull/31020 
   "Fix old compilers when missing AVX2 intrinsics"
 * https://github.com/openssl/openssl/pull/31021 
   "Fix false success when BIO_write returns 0 without retry"
 * https://github.com/openssl/openssl/pull/31022 
   "Harden SSL_set_session_ticket_ext and add docs"
 * https://github.com/openssl/openssl/pull/31023 
   "ssl: guard ciphersuite_cb() against NULL elem from CONF_parse_list "
 * https://github.com/openssl/openssl/pull/31026 
   "Treat an unknown PSK identity the same way as a binder validation failure"
 * https://github.com/openssl/openssl/pull/31029 
   "slh_dsa: cleanse generated add_random buffer"
 * https://github.com/openssl/openssl/pull/31032 
   "DTLS 1.3 Update documentation"
 * https://github.com/openssl/openssl/pull/31033 
   "Fix memory leak in asn_mime multi_split"
 * https://github.com/openssl/openssl/pull/31034 
   "DTLS 1.3 Fixing No Integrity Ciphers CI"
 * https://github.com/openssl/openssl/pull/31035 
   "sparse_array: avoid ubsan violation in typed doall"
 * https://github.com/openssl/openssl/pull/31038 
   "ssl/quic/quic_port.c: fix user_ssl/TLS leak in port_make_channel()"
 * https://github.com/openssl/openssl/pull/31042 
   "DTLS 1.3 Demo and Bug Fix"
 * https://github.com/openssl/openssl/pull/31044 
   "Reject delta CRLs as complete CRLs to avoid accepting previously revoked certs"
 * https://github.com/openssl/openssl/pull/31045 
   "Add ACVP test util"
 * https://github.com/openssl/openssl/pull/31046 
   "Don&#39;t rely on cmp of uninitialized values in obj_dat.pl"
 * https://github.com/openssl/openssl/pull/31048 
   "Fix potential UB memcmps in obj_dat.c"
 * https://github.com/openssl/openssl/pull/31049 
   "Guard memcmp for ub in X509_vpm.c"
 * https://github.com/openssl/openssl/pull/31051 
   "Avoid needless casting away of `const` in `X509_VERIFY_PARAM_get1_ip_asc`"
 * https://github.com/openssl/openssl/pull/31058 
   "Validate that a PSK identity is at least one byte long"
 * https://github.com/openssl/openssl/pull/31059 
   "Limit job count on compiler zoo builds"
 * https://github.com/openssl/openssl/pull/31064 
   "Fix: Typo &quot;configdata.pem&quot; -&gt; &quot;configdata.pm&quot;"
 * https://github.com/openssl/openssl/pull/31069 
   "Fixes #30979: Added `BN_CTX_end` before free in sm2_sign and sm2_crypt."
 * https://github.com/openssl/openssl/pull/31071 
   "Add coverage files clean up make targets"
 * https://github.com/openssl/openssl/pull/31073 
   "Add /MTd build for debug configuration for VC-noCE-common"
 * https://github.com/openssl/openssl/pull/31075 
   "Use .inc directly at places needed"
 * https://github.com/openssl/openssl/pull/31076 
   "Fix unreachable nested preprocessor conditions"
 * https://github.com/openssl/openssl/pull/31078 
   "Fix function pointer type mismatch when freeing ML-KEM and ECX keys"
 * https://github.com/openssl/openssl/pull/31089 
   "DTLS 1.3 Fixing test SKIPs not in code block"
 * https://github.com/openssl/openssl/pull/31091 
   "The tag value must fit into int"
 * https://github.com/openssl/openssl/pull/31092 
   "ossl_rcu_call skips cb call on failed allocation"
 * https://github.com/openssl/openssl/pull/31095 
   "Make test/quic_fc_test.c clang-format friendly"
 * https://github.com/openssl/openssl/pull/31098 
   "FFC params copy memory leak"
 * https://github.com/openssl/openssl/pull/31100 
   "HTTP: reject CR/LF in request components"
 * https://github.com/openssl/openssl/pull/31104 
   "chacha_poly: Use IV_STATE guard to prevent IV reuse"
 * https://github.com/openssl/openssl/pull/31107 
   "[Coverity 1593754] crypto/evp/evp_lib.c: call `va_end()` in `EVP_PKEY_Q_keygen()` on error"
 * https://github.com/openssl/openssl/pull/31109 
   "ossl_quic_new client mfail issues"
 * https://github.com/openssl/openssl/pull/31111 
   "`cmp_client_test.c`: fix partly too generous `total_timeout` limit for IR session with polling"
 * https://github.com/openssl/openssl/pull/31112 
   "ossl_quic_new_listener memory failure issues"
 * https://github.com/openssl/openssl/pull/31113 
   "Correct ASN1_STRING_set to match its documented API"
 * https://github.com/openssl/openssl/pull/31116 
   "Further improve the decryption performance of AES-128-CBC on the RISC-V architecture"
 * https://github.com/openssl/openssl/pull/31119 
   "Update openssl-s_client.pod.in"
 * https://github.com/openssl/openssl/pull/31121 
   "BIO dgram pair leak"
 * https://github.com/openssl/openssl/pull/31128 
   "Fix OOB read in EC_GROUP_new_from_params() with zero-length generator"
 * https://github.com/openssl/openssl/pull/31137 
   "DTLS 1.3 Limit DTLSv1_listen to DTLS1.2 and add SSL Listener for DTLS"
 * https://github.com/openssl/openssl/pull/31141 
   "doc/man7/EVP_CIPHER-DES.pod: remove trailing whitespace"
 * https://github.com/openssl/openssl/pull/31142 
   "Fix circular dependency between macros.h and opensslconf.h"
 * https://github.com/openssl/openssl/pull/31143 
   "Refcount mitigation and opportunistic removal for EVP objects"
 * https://github.com/openssl/openssl/pull/31144 
   "Extend and separate mfail test framework"
 * https://github.com/openssl/openssl/pull/31147 
   "crypto/x509: replace O(N^2) RFC 3779 canonicalisation merge with linear sweep"
 * https://github.com/openssl/openssl/pull/31151 
   "Avoid function-pointer-type UB in EVP_*_do_all_provided and STACK_OF"
 * https://github.com/openssl/openssl/pull/31153 
   "Include what you use (IWYU) preparations"
 * https://github.com/openssl/openssl/pull/31155 
   "Use CRYPTO_memcmp() when comparing the private keys"
 * https://github.com/openssl/openssl/pull/31157 
   "Consistenly zeroize public parameters based on OPENSSL_PEDANTIC_ZEROIZATION"
 * https://github.com/openssl/openssl/pull/31158 
   "`mem_alloc_test` fixes"
 * https://github.com/openssl/openssl/pull/31159 
   "Revert &quot;Preserve connection custom extensions in SSL_set_SSL_CTX()&quot;"
 * https://github.com/openssl/openssl/pull/31163 
   "Fix memleak in hashtable free if flush fails"
 * https://github.com/openssl/openssl/pull/31168 
   "ffc_internal_test.c: The ffc_params_copy_mfail test needs DSA enabled"
 * https://github.com/openssl/openssl/pull/31170 
   "Fix app param memory cleaning"
 * https://github.com/openssl/openssl/pull/31171 
   "Use valid DH peer pubkey in the KAT tests"
 * https://github.com/openssl/openssl/pull/31173 
   "Fix const qualifier warning in `OBJ_bsearch_ex_` "
 * https://github.com/openssl/openssl/pull/31175 
   "ssl/d1_lib.c: remove `g_probable_mtu` array"
 * https://github.com/openssl/openssl/pull/31177 
   "quic: make ch_cleanup() idempotent and simplify channel error path"
 * https://github.com/openssl/openssl/pull/31189 
   "Fix function pointer type mismatch in MSBLOB/PVK key encoder"
 * https://github.com/openssl/openssl/pull/31190 
   "Add apps test for external PSK callbacks"
 * https://github.com/openssl/openssl/pull/31191 
   "Added Nvidia/Olympus CPU dispatch for SHA3/EOR3 AES GCM on Vera CPU"
 * https://github.com/openssl/openssl/pull/31198 
   "Configure: update `$apitable` with the recent versions"
 * https://github.com/openssl/openssl/pull/31201 
   "Make IPAddressFamily_cmp safe for 0 length objects with NULL data."
 * https://github.com/openssl/openssl/pull/31202 
   "fix cmp mock server to not depend on NUL bytes in ASN1_STRING"
 * https://github.com/openssl/openssl/pull/31209 
   "fix UB in priority_queue"
 * https://github.com/openssl/openssl/pull/31212 
   "Configurations/unix-Makefile.tmpl: make cleanup faster"
 * https://github.com/openssl/openssl/pull/31215 
   "Remove unused crl_dir setting from config files"
 * https://github.com/openssl/openssl/pull/31216 
   "Remove copy/paste remnants from ancient times"
 * https://github.com/openssl/openssl/pull/31219 
   "Split mfail output into counting and injection subtests"
 * https://github.com/openssl/openssl/pull/31221 
   "Ignore memfail test binaries"
 * https://github.com/openssl/openssl/pull/31223 
   "Test: SSL_TICKET_NO_DECRYPT path in tls_parse_ctos_psk()"
 * https://github.com/openssl/openssl/pull/31224 
   "Fix Solaris X64 stack_test compiler error"
 * https://github.com/openssl/openssl/pull/31226 
   "crypto/objects/obj_dat.c: return strlcpy result in OBJ_obj2txt()"
 * https://github.com/openssl/openssl/pull/31230 
   "crypto/cmp/cmp_genm.c: avoid `strcat()` in `get_genm_itav()`"
 * https://github.com/openssl/openssl/pull/31237 
   "Optimize hashtable without rcu freeing"
 * https://github.com/openssl/openssl/pull/31238 
   "Reapply custom extension processing code when 3rd party QUIC is in use"
 * https://github.com/openssl/openssl/pull/31244 
   "Add indirect CRL path validation tests"
 * https://github.com/openssl/openssl/pull/31248 
   "Add SLH-DSA SignatureScheme constants"
 * https://github.com/openssl/openssl/pull/31249 
   "Add mfail test for SSL_new() with ctx QUIC client method"
 * https://github.com/openssl/openssl/pull/31252 
   "Fix EVP_PKEY_dup() for ML-KEM keys"
 * https://github.com/openssl/openssl/pull/31254 
   "Use integer types from stdint.h instead of hand rolled artisinally defined integer types. "
 * https://github.com/openssl/openssl/pull/31257 
   "Pass correct parameters to ossl_ssl_connection_new_int"
 * https://github.com/openssl/openssl/pull/31258 
   "Fix unhandled memfail in QUIC tx pkt history map insert"
 * https://github.com/openssl/openssl/pull/31263 
   "s390x: Selectively re-format s390xcap.c"
 * https://github.com/openssl/openssl/pull/31265 
   "`doc/man7/ossl-guide-migration.pod`: reword `DESCRIPTION` section a bit"
 * https://github.com/openssl/openssl/pull/31266 
   "Fix win32_joiner buffer sizing for dir-only paths"
 * https://github.com/openssl/openssl/pull/31268 
   "quic: delay el keyslot teardown after creation in setup"
 * https://github.com/openssl/openssl/pull/31270 
   "Document OSSL_BEGIN_ALLOW_DEPRECATED OSSL_END_ALLOW_DEPRECATED"
 * https://github.com/openssl/openssl/pull/31271 
   "Don&#39;t attempt to check the security level on what signed our own cert…"
 * https://github.com/openssl/openssl/pull/31272 
   "quic: read key update mfail"
 * https://github.com/openssl/openssl/pull/31274 
   "slh_dsa: Remove redundant cleanup to prevent double free"
 * https://github.com/openssl/openssl/pull/31275 
   "providers: Nullify BIO pointer after free to prevent double free"
 * https://github.com/openssl/openssl/pull/31276 
   "evp: Fix potential double free on error path in m_sigver.c"
 * https://github.com/openssl/openssl/pull/31282 
   "Fix example EB for RFC 7468 compliance"
 * https://github.com/openssl/openssl/pull/31284 
   "asm: missing function alignment"
 * https://github.com/openssl/openssl/pull/31288 
   "CHANGES.md: Disable tickets when SSL_OP_NO_TICKET and SSL_SESS_CACHE_OFF are set"
 * https://github.com/openssl/openssl/pull/31289 
   "doc: match provider-asym_cipher(7) prototypes with core_dispatch.h"
 * https://github.com/openssl/openssl/pull/31290 
   "doc: update signature_dupctx usage note"
 * https://github.com/openssl/openssl/pull/31291 
   "doc: clarify resumption semantics with -anti_replay in s_server"
 * https://github.com/openssl/openssl/pull/31292 
   "aes_wrap: prevent crash on update without a key"
 * https://github.com/openssl/openssl/pull/31295 
   "doc: fix rsa_oaep_md default digest documentation"
 * https://github.com/openssl/openssl/pull/31298 
   "poly1305: prevent crash on final without a key"
 * https://github.com/openssl/openssl/pull/31301 
   "Fixes: 8b6a8a42afaa &quot;Add a CHANGES.md entry&quot;"
 * https://github.com/openssl/openssl/pull/31304 
   "Refactor BN_mod() and BN_nnmod() arguments to match documentation"
 * https://github.com/openssl/openssl/pull/31312 
   "crypto/evp: fix double free of tmp_keymgmt in sig/kem/asym init"
 * https://github.com/openssl/openssl/pull/31314 
   "Bite the bullet, and attempt something close to documentation for X509_verify_cert. "
 * https://github.com/openssl/openssl/pull/31316 
   "quic: fix handling of the first rxe mfail in qrx_process_pkt"
 * https://github.com/openssl/openssl/pull/31319 
   "Provide independent lock failure signal on cmp_exch_ptr"
 * https://github.com/openssl/openssl/pull/31321 
   "crypto/hpke/hpke_util: Fixes redundant mdname is valid check."
 * https://github.com/openssl/openssl/pull/31323 
   "quic: fix keyslot cctx leak by not checking EL state in teardown"
 * https://github.com/openssl/openssl/pull/31324 
   "quic: add mfail test for handshake multi-packet processing"
 * https://github.com/openssl/openssl/pull/31327 
   "Fix missing function alignment for arm"
 * https://github.com/openssl/openssl/pull/31331 
   "quic: add mfail test for multi-packet RXE"
 * https://github.com/openssl/openssl/pull/31333 
   "quic: Fix missing LHASH error checks in stream map &amp; peer token cache"
 * https://github.com/openssl/openssl/pull/31334 
   "Add documentation for NAME_CONSTRAINTS_check"
 * https://github.com/openssl/openssl/pull/31335 
   "DOC: ticket suppression for SSL_OP_NO_TICKET and SSL_SESS_CACHE_OFF"
 * https://github.com/openssl/openssl/pull/31338 
   "statem: fix missing fatal if valid_flags mfail in process cert req"
 * https://github.com/openssl/openssl/pull/31339 
   "convert CRYPTO_THREAD_run_once to use InitOnceExecuteOnce api"
 * https://github.com/openssl/openssl/pull/31340 
   "rsa_sig: reject short buffers in raw verify_recover"
 * https://github.com/openssl/openssl/pull/31342 
   "doc: Add a missing comma in -traditional option explanation of openssl-pkcs8"
 * https://github.com/openssl/openssl/pull/31344 
   "test: fix unreachable code in test_kdf_pbkdf2_large_output in evp_kdf_test.c"
 * https://github.com/openssl/openssl/pull/31345 
   "lms: free previous encoded public key in ossl_lms_pubkey_decode"
 * https://github.com/openssl/openssl/pull/31346 
   "quic: cleanse derived IV on setup failure"
 * https://github.com/openssl/openssl/pull/31349 
   "quic: avoid one-byte over-read of conn close reason in copy_tcause"
 * https://github.com/openssl/openssl/pull/31350 
   "Fix broken hex data by reformatting"
 * https://github.com/openssl/openssl/pull/31352 
   "pvkfmt: check keylen before copying the BLOBHEADER"
 * https://github.com/openssl/openssl/pull/31353 
   "Add fingerprint of the new OpenPGP key"
 * https://github.com/openssl/openssl/pull/31356 
   "Add TEST_ALL memfail variants and some tests"
 * https://github.com/openssl/openssl/pull/31359 
   "FIPS: Key generation pairwise consistency tests (PCT) no longer cause the  FIPS provider to enter a non recoverable error state."
 * https://github.com/openssl/openssl/pull/31362 
   "curve448: add `static` qualifiers, remove unused functions"
 * https://github.com/openssl/openssl/pull/31363 
   "exporters/cmake/OpenSSLConfig.cmake.in: Added missing crypto libs."
 * https://github.com/openssl/openssl/pull/31364 
   "DTLS 1.3 Remove SSL_stateless support"
 * https://github.com/openssl/openssl/pull/31366 
   "build: make enable-asan work for VC targets"
 * https://github.com/openssl/openssl/pull/31370 
   "test: add pkey -ec_conv_form coverage"
 * https://github.com/openssl/openssl/pull/31378 
   "uni2utf8: reject negative length like uni2asc"
 * https://github.com/openssl/openssl/pull/31382 
   "poly1305: reject update without key and NULL key params"
 * https://github.com/openssl/openssl/pull/31385 
   "Fix missing dependency on ml_kem_kmgmt.c"
 * https://github.com/openssl/openssl/pull/31386 
   "Fix macro staircase formatting issue"
 * https://github.com/openssl/openssl/pull/31389 
   "TEST: Add DTLS 1.2 coverage for Session ID verification"
 * https://github.com/openssl/openssl/pull/31390 
   "Fix up mismatched error reason codes"
 * https://github.com/openssl/openssl/pull/31394 
   "crypto/evp: fix double free of tmp_keymgmt in evp_keyexch_init()"
 * https://github.com/openssl/openssl/pull/31398 
   "Add constant-time validation for CRYPTO_memcmp"
 * https://github.com/openssl/openssl/pull/31409 
   "cms: reject Ed448 signedAttrs when digest is unavailable"
 * https://github.com/openssl/openssl/pull/31410 
   "`doc/man3/EVP_PKEY_get_size.pod`: add `man` formatting for the security categories table"
 * https://github.com/openssl/openssl/pull/31418 
   "apps: test pkeyutl -pkeyopt_passin"
 * https://github.com/openssl/openssl/pull/31420 
   "Adjusted nasm version check for sm3 &amp; sm4 to cope with &#39;3.00rc8&#39; (was…"
 * https://github.com/openssl/openssl/pull/31421 
   "Fix use-after-free issue in radix test framework for QUIC."
 * https://github.com/openssl/openssl/pull/31424 
   "Remove `crypto/aes/aes_x86core.c` because it&#39;s dead code"
 * https://github.com/openssl/openssl/pull/31432 
   "ml_kem: return an error on catastrophic failure in decap"
 * https://github.com/openssl/openssl/pull/31434 
   "Fix BIO_write on file BIOs to report partial writes."
 * https://github.com/openssl/openssl/pull/31435 
   "doc: document SSL_set_*_state SSL argument"
 * https://github.com/openssl/openssl/pull/31446 
   "aes_core.c: Fix staircase formatting issue"
 * https://github.com/openssl/openssl/pull/31447 
   "fix use after free for apkt"
 * https://github.com/openssl/openssl/pull/31454 
   "Use %zu for printing size_t values"
 * https://github.com/openssl/openssl/pull/31457 
   "test: Invert bad TEST() condition calls"
 * https://github.com/openssl/openssl/pull/31459 
   "Revert &quot;Add indirect CRL path validation tests&quot;"
 * https://github.com/openssl/openssl/pull/31468 
   "Fix s_client Sieve STARTTLS response parsing"
 * https://github.com/openssl/openssl/pull/31478 
   "doc: clarify pkeyutl -rawin and -digest for no-prehash signatures"
 * https://github.com/openssl/openssl/pull/31482 
   "s390x: Don&#39;t ignore errors from s390x_HMAC_init(), s390x_mod_exp_hw() and s390x_crt()"
 * https://github.com/openssl/openssl/pull/31485 
   "allow SSL_set_retry_verify on server session"
 * https://github.com/openssl/openssl/pull/31487 
   "clean up a few bugs in ossl_method_store"
 * https://github.com/openssl/openssl/pull/31490 
   "Removes unused args for new record layers."
 * https://github.com/openssl/openssl/pull/31493 
   "Remove duplicate defines in tls1.h"
 * https://github.com/openssl/openssl/pull/31494 
   "test: run RIO notifier smoke test on all QUIC builds"
 * https://github.com/openssl/openssl/pull/31497 
   "ci: Switch to VS 2026 for windows-2025 image"
 * https://github.com/openssl/openssl/pull/31505 
   "windows_comp.yml: windows-latest image uses VS-2026 now"
 * https://github.com/openssl/openssl/pull/31506 
   ".github/workflows/backport.yml: show diff on cherry-pick failure"
 * https://github.com/openssl/openssl/pull/31507 
   "Fix no-psk build"
 * https://github.com/openssl/openssl/pull/31508 
   "TSAN: data race in ossl_default_provider_init in openssl"
 * https://github.com/openssl/openssl/pull/31509 
   "[master] `CHANGES.md`, `NEWS.md`: update for 4.0.1"
 * https://github.com/openssl/openssl/pull/31512 
   "Fix encrypt decrypt fetch for cms from provider side"
 * https://github.com/openssl/openssl/pull/31515 
   "Remove duplicate TLS_MD_SERVER_WRITE_KEY_CONST macro defines"
 * https://github.com/openssl/openssl/pull/31518 
   "apps: test pkeyutl -derive peer key setup"
 * https://github.com/openssl/openssl/pull/31520 
   "demos/http3: fix missing NUL terminator on h3ssl-&gt;url"
 * https://github.com/openssl/openssl/pull/31521 
   "apps: extend test for pkey text and text_pub output"
 * https://github.com/openssl/openssl/pull/31522 
   "pkcs11-provider: update to latest version"
 * https://github.com/openssl/openssl/pull/31523 
   "Fix various function pointer UBSAN "
 * https://github.com/openssl/openssl/pull/31524 
   "Document trailing data handling for DER input"
 * https://github.com/openssl/openssl/pull/31526 
   "thunk ossl_cmp_mock_srv_set1 functions"
 * https://github.com/openssl/openssl/pull/31527 
   "Prevent integer overflow in ASN1_mbstring_ncopy"
 * https://github.com/openssl/openssl/pull/31538 
   "tls_common: prevent max_early_data overflow"
 * https://github.com/openssl/openssl/pull/31539 
   "Revert &quot;convert CRYPTO_THREAD_run_once to use InitOnceExecuteOnce api&quot; (API/ABI break)"
 * https://github.com/openssl/openssl/pull/31540 
   "Don&#39;t call remove_session_cb under a lock"
 * https://github.com/openssl/openssl/pull/31541 
   "asn1: centralize aux const-callback dispatch to avoid function pointe…"
 * https://github.com/openssl/openssl/pull/31547 
   "This change should allow us to move QUIC test scripts from"
 * https://github.com/openssl/openssl/pull/31548 
   "add test case for CVE-2026-42770"
 * https://github.com/openssl/openssl/pull/31549 
   "Correct the return code documentation for the asn1 callbacks."
 * https://github.com/openssl/openssl/pull/31555 
   "[test] various zero-length message positive and negative tests for AEAD ciphers"
 * https://github.com/openssl/openssl/pull/31558 
   "s_client: skip TCP shutdown drain for datagram protocols"
 * https://github.com/openssl/openssl/pull/31559 
   "pk7_lib: Fix return value in PKCS7_set_digest"
 * https://github.com/openssl/openssl/pull/31561 
   "Fix intermittent failure in check_pc_flood radix test"
 * https://github.com/openssl/openssl/pull/31562 
   "Remove aliases for IANA-GOST2012-GOST8912-GOST8912"
 * https://github.com/openssl/openssl/pull/31568 
   "property: do not overwrite the NULL-provider cache entry on set"
 * https://github.com/openssl/openssl/pull/31570 
   "doc: document that HMAC_Update cannot be called after HMAC_Final"
 * https://github.com/openssl/openssl/pull/31582 
   "quic: reject ACK of an unsent packet number"
 * https://github.com/openssl/openssl/pull/31587 
   "Remove direct includes of windows.h where possible"
 * https://github.com/openssl/openssl/pull/31589 
   "quic: add mfail test for QUIC SRT generator"
 * https://github.com/openssl/openssl/pull/31591 
   "Fix SSKDF key parameter documentation"
 * https://github.com/openssl/openssl/pull/31592 
   "Fix SNMPKDF password parameter documentation"
 * https://github.com/openssl/openssl/pull/31593 
   "quic: add mfail tests for QUIC SRTM"
 * https://github.com/openssl/openssl/pull/31594 
   "Fix `get_cert_by_subject_ex()` to gracefully handle broken symlinks"
 * https://github.com/openssl/openssl/pull/31596 
   "Fix spelling mistakes in documentation"
 * https://github.com/openssl/openssl/pull/31597 
   "Document property string case handling"
 * https://github.com/openssl/openssl/pull/31598 
   "Mention removed ERR macros in changelog"
 * https://github.com/openssl/openssl/pull/31599 
   "Document Ed448 property query parameter"
 * https://github.com/openssl/openssl/pull/31600 
   "Fix OSSL_ATOMICS_LOCKLESS detection for Windows toolchains."
 * https://github.com/openssl/openssl/pull/31602 
   "quic: add mfail test for RCIDM"
 * https://github.com/openssl/openssl/pull/31604 
   "Add the AI declaration policy to CONTRIBUTING"
 * https://github.com/openssl/openssl/pull/31610 
   "siv128.c: Assigned -1 to final_ret(ctx) variable on auth. failure."
 * https://github.com/openssl/openssl/pull/31618 
   "statem: clnt construct ch test and negotiate_dhe fix"
 * https://github.com/openssl/openssl/pull/31619 
   "Avoid NULL dereference if RSA_PSS_PARAMS_dup() fails in ossl_rsa_dup()"
 * https://github.com/openssl/openssl/pull/31627 
   "Removes remaining SSLv2 specific code"
 * https://github.com/openssl/openssl/pull/31628 
   "`rec_layer_s3.c`: prevent `max_early_data` overflow in `ossl_early_data_count_ok()`"
 * https://github.com/openssl/openssl/pull/31639 
   "Return error if running non-existent test"
 * https://github.com/openssl/openssl/pull/31643 
   "CONTRIBUTING.md: tweak wording with regards to ML tooling usage"
 * https://github.com/openssl/openssl/pull/31644 
   "apps: cover pkeyutl oneshot buffer path with empty file input"
 * https://github.com/openssl/openssl/pull/31646 
   "Clean up the cpu id stuff by hoisting the append into a helper"
 * https://github.com/openssl/openssl/pull/31647 
   "Fix unqualified reference to openssl in 25-test_verify_store.t"
 * https://github.com/openssl/openssl/pull/31648 
   "apps: add error-path test recipe for skeyutl"
 * https://github.com/openssl/openssl/pull/31651 
   "apps: cover the kdf -cipher option in the test recipe"
 * https://github.com/openssl/openssl/pull/31652 
   "apps: cover the ec -conv_form option in the test recipe"
 * https://github.com/openssl/openssl/pull/31653 
   "apps: cover the pkcs8 -inform/-outform DER options"
 * https://github.com/openssl/openssl/pull/31654 
   "Add a demo program that shows how to query the FIPS provider version"
 * https://github.com/openssl/openssl/pull/31661 
   "`crypto/ctype.c`: fix off-by-one OOB in `ossl_toascii()`/`ossl_fromascii()`"
 * https://github.com/openssl/openssl/pull/31662 
   "Always ignore the contents of the legacy record version"
 * https://github.com/openssl/openssl/pull/31663 
   "`include/internal/hashtable.h`: avoid OOB read in `ossl_ht_strcase()`"
 * https://github.com/openssl/openssl/pull/31664 
   "crypto/armcap.c: reformat MIDR CPU-model conditionals for readability"
 * https://github.com/openssl/openssl/pull/31665 
   "apps: cover the unencrypted key bag path in the pkcs12 test"
 * https://github.com/openssl/openssl/pull/31666 
   "apps: cover the CRL printing path in the pkcs7 test recipe"
 * https://github.com/openssl/openssl/pull/31667 
   "`test/asn1_string_test.c`: allocate `tmpstring` properly in `asn1_string_new_not_owned_test`"
 * https://github.com/openssl/openssl/pull/31674 
   "Remove make-release.yml"
 * https://github.com/openssl/openssl/pull/31675 
   "apps: cover the smime multiple -signer parsing path"
 * https://github.com/openssl/openssl/pull/31676 
   "Restore the check for missing IV param in evp_cipher_asn1_to_param_ex"
 * https://github.com/openssl/openssl/pull/31677 
   "Remove old compiler support. "
 * https://github.com/openssl/openssl/pull/31678 
   "Fix/x509 policy nc leaks"
 * https://github.com/openssl/openssl/pull/31700 
   "25-test_verify_store.t: Add missing capture for bare run()"
 * https://github.com/openssl/openssl/pull/31704 
   "file_store_any2obj.c: validate bitlen before allocating MSBLOB buffer"
 * https://github.com/openssl/openssl/pull/31705 
   "ci: run full cross-compile tests on PRs with &#39;extended tests&#39; label"
 * https://github.com/openssl/openssl/pull/31707 
   "Remove QUIC_TSERVER: Move script_5 to script_9"
 * https://github.com/openssl/openssl/pull/31708 
   "Clarify the comment in asn1.h.in for ASN1_VALUE"
 * https://github.com/openssl/openssl/pull/31713 
   "ensure writes are syncronized on windows in CRYPTO_THREAD_run_once"
 * https://github.com/openssl/openssl/pull/31714 
   "x509: add delta CRL success test"
 * https://github.com/openssl/openssl/pull/31716 
   "pkcs7: null-guard enveloped and signedAndEnveloped arms in PKCS7_stream"
 * https://github.com/openssl/openssl/pull/31717 
   "Fix a bug in BN_ucmp() when comparing constant-time BIGNUMs of different lengths"
 * https://github.com/openssl/openssl/pull/31718 
   "LPdir_wince.c: Remove dead source file"
 * https://github.com/openssl/openssl/pull/31719 
   "Removes unused functions and macros from ssl_local.h and recmethod_local.h"
 * https://github.com/openssl/openssl/pull/31722 
   "pkcs7: use PKCS7_get_octet_string in PKCS7_stream signed arm"
 * https://github.com/openssl/openssl/pull/31723 
   "s390x: Fix return code handling in HMAC_Init_ex()"
 * https://github.com/openssl/openssl/pull/31730 
   "apps: cover the req -set_serial option"
 * https://github.com/openssl/openssl/pull/31731 
   "Remove remaining atoi/atol calls"
 * https://github.com/openssl/openssl/pull/31733 
   "apps: cover x509 DER key/cert input formats"
 * https://github.com/openssl/openssl/pull/31734 
   "[test] check tag abuse for AEAD ciphers"
 * https://github.com/openssl/openssl/pull/31736 
   "apps: cover crl signature verification"
 * https://github.com/openssl/openssl/pull/31737 
   "Remove unused source files poly1305_ieee754.c and poly1305_base2_44.c"
 * https://github.com/openssl/openssl/pull/31738 
   "property: add cache provider-order regression test"
 * https://github.com/openssl/openssl/pull/31743 
   "SSL_poll: fix abort_blocking mishandling in poll_translate()/poll_block()"
 * https://github.com/openssl/openssl/pull/31744 
   "s390x: Fix montgomery_multiplication_vectorized"
 * https://github.com/openssl/openssl/pull/31745 
   "Changes internal prov_drbg_st member variable type"
 * https://github.com/openssl/openssl/pull/31746 
   "quic: fix intermittent idle-test failure in tserver test"
 * https://github.com/openssl/openssl/pull/31748 
   "Fix coverity issues stemming from making `EVP_*_free` no-ops"
 * https://github.com/openssl/openssl/pull/31750 
   "Eliminate CRYPTO_GET_REF"
 * https://github.com/openssl/openssl/pull/31751 
   "`demos`: wire up `echecho`, `pkread`, `pkwrite`, and `tls-server-block`"
 * https://github.com/openssl/openssl/pull/31753 
   "Make sure we always check return of CRYPTO_UP_REF which can fail."
 * https://github.com/openssl/openssl/pull/31756 
   "Reject AES-XTS operations without an IV"
 * https://github.com/openssl/openssl/pull/31761 
   "FIPS: EC keygen - remove unnecessary self tests."
 * https://github.com/openssl/openssl/pull/31762 
   "demo: fix fips-version Makefile so it loads the FIPS provider correctly"
 * https://github.com/openssl/openssl/pull/31764 
   "x509: fix OCSP BasicResponse leak during verification"
 * https://github.com/openssl/openssl/pull/31765 
   "Suppress MSVC C4996 for legacy AppLink CRT calls"
 * https://github.com/openssl/openssl/pull/31774 
   "Use more recent default for _WIN32_WINNT"
 * https://github.com/openssl/openssl/pull/31775 
   "s390x: Fix AES-XTS hardware acceleration in IBM z17"
 * https://github.com/openssl/openssl/pull/31777 
   "fix rio_notifier to not clean/re-init Winsock"
 * https://github.com/openssl/openssl/pull/31780 
   "mfail: add sampled and count-only modes to test driver"
 * https://github.com/openssl/openssl/pull/31781 
   "test: build the fake cipher provider as a loadable module"
 * https://github.com/openssl/openssl/pull/31782 
   "Fix non-caching providers"
 * https://github.com/openssl/openssl/pull/31784 
   "crypto/x509/x509_lu.c: fix memory leak in obj_ht_foreach_object()"
 * https://github.com/openssl/openssl/pull/31789 
   "apps/s_server.c: fix SSL object leak on rpk_enable() failure"
 * https://github.com/openssl/openssl/pull/31792 
   "[Coverity 1695451, 1695453, 1695454] Assorted fixes"
 * https://github.com/openssl/openssl/pull/31798 
   "apps: test pkey -ec_param_enc option"
 * https://github.com/openssl/openssl/pull/31799 
   "apps: test the -param_enc option of the ec and ecparam apps"
 * https://github.com/openssl/openssl/pull/31801 
   "apps: test dsa app PVK output"
 * https://github.com/openssl/openssl/pull/31802 
   "apps: test rsa app -RSAPublicKey_in/-RSAPublicKey_out options"
 * https://github.com/openssl/openssl/pull/31811 
   "crypto/x509/x509_lu.c: check X509_OBJECT_up_ref_count() in x509_objec…"
 * https://github.com/openssl/openssl/pull/31812 
   "Explain inconsistency in X25519 ladder copies"
 * https://github.com/openssl/openssl/pull/31814 
   "x509: avoid NULL memcmp argument in nc_dn()"
 * https://github.com/openssl/openssl/pull/31815 
   "Fix typo in ASN1_INTEGER_get_int64.pod."
 * https://github.com/openssl/openssl/pull/31818 
   "Do not raise NOT_ENOUGH_DATA on a clean EOF at an object boundary"
 * https://github.com/openssl/openssl/pull/31820 
   "fips: make diagnosing `*-mac` issues in openssl.cnf easier"
 * https://github.com/openssl/openssl/pull/31821 
   "Remove QUIC_TSERVER: Move script_10 to script_12"
 * https://github.com/openssl/openssl/pull/31822 
   "ml_kem: Add a check for shared_secret"
 * https://github.com/openssl/openssl/pull/31826 
   "[test] exercise AEAD tag read rejection when actually present during decryption"
 * https://github.com/openssl/openssl/pull/31828 
   "x509: add ocsptest for the OCSP stapled-response verification path"
 * https://github.com/openssl/openssl/pull/31834 
   "apps: add offline OCSP request/responder/verify round-trip test"
 * https://github.com/openssl/openssl/pull/31837 
   "Suppress function pointer type validation in clang ubsan"
 * https://github.com/openssl/openssl/pull/31839 
   "Update man links in Readme."
 * https://github.com/openssl/openssl/pull/31842 
   "BIO_vprintf: fix off-by-one at 512-byte buffer boundary"
 * https://github.com/openssl/openssl/pull/31843 
   "util/mkinstallvars.pl: Suppress more debug logs"
 * https://github.com/openssl/openssl/pull/31844 
   "Fix refcounting on decoder, encoder and store fetching "
 * https://github.com/openssl/openssl/pull/31848 
   "crypto/pkcs12/p12_decr.c: fix EVP_CIPHER_CTX_ctrl error checks"
 * https://github.com/openssl/openssl/pull/31854 
   "Fix EVP_CIPHER_CTX leak in cipher BIO duplication"
 * https://github.com/openssl/openssl/pull/31857 
   "x509: keep RFC 3779 stacks hole-free after a failed canonize"
 * https://github.com/openssl/openssl/pull/31858 
   "Fix typos"
 * https://github.com/openssl/openssl/pull/31860 
   "Start fixing issues reported by the Linux script `checkpatch.pl`"
 * https://github.com/openssl/openssl/pull/31861 
   "statem: extend clnt construct tests to EndOfEarlyData and Certificate"
 * https://github.com/openssl/openssl/pull/31862 
   "pkcs12: free PKCS7 elements on error in PKCS12_unpack_authsafes"
 * https://github.com/openssl/openssl/pull/31867 
   "Fix crash in EVP_MD_CTX_copy_ex on inconsistent context"
 * https://github.com/openssl/openssl/pull/31870 
   "quic: do not hard fail mfail test for old fips providers"
 * https://github.com/openssl/openssl/pull/31871 
   "Fix capitalization in OpenSSL description CLA: Trivial"
 * https://github.com/openssl/openssl/pull/31874 
   "Fix SM2 RISC-V64 crash from functions emitted into .rodata"
 * https://github.com/openssl/openssl/pull/31875 
   "NULL-pointer subtraction UB in tls_collect_extensions()"
 * https://github.com/openssl/openssl/pull/31876 
   "Document the effect of SSL_VERIFY_FAIL_IF_NO_PEER_CERT on post-handsh…"
 * https://github.com/openssl/openssl/pull/31877 
   "Fix doubled semicolons as statement terminations"
 * https://github.com/openssl/openssl/pull/31878 
   "coveralls.yml: Disable the allocfail-tests"
 * https://github.com/openssl/openssl/pull/31879 
   "EVP_CTRL_AEAD_SET_IV_FIXED: reject negative arg values below -1"
 * https://github.com/openssl/openssl/pull/31880 
   "property: replace property_memfail with in-tree mfail tests"
 * https://github.com/openssl/openssl/pull/31882 
   "Allow `getentropy` for Emscripten"
 * https://github.com/openssl/openssl/pull/31885 
   "rand: add mfail tests for generation and seeding"
 * https://github.com/openssl/openssl/pull/31886 
   "apps: add test coverage for dgst -list"
 * https://github.com/openssl/openssl/pull/31887 
   "apps: test dsa app -modulus option"
 * https://github.com/openssl/openssl/pull/31888 
   "apps: test dsaparam app DER output paths"
 * https://github.com/openssl/openssl/pull/31889 
   "Remove QUIC_TSERVER: Move script_15 to script_19"
 * https://github.com/openssl/openssl/pull/31890 
   "pkcs7_test: disable time checks in pkcs7_verify_test"
 * https://github.com/openssl/openssl/pull/31891 
   "apps: test pkeyutl app -rev option"
 * https://github.com/openssl/openssl/pull/31893 
   "apps: test genpkey app cipher option"
 * https://github.com/openssl/openssl/pull/31896 
   "Rebase the feature/dtls1.3 branch"
 * https://github.com/openssl/openssl/pull/31901 
   "x509: replace x509_memfail with in-tree mfail tests"
 * https://github.com/openssl/openssl/pull/31905 
   "apps: cover the req -pkeyopt option"
 * https://github.com/openssl/openssl/pull/31906 
   "[test] check late AAD rejection across AEADs"
 * https://github.com/openssl/openssl/pull/31907 
   "Update pkcs11-provider submodule (5dcc876)"
 * https://github.com/openssl/openssl/pull/31908 
   "apps: cover the x509 -sigopt and -vfyopt options"
 * https://github.com/openssl/openssl/pull/31910 
   "apps: cover the crl -gendelta, -key and -keyform options"
 * https://github.com/openssl/openssl/pull/31915 
   "test: add Windows unit tests setup and initial dgram test"
 * https://github.com/openssl/openssl/pull/31916 
   "Avoid undefined behavior adding two BN_zero() values"
 * https://github.com/openssl/openssl/pull/31917 
   "Document application defined security callbacks"
 * https://github.com/openssl/openssl/pull/31918 
   "quic-radix: add thread-assisted idle keepalive test"
 * https://github.com/openssl/openssl/pull/31924 
   "quic: make tserver fake-time idle test deterministic"
 * https://github.com/openssl/openssl/pull/31926 
   "Fix removal of sole key exchange group in tuple"
 * https://github.com/openssl/openssl/pull/31927 
   "test: don&#39;t depend on DTLS alert delivery in sslrecords test"
 * https://github.com/openssl/openssl/pull/31931 
   "The wrong comment about the BN_FLG_STATIC_DATA flag."
 * https://github.com/openssl/openssl/pull/31935 
   "DTLS 1.3 Fix CI failures"
 * https://github.com/openssl/openssl/pull/31936 
   "mkwraps: resolve system (libc) functions via compiler include paths"
 * https://github.com/openssl/openssl/pull/31937 
   "docs: document the WRAP and UNIT_TEST build.info statements"
 * https://github.com/openssl/openssl/pull/31938 
   "rand: pre-fetch JITTER seed when jitter used"
 * https://github.com/openssl/openssl/pull/31942 
   "keccak1600x4-avx512vl: fix undefined symbols on macOS (#31941)"
 * https://github.com/openssl/openssl/pull/31943 
   "[Coverity] Check the return values of BN_hex2bn in tests"
 * https://github.com/openssl/openssl/pull/31945 
   "Remove QUIC_TSERVER: Move script_13 to script_14"
 * https://github.com/openssl/openssl/pull/31946 
   "apps: add dgst test coverage for -keyform option"
 * https://github.com/openssl/openssl/pull/31947 
   "tests: reduce pkcs11-provider log to test failures"
 * https://github.com/openssl/openssl/pull/31948 
   "apps: test enc -P, -nosalt, -md and -iter options"
 * https://github.com/openssl/openssl/pull/31949 
   "apps: test dsa -text option"
 * https://github.com/openssl/openssl/pull/31950 
   "apps: test rsa -text option"
 * https://github.com/openssl/openssl/pull/31951 
   "apps: test pkey -encopt option"
 * https://github.com/openssl/openssl/pull/31952 
   "apps: test ec and ecparam -text options"
 * https://github.com/openssl/openssl/pull/31953 
   "apps: test pkeyutl -peerform option"
 * https://github.com/openssl/openssl/pull/31954 
   "Fix dsaparams decoding from DER files"
 * https://github.com/openssl/openssl/pull/31955 
   "apps: test pkcs8 -nocrypt reading a PKCS#8 PEM"
 * https://github.com/openssl/openssl/pull/31956 
   "apps: test pkcs12 -clcerts/-cacerts and -name options"
 * https://github.com/openssl/openssl/pull/31957 
   "Add some missing value_barrier calls"
 * https://github.com/openssl/openssl/pull/31960 
   "cms: fix AuthenticatedData authAttrs and unauthAttrs types"
 * https://github.com/openssl/openssl/pull/31961 
   "Fix the valgrind CI pipeline"
 * https://github.com/openssl/openssl/pull/31965 
   "apps: cover the req -subj modification of an existing request"
 * https://github.com/openssl/openssl/pull/31967 
   "apps: cover the x509 -serial, name-hash and -fingerprint print options"
 * https://github.com/openssl/openssl/pull/31968 
   "apps: drop invalid trust setting in check_cert_might_be_valid()"
 * https://github.com/openssl/openssl/pull/31969 
   "apps: cover the crl -crlnumber and -issuer print options"
 * https://github.com/openssl/openssl/pull/31970 
   "rand: fix jitter seed macro logic"
 * https://github.com/openssl/openssl/pull/31972 
   "Split up and correct the X509_VERIFY_PARAM man pages"
 * https://github.com/openssl/openssl/pull/31973 
   "`doc/man7/openssl-env.pod`: fix and augment `OPENSSL_RUNNING_UNIT_TESTS` description"
 * https://github.com/openssl/openssl/pull/31974 
   "Fix Coverity CHECKED_RETURN defect (CID 1696969)"
 * https://github.com/openssl/openssl/pull/31978 
   "DTLS 1.3 Don&#39;t reset the handshake seq number after connection finish"
 * https://github.com/openssl/openssl/pull/31979 
   "DTLS 1.3 SSL Listener does not currently buffer handshake messages"
 * https://github.com/openssl/openssl/pull/31980 
   "DTLS 1.3 SSL Listener CAP pending connections"
 * https://github.com/openssl/openssl/pull/31981 
   "Rework v3nametest for SAN-first matching, add flag and long-name tests"
 * https://github.com/openssl/openssl/pull/31983 
   "DTLS 1.3 SSL Listener Demo"
 * https://github.com/openssl/openssl/pull/31991 
   "Add BIO bss_file test"
 * https://github.com/openssl/openssl/pull/31992 
   "Misc Coverity fixes"
 * https://github.com/openssl/openssl/pull/31993 
   "errors: fix stale string overrides in openssl.txt for renamed SSL err…"
 * https://github.com/openssl/openssl/pull/31994 
   "apps: decode DTLSv1.2 records in s_client/s_server -msg output"
 * https://github.com/openssl/openssl/pull/31995 
   "docs: clarify EVP_PKEY context handling after key generation"
 * https://github.com/openssl/openssl/pull/31996 
   "docs: clarify raw RSA migration"
 * https://github.com/openssl/openssl/pull/31998 
   "Fix issues found by asan/ubsan fuzzer CI"
 * https://github.com/openssl/openssl/pull/32003 
   "Remove QUIC_TSERVER: Move script_20 to script_24"
 * https://github.com/openssl/openssl/pull/32006 
   "Fix clean target find/-prune precedence bug"
 * https://github.com/openssl/openssl/pull/32007 
   "Update SSL_CTX_set1_curves.pod for OpenSSL 3.5 additions"
 * https://github.com/openssl/openssl/pull/32014 
   "test_ocsp: bump test number"
 * https://github.com/openssl/openssl/pull/32015 
   "Rename `ASN1_STRING_length_ex`, `ASN1_STRING_set_data`, and `ASN1_STRING_set_string`"
 * https://github.com/openssl/openssl/pull/32019 
   "Add encoder/decoder API test and fix encoder chain data type"
 * https://github.com/openssl/openssl/pull/32020 
   "QUIC: ignore rejected default stream candidates"
 * https://github.com/openssl/openssl/pull/32021 
   "Add OSSL_ECHSTORE_read_echconfiglist fuzzer"
 * https://github.com/openssl/openssl/pull/32023 
   "Remove QUIC_TSERVER: Move script_25 to script_29"
 * https://github.com/openssl/openssl/pull/32029 
   "rand: factor out seed source creation and fix store race"
 * https://github.com/openssl/openssl/pull/32031 
   "add ossl_list_##name##_append(head, tail) function"
 * https://github.com/openssl/openssl/pull/32033 
   "RedBlack tree for OpenSSL."
 * https://github.com/openssl/openssl/pull/32035 
   "apps: test dgst -r and -c output formats"
 * https://github.com/openssl/openssl/pull/32036 
   "apps: fix and test skeyutl -skeyopt handling"
 * https://github.com/openssl/openssl/pull/32037 
   "quic: use @-style Doxygen tags in ossl_quic_srtm_remove doc comment"
 * https://github.com/openssl/openssl/pull/32039 
   "Update CHANGES/NEWS to mention the HollowByte fix"
 * https://github.com/openssl/openssl/pull/32045 
   "DOCS: Fix KEM init function documentation"
 * https://github.com/openssl/openssl/pull/32046 
   "DOCS: Fix derive_skey provider documentation"
 * https://github.com/openssl/openssl/pull/32048 
   "apps: test rsa -modulus output"
 * https://github.com/openssl/openssl/pull/32049 
   "apps: test pkey -inform and -outform handling"
 * https://github.com/openssl/openssl/pull/32052 
   "QUIC server: limit the number of pending connections"
 * https://github.com/openssl/openssl/pull/32053 
   "ci: add pilot auto-dispatch entry points for approved PRs"
 * https://github.com/openssl/openssl/pull/32058 
   "Add note about internal documentation"
 * https://github.com/openssl/openssl/pull/32059 
   "apps: test ec -check key consistency reporting"
 * https://github.com/openssl/openssl/pull/32061 
   "apps: test ecparam -inform, -outform and -conv_form handling"
 * https://github.com/openssl/openssl/pull/32062 
   "Add OIDs specified by RFC 9925"
 * https://github.com/openssl/openssl/pull/32064 
   "dtls: fix DTLSv1_listen record sequence after cookie verify"
 * https://github.com/openssl/openssl/pull/32065 
   "Fix data race in `check_pc_flood` radix test"
 * https://github.com/openssl/openssl/pull/32067 
   "updating fuzz-corpora submodule"
 * https://github.com/openssl/openssl/pull/32070 
   "ech: check memory failure in vpm allocation in store final check"
 * https://github.com/openssl/openssl/pull/32072 
   "CMS: Guard against int overflow in cms_kek_cipher()"
 * https://github.com/openssl/openssl/pull/32073 
   "apps: test info options of the list command"
 * https://github.com/openssl/openssl/pull/32077 
   "Fix oqs double free on mixed cacheable/noncacheable lookups."
 * https://github.com/openssl/openssl/pull/32083 
   "test: fix flaky -md and -iter mismatch checks in 20-test_enc.t"
 * https://github.com/openssl/openssl/pull/32086 
   "quic: fix BIO ownership in test helper"
 * https://github.com/openssl/openssl/pull/32092 
   "add d2i regression test to asn1 decode test suite"
 * https://github.com/openssl/openssl/pull/32093 
   "Add PKCS7_verify fuzzer"
 * https://github.com/openssl/openssl/pull/32094 
   "test: add precise Valgrind suppression for direct provider init path"
 * https://github.com/openssl/openssl/pull/32098 
   "Add a comment justifying non-constant-time memcmp"
 * https://github.com/openssl/openssl/pull/32099 
   "Document the behavior of BN_generate_prime() on failure"
 * https://github.com/openssl/openssl/pull/32102 
   "storemgmt: Validate blob length before buffer allocation"
 * https://github.com/openssl/openssl/pull/32104 
   "Fix some missing close parens in signature docs"
 * https://github.com/openssl/openssl/pull/32105 
   "Doc fips provider cross version compat"
 * https://github.com/openssl/openssl/pull/32107 
   "Remove QUIC_TSERVER: Move script_30 to script_34"
 * https://github.com/openssl/openssl/pull/32117 
   "Fix duplicate fd event merging in poll() RIO backend"
 * https://github.com/openssl/openssl/pull/32119 
   "Harmonise formatting of `OSSL_DEPRECATEDIN_._._FOR` messages"
 * https://github.com/openssl/openssl/pull/32122 
   "SSL_dup() should copy additional members"
 * https://github.com/openssl/openssl/pull/32124 
   "Reject clearly degenerate RSASVE parameters."
 * https://github.com/openssl/openssl/pull/32132 
   "Fix AArch64 Poly1305 SVE2 symbol visibility"
 * https://github.com/openssl/openssl/pull/32136 
   "Document SM4 portable table-lookup side-channel risk"
 * https://github.com/openssl/openssl/pull/32138 
   "Remove QUIC_TSERVER: Move script_35 to script_39"
 * https://github.com/openssl/openssl/pull/32139 
   "docs: document thread cancellation safety limitations"
 * https://github.com/openssl/openssl/pull/32143 
   "Add X509v3 configuration fuzzer"
 * https://github.com/openssl/openssl/pull/32148 
   "Additional cleansing of intermediate (potentially sensitive) data in ML-KEM, ML-DSA and SLH-DSA (master)"
 * https://github.com/openssl/openssl/pull/32153 
   "Integration regression: Fix variable shadowing in TLS write retry path"
 * https://github.com/openssl/openssl/pull/32155 
   "`doc/internal/man7/deprecation.pod`: document `OSSL_DEPRECATEDIN_._._FOR` macros"
 * https://github.com/openssl/openssl/pull/32173 
   "Check the tag on EVP_Cipher() finalize: Poly1305 and OCB AEADs"
 * https://github.com/openssl/openssl/pull/32174 
   "ci: add a CI-bot dispatch entry point to compiler-zoo, run-checker-merge and avx512-sde"
 * https://github.com/openssl/openssl/pull/32175 
   "ci: dispatch os-zoo, the cross-compiles, oss-fuzz and interop-tests against a PR head"
 * https://github.com/openssl/openssl/pull/32177 
   "Fix NULL dereference in v2i_AUTHORITY_KEYID()"
 * https://github.com/openssl/openssl/pull/32178 
   "Fix latent bugs where ASN1_STRING data values are assumed to be C strings."
 * https://github.com/openssl/openssl/pull/32180 
   "Update pkcs11-provider and drop test disablement"
 * https://github.com/openssl/openssl/pull/32182 
   "DTLS 1.3 Update CHANGES.md"
 * https://github.com/openssl/openssl/pull/32183 
   "statem: fix missing SSLfatal in TLSv1.3 ticket construction"
 * https://github.com/openssl/openssl/pull/32190 
   "apps/x509: return failure for later -multi errors"
 * https://github.com/openssl/openssl/pull/32192 
   "fix module extension on non-.so platforms"
 * https://github.com/openssl/openssl/pull/32195 
   "ssl: add missing SSLfatal in PSK premaster secret generation"
 * https://github.com/openssl/openssl/pull/32196 
   "ssl: restore missing SSLfatal in keylog output"
 * https://github.com/openssl/openssl/pull/32197 
   "statem: add missing SSLfatal in compressed certificate construction"
 * https://github.com/openssl/openssl/pull/32198 
   "ssl: add missing SSLfatal in TLSv1.3 finished MAC computation"
 * https://github.com/openssl/openssl/pull/32199 
   "statem: add missing SSLfatal in padding extension construction"
 * https://github.com/openssl/openssl/pull/32200 
   "ssl: add missing SSLfatal on session ID lock failure"
 * https://github.com/openssl/openssl/pull/32206 
   "Fix ASN1_TYPE memory leak in asn1_multi()"
 * https://github.com/openssl/openssl/pull/32230 
   "CI: fix check_docs failures by pining mdl to 0.17.0"
 * https://github.com/openssl/openssl/pull/32233 
   "Add a migration entry for ASN1_STRINGs"
 * https://github.com/openssl/openssl/pull/32235 
   "FIPS derivation functions combined PR"
 * https://github.com/openssl/openssl/pull/32236 
   "Remove QUIC_TSERVER: Move script_40 to script_44"
 * https://github.com/openssl/openssl/pull/32238 
   "Fix BIT STRING handling in X509_ATTRIBUTE_set1_data()"
 * https://github.com/openssl/openssl/pull/32239 
   "Fix 5 bugs in the DTLS Listener/SSL_poll() implementation"
 * https://github.com/openssl/openssl/pull/32240 
   "TLS 1.3: Apply the cap to the lifetime hint in the session"
 * https://github.com/openssl/openssl/pull/32243 
   "Build system improvements - Make it much faster."
 * https://github.com/openssl/openssl/pull/32255 
   "Test the constant-time validation helpers"
 * https://github.com/openssl/openssl/pull/32257 
   "Fix VAES CBC round-key stack cleanup"
 * https://github.com/openssl/openssl/pull/32260 
   "ci: trigger backports on label changes"
 * https://github.com/openssl/openssl/pull/32269 
   "Fix RSA SHA-512 truncated digest signature mappings"
 * https://github.com/openssl/openssl/pull/32270 
   "CI: specify RISC-V vector extension version in QEMU"
 * https://github.com/openssl/openssl/pull/32272 
   "Do not test for strtol input validation on older providers that use atoi. "
 * https://github.com/openssl/openssl/pull/32276 
   "Fix DTLS 1.3 early data transcript hash stripping"
 * https://github.com/openssl/openssl/pull/32299 
   "statem: test tls_construct_client_key_exchange"
 * https://github.com/openssl/openssl/pull/32302 
   "ci: fix race condition in parallel Perl 5.10 build"
 * https://github.com/openssl/openssl/pull/32303 
   "cms: clear temporary key buffers on failure"
 * https://github.com/openssl/openssl/pull/32309 
   "Test EVP_PKEY_get_size for zero return"
 * https://github.com/openssl/openssl/pull/32310 
   "Use an int for the return value of i2a_ASN1_OBJECT"
 * https://github.com/openssl/openssl/pull/32312 
   "test: let the kernel pick the DTLS client port in TLSProxy"
 * https://github.com/openssl/openssl/pull/32314 
   "Revised RSASVE degenerate ciphertext check."
 * https://github.com/openssl/openssl/pull/32315 
   "doc: correct pkcs12 passin and passout descriptions"
 * https://github.com/openssl/openssl/pull/32324 
   "DTLS 1.3 Support blocking mode on listeners and connections (pending #32239)"
 * https://github.com/openssl/openssl/pull/32330 
   "Add an MFAIL regression test for asn1_multi() memleak"
 * https://github.com/openssl/openssl/pull/32331 
   "Skip the common test options in dtls_multithread_test"
 * https://github.com/openssl/openssl/pull/32335 
   "Remove QUIC_TSERVER: Move script_45 to script_49"
 * https://github.com/openssl/openssl/pull/32337 
   "test: use portable function-name macro in QUIC test helper"
 * https://github.com/openssl/openssl/pull/32340 
   "Dtls 1 3 new ci fixes"
 * https://github.com/openssl/openssl/pull/32343 
   "Add a test that generated files are gitignored and untracked"
 * https://github.com/openssl/openssl/pull/32345 
   "Deal with riscv64 qemu-user stderr noise"
 * https://github.com/openssl/openssl/pull/32346 
   "test: fix FIPS identity DRBG coverage"
 * https://github.com/openssl/openssl/pull/32356 
   "test_pending_limit(): Use OPENSSL_FUNC instead of __func__"
 * https://github.com/openssl/openssl/pull/32382 
   "Bugfix in the file BIO - avoiding false negatives based on previous errno"
 * https://github.com/openssl/openssl/pull/32384 
   "ci: Reduce mfail fuzz test to only few corpus samples"
 * https://github.com/openssl/openssl/pull/32388 
   "Consistently use ASN1_ITEM_rptr() for ASN1_ITEMs"
 * https://github.com/openssl/openssl/pull/32395 
   "test: keep QUIC RADIX diagnostics out of the TAP pipe"
 * https://github.com/openssl/openssl/pull/32400 
   "ocsp: Report expired nextUpdate with the correct reason"
 * https://github.com/openssl/openssl/pull/32404 
   "Make CI run a lot faster. "
 * https://github.com/openssl/openssl/pull/32406 
   "Fix tick race in radix fault-injection scripts"
 * https://github.com/openssl/openssl/pull/32407 
   "Fix memory leak in PKCS12_parse"
 * https://github.com/openssl/openssl/pull/32408 
   "Revert &quot;.github/workflows/ci-doc-changes.yml: pin mdl to 0.17.0&quot;"
 * https://github.com/openssl/openssl/pull/32410 
   "Fix time_t / integer compares in tls13tickettest"
 * https://github.com/openssl/openssl/pull/32421 
   "Free connections before listeners in the radix test cleanup"
 * https://github.com/openssl/openssl/pull/32422 
   "doc: add missing const to PEM write SYNOPSIS"
 * https://github.com/openssl/openssl/pull/32429 
   "Fix TAP stream corruption in ML codec and pkeyutl test recipes"
 * https://github.com/openssl/openssl/pull/32431 
   "test: forward real stdio calls in bss_file unit test mocks"
 * https://github.com/openssl/openssl/pull/32432 
   "ci: use long calls for HPPA cross-compilation"
 * https://github.com/openssl/openssl/pull/32435 
   "Skip the legacy session ID check for DTLS 1.3 resumption"
 * https://github.com/openssl/openssl/pull/32441 
   "Rebase the feature/dtls-1.3 branch onto the latest master"
 * https://github.com/openssl/openssl/pull/32443 
   "Init libssl to sort the ciphers"
 * https://github.com/openssl/openssl/pull/32444 
   "Allow X448MLKEM1024 to be fips approved"
 * https://github.com/openssl/openssl/pull/32461 
   "docs: fix doubled words in man pages and design docs"
 * https://github.com/openssl/openssl/pull/32465 
   "Revert &quot;Allow X448MLKEM1024 to be fips approved&quot;"
 * https://github.com/openssl/openssl/pull/32484 
   "[master] `CHANGES.md`, `NEWS.md`: update for 4.0.2"
 * https://github.com/openssl/openssl/pull/32496 
   "Fix test for CVE-2026-63072"
 * https://github.com/openssl/openssl/pull/32502 
   "Generated decoders for RSA and EC parameter handling"
 * https://github.com/openssl/openssl/pull/32505 
   "Keep GREASE key shares valid after HelloRetryRequest"
 * https://github.com/openssl/openssl/pull/32510 
   "Fix build warnings in fuzzing and ANSI C builds for openssl-3.5"
 * https://github.com/openssl/openssl/pull/32513 
   "CMS/PKCS7: do not leave stale errors on the queue"
 * https://github.com/openssl/openssl/pull/32515 
   "quic: test the rstream packet pinning path"
 * https://github.com/openssl/openssl/pull/32516 
   "Fix check-style truncation"
 * https://github.com/openssl/openssl/pull/32521 
   "CI: skip rejection-path test under fuzzing builds"
 * https://github.com/openssl/openssl/pull/32533 
   "dtls: BIO_snprintf() to snprintf() in the DTLS echo demos"
 * https://github.com/openssl/openssl/pull/32537 
   "add VS2013 compiler testing job to CI workflow"
 * https://github.com/openssl/openssl/pull/32543 
   "Fix potential double-free in DSA/DH finish slots"
 * https://github.com/openssl/openssl/pull/32544 
   "Strengthen the guidance on bulk submission of pull requests"
 * https://github.com/openssl/openssl/pull/32547 
   "Don&#39;t use BIO_snprintf as it is deprecated"
 * https://github.com/openssl/openssl/pull/32551 
   "dtls: fix flaky cookie exchange loop in listener test"
 * https://github.com/openssl/openssl/pull/32557 
   "quic: collect rejected incoming streams and return their stream credit"
 * https://github.com/openssl/openssl/pull/32570 
   "apps: test enc app opaque symmetric key options"
 * https://github.com/openssl/openssl/pull/32574 
   "apps: test enc -kfile option"
 * https://github.com/openssl/openssl/pull/32576 
   "Fix coverity issues 1700563, 1700562"
 * https://github.com/openssl/openssl/pull/32578 
   "apps: cover the kdf -binary option in the test recipe"
 * https://github.com/openssl/openssl/pull/32580 
   "apps: cover the prime -generate option in the test recipe"
 * https://github.com/openssl/openssl/pull/32582 
   "Print the correct length for the private key"
 * https://github.com/openssl/openssl/pull/32587 
   "AEADs: add an error to the queue on tag mismatch"
 * https://github.com/openssl/openssl/pull/32588 
   "apps: cover the dhparam -dsaparam file input in the test recipe"
 * https://github.com/openssl/openssl/pull/32592 
   "apps: cover the genrsa, gendsa and genpkey error cases"
 * https://github.com/openssl/openssl/pull/32596 
   "apps: cover the ec no_public option in the test recipe"
 * https://github.com/openssl/openssl/pull/32597 
   "Build for the right targets on msvc2013 in compiler zoo CI"
 * https://github.com/openssl/openssl/pull/32601 
   "Fix DTLS 1.3 sequence number truncation and reconstruction"
 * https://github.com/openssl/openssl/pull/32604 
   "test: use the portable null device in Perl recipes"
 * https://github.com/openssl/openssl/pull/32615 
   "Don&#39;t let stderr block when filling up."
 * https://github.com/openssl/openssl/pull/32617 
   "DTLS 1.3 Enforce the RFC 9147 Section 8 sending epoch limit"
 * https://github.com/openssl/openssl/pull/32622 
   "[4.1 blocker] Fix DTLS 1.3 accepting unauthenticated plaintext alerts"
 * https://github.com/openssl/openssl/pull/32623 
   "`doc/man3/EVP_PKEY_get_size.pod`: remove stray &quot;&gt;&quot; from HTML table formatting"
 * https://github.com/openssl/openssl/pull/32626 
   "We don&#39;t need linking s_lib into FIPS provider"
 * https://github.com/openssl/openssl/pull/32629 
   "Let TLSProxy tests set the expected NewSessionTicket count"
 * https://github.com/openssl/openssl/pull/32630 
   "test: tolerate DTLS peer change with fragment data"
 * https://github.com/openssl/openssl/pull/32637 
   "Dereference variable after NULL check"
 * https://github.com/openssl/openssl/pull/32646 
   "Do not advertise OPENSSL_INIT_LOAD_CONFIG in optsdone too soon"
 * https://github.com/openssl/openssl/pull/32652 
   "fix MSVC 2013 builds in shared mode"
 * https://github.com/openssl/openssl/pull/32717 
   "quic_multistream_test.c: Fix test failure in fuzzing build"
 * https://github.com/openssl/openssl/pull/32723 
   "statem_clnt_construct_test.c: Use snprintf() instead of BIO_snprintf()"
