### PR TITLE
Fix memory leak on error on OSSL_PROVIDER_available()

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1674,10 +1674,10 @@ int OSSL_PROVIDER_available(OSSL_LIB_CTX *libctx, const char *name)
 
     prov = ossl_provider_find(libctx, name, 0);
     if (prov != NULL) {
-        if (!CRYPTO_THREAD_read_lock(prov->flag_lock))
-            return 0;
-        available = prov->flag_activated;
-        CRYPTO_THREAD_unlock(prov->flag_lock);
+        if (CRYPTO_THREAD_read_lock(prov->flag_lock)) {
+            available = prov->flag_activated;
+            CRYPTO_THREAD_unlock(prov->flag_lock);
+        }
         ossl_provider_free(prov);
     }
     return available;


### PR DESCRIPTION
`ossl_provider_free` must be called, but the `CRYPTO_THREAD_read_lock` error path does not do this. By inverting the condition and restructuring the code we can solve this cleanly without introducing a goto.

Found by an experimental static analyser I'm working on. A bit theoretical, but the error condition is there...