### PR TITLE
70-test_stime.t: SIGKILL the server instead of SIGHUP

### DIFF
--- a/test/recipes/70-test_stime.t
+++ b/test/recipes/70-test_stime.t
@@ -74,5 +74,8 @@ SKIP: {
 }
 
 close $srv_in;
-kill 'HUP', $srv_pid;
+# SIGKILL rather than SIGHUP: this s_server has no -naccept, so it runs
+# until it is stopped, and an ignored SIGHUP inherited from an ancestor
+# (SIG_IGN survives exec) would leave the waitpid() below hanging.
+kill 'KILL', $srv_pid;
 waitpid($srv_pid, 0);

--- a/util/wrap.pl.in
+++ b/util/wrap.pl.in
@@ -118,8 +118,16 @@ if ($^O eq 'VMS') {
     @cmd = ( @ARGV );
 }
 
-# The exec() statement on MSWin32 doesn't seem to give back the exit code
-# from the call, so we resort to using system() instead.
+# exec() keeps this script's pid, which matters to callers that signal the
+# command they started: a test recipe using open3() is handed this pid, not
+# the command's, so with a subprocess the signal never reaches the command.
+# MSWin32 can't use exec() because it doesn't give back the exit code, and
+# VMS needs the exit code translated below, so both keep the subprocess.
+if ($^O ne 'MSWin32' && $^O ne 'VMS') {
+    exec @cmd
+        or die "wrap.pl: Failed to execute '", join(' ', @cmd), "': $!\n";
+}
+
 my $waitcode;
 if ($^O eq 'MSWin32') {
     $waitcode = system(quote_cmd_win32(@cmd));


### PR DESCRIPTION
This s_server has no -naccept, so it runs until it is stopped. SIGHUP
can be ignored, and an inherited SIG_IGN survives exec -- under nohup,
for instance -- so the signal was delivered and discarded, leaving the
waitpid() after it hanging indefinitely. SIGKILL cannot be ignored or
blocked, so the teardown always completes.
82-test_ech_client_server.t already stops its server this way.

Fixes https://github.com/openssl/openssl/issues/32618

We also fix wrap.pl to use exec so that signals reach the right pid.