### PR TITLE
Fix set but unsued variable in lib/opt.c

### DIFF
--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -37,7 +37,6 @@ const char OPT_PARAM_STR[] = "-P";
 
 /* Our state */
 static char **argv;
-static int argc;
 static int opt_index;
 static char *arg;
 static char *flag;
@@ -162,7 +161,6 @@ char *opt_getprog(void)
 char *opt_init(int ac, char **av, const OPTIONS *o)
 {
     /* Store state. */
-    argc = ac;
     argv = av;
     opt_begin();
     opts = o;


### PR DESCRIPTION
https://github.com/openssl/openssl/actions/runs/34494520852/job/102982686286

CI is failing because we have a varaible in opt.c that is set but never used.

Just remove it.

