### PR TITLE
Enable coveralls 4.1

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -49,6 +49,9 @@ jobs:
               "branch": "master",
               "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-unit-tests"
             }, {
+              "branch": "openssl-4.1",
+              "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-unit-tests"
+            }, {
               "branch": "openssl-4.0",
               "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug"
             },{


### PR DESCRIPTION
Now that we've branched 4.1 we need to enable coveralls for that branch on both master and the 4.1 branch