### PR TITLE
Fix return value of i2d_*() on error

### DIFF
--- a/crypto/asn1/i2d_evp.c
+++ b/crypto/asn1/i2d_evp.c
@@ -116,7 +116,7 @@ i2d_PrivateKey_impl(const EVP_PKEY *a, unsigned char **pp, int traditional)
 
     if (a->ameth != NULL && a->ameth->priv_encode != NULL) {
         PKCS8_PRIV_KEY_INFO *p8 = EVP_PKEY2PKCS8(a);
-        int ret = 0;
+        int ret = -1;
 
         if (p8 != NULL) {
             ret = i2d_PKCS8_PRIV_KEY_INFO(p8, pp);

--- a/crypto/asn1/i2d_evp.c
+++ b/crypto/asn1/i2d_evp.c
@@ -159,8 +159,12 @@ int i2d_PublicKey(const EVP_PKEY *a, unsigned char **pp)
         return i2d_DSAPublicKey(EVP_PKEY_get0_DSA(a), pp);
 #endif
 #ifndef OPENSSL_NO_EC
-    case EVP_PKEY_EC:
-        return i2o_ECPublicKey(EVP_PKEY_get0_EC_KEY(a), pp);
+    case EVP_PKEY_EC: {
+        int ret = i2o_ECPublicKey(EVP_PKEY_get0_EC_KEY(a), pp);
+        if (ret == 0)
+            return -1;
+        return ret;
+    }
 #endif
     default:
         ERR_raise(ERR_LIB_ASN1, ASN1_R_UNSUPPORTED_PUBLIC_KEY_TYPE);

--- a/crypto/dh/dh_asn1.c
+++ b/crypto/dh/dh_asn1.c
@@ -136,7 +136,7 @@ DH *d2i_DHxparams(DH **a, const unsigned char **pp, long length)
 
 int i2d_DHxparams(const DH *dh, unsigned char **pp)
 {
-    int ret = 0;
+    int ret = -1;
     int_dhx942_dh dhx;
     int_dhvparams dhv = { NULL, NULL };
     ASN1_BIT_STRING seed;
@@ -155,7 +155,7 @@ int i2d_DHxparams(const DH *dh, unsigned char **pp)
         dhv.seed = &seed;
         dhv.counter = BN_new();
         if (dhv.counter == NULL)
-            return 0;
+            goto err;
         if (!BN_set_word(dhv.counter, (BN_ULONG)counter))
             goto err;
         dhx.vparams = &dhv;

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -908,16 +908,16 @@ EC_GROUP *d2i_ECPKParameters(EC_GROUP **a, const unsigned char **in, long len)
 
 int i2d_ECPKParameters(const EC_GROUP *a, unsigned char **out)
 {
-    int ret = 0;
+    int ret;
     ECPKPARAMETERS *tmp = EC_GROUP_get_ecpkparameters(a, NULL);
     if (tmp == NULL) {
         ERR_raise(ERR_LIB_EC, EC_R_GROUP2PKPARAMETERS_FAILURE);
-        return 0;
+        return -1;
     }
-    if ((ret = i2d_ECPKPARAMETERS(tmp, out)) == 0) {
+    if ((ret = i2d_ECPKPARAMETERS(tmp, out)) < 0) {
         ERR_raise(ERR_LIB_EC, EC_R_I2D_ECPKPARAMETERS_FAILURE);
         ECPKPARAMETERS_free(tmp);
-        return 0;
+        return ret;
     }
     ECPKPARAMETERS_free(tmp);
     return ret;
@@ -1022,7 +1022,7 @@ err:
 
 int i2d_ECPrivateKey(const EC_KEY *a, unsigned char **out)
 {
-    int ret = 0, ok = 0;
+    int ret = -1;
     unsigned char *priv = NULL, *pub = NULL;
     size_t privlen = 0, publen = 0;
 
@@ -1078,23 +1078,22 @@ int i2d_ECPrivateKey(const EC_KEY *a, unsigned char **out)
         pub = NULL;
     }
 
-    if ((ret = i2d_EC_PRIVATEKEY(priv_key, out)) == 0) {
+    if ((ret = i2d_EC_PRIVATEKEY(priv_key, out)) < 0) {
         ERR_raise(ERR_LIB_EC, ERR_R_EC_LIB);
         goto err;
     }
-    ok = 1;
 err:
     OPENSSL_clear_free(priv, privlen);
     OPENSSL_free(pub);
     EC_PRIVATEKEY_free(priv_key);
-    return ok ? ret : 0;
+    return ret;
 }
 
 int i2d_ECParameters(const EC_KEY *a, unsigned char **out)
 {
     if (a == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return -1;
     }
     return i2d_ECPKParameters(a->group, out);
 }

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -562,7 +562,7 @@ int i2d_PUBKEY(const EVP_PKEY *a, unsigned char **pp)
     int ret = -1;
 
     if (a == NULL)
-        return 0;
+        return -1;
     if (a->ameth != NULL) {
         X509_PUBKEY *xpk = NULL;
 
@@ -637,7 +637,7 @@ int i2d_RSA_PUBKEY(const RSA *a, unsigned char **pp)
     EVP_PKEY *pktmp;
     int ret;
     if (!a)
-        return 0;
+        return -1;
     pktmp = EVP_PKEY_new();
     if (pktmp == NULL) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_EVP_LIB);
@@ -679,7 +679,7 @@ int ossl_i2d_DH_PUBKEY(const DH *a, unsigned char **pp)
     EVP_PKEY *pktmp;
     int ret;
     if (!a)
-        return 0;
+        return -1;
     pktmp = EVP_PKEY_new();
     if (pktmp == NULL) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_EVP_LIB);
@@ -786,7 +786,7 @@ int i2d_DSA_PUBKEY(const DSA *a, unsigned char **pp)
     EVP_PKEY *pktmp;
     int ret;
     if (!a)
-        return 0;
+        return -1;
     pktmp = EVP_PKEY_new();
     if (pktmp == NULL) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_EVP_LIB);
@@ -832,7 +832,7 @@ int i2d_EC_PUBKEY(const EC_KEY *a, unsigned char **pp)
     int ret;
 
     if (a == NULL)
-        return 0;
+        return -1;
     if ((pktmp = EVP_PKEY_new()) == NULL) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_EVP_LIB);
         return -1;

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1251,7 +1251,7 @@ OSSL_DEPRECATEDIN_3_0 EC_KEY *o2i_ECPublicKey(EC_KEY **key,
  *  \param  key  the EC_KEY object with the public key
  *  \param  out  the buffer for the result (if NULL the function returns number
  *               of bytes needed).
- *  \return 1 on success and 0 if an error occurred
+ *  \return the length of the encoded octet string or 0 if an error occurred
  */
 OSSL_DEPRECATEDIN_3_0 int i2o_ECPublicKey(const EC_KEY *key, unsigned char **out);
 


### PR DESCRIPTION
Related to https://github.com/openssl/openssl/issues/31015
Spun off from https://github.com/openssl/openssl/pull/32251

Most[1] `i2d_*()` functions are documented to return a negative value on error. Most of them simply wrap `ASN1_item_i2d()` and behave accordingly. In #32251, @idrassi found that `i2d_ECPKParameters()` does not follow it.

It appears that it was not the only remaining issue. This PR updates the other instances I could find to match the documented behavior.

[1] One exception is `i2d_SSL_SESSION()`, where the 0 return is given a special meaning: "i2d_SSL_SESSION() returns the size of the ASN1 representation in bytes.  When the session is not valid, 0 is returned and no operation is performed."

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated