### PR TITLE
NULL-initialize BIGNUM* in OSSL_PARAM_print_to_bio

### DIFF
--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -218,7 +218,7 @@ int OSSL_PARAM_print_to_bio(const OSSL_PARAM *p, BIO *bio, int print_values)
 {
     int64_t i;
     uint64_t u;
-    BIGNUM *bn;
+    BIGNUM *bn = NULL;
 #ifndef OPENSSL_SYS_UEFI
     double d;
     int dok;


### PR DESCRIPTION
OSSL_PARAM_get_BN is documented as «The BIGNUM referenced by val is updated and is allocated if *val is NULL.», but in OSSL_PARAM_print_bio the argument is not NULL-initialize. If the stack happens to be null initialized all is well, but if it isn't it wil try to write to a random address and can segfault.