### PR TITLE
Fix memory leaks from duplicate X509v3 section fields 

### DIFF
--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -54,6 +54,11 @@ int _CONF_add_string(CONF *conf, CONF_VALUE *section, CONF_VALUE *value)
         return 0;
 
     v = lh_CONF_VALUE_insert(conf->data, value);
+    if (lh_CONF_VALUE_error(conf->data)) {
+        (void)sk_CONF_VALUE_pop(ts);
+        return 0;
+    }
+
     if (v != NULL) {
         (void)sk_CONF_VALUE_delete_ptr(ts, v);
         OPENSSL_free(v->name);

--- a/crypto/x509/v3_cpols.c
+++ b/crypto/x509/v3_cpols.c
@@ -168,6 +168,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
     STACK_OF(CONF_VALUE) *polstrs, int ia5org)
 {
     int i;
+    int policyid_seen = 0;
     CONF_VALUE *cnf;
     POLICYINFO *pol;
     POLICYQUALINFO *qual;
@@ -181,12 +182,18 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
         if (strcmp(cnf->name, "policyIdentifier") == 0) {
             ASN1_OBJECT *pobj;
 
+            if (policyid_seen) {
+                ERR_raise_data(ERR_LIB_X509V3, X509V3_R_DUPLICATE_FIELD,
+                    "field=%s", cnf->name);
+                goto err;
+            }
             if ((pobj = OBJ_txt2obj(cnf->value, 0)) == NULL) {
                 ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_OBJECT_IDENTIFIER);
                 X509V3_conf_err(cnf);
                 goto err;
             }
             pol->policyid = pobj;
+            policyid_seen = 1;
 
         } else if (!ossl_v3_name_cmp(cnf->name, "CPS")) {
             if (pol->qualifiers == NULL)
@@ -243,7 +250,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
             goto err;
         }
     }
-    if (pol->policyid == NULL) {
+    if (!policyid_seen) {
         ERR_raise(ERR_LIB_X509V3, X509V3_R_NO_POLICY_IDENTIFIER);
         goto err;
     }
@@ -316,6 +323,11 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
 
         value = cnf->value;
         if (strcmp(cnf->name, "explicitText") == 0) {
+            if (not->exptext != NULL) {
+                ERR_raise_data(ERR_LIB_X509V3, X509V3_R_DUPLICATE_FIELD,
+                    "field=%s", cnf->name);
+                goto err;
+            }
             tag = displaytext_str2tag(value, &tag_len);
             if ((not->exptext = ASN1_STRING_type_new(tag)) == NULL) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);

--- a/crypto/x509/v3_crld.c
+++ b/crypto/x509/v3_crld.c
@@ -226,6 +226,11 @@ static DIST_POINT *crldp_from_section(X509V3_CTX *ctx,
             if (!set_reasons(&point->reasons, cnf->value))
                 goto err;
         } else if (strcmp(cnf->name, "CRLissuer") == 0) {
+            if (point->CRLissuer != NULL) {
+                ERR_raise_data(ERR_LIB_X509V3, X509V3_R_DUPLICATE_FIELD,
+                    "field=%s", cnf->name);
+                goto err;
+            }
             point->CRLissuer = gnames_from_sectname(ctx, cnf->value);
             if (point->CRLissuer == NULL)
                 goto err;

--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -206,6 +206,32 @@ static int test_check_overflow(void)
     return 1;
 }
 
+static int test_load_duplicate_mfail(void)
+{
+    const char config[] = "a=1\na=2\n";
+    CONF *test_conf = NULL;
+    BIO *test_bio = NULL;
+    int ret = -1;
+
+    if (!TEST_ptr(test_conf = NCONF_new(NULL))
+        || !TEST_ptr(test_bio = BIO_new_mem_buf(config, sizeof(config) - 1)))
+        goto end;
+
+    MFAIL_start();
+    ret = NCONF_load_bio(test_conf, test_bio, NULL);
+    MFAIL_end();
+
+    if (ret > 0
+        && (!TEST_str_eq(NCONF_get_string(test_conf, "default", "a"), "2")
+            || !TEST_int_eq(sk_CONF_VALUE_num(NCONF_get_section(test_conf, "default")), 1)))
+        ret = -1;
+
+end:
+    BIO_free(test_bio);
+    NCONF_free(test_conf);
+    return ret;
+}
+
 static int test_available_providers(void)
 {
     libctx = OSSL_LIB_CTX_new();
@@ -290,6 +316,7 @@ int setup_tests(void)
     ADD_TEST(test_load_config);
     ADD_TEST(test_check_null_numbers);
     ADD_TEST(test_check_overflow);
+    ADD_MFAIL_TEST(test_load_duplicate_mfail);
     if (test_providers != 0)
         ADD_TEST(test_available_providers);
 


### PR DESCRIPTION
If lh_CONF_VALUE_insert() fails in _CONF_add_string() then new
CONF value is still left in stack. This can prevent
proper duplicate field replacement causing multiple values
with same field name to stay on stack.

Minimal fix is only the : e0dd8b8e1816f5709163e01e4c06bcddc7af8a26

But I also added fixes for the the possible individual leaks 
but these are not really reachable after the lh_CONF_VALUE_insert().

- [x] tests are added or updated
