### PR TITLE
CI and CHANGES/NEWS updates after 4.1 branching and 3.0 EOL

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -39,9 +39,6 @@ jobs:
           }, {
             branch: '3.4',
             cppflags: 'CPPFLAGS=-ansi'
-          }, {
-            branch: '3.0',
-            cppflags: 'CPPFLAGS=-ansi'
           }
         ]
     runs-on: ubuntu-latest

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,6 +25,9 @@ jobs:
       matrix:
         release: [
           {
+            branch: '4.1',
+            cppflags: ''
+          }, {
             branch: '4.0',
             cppflags: ''
           }, {

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -49,6 +49,9 @@ jobs:
               "branch": "master",
               "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-unit-tests"
             }, {
+              "branch": "openssl-4.1",
+              "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-unit-tests"
+            }, {
               "branch": "openssl-4.0",
               "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug"
             },{

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -63,9 +63,6 @@ jobs:
             },{
               "branch": "openssl-3.4",
               "extra_config": "no-afalgeng enable-fips enable-tfo"
-            }, {
-              "branch": "openssl-3.0",
-              "extra_config": "no-afalgeng enable-fips"
           }]
           EOF
           )

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -113,6 +113,7 @@ jobs:
       matrix:
         branch: [
           { openssl: 'master', openssh: 'openssl-master', openssl_config: 'no-docs'},
+          { openssl: 'openssl-4.1', openssh: 'openssl-4.1', openssl_config: 'no-docs'},
           { openssl: 'openssl-4.0', openssh: 'openssl-4.0', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.6', openssh: 'openssl-3.6', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.5', openssh: 'openssl-3.5', openssl_config: 'no-docs'},

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -117,8 +117,7 @@ jobs:
           { openssl: 'openssl-4.0', openssh: 'openssl-4.0', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.6', openssh: 'openssl-3.6', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.5', openssh: 'openssl-3.5', openssl_config: 'no-docs'},
-          { openssl: 'openssl-3.4', openssh: 'openssl-3.4', openssl_config: 'no-docs'},
-          { openssl: 'openssl-3.0', openssh: 'openssl-3.0', openssl_config: ''}
+          { openssl: 'openssl-3.4', openssh: 'openssl-3.4', openssl_config: 'no-docs'}
         ]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -120,11 +120,6 @@ jobs:
             tgz: PR.tar.gz,
             extra_config: "enable-lms enable-tls-deprecated-ec",
           }, {
-            name: openssl-3.0,
-            dir: branch-3.0,
-            tgz: branch-3.0.tar.gz,
-            extra_config: "",
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -219,7 +214,7 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-4.1, branch-4.0, branch-3.6, branch-3.5, branch-3.4, branch-3.0,
+        tree_a: [ branch-4.1, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
@@ -235,8 +230,6 @@ jobs:
             tree_b: branch-3.5
           - tree_a: PR
             tree_b: branch-3.4
-          - tree_a: PR
-            tree_b: branch-3.0
     steps:
       - name: early exit checks
         id: early_exit

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -145,6 +145,11 @@ jobs:
             tgz: branch-4.0.tar.gz,
             extra_config: "enable-lms enable-tls-deprecated-ec",
           }, {
+            name: openssl-4.1,
+            dir: branch-4.1,
+            tgz: branch-4.1.tar.gz,
+            extra_config: "enable-lms enable-tls-deprecated-ec",
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,
@@ -214,12 +219,14 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-4.0, branch-3.6, branch-3.5, branch-3.4, branch-3.0,
+        tree_a: [ branch-4.1, branch-4.0, branch-3.6, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
           - tree_a: PR
             tree_b: branch-master
+          - tree_a: PR
+            tree_b: branch-4.1
           - tree_a: PR
             tree_b: branch-4.0
           - tree_a: PR

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -115,11 +115,6 @@ jobs:
           #         the build.
           #     `extra_config` adds extra config build option for the branch.
           {
-            name: openssl-3.0,
-            dir: branch-3.0,
-            tgz: branch-3.0.tar.gz,
-            extra_config: "",
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -219,10 +214,8 @@ jobs:
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
         tree_a: [ branch-master, branch-4.1, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
-                  branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
-        tree_b: [ branch-master, branch-4.1, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
-                  branch-3.0  ]
+        tree_b: [ branch-master, branch-4.1, branch-4.0, branch-3.6, branch-3.5, branch-3.4 ]
     steps:
       - name: early exit checks
         id: early_exit

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -140,6 +140,11 @@ jobs:
             tgz: branch-4.0.tar.gz,
             extra_config: "enable-lms enable-tls-deprecated-ec",
           }, {
+            name: openssl-4.1,
+            dir: branch-4.1,
+            tgz: branch-4.1.tar.gz,
+            extra_config: "enable-lms enable-tls-deprecated-ec",
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,
@@ -213,10 +218,10 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-master, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
+        tree_a: [ branch-master, branch-4.1, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
                   branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
-        tree_b: [ branch-master, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
+        tree_b: [ branch-master, branch-4.1, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
                   branch-3.0  ]
     steps:
       - name: early exit checks

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ appropriate release branch.
 OpenSSL Releases
 ----------------
 
+ - [OpenSSL 4.2](#openssl-42)
  - [OpenSSL 4.1](#openssl-41)
  - [OpenSSL 4.0](#openssl-40)
  - [OpenSSL 3.6](#openssl-36)
@@ -28,12 +29,15 @@ OpenSSL Releases
  - [OpenSSL 1.0.0](#openssl-100)
  - [OpenSSL 0.9.x](#openssl-09x)
 
-OpenSSL 4.1
+OpenSSL 4.2
 -----------
 
 ### Changes between 4.1 and 4.2 [xx XXX xxxx]
 
  * none yet
+
+OpenSSL 4.1
+-----------
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ release. For more details please read the CHANGES file.
 OpenSSL Releases
 ----------------
 
+ - [OpenSSL 4.2](#openssl-42)
  - [OpenSSL 4.1](#openssl-41)
  - [OpenSSL 4.0](#openssl-40)
  - [OpenSSL 3.6](#openssl-36)
@@ -23,12 +24,15 @@ OpenSSL Releases
  - [OpenSSL 1.0.0](#openssl-100)
  - [OpenSSL 0.9.x](#openssl-09x)
 
-OpenSSL 4.1
+OpenSSL 4.2
 -----------
 
 ### Major changes between OpenSSL 4.1 and OpenSSL 4.2 [under development]
 
   * none
+
+OpenSSL 4.1
+-----------
 
 ### Major changes between OpenSSL 4.0 and OpenSSL 4.1 [under development]
 


### PR DESCRIPTION
This needs to be cherry-picked to all the active branches as applicable. I.e., first commit should go only to master, the second and the third should go to all the active branches, but might need small adjustments.

