### PR TITLE
Bound the DTLS 1.3 ACK body read by the record, not init_num

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -1026,14 +1026,19 @@ redo:
         goto f_err;
     }
     if (recvd_type == SSL3_RT_ACK) {
-        if (readbytes == DTLS1_HM_HEADER_LENGTH) {
+        /*
+         * An ACK has no message header: the bytes already read are body, and
+         * an ACK never spans records, so read the rest of this one. Nothing
+         * left means a malformed ACK; dtls_process_ack() rejects it.
+         */
+        if (readbytes == DTLS1_HM_HEADER_LENGTH
+            && s->rlayer.curr_rec < s->rlayer.num_recs) {
             const size_t first_readbytes = readbytes;
 
             p += DTLS1_HM_HEADER_LENGTH;
 
             i = ssl->method->ssl_read_bytes(ssl, SSL3_RT_HANDSHAKE, NULL, p,
-                s->init_num - DTLS1_HM_HEADER_LENGTH,
-                0, &readbytes);
+                s->rlayer.tlsrecs[s->rlayer.curr_rec].length, 0, &readbytes);
             readbytes += first_readbytes;
             /*
              * This shouldn't ever fail due to NBIO because we already checked


### PR DESCRIPTION
dtls_get_reassembled_message() reads an ACK in two steps: the first DTLS1_HM_HEADER_LENGTH bytes, then the rest. The second read was bounded by "s->init_num - DTLS1_HM_HEADER_LENGTH", but s->init_num does not describe this message -- the read state machine zeroes it after the previous one. The subtraction underflows to near SIZE_MAX, and the read is correct only because dtls1_read_bytes() clamps to the bytes left in the record.

Ask for that remainder directly: an ACK never spans records. An ACK body is 2 + 16n bytes, so a record yielding exactly DTLS1_HM_HEADER_LENGTH is malformed; skip the second read there rather than ask for 0 bytes, which dtls1_read_bytes() reports as a retry.

No functional change, hence no test.

Assisted-by: Claude Code:claude-opus-5[1m]
