### PR TITLE
Fix unintended context reset in EVP_PKEY_fromdata_settable()

### DIFF
--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -340,10 +340,15 @@ int EVP_PKEY_fromdata(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey, int selection,
 
 const OSSL_PARAM *EVP_PKEY_fromdata_settable(EVP_PKEY_CTX *ctx, int selection)
 {
-    /* We call fromdata_init to get ctx->keymgmt populated */
-    if (fromdata_init(ctx, EVP_PKEY_OP_UNDEFINED) == 1)
-        return evp_keymgmt_import_types(ctx->keymgmt, selection);
-    return NULL;
+    /*
+     * Query the existing keymgmt without resetting the context or freeing
+     * active operation state.
+     */
+    if (ctx == NULL || ctx->keytype == NULL || ctx->keymgmt == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        return NULL;
+    }
+    return evp_keymgmt_import_types(ctx->keymgmt, selection);
 }
 
 static OSSL_CALLBACK ossl_pkey_todata_cb;

--- a/doc/man3/EVP_PKEY_fromdata.pod
+++ b/doc/man3/EVP_PKEY_fromdata.pod
@@ -55,6 +55,11 @@ rendering as a man-page while still getting proper links in HTML
 EVP_PKEY_fromdata_settable() gets a constant L<OSSL_PARAM(3)> array that describes
 the settable parameters that can be used with EVP_PKEY_fromdata().
 I<selection> is described in L</Selections>.
+This function does not initialize the context or alter its current operation
+or operation-specific configuration.  It may be called before or after
+EVP_PKEY_fromdata_init(), or on a context initialized for another operation.
+The returned array is owned by the key management implementation and must
+not be freed by the caller.
 
 Parameters in the I<params> array that are not among the settable parameters
 for the given I<selection> are ignored.
@@ -96,6 +101,10 @@ To enable, specify the B<enable-lms> build configuration option.
 EVP_PKEY_fromdata_init() and EVP_PKEY_fromdata() return 1 for success and 0 or
 a negative value for failure.  In particular a return value of -2 indicates the
 operation is not supported by the public key algorithm.
+
+EVP_PKEY_fromdata_settable() returns a constant array of L<OSSL_PARAM(3)>
+descriptors, or NULL if no descriptor array is available for the key
+management implementation and I<selection>.
 
 =head1 EXAMPLES
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4027,6 +4027,55 @@ static int test_DSA_priv_pub(void)
 
 #endif /* !OPENSSL_NO_DSA */
 
+/*
+ * EVP_PKEY_fromdata_settable() is a pure query: it must not reset the
+ * context operation state (issue #32776).
+ */
+static int test_fromdata_settable_nonmutating(void)
+{
+    static unsigned long key_numbers[] = {
+        0xbc747fc5, /* N */
+        0x10001, /* E */
+    };
+    OSSL_PARAM fromdata_params[] = {
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_N, &key_numbers[0]),
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_E, &key_numbers[1]),
+        OSSL_PARAM_END
+    };
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    const OSSL_PARAM *settable = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(testctx, "RSA", testpropq)))
+        goto err;
+
+    /* The query must not undo EVP_PKEY_fromdata_init() */
+    if (!TEST_int_gt(EVP_PKEY_fromdata_init(ctx), 0)
+        || !TEST_ptr(settable = EVP_PKEY_fromdata_settable(ctx,
+                         EVP_PKEY_KEYPAIR))
+        || !TEST_ptr(OSSL_PARAM_locate_const(settable, OSSL_PKEY_PARAM_RSA_N))
+        || !TEST_int_gt(EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEYPAIR,
+                            fromdata_params),
+            0))
+        goto err;
+    EVP_PKEY_free(pkey);
+    pkey = NULL;
+
+    /* The query must not discard key generation state or configuration */
+    if (!TEST_int_gt(EVP_PKEY_keygen_init(ctx), 0)
+        || !TEST_int_gt(EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 512), 0)
+        || !TEST_ptr(EVP_PKEY_fromdata_settable(ctx, EVP_PKEY_KEYPAIR))
+        || !TEST_int_gt(EVP_PKEY_keygen(ctx, &pkey), 0)
+        || !TEST_int_eq(EVP_PKEY_get_bits(pkey), 512))
+        goto err;
+    ret = 1;
+err:
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_CTX_free(ctx);
+    return ret;
+}
+
 static int test_RSA_get_set_params(void)
 {
     OSSL_PARAM_BLD *bld = NULL;
@@ -10135,6 +10184,7 @@ int setup_tests(void)
     ADD_TEST(test_DSA_get_set_params);
     ADD_TEST(test_DSA_priv_pub);
 #endif
+    ADD_TEST(test_fromdata_settable_nonmutating);
     ADD_TEST(test_RSA_get_set_params);
     ADD_TEST(test_RSA_OAEP_set_get_params);
     ADD_TEST(test_RSA_OAEP_set_null_label);


### PR DESCRIPTION
Fixes #32776

`EVP_PKEY_fromdata_settable` is documented as a metadata query, but it runs `fromdata_init(ctx, EVP_PKEY_OP_UNDEFINED)`, the helper that `EVP_PKEY_fromdata_init` uses to set the context up. That helper tears down whatever operation the context is currently running and then stores `EVP_PKEY_OP_UNDEFINED` in `ctx->operation`. Asking a question about supported parameters ends up resetting the context behind the caller's back.

The symptom from the issue: with the query issued between `EVP_PKEY_fromdata_init` and `EVP_PKEY_fromdata`, the import fails with -2 (`EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE`), because the flag the import call checks has been cleared. The same reset also throws away a signing operation that's already underway, or a key generation setup with its parameters, when the query is made on such a context.

The call into `fromdata_init` is a leftover. It made sense in late 2019 when the keymgmt was fetched lazily on first use, but the fetch moved into context creation a few months later (4b9e90f42a), so the query hasn't had a reason to initialise anything since then.

What I'm changing:

- The query returns `evp_keymgmt_import_types` directly; the keymgmt is already attached at context creation. Existing return values and error reporting are preserved: a NULL context or missing key type or keymgmt still produces NULL plus an error, while a provider query can return NULL without adding an error.
- New `test_fromdata_settable_nonmutating` runs the call order from the issue with RSA key data, and checks that key generation settings (RSA bits) survive the query. The test fails without the fix and passes with it.
- `EVP_PKEY_fromdata(3)` now spells out that the query doesn't touch operation state and can run before or after `EVP_PKEY_fromdata_init`. The returned array is documented as borrowed and mustn't be freed, and RETURN VALUES finally lists the function.

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated